### PR TITLE
refactor: make clippy almost silent, some optimizations

### DIFF
--- a/examples/styling/src/main.rs
+++ b/examples/styling/src/main.rs
@@ -110,14 +110,11 @@ impl Sandbox for Styling {
         )
         .style(self.theme);
 
-        let toggler = Toggler::new(
-            self.toggler_value,
-            String::from("Toggle me!"),
-            Message::TogglerToggled,
-        )
-        .width(Length::Shrink)
-        .spacing(10)
-        .style(self.theme);
+        let toggler = Toggler::new(self.toggler_value, Message::TogglerToggled)
+            .label("Toggle me!")
+            .width(Length::Shrink)
+            .spacing(10)
+            .style(self.theme);
 
         let content = Column::new()
             .spacing(20)

--- a/examples/tour/src/main.rs
+++ b/examples/tour/src/main.rs
@@ -566,11 +566,10 @@ impl<'a> Step {
                 "A toggler is mostly used to enable or disable something.",
             ))
             .push(
-                Container::new(Toggler::new(
-                    can_continue,
-                    String::from("Toggle me to continue..."),
-                    StepMessage::TogglerChanged,
-                ))
+                Container::new(
+                    Toggler::new(can_continue, StepMessage::TogglerChanged)
+                        .label("Toggle me to continue..."),
+                )
                 .padding([0, 40]),
             )
     }
@@ -767,14 +766,20 @@ impl Language {
 
 impl From<Language> for String {
     fn from(language: Language) -> String {
-        String::from(match language {
+        String::from(language.as_ref())
+    }
+}
+
+impl AsRef<str> for Language {
+    fn as_ref(&self) -> &str {
+        match self {
             Language::Rust => "Rust",
             Language::Elm => "Elm",
             Language::Ruby => "Ruby",
             Language::Haskell => "Haskell",
             Language::C => "C",
             Language::Other => "Other",
-        })
+        }
     }
 }
 

--- a/futures/src/runtime.rs
+++ b/futures/src/runtime.rs
@@ -61,8 +61,6 @@ where
 
             let future = future.then(|message| async move {
                 let _ = sender.send(message).await;
-
-                ()
             });
 
             self.executor.spawn(future);

--- a/futures/src/subscription.rs
+++ b/futures/src/subscription.rs
@@ -183,11 +183,7 @@ where
 
         let mapper = self.mapper;
 
-        Box::pin(
-            self.recipe
-                .stream(input)
-                .map(move |element| mapper(element)),
-        )
+        Box::pin(self.recipe.stream(input).map(mapper))
     }
 }
 

--- a/futures/src/subscription/tracker.rs
+++ b/futures/src/subscription/tracker.rs
@@ -14,6 +14,16 @@ pub struct Tracker<Hasher, Event> {
     _hasher: PhantomData<Hasher>,
 }
 
+impl<Hasher, Event> Default for Tracker<Hasher, Event>
+where
+    Hasher: std::hash::Hasher + Default,
+    Event: 'static + Send + Clone,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[derive(Debug)]
 pub struct Execution<Event> {
     _cancel: futures::channel::oneshot::Sender<()>,

--- a/glow/src/backend.rs
+++ b/glow/src/backend.rs
@@ -162,7 +162,6 @@ impl Backend {
                                 glow_glyph::VerticalAlign::Bottom
                             }
                         }),
-                    ..Default::default()
                 };
 
                 self.text_pipeline.queue(text);

--- a/glow/src/quad.rs
+++ b/glow/src/quad.rs
@@ -111,6 +111,7 @@ impl Pipeline {
             }
         }
 
+        #[allow(clippy::float_cmp)] // scale should be precise enough
         if scale != self.current_scale {
             unsafe {
                 gl.uniform_1_f32(Some(&self.scale_location), scale);

--- a/glow/src/triangle.rs
+++ b/glow/src/triangle.rs
@@ -121,16 +121,13 @@ impl Pipeline {
             gl.bind_vertex_array(Some(self.vertex_array));
         }
 
-        // This looks a bit crazy, but we are just counting how many vertices
-        // and indices we will need to handle.
-        // TODO: Improve readability
-        let (total_vertices, total_indices) = meshes
-            .iter()
-            .map(|layer::Mesh { buffers, .. }| {
-                (buffers.vertices.len(), buffers.indices.len())
-            })
-            .fold((0, 0), |(total_v, total_i), (v, i)| {
-                (total_v + v, total_i + i)
+        // Count how many vertices and indices we will need to handle.
+        let (total_vertices, total_indices) =
+            meshes.iter().fold((0, 0), |(total_v, total_i), mesh| {
+                (
+                    total_v + mesh.buffers.vertices.len(),
+                    total_i + mesh.buffers.indices.len(),
+                )
             });
 
         // Then we ensure the current buffers are big enough, resizing if

--- a/glutin/src/application.rs
+++ b/glutin/src/application.rs
@@ -136,6 +136,7 @@ where
     });
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_instance<A, E, C>(
     mut application: A,
     mut compositor: C,
@@ -187,7 +188,7 @@ async fn run_instance<A, E, C>(
                 let statuses = user_interface.update(
                     &events,
                     state.cursor_position(),
-                    &mut renderer,
+                    &renderer,
                     &mut clipboard,
                     &mut messages,
                 );

--- a/graphics/src/font/source.rs
+++ b/graphics/src/font/source.rs
@@ -6,6 +6,12 @@ pub struct Source {
     raw: font_kit::source::SystemSource,
 }
 
+impl Default for Source {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Source {
     /// Creates a new [`Source`].
     pub fn new() -> Self {

--- a/graphics/src/widget/canvas/path/builder.rs
+++ b/graphics/src/widget/canvas/path/builder.rs
@@ -11,6 +11,12 @@ pub struct Builder {
     raw: lyon::path::builder::SvgPathBuilder<lyon::path::Builder>,
 }
 
+impl Default for Builder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Builder {
     /// Creates a new [`Builder`].
     pub fn new() -> Builder {

--- a/graphics/src/widget/qr_code.rs
+++ b/graphics/src/widget/qr_code.rs
@@ -66,10 +66,7 @@ where
         let side_length = (self.state.width + 2 * QUIET_ZONE) as f32
             * f32::from(self.cell_size);
 
-        layout::Node::new(Size::new(
-            f32::from(side_length),
-            f32::from(side_length),
-        ))
+        layout::Node::new(Size::new(side_length, side_length))
     }
 
     fn hash_layout(&self, state: &mut Hasher) {
@@ -132,12 +129,12 @@ where
     }
 }
 
-impl<'a, Message, B> Into<Element<'a, Message, Renderer<B>>> for QRCode<'a>
+impl<'a, Message, B> From<QRCode<'a>> for Element<'a, Message, Renderer<B>>
 where
     B: Backend,
 {
-    fn into(self) -> Element<'a, Message, Renderer<B>> {
-        Element::new(self)
+    fn from(qr_code: QRCode<'a>) -> Self {
+        Element::new(qr_code)
     }
 }
 

--- a/graphics/src/widget/slider.rs
+++ b/graphics/src/widget/slider.rs
@@ -72,18 +72,16 @@ where
             },
         );
 
-        let (handle_width, handle_height, handle_border_radius) = match style
-            .handle
-            .shape
-        {
-            HandleShape::Circle { radius } => {
-                (radius * 2.0, radius * 2.0, radius)
-            }
-            HandleShape::Rectangle {
-                width,
-                border_radius,
-            } => (f32::from(width), f32::from(bounds.height), border_radius),
-        };
+        let (handle_width, handle_height, handle_border_radius) =
+            match style.handle.shape {
+                HandleShape::Circle { radius } => {
+                    (radius * 2.0, radius * 2.0, radius)
+                }
+                HandleShape::Rectangle {
+                    width,
+                    border_radius,
+                } => (f32::from(width), bounds.height, border_radius),
+            };
 
         let (range_start, range_end) = range.into_inner();
 

--- a/graphics/src/widget/text_input.rs
+++ b/graphics/src/widget/text_input.rs
@@ -255,7 +255,7 @@ where
 {
     use iced_native::text_input::Renderer;
 
-    let text_before_cursor = value.until(cursor_index).to_string();
+    let text_before_cursor = value.until(cursor_index).concat();
 
     let text_value_width =
         renderer.measure_value(&text_before_cursor, size, font);

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -14,6 +14,7 @@ debug = []
 twox-hash = "1.5"
 unicode-segmentation = "1.6"
 num-traits = "0.2"
+smol_str = "0.1"
 
 [dependencies.iced_core]
 version = "0.4"

--- a/native/src/debug/basic.rs
+++ b/native/src/debug/basic.rs
@@ -31,6 +31,12 @@ pub struct Debug {
     last_messages: VecDeque<String>,
 }
 
+impl Default for Debug {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Debug {
     /// Creates a new [`struct@Debug`].
     pub fn new() -> Self {

--- a/native/src/debug/null.rs
+++ b/native/src/debug/null.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs)]
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Debug;
 
 impl Debug {

--- a/native/src/overlay/menu.rs
+++ b/native/src/overlay/menu.rs
@@ -158,9 +158,9 @@ where
 
         Self {
             container,
-            width: width,
+            width,
             target_height,
-            style: style,
+            style,
         }
     }
 }
@@ -224,7 +224,7 @@ where
         messages: &mut Vec<Message>,
     ) -> event::Status {
         self.container.on_event(
-            event.clone(),
+            event,
             layout,
             cursor_position,
             renderer,
@@ -289,13 +289,15 @@ where
         use std::f32;
 
         let limits = limits.width(Length::Fill).height(Length::Shrink);
-        let text_size = self.text_size.unwrap_or(renderer.default_size());
 
         let size = {
+            #[allow(clippy::or_fun_call)]
             let intrinsic = Size::new(
                 0.0,
-                f32::from(text_size + self.padding.vertical())
-                    * self.options.len() as f32,
+                f32::from(
+                    self.text_size.unwrap_or(renderer.default_size())
+                        + self.padding.vertical(),
+                ) * self.options.len() as f32,
             );
 
             limits.resolve(intrinsic)
@@ -326,9 +328,7 @@ where
     ) -> event::Status {
         match event {
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) => {
-                let bounds = layout.bounds();
-
-                if bounds.contains(cursor_position) {
+                if layout.bounds().contains(cursor_position) {
                     if let Some(index) = *self.hovered_option {
                         if let Some(option) = self.options.get(index) {
                             *self.last_selection = Some(option.clone());
@@ -339,28 +339,30 @@ where
             Event::Mouse(mouse::Event::CursorMoved { .. }) => {
                 let bounds = layout.bounds();
 
+                #[allow(clippy::or_fun_call)]
                 if bounds.contains(cursor_position) {
-                    let text_size =
-                        self.text_size.unwrap_or(renderer.default_size());
-
                     *self.hovered_option = Some(
                         ((cursor_position.y - bounds.y)
-                            / f32::from(text_size + self.padding.vertical()))
-                            as usize,
+                            / f32::from(
+                                self.text_size
+                                    .unwrap_or(renderer.default_size())
+                                    + self.padding.vertical(),
+                            )) as usize,
                     );
                 }
             }
             Event::Touch(touch::Event::FingerPressed { .. }) => {
                 let bounds = layout.bounds();
 
+                #[allow(clippy::or_fun_call)]
                 if bounds.contains(cursor_position) {
-                    let text_size =
-                        self.text_size.unwrap_or(renderer.default_size());
-
                     *self.hovered_option = Some(
                         ((cursor_position.y - bounds.y)
-                            / f32::from(text_size + self.padding.vertical()))
-                            as usize,
+                            / f32::from(
+                                self.text_size
+                                    .unwrap_or(renderer.default_size())
+                                    + self.padding.vertical(),
+                            )) as usize,
                     );
 
                     if let Some(index) = *self.hovered_option {
@@ -392,6 +394,7 @@ where
             self.options,
             *self.hovered_option,
             self.padding,
+            #[allow(clippy::or_fun_call)]
             self.text_size.unwrap_or(renderer.default_size()),
             self.font,
             &self.style,
@@ -423,6 +426,7 @@ pub trait Renderer:
     ) -> Self::Output;
 
     /// Draws the list of options of a [`Menu`].
+    #[allow(clippy::too_many_arguments)]
     fn draw<T: ToString>(
         &mut self,
         bounds: Rectangle,
@@ -437,14 +441,14 @@ pub trait Renderer:
     ) -> Self::Output;
 }
 
-impl<'a, T, Message, Renderer> Into<Element<'a, Message, Renderer>>
-    for List<'a, T, Renderer>
+impl<'a, T, Message, Renderer> From<List<'a, T, Renderer>>
+    for Element<'a, Message, Renderer>
 where
     T: ToString + Clone,
     Message: 'a,
     Renderer: 'a + self::Renderer,
 {
-    fn into(self) -> Element<'a, Message, Renderer> {
-        Element::new(self)
+    fn from(list: List<'a, T, Renderer>) -> Self {
+        Element::new(list)
     }
 }

--- a/native/src/renderer/null.rs
+++ b/native/src/renderer/null.rs
@@ -8,7 +8,7 @@ use crate::{
 /// A renderer that does nothing.
 ///
 /// It can be useful if you are writing tests!
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 pub struct Null;
 
 impl Null {

--- a/native/src/widget/button.rs
+++ b/native/src/widget/button.rs
@@ -291,6 +291,7 @@ pub trait Renderer: crate::Renderer + Sized {
     type Style: Default;
 
     /// Draws a [`Button`].
+    #[allow(clippy::too_many_arguments)]
     fn draw<Message>(
         &mut self,
         defaults: &Self::Defaults,

--- a/native/src/widget/checkbox.rs
+++ b/native/src/widget/checkbox.rs
@@ -145,6 +145,7 @@ where
                     .height(Length::Units(self.size)),
             )
             .push(
+                #[allow(clippy::or_fun_call)]
                 Text::new(&self.label)
                     .font(self.font)
                     .width(self.width)
@@ -199,6 +200,7 @@ where
             defaults,
             label_layout.bounds(),
             &self.label,
+            #[allow(clippy::or_fun_call)]
             self.text_size.unwrap_or(renderer.default_size()),
             self.font,
             self.text_color,

--- a/native/src/widget/checkbox.rs
+++ b/native/src/widget/checkbox.rs
@@ -1,6 +1,8 @@
 //! Show toggle controls using checkboxes.
 use std::hash::Hash;
 
+use smol_str::SmolStr;
+
 use crate::event::{self, Event};
 use crate::layout;
 use crate::mouse;
@@ -33,7 +35,7 @@ use crate::{
 pub struct Checkbox<Message, Renderer: self::Renderer + text::Renderer> {
     is_checked: bool,
     on_toggle: Box<dyn Fn(bool) -> Message>,
-    label: String,
+    label: SmolStr,
     width: Length,
     size: u16,
     spacing: u16,
@@ -54,7 +56,7 @@ impl<Message, Renderer: self::Renderer + text::Renderer>
     ///   * a function that will be called when the [`Checkbox`] is toggled. It
     ///     will receive the new state of the [`Checkbox`] and must produce a
     ///     `Message`.
-    pub fn new<F>(is_checked: bool, label: impl Into<String>, f: F) -> Self
+    pub fn new<F>(is_checked: bool, label: impl Into<SmolStr>, f: F) -> Self
     where
         F: 'static + Fn(bool) -> Message,
     {
@@ -146,7 +148,7 @@ where
             )
             .push(
                 #[allow(clippy::or_fun_call)]
-                Text::new(&self.label)
+                Text::new(self.label.clone())
                     .font(self.font)
                     .width(self.width)
                     .size(self.text_size.unwrap_or(renderer.default_size())),

--- a/native/src/widget/column.rs
+++ b/native/src/widget/column.rs
@@ -24,6 +24,12 @@ pub struct Column<'a, Message, Renderer> {
     children: Vec<Element<'a, Message, Renderer>>,
 }
 
+impl<'a, Message, Renderer> Default for Column<'a, Message, Renderer> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<'a, Message, Renderer> Column<'a, Message, Renderer> {
     /// Creates an empty [`Column`].
     pub fn new() -> Self {

--- a/native/src/widget/container.rs
+++ b/native/src/widget/container.rs
@@ -218,6 +218,7 @@ pub trait Renderer: crate::Renderer {
     type Style: Default;
 
     /// Draws a [`Container`].
+    #[allow(clippy::too_many_arguments)]
     fn draw<Message>(
         &mut self,
         defaults: &Self::Defaults,

--- a/native/src/widget/pane_grid.rs
+++ b/native/src/widget/pane_grid.rs
@@ -97,6 +97,7 @@ pub struct PaneGrid<'a, Message, Renderer: self::Renderer> {
     spacing: u16,
     on_click: Option<Box<dyn Fn(Pane) -> Message + 'a>>,
     on_drag: Option<Box<dyn Fn(DragEvent) -> Message + 'a>>,
+    #[allow(clippy::type_complexity)]
     on_resize: Option<(u16, Box<dyn Fn(ResizeEvent) -> Message + 'a>)>,
     style: <Renderer as self::Renderer>::Style,
 }
@@ -586,6 +587,7 @@ pub trait Renderer: crate::Renderer + container::Renderer + Sized {
     /// - the [`Axis`] that is currently being resized
     /// - the [`Layout`] of the [`PaneGrid`] and its elements
     /// - the cursor position
+    #[allow(clippy::too_many_arguments)]
     fn draw<Message>(
         &mut self,
         defaults: &Self::Defaults,
@@ -605,6 +607,7 @@ pub trait Renderer: crate::Renderer + container::Renderer + Sized {
     /// - the [`Content`] of the [`Pane`]
     /// - the [`Layout`] of the [`Pane`] and its elements
     /// - the cursor position
+    #[allow(clippy::too_many_arguments)]
     fn draw_pane<Message>(
         &mut self,
         defaults: &Self::Defaults,
@@ -624,6 +627,7 @@ pub trait Renderer: crate::Renderer + container::Renderer + Sized {
     /// - the content of the [`TitleBar`] with its layout
     /// - the controls of the [`TitleBar`] with their [`Layout`], if any
     /// - the cursor position
+    #[allow(clippy::too_many_arguments)]
     fn draw_title_bar<Message>(
         &mut self,
         defaults: &Self::Defaults,
@@ -659,8 +663,7 @@ fn hovered_split<'a>(
 ) -> Option<(Split, Axis, Rectangle)> {
     splits
         .filter_map(|(split, (axis, region, ratio))| {
-            let bounds =
-                axis.split_line_bounds(*region, *ratio, f32::from(spacing));
+            let bounds = axis.split_line_bounds(*region, *ratio, spacing);
 
             if bounds.contains(cursor_position) {
                 Some((*split, *axis, bounds))

--- a/native/src/widget/pane_grid/node.rs
+++ b/native/src/widget/pane_grid/node.rs
@@ -38,14 +38,11 @@ impl Node {
 
         std::iter::from_fn(move || {
             while let Some(node) = unvisited_nodes.pop() {
-                match node {
-                    Node::Split { id, a, b, .. } => {
-                        unvisited_nodes.push(a);
-                        unvisited_nodes.push(b);
+                if let Node::Split { id, a, b, .. } = node {
+                    unvisited_nodes.push(a);
+                    unvisited_nodes.push(b);
 
-                        return Some(id);
-                    }
-                    _ => {}
+                    return Some(id);
                 }
             }
 
@@ -126,12 +123,9 @@ impl Node {
     }
 
     pub(crate) fn update(&mut self, f: &impl Fn(&mut Node)) {
-        match self {
-            Node::Split { a, b, .. } => {
-                a.update(f);
-                b.update(f);
-            }
-            _ => {}
+        if let Node::Split { a, b, .. } = self {
+            a.update(f);
+            b.update(f);
         }
 
         f(self);

--- a/native/src/widget/pane_grid/state.rs
+++ b/native/src/widget/pane_grid/state.rs
@@ -52,6 +52,13 @@ impl<T> State<T> {
         }
     }
 
+    /// Returns whether the [`State`] is empty or not.
+    ///
+    /// A [`State`] is empty when it contains no panes.
+    pub fn is_empty(&self) -> bool {
+        self.panes.len() == 0
+    }
+
     /// Returns the total amount of panes in the [`State`].
     pub fn len(&self) -> usize {
         self.panes.len()

--- a/native/src/widget/pick_list.rs
+++ b/native/src/widget/pick_list.rs
@@ -152,7 +152,7 @@ where
             .width(self.width)
             .height(Length::Shrink)
             .pad(self.padding);
-
+        #[allow(clippy::or_fun_call)]
         let text_size = self.text_size.unwrap_or(renderer.default_size());
 
         let max_width = match self.width {
@@ -266,6 +266,7 @@ where
             cursor_position,
             self.selected.as_ref().map(ToString::to_string),
             self.padding,
+            #[allow(clippy::or_fun_call)]
             self.text_size.unwrap_or(renderer.default_size()),
             self.font,
             &self.style,
@@ -320,6 +321,7 @@ pub trait Renderer: text::Renderer + menu::Renderer {
     ) -> <Self as menu::Renderer>::Style;
 
     /// Draws a [`PickList`].
+    #[allow(clippy::too_many_arguments)]
     fn draw(
         &mut self,
         bounds: Rectangle,
@@ -332,15 +334,15 @@ pub trait Renderer: text::Renderer + menu::Renderer {
     ) -> Self::Output;
 }
 
-impl<'a, T: 'a, Message, Renderer> Into<Element<'a, Message, Renderer>>
-    for PickList<'a, T, Message, Renderer>
+impl<'a, T: 'a, Message, Renderer> From<PickList<'a, T, Message, Renderer>>
+    for Element<'a, Message, Renderer>
 where
     T: Clone + ToString + Eq,
     [T]: ToOwned<Owned = Vec<T>>,
     Renderer: self::Renderer + 'a,
     Message: 'static,
 {
-    fn into(self) -> Element<'a, Message, Renderer> {
-        Element::new(self)
+    fn from(list: PickList<'a, T, Message, Renderer>) -> Self {
+        Element::new(list)
     }
 }

--- a/native/src/widget/radio.rs
+++ b/native/src/widget/radio.rs
@@ -1,6 +1,8 @@
 //! Create choices using radio buttons.
 use std::hash::Hash;
 
+use smol_str::SmolStr;
+
 use crate::event::{self, Event};
 use crate::mouse;
 use crate::row;
@@ -42,7 +44,7 @@ use crate::{
 pub struct Radio<Message, Renderer: self::Renderer + text::Renderer> {
     is_selected: bool,
     on_click: Message,
-    label: String,
+    label: SmolStr,
     width: Length,
     size: u16,
     spacing: u16,
@@ -67,7 +69,7 @@ where
     ///   receives the value of the radio and must produce a `Message`.
     pub fn new<F, V>(
         value: V,
-        label: impl Into<String>,
+        label: impl Into<SmolStr>,
         selected: Option<V>,
         f: F,
     ) -> Self
@@ -161,7 +163,7 @@ where
             )
             .push(
                 #[allow(clippy::or_fun_call)]
-                Text::new(&self.label)
+                Text::new(self.label.clone())
                     .width(self.width)
                     .size(self.text_size.unwrap_or(renderer.default_size())),
             )

--- a/native/src/widget/radio.rs
+++ b/native/src/widget/radio.rs
@@ -160,6 +160,7 @@ where
                     .height(Length::Units(self.size)),
             )
             .push(
+                #[allow(clippy::or_fun_call)]
                 Text::new(&self.label)
                     .width(self.width)
                     .size(self.text_size.unwrap_or(renderer.default_size())),
@@ -211,6 +212,7 @@ where
             defaults,
             label_layout.bounds(),
             &self.label,
+            #[allow(clippy::or_fun_call)]
             self.text_size.unwrap_or(renderer.default_size()),
             self.font,
             self.text_color,

--- a/native/src/widget/row.rs
+++ b/native/src/widget/row.rs
@@ -23,6 +23,12 @@ pub struct Row<'a, Message, Renderer> {
     children: Vec<Element<'a, Message, Renderer>>,
 }
 
+impl<'a, Message, Renderer> Default for Row<'a, Message, Renderer> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<'a, Message, Renderer> Row<'a, Message, Renderer> {
     /// Creates an empty [`Row`].
     pub fn new() -> Self {

--- a/native/src/widget/rule.rs
+++ b/native/src/widget/rule.rs
@@ -20,7 +20,7 @@ impl<Renderer: self::Renderer> Rule<Renderer> {
     pub fn horizontal(spacing: u16) -> Self {
         Rule {
             width: Length::Fill,
-            height: Length::from(Length::Units(spacing)),
+            height: Length::Units(spacing),
             style: Renderer::Style::default(),
             is_horizontal: true,
         }
@@ -29,7 +29,7 @@ impl<Renderer: self::Renderer> Rule<Renderer> {
     /// Creates a vertical [`Rule`] for dividing content by the given horizontal spacing.
     pub fn vertical(spacing: u16) -> Self {
         Rule {
-            width: Length::from(Length::Units(spacing)),
+            width: Length::Units(spacing),
             height: Length::Fill,
             style: Renderer::Style::default(),
             is_horizontal: false,

--- a/native/src/widget/scrollable.rs
+++ b/native/src/widget/scrollable.rs
@@ -662,6 +662,7 @@ pub trait Renderer: column::Renderer + Sized {
     /// - a optional [`Scrollbar`] to be rendered
     /// - the scrolling offset
     /// - the drawn content
+    #[allow(clippy::too_many_arguments)]
     fn draw(
         &mut self,
         scrollable: &State,

--- a/native/src/widget/text.rs
+++ b/native/src/widget/text.rs
@@ -1,4 +1,6 @@
 //! Write some text for your users to read.
+use smol_str::SmolStr;
+
 use crate::{
     layout, Color, Element, Hasher, HorizontalAlignment, Layout, Length, Point,
     Rectangle, Size, VerticalAlignment, Widget,
@@ -21,7 +23,7 @@ use std::hash::Hash;
 /// ![Text drawn by `iced_wgpu`](https://github.com/hecrj/iced/blob/7760618fb112074bc40b148944521f312152012a/docs/images/text.png?raw=true)
 #[derive(Debug, Clone)]
 pub struct Text<Renderer: self::Renderer> {
-    content: String,
+    content: SmolStr,
     size: Option<u16>,
     color: Option<Color>,
     font: Renderer::Font,
@@ -33,7 +35,7 @@ pub struct Text<Renderer: self::Renderer> {
 
 impl<Renderer: self::Renderer> Text<Renderer> {
     /// Create a new fragment of [`Text`] with the given contents.
-    pub fn new<T: Into<String>>(label: T) -> Self {
+    pub fn new<T: Into<SmolStr>>(label: T) -> Self {
         Text {
             content: label.into(),
             size: None,

--- a/native/src/widget/text.rs
+++ b/native/src/widget/text.rs
@@ -19,7 +19,7 @@ use std::hash::Hash;
 /// ```
 ///
 /// ![Text drawn by `iced_wgpu`](https://github.com/hecrj/iced/blob/7760618fb112074bc40b148944521f312152012a/docs/images/text.png?raw=true)
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Text<Renderer: self::Renderer> {
     content: String,
     size: Option<u16>,
@@ -113,12 +113,15 @@ where
     ) -> layout::Node {
         let limits = limits.width(self.width).height(self.height);
 
-        let size = self.size.unwrap_or(renderer.default_size());
-
         let bounds = limits.max();
 
-        let (width, height) =
-            renderer.measure(&self.content, size, self.font, bounds);
+        #[allow(clippy::or_fun_call)]
+        let (width, height) = renderer.measure(
+            &self.content,
+            self.size.unwrap_or(renderer.default_size()),
+            self.font,
+            bounds,
+        );
 
         let size = limits.resolve(Size::new(width, height));
 
@@ -137,6 +140,7 @@ where
             defaults,
             layout.bounds(),
             &self.content,
+            #[allow(clippy::or_fun_call)]
             self.size.unwrap_or(renderer.default_size()),
             self.font,
             self.color,
@@ -188,6 +192,7 @@ pub trait Renderer: crate::Renderer {
     ///   * the color of the [`Text`]
     ///   * the [`HorizontalAlignment`] of the [`Text`]
     ///   * the [`VerticalAlignment`] of the [`Text`]
+    #[allow(clippy::too_many_arguments)]
     fn draw(
         &mut self,
         defaults: &Self::Defaults,
@@ -208,20 +213,5 @@ where
 {
     fn from(text: Text<Renderer>) -> Element<'a, Message, Renderer> {
         Element::new(text)
-    }
-}
-
-impl<Renderer: self::Renderer> Clone for Text<Renderer> {
-    fn clone(&self) -> Self {
-        Self {
-            content: self.content.clone(),
-            size: self.size,
-            color: self.color,
-            font: self.font,
-            width: self.width,
-            height: self.height,
-            horizontal_alignment: self.horizontal_alignment,
-            vertical_alignment: self.vertical_alignment,
-        }
     }
 }

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -7,6 +7,7 @@ mod value;
 pub mod cursor;
 
 pub use cursor::Cursor;
+use smol_str::SmolStr;
 pub use value::Value;
 
 use editor::Editor;
@@ -51,7 +52,7 @@ use std::u32;
 #[allow(missing_debug_implementations)]
 pub struct TextInput<'a, Message, Renderer: self::Renderer> {
     state: &'a mut State,
-    placeholder: String,
+    placeholder: SmolStr,
     value: Value,
     is_secure: bool,
     font: Renderer::Font,
@@ -78,7 +79,7 @@ where
     /// - a function that produces a message when the [`TextInput`] changes
     pub fn new<F>(
         state: &'a mut State,
-        placeholder: &str,
+        placeholder: impl Into<SmolStr>,
         value: &str,
         on_change: F,
     ) -> Self
@@ -87,7 +88,7 @@ where
     {
         TextInput {
             state,
-            placeholder: String::from(placeholder),
+            placeholder: placeholder.into(),
             value: Value::new(value),
             is_secure: false,
             font: Default::default(),

--- a/native/src/widget/text_input/editor.rs
+++ b/native/src/widget/text_input/editor.rs
@@ -15,12 +15,9 @@ impl<'a> Editor<'a> {
     }
 
     pub fn insert(&mut self, character: char) {
-        match self.cursor.selection(self.value) {
-            Some((left, right)) => {
-                self.cursor.move_left(self.value);
-                self.value.remove_many(left, right);
-            }
-            _ => {}
+        if let Some((left, right)) = self.cursor.selection(self.value) {
+            self.cursor.move_left(self.value);
+            self.value.remove_many(left, right);
         }
 
         self.value.insert(self.cursor.end(self.value), character);
@@ -30,12 +27,9 @@ impl<'a> Editor<'a> {
     pub fn paste(&mut self, content: Value) {
         let length = content.len();
 
-        match self.cursor.selection(self.value) {
-            Some((left, right)) => {
-                self.cursor.move_left(self.value);
-                self.value.remove_many(left, right);
-            }
-            _ => {}
+        if let Some((left, right)) = self.cursor.selection(self.value) {
+            self.cursor.move_left(self.value);
+            self.value.remove_many(left, right);
         }
 
         self.value.insert_many(self.cursor.end(self.value), content);

--- a/native/src/widget/text_input/value.rs
+++ b/native/src/widget/text_input/value.rs
@@ -1,5 +1,7 @@
 use unicode_segmentation::UnicodeSegmentation;
 
+use std::fmt::{self, Display, Formatter};
+
 /// The value of a [`TextInput`].
 ///
 /// [`TextInput`]: crate::widget::TextInput
@@ -58,9 +60,10 @@ impl Value {
     pub fn next_end_of_word(&self, index: usize) -> usize {
         let next_string = &self.graphemes[index..].concat();
 
+        #[allow(clippy::or_fun_call)]
+        // self.len() is very cheap, we don't need lazy eval
         UnicodeSegmentation::split_word_bound_indices(&next_string as &str)
-            .filter(|(_, word)| !word.trim_start().is_empty())
-            .next()
+            .find(|(_, word)| !word.trim_start().is_empty())
             .map(|(i, next_word)| {
                 index
                     + UnicodeSegmentation::graphemes(next_word, true).count()
@@ -88,11 +91,6 @@ impl Value {
         let graphemes = self.graphemes[..index.min(self.len())].to_vec();
 
         Self { graphemes }
-    }
-
-    /// Converts the [`Value`] into a `String`.
-    pub fn to_string(&self) -> String {
-        self.graphemes.concat()
     }
 
     /// Inserts a new `char` at the given grapheme `index`.
@@ -130,5 +128,14 @@ impl Value {
                 .take(self.graphemes.len())
                 .collect(),
         }
+    }
+}
+
+impl Display for Value {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        for grapheme in &self.graphemes {
+            write!(f, "{}", grapheme)?;
+        }
+        Ok(())
     }
 }

--- a/native/src/widget/toggler.rs
+++ b/native/src/widget/toggler.rs
@@ -134,6 +134,7 @@ where
             .spacing(self.spacing)
             .align_items(Align::Center);
 
+        #[allow(clippy::or_fun_call)]
         if let Some(label) = &self.label {
             row = row.push(
                 Text::new(label)
@@ -198,6 +199,7 @@ where
                     defaults,
                     label_layout.bounds(),
                     &label,
+                    #[allow(clippy::or_fun_call)]
                     self.text_size.unwrap_or(renderer.default_size()),
                     self.font,
                     None,

--- a/native/src/widget/tooltip.rs
+++ b/native/src/widget/tooltip.rs
@@ -181,6 +181,7 @@ pub trait Renderer:
     /// Draws a [`Tooltip`].
     ///
     /// [`Tooltip`]: struct.Tooltip.html
+    #[allow(clippy::too_many_arguments)]
     fn draw<Message>(
         &mut self,
         defaults: &Self::Defaults,

--- a/native/src/widget/tooltip.rs
+++ b/native/src/widget/tooltip.rs
@@ -2,6 +2,7 @@
 use std::hash::Hash;
 
 use iced_core::Rectangle;
+use smol_str::SmolStr;
 
 use crate::widget::container;
 use crate::widget::text::{self, Text};
@@ -30,12 +31,12 @@ where
     /// [`Tooltip`]: struct.Tooltip.html
     pub fn new(
         content: impl Into<Element<'a, Message, Renderer>>,
-        tooltip: impl ToString,
+        tooltip: impl Into<SmolStr>,
         position: Position,
     ) -> Self {
         Tooltip {
             content: content.into(),
-            tooltip: Text::new(tooltip.to_string()),
+            tooltip: Text::new(tooltip),
             position,
             style: Default::default(),
             gap: 0,

--- a/web/src/bus.rs
+++ b/web/src/bus.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 /// [`Application`]: crate::Application
 #[allow(missing_debug_implementations)]
 pub struct Bus<Message> {
-    publish: Rc<Box<dyn Fn(Message) -> ()>>,
+    publish: Rc<dyn Fn(Message)>,
 }
 
 impl<Message> Clone for Bus<Message> {
@@ -40,7 +40,7 @@ where
 
     /// Creates a new [`Bus`] that applies the given function to the messages
     /// before publishing.
-    pub fn map<B>(&self, mapper: Rc<Box<dyn Fn(B) -> Message>>) -> Bus<B>
+    pub fn map<B>(&self, mapper: Rc<dyn Fn(B) -> Message>) -> Bus<B>
     where
         B: 'static,
     {

--- a/web/src/clipboard.rs
+++ b/web/src/clipboard.rs
@@ -5,6 +5,7 @@ pub struct Clipboard;
 
 impl Clipboard {
     /// Creates a new [`Clipboard`].
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Self
     }

--- a/web/src/css.rs
+++ b/web/src/css.rs
@@ -21,7 +21,7 @@ pub enum Rule {
 
 impl Rule {
     /// Returns the class name of the [`Rule`].
-    pub fn class<'a>(&self) -> String {
+    pub fn class(&self) -> String {
         match self {
             Rule::Column => String::from("c"),
             Rule::Row => String::from("r"),
@@ -107,6 +107,12 @@ impl Rule {
 #[derive(Debug)]
 pub struct Css<'a> {
     rules: BTreeMap<String, &'a str>,
+}
+
+impl<'a> Default for Css<'a> {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl<'a> Css<'a> {

--- a/web/src/element.rs
+++ b/web/src/element.rs
@@ -58,7 +58,7 @@ impl<'a, Message> Element<'a, Message> {
 
 struct Map<'a, A, B> {
     widget: Box<dyn Widget<A> + 'a>,
-    mapper: Rc<Box<dyn Fn(A) -> B>>,
+    mapper: Rc<dyn Fn(A) -> B>,
 }
 
 impl<'a, A, B> Map<'a, A, B> {

--- a/web/src/widget/column.rs
+++ b/web/src/widget/column.rs
@@ -18,6 +18,12 @@ pub struct Column<'a, Message> {
     children: Vec<Element<'a, Message>>,
 }
 
+impl<'a, Message> Default for Column<'a, Message> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<'a, Message> Column<'a, Message> {
     /// Creates an empty [`Column`].
     pub fn new() -> Self {

--- a/web/src/widget/container.rs
+++ b/web/src/widget/container.rs
@@ -124,8 +124,8 @@ where
                     css::padding(self.padding),
                     css::align(self.horizontal_alignment),
                     css::align(self.vertical_alignment),
-                    style.background.map(css::background).unwrap_or(String::from("initial")),
-                    style.text_color.map(css::color).unwrap_or(String::from("inherit")),
+                    style.background.map(css::background).unwrap_or_else(|| String::from("initial")),
+                    style.text_color.map(css::color).unwrap_or_else(|| String::from("inherit")),
                     style.border_width,
                     css::color(style.border_color),
                     style.border_radius

--- a/web/src/widget/row.rs
+++ b/web/src/widget/row.rs
@@ -18,6 +18,12 @@ pub struct Row<'a, Message> {
     children: Vec<Element<'a, Message>>,
 }
 
+impl<'a, Message> Default for Row<'a, Message> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<'a, Message> Row<'a, Message> {
     /// Creates an empty [`Row`].
     pub fn new() -> Self {

--- a/web/src/widget/slider.rs
+++ b/web/src/widget/slider.rs
@@ -37,7 +37,7 @@ pub struct Slider<'a, T, Message> {
     range: RangeInclusive<T>,
     step: T,
     value: T,
-    on_change: Rc<Box<dyn Fn(T) -> Message>>,
+    on_change: Rc<dyn Fn(T) -> Message>,
     #[allow(dead_code)]
     width: Length,
     #[allow(dead_code)]

--- a/web/src/widget/text.rs
+++ b/web/src/widget/text.rs
@@ -105,7 +105,7 @@ impl<'a, Message> Widget<Message> for Text {
         let color = self
             .color
             .map(css::color)
-            .unwrap_or(String::from("inherit"));
+            .unwrap_or_else(|| String::from("inherit"));
 
         let width = css::length(self.width);
         let height = css::length(self.height);

--- a/web/src/widget/text_input.rs
+++ b/web/src/widget/text_input.rs
@@ -37,7 +37,7 @@ pub struct TextInput<'a, Message> {
     max_width: u32,
     padding: Padding,
     size: Option<u16>,
-    on_change: Rc<Box<dyn Fn(String) -> Message>>,
+    on_change: Rc<dyn Fn(String) -> Message>,
     on_submit: Option<Message>,
     style_sheet: Box<dyn StyleSheet>,
 }
@@ -187,11 +187,8 @@ where
                     let event =
                         event.unchecked_into::<web_sys::KeyboardEvent>();
 
-                    match event.key_code() {
-                        13 => {
-                            submit_event_bus.publish(on_submit);
-                        }
-                        _ => {}
+                    if event.key_code() == 13 {
+                        submit_event_bus.publish(on_submit);
                     }
                 }
             })

--- a/web/src/widget/toggler.rs
+++ b/web/src/widget/toggler.rs
@@ -19,7 +19,7 @@ use std::rc::Rc;
 ///
 /// let is_active = true;
 ///
-/// Toggler::new(is_active, String::from("Toggle me!"), Message::TogglerToggled);
+/// Toggler::new(is_active, Message::TogglerToggled).label("Toggle me!");
 /// ```
 ///
 #[allow(missing_debug_implementations)]
@@ -43,22 +43,24 @@ impl<Message> Toggler<Message> {
     ///     `Message`.
     ///
     /// [`Toggler`]: struct.Toggler.html
-    pub fn new<F>(
-        is_active: bool,
-        label: impl Into<Option<String>>,
-        f: F,
-    ) -> Self
+    pub fn new<F>(is_active: bool, f: F) -> Self
     where
         F: 'static + Fn(bool) -> Message,
     {
         Toggler {
             is_active,
             on_toggle: Rc::new(f),
-            label: label.into(),
+            label: None,
             id: None,
             width: Length::Shrink,
             style: Default::default(),
         }
+    }
+
+    /// Sets the label of the [`Toggler`].
+    pub fn label(mut self, label: impl Into<String>) -> Self {
+        self.label = Some(label.into());
+        self
     }
 
     /// Sets the width of the [`Toggler`].

--- a/wgpu/src/backend.rs
+++ b/wgpu/src/backend.rs
@@ -59,6 +59,7 @@ impl Backend {
     ///
     /// The text provided as overlay will be rendered on top of the primitives.
     /// This is useful for rendering debug information.
+    #[allow(clippy::too_many_arguments)]
     pub fn draw<T: AsRef<str>>(
         &mut self,
         device: &wgpu::Device,
@@ -98,6 +99,7 @@ impl Backend {
         *mouse_interaction
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn flush(
         &mut self,
         device: &wgpu::Device,
@@ -221,7 +223,6 @@ impl Backend {
                                 wgpu_glyph::VerticalAlign::Bottom
                             }
                         }),
-                    ..Default::default()
                 };
 
                 self.text_pipeline.queue(text);

--- a/wgpu/src/image.rs
+++ b/wgpu/src/image.rs
@@ -298,6 +298,7 @@ impl Pipeline {
         svg.viewport_dimensions()
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn draw(
         &mut self,
         device: &wgpu::Device,

--- a/wgpu/src/image/atlas.rs
+++ b/wgpu/src/image/atlas.rs
@@ -279,6 +279,7 @@ impl Atlas {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn upload_allocation(
         &mut self,
         buffer: &wgpu::Buffer,

--- a/wgpu/src/image/atlas/layer.rs
+++ b/wgpu/src/image/atlas/layer.rs
@@ -9,9 +9,6 @@ pub enum Layer {
 
 impl Layer {
     pub fn is_empty(&self) -> bool {
-        match self {
-            Layer::Empty => true,
-            _ => false,
-        }
+        matches!(self, Layer::Empty)
     }
 }

--- a/wgpu/src/quad.rs
+++ b/wgpu/src/quad.rs
@@ -186,6 +186,7 @@ impl Pipeline {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn draw(
         &mut self,
         device: &wgpu::Device,

--- a/wgpu/src/triangle.rs
+++ b/wgpu/src/triangle.rs
@@ -114,11 +114,7 @@ impl Pipeline {
                         wgpu::BufferBinding {
                             buffer: &constants_buffer.raw,
                             offset: 0,
-                            size: wgpu::BufferSize::new(std::mem::size_of::<
-                                Uniforms,
-                            >(
-                            )
-                                as u64),
+                            size: wgpu::BufferSize::new(UNIFORMS_SIZE as u64),
                         },
                     ),
                 }],
@@ -233,16 +229,13 @@ impl Pipeline {
         scale_factor: f32,
         meshes: &[layer::Mesh<'_>],
     ) {
-        // This looks a bit crazy, but we are just counting how many vertices
-        // and indices we will need to handle.
-        // TODO: Improve readability
-        let (total_vertices, total_indices) = meshes
-            .iter()
-            .map(|layer::Mesh { buffers, .. }| {
-                (buffers.vertices.len(), buffers.indices.len())
-            })
-            .fold((0, 0), |(total_v, total_i), (v, i)| {
-                (total_v + v, total_i + i)
+        // Count how many vertices and indices we will need to handle.
+        let (total_vertices, total_indices) =
+            meshes.iter().fold((0, 0), |(total_v, total_i), mesh| {
+                (
+                    total_v + mesh.buffers.vertices.len(),
+                    total_i + mesh.buffers.indices.len(),
+                )
             });
 
         // Then we ensure the current buffers are big enough, resizing if
@@ -264,7 +257,7 @@ impl Pipeline {
                                 buffer: &self.uniforms_buffer.raw,
                                 offset: 0,
                                 size: wgpu::BufferSize::new(
-                                    std::mem::size_of::<Uniforms>() as u64,
+                                    UNIFORMS_SIZE as u64,
                                 ),
                             },
                         ),
@@ -389,7 +382,7 @@ impl Pipeline {
                 render_pass.set_bind_group(
                     0,
                     &self.constants,
-                    &[(std::mem::size_of::<Uniforms>() * i) as u32],
+                    &[(UNIFORMS_SIZE * i) as u32],
                 );
 
                 render_pass.set_index_buffer(
@@ -415,6 +408,8 @@ impl Pipeline {
         }
     }
 }
+
+const UNIFORMS_SIZE: usize = std::mem::size_of::<Uniforms>();
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy, Zeroable, Pod)]

--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -63,8 +63,8 @@ impl Compositor {
         let local_pool = futures::executor::LocalPool::new();
 
         Some(Compositor {
-            instance,
             settings,
+            instance,
             device,
             queue,
             staging_belt,
@@ -167,7 +167,7 @@ impl iced_graphics::window::Compositor for Compositor {
         });
 
         let mouse_interaction = renderer.backend_mut().draw(
-            &mut self.device,
+            &self.device,
             &mut self.staging_belt,
             &mut encoder,
             &frame.output.view,

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -200,6 +200,7 @@ where
     });
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_instance<A, E, C>(
     mut application: A,
     mut compositor: C,
@@ -261,7 +262,7 @@ async fn run_instance<A, E, C>(
                 let statuses = user_interface.update(
                     &events,
                     state.cursor_position(),
-                    &mut renderer,
+                    &renderer,
                     &mut clipboard,
                     &mut messages,
                 );
@@ -405,6 +406,7 @@ pub fn requests_exit(
 ) -> bool {
     use winit::event::WindowEvent;
 
+    #[allow(clippy::match_like_matches_macro)]
     match event {
         WindowEvent::CloseRequested => true,
         #[cfg(target_os = "macos")]

--- a/winit/src/application/state.rs
+++ b/winit/src/application/state.rs
@@ -193,6 +193,7 @@ impl<A: Application> State<A> {
         // Update scale factor
         let new_scale_factor = application.scale_factor();
 
+        #[allow(clippy::float_cmp)] // scale should be precise enough
         if self.scale_factor != new_scale_factor {
             let size = window.inner_size();
 

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -434,10 +434,5 @@ pub fn key_code(
 
 // As defined in: http://www.unicode.org/faq/private_use.html
 pub(crate) fn is_private_use_character(c: char) -> bool {
-    match c {
-        '\u{E000}'..='\u{F8FF}'
-        | '\u{F0000}'..='\u{FFFFD}'
-        | '\u{100000}'..='\u{10FFFD}' => true,
-        _ => false,
-    }
+    matches!(c, '\u{E000}'..='\u{F8FF}' | '\u{F0000}'..='\u{FFFFD}' | '\u{100000}'..='\u{10FFFD}')
 }


### PR DESCRIPTION
I was annoyed by the many clippy warnings so I tried to make it shut up as much as possible.

This PR also reduces allocations in `text_input`. It adds one new dependency, [smol_str](https://lib.rs/crates/smol_str).

Commit 9be7a368030c11560fd8de6bd2d7e6fda8cc2128 changes some public API (especially `Toggler`) to make them take `Into<SmolStr>` instead of `Into<String>`. This causes some minimal breakages (easily fixable, see tour example changes + i think it looks nicer), but if it's not okay I can leave it out. 