### PR TITLE
feat: offscreen rendering

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,8 @@ async-std = ["iced_futures/async-std"]
 smol = ["iced_futures/smol"]
 # Enables advanced color conversion via `palette`
 palette = ["iced_core/palette"]
+# Enables offscreen rendering
+offscreen = ["iced_glutin/offscreen", "iced_glow/offscreen"]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ smol = ["iced_futures/smol"]
 # Enables advanced color conversion via `palette`
 palette = ["iced_core/palette"]
 # Enables offscreen rendering
-offscreen = ["iced_glutin/offscreen", "iced_glow/offscreen"]
+offscreen = ["iced_glutin/offscreen", "iced_glow/offscreen", "iced_winit/offscreen", "iced_wgpu/offscreen"]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/glow/Cargo.toml
+++ b/glow/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/hecrj/iced"
 canvas = ["iced_graphics/canvas"]
 qr_code = ["iced_graphics/qr_code"]
 default_system_font = ["iced_graphics/font-source"]
+offscreen = []
 # Not supported yet!
 image = []
 svg = []

--- a/glow/src/backend.rs
+++ b/glow/src/backend.rs
@@ -56,7 +56,9 @@ impl Backend {
         let mut layers = Layer::generate(primitive, viewport);
         layers.push(Layer::overlay(overlay_text, viewport));
 
-        unsafe{ gl.bind_framebuffer(glow::RENDERBUFFER, target); }
+        unsafe {
+            gl.bind_framebuffer(glow::RENDERBUFFER, target);
+        }
 
         for layer in layers {
             self.flush(

--- a/glow/src/backend.rs
+++ b/glow/src/backend.rs
@@ -2,6 +2,7 @@ use crate::quad;
 use crate::text;
 use crate::triangle;
 use crate::{Settings, Transformation, Viewport};
+use glow::HasContext;
 use iced_graphics::backend;
 use iced_graphics::font;
 use iced_graphics::Layer;
@@ -36,7 +37,7 @@ impl Backend {
         }
     }
 
-    /// Draws the provided primitives in the default framebuffer.
+    /// Draws the provided primitives in the target framebuffer.
     ///
     /// The text provided as overlay will be rendered on top of the primitives.
     /// This is useful for rendering debug information.
@@ -46,6 +47,7 @@ impl Backend {
         viewport: &Viewport,
         (primitive, mouse_interaction): &(Primitive, mouse::Interaction),
         overlay_text: &[T],
+        target: Option<glow::Framebuffer>,
     ) -> mouse::Interaction {
         let viewport_size = viewport.physical_size();
         let scale_factor = viewport.scale_factor() as f32;
@@ -53,6 +55,8 @@ impl Backend {
 
         let mut layers = Layer::generate(primitive, viewport);
         layers.push(Layer::overlay(overlay_text, viewport));
+
+        unsafe{ gl.bind_framebuffer(glow::RENDERBUFFER, target); }
 
         for layer in layers {
             self.flush(

--- a/glow/src/window/compositor.rs
+++ b/glow/src/window/compositor.rs
@@ -34,24 +34,34 @@ impl iced_graphics::window::GLCompositor for Compositor {
         gl.disable(glow::MULTISAMPLE);
 
         let renderer = Renderer::new(Backend::new(&gl, settings));
-        
+
         // Allocate an offscreen framebuffer if needed
         #[cfg(feature = "offscreen")]
         let framebuffer = {
             let renderbuffer = gl.create_renderbuffer().ok();
             gl.bind_renderbuffer(glow::RENDERBUFFER, renderbuffer);
-            gl.renderbuffer_storage(glow::RENDERBUFFER, glow::RGB8, viewport_size.width as i32, viewport_size.height as i32);
-            
+            gl.renderbuffer_storage(
+                glow::RENDERBUFFER,
+                glow::RGB8,
+                viewport_size.width as i32,
+                viewport_size.height as i32,
+            );
+
             let framebuffer = gl.create_framebuffer().ok();
             gl.bind_framebuffer(glow::FRAMEBUFFER, framebuffer);
-            gl.framebuffer_renderbuffer(glow::FRAMEBUFFER, glow::COLOR_ATTACHMENT0, glow::RENDERBUFFER, renderbuffer);
+            gl.framebuffer_renderbuffer(
+                glow::FRAMEBUFFER,
+                glow::COLOR_ATTACHMENT0,
+                glow::RENDERBUFFER,
+                renderbuffer,
+            );
 
-            framebuffer 
+            framebuffer
         };
 
         // `glow` translates `None` as the reserved 'zero' system-shared framebuffer (so, `None` is the same as `Some(0)`)
         #[cfg(not(feature = "offscreen"))]
-        let framebuffer = None;        
+        let framebuffer = None;
 
         Ok((Self { gl, framebuffer }, renderer))
     }
@@ -91,16 +101,30 @@ impl iced_graphics::window::GLCompositor for Compositor {
             gl.clear(glow::COLOR_BUFFER_BIT);
         }
 
-        renderer.backend_mut().draw(gl, viewport, output, overlay, self.framebuffer)
+        renderer.backend_mut().draw(
+            gl,
+            viewport,
+            output,
+            overlay,
+            self.framebuffer,
+        )
     }
-    
-    fn read(&self, region: Rectangle<u32>, buffer: &mut [u8]){
+
+    fn read(&self, region: Rectangle<u32>, buffer: &mut [u8]) {
         let gl = &self.gl;
 
         // TODO: Validate the buffer
-        // assert_eq!(buffer.len(), 3 * region.width as usize * region.height as usize);        
-        unsafe{
-            gl.read_pixels(region.x as i32, region.y as i32, region.width as i32, region.height as i32, glow::RGB, glow::UNSIGNED_BYTE, glow::PixelPackData::Slice(buffer));
+        // assert_eq!(buffer.len(), 3 * region.width as usize * region.height as usize);
+        unsafe {
+            gl.read_pixels(
+                region.x as i32,
+                region.y as i32,
+                region.width as i32,
+                region.height as i32,
+                glow::RGB,
+                glow::UNSIGNED_BYTE,
+                glow::PixelPackData::Slice(buffer),
+            );
         }
     }
 }

--- a/glow/src/window/compositor.rs
+++ b/glow/src/window/compositor.rs
@@ -2,13 +2,14 @@ use crate::{Backend, Color, Error, Renderer, Settings, Viewport};
 
 use core::ffi::c_void;
 use glow::HasContext;
-use iced_graphics::{Antialiasing, Size};
+use iced_graphics::{Antialiasing, Rectangle, Size};
 use iced_native::mouse;
 
 /// A window graphics backend for iced powered by `glow`.
 #[allow(missing_debug_implementations)]
 pub struct Compositor {
     gl: glow::Context,
+    framebuffer: Option<glow::Framebuffer>,
 }
 
 impl iced_graphics::window::GLCompositor for Compositor {
@@ -17,6 +18,7 @@ impl iced_graphics::window::GLCompositor for Compositor {
 
     unsafe fn new(
         settings: Self::Settings,
+        viewport_size: Size<u32>,
         loader_function: impl FnMut(&str) -> *const c_void,
     ) -> Result<(Self, Self::Renderer), Error> {
         let gl = glow::Context::from_loader_function(loader_function);
@@ -32,8 +34,26 @@ impl iced_graphics::window::GLCompositor for Compositor {
         gl.disable(glow::MULTISAMPLE);
 
         let renderer = Renderer::new(Backend::new(&gl, settings));
+        
+        // Allocate an offscreen framebuffer if needed
+        #[cfg(feature = "offscreen")]
+        let framebuffer = {
+            let renderbuffer = gl.create_renderbuffer().ok();
+            gl.bind_renderbuffer(glow::RENDERBUFFER, renderbuffer);
+            gl.renderbuffer_storage(glow::RENDERBUFFER, glow::RGB8, viewport_size.width as i32, viewport_size.height as i32);
+            
+            let framebuffer = gl.create_framebuffer().ok();
+            gl.bind_framebuffer(glow::FRAMEBUFFER, framebuffer);
+            gl.framebuffer_renderbuffer(glow::FRAMEBUFFER, glow::COLOR_ATTACHMENT0, glow::RENDERBUFFER, renderbuffer);
 
-        Ok((Self { gl }, renderer))
+            framebuffer 
+        };
+
+        // `glow` translates `None` as the reserved 'zero' system-shared framebuffer (so, `None` is the same as `Some(0)`)
+        #[cfg(not(feature = "offscreen"))]
+        let framebuffer = None;        
+
+        Ok((Self { gl, framebuffer }, renderer))
     }
 
     fn sample_count(settings: &Settings) -> u32 {
@@ -71,6 +91,16 @@ impl iced_graphics::window::GLCompositor for Compositor {
             gl.clear(glow::COLOR_BUFFER_BIT);
         }
 
-        renderer.backend_mut().draw(gl, viewport, output, overlay)
+        renderer.backend_mut().draw(gl, viewport, output, overlay, self.framebuffer)
+    }
+    
+    fn read(&self, region: Rectangle<u32>, buffer: &mut [u8]){
+        let gl = &self.gl;
+
+        // TODO: Validate the buffer
+        // assert_eq!(buffer.len(), 3 * region.width as usize * region.height as usize);        
+        unsafe{
+            gl.read_pixels(region.x as i32, region.y as i32, region.width as i32, region.height as i32, glow::RGB, glow::UNSIGNED_BYTE, glow::PixelPackData::Slice(buffer));
+        }
     }
 }

--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -12,11 +12,15 @@ categories = ["gui"]
 
 [features]
 debug = ["iced_winit/debug"]
+offscreen = []
 
 [dependencies.glutin]
 version = "0.27"
 git = "https://github.com/iced-rs/glutin"
 rev = "03437d8a1826d83c62017b2bb7bf18bfc9e352cc"
+
+[dependencies.image]
+version = "0.23"
 
 [dependencies.iced_native]
 version = "0.4"

--- a/glutin/src/application.rs
+++ b/glutin/src/application.rs
@@ -81,7 +81,10 @@ where
         }
     };
 
-    let viewport_size = Size::new(context.window().inner_size().width, context.window().inner_size().height);
+    let viewport_size = Size::new(
+        context.window().inner_size().width,
+        context.window().inner_size().height,
+    );
 
     #[allow(unsafe_code)]
     let (compositor, renderer) = unsafe {
@@ -178,7 +181,13 @@ async fn run_instance<A, E, C>(
     let mut messages = Vec::new();
 
     #[cfg(feature = "offscreen")]
-    let (mut pixels, mut saved) = (Vec::with_capacity(3*state.viewport().physical_width() as usize*state.viewport().physical_height() as usize), false);
+    let (mut pixels, mut saved) = (
+        Vec::with_capacity(
+            3 * state.viewport().physical_width() as usize
+                * state.viewport().physical_height() as usize,
+        ),
+        false,
+    );
 
     debug.startup_finished();
 
@@ -296,20 +305,30 @@ async fn run_instance<A, E, C>(
                 );
 
                 #[cfg(feature = "offscreen")]
-                {                    
+                {
                     // Really simple "save on first frame"
-                    if !saved{
-                        let region = iced_graphics::Rectangle{
+                    if !saved {
+                        let region = iced_graphics::Rectangle {
                             width: state.viewport().physical_width(),
                             height: state.viewport().physical_height(),
-                            .. Default::default()
+                            ..Default::default()
                         };
-    
-                        pixels.resize(3*region.width as usize*region.height as usize, 0);
+
+                        pixels.resize(
+                            3 * region.width as usize * region.height as usize,
+                            0,
+                        );
                         compositor.read(region, &mut pixels);
-                                                
-                        let image = image::RgbImage::from_raw(region.width, region.height, pixels.clone()).unwrap();
-                        image::imageops::flip_vertical(&image).save("framebuffer.png").unwrap();
+
+                        let image = image::RgbImage::from_raw(
+                            region.width,
+                            region.height,
+                            pixels.clone(),
+                        )
+                        .unwrap();
+                        image::imageops::flip_vertical(&image)
+                            .save("framebuffer.png")
+                            .unwrap();
 
                         saved = true;
                     }

--- a/graphics/src/window/compositor.rs
+++ b/graphics/src/window/compositor.rs
@@ -1,4 +1,4 @@
-use crate::{Color, Error, Viewport, Rectangle, Size};
+use crate::{Color, Error, Rectangle, Size, Viewport};
 use iced_native::mouse;
 use raw_window_handle::HasRawWindowHandle;
 

--- a/graphics/src/window/compositor.rs
+++ b/graphics/src/window/compositor.rs
@@ -1,4 +1,4 @@
-use crate::{Color, Error, Viewport};
+use crate::{Color, Error, Viewport, Rectangle, Size};
 use iced_native::mouse;
 use raw_window_handle::HasRawWindowHandle;
 
@@ -19,6 +19,7 @@ pub trait Compositor: Sized {
     /// Creates a new [`Compositor`].
     fn new<W: HasRawWindowHandle>(
         settings: Self::Settings,
+        viewport_size: Size<u32>,
         compatible_window: Option<&W>,
     ) -> Result<(Self, Self::Renderer), Error>;
 
@@ -53,4 +54,7 @@ pub trait Compositor: Sized {
         output: &<Self::Renderer as iced_native::Renderer>::Output,
         overlay: &[T],
     ) -> mouse::Interaction;
+
+    /// Reads the framebuffer pixels on the provided region into the provided buffer.
+    fn read(&self, buffer: &mut [u8]);
 }

--- a/graphics/src/window/gl_compositor.rs
+++ b/graphics/src/window/gl_compositor.rs
@@ -1,4 +1,4 @@
-use crate::{Color, Error, Size, Viewport, Rectangle};
+use crate::{Color, Error, Rectangle, Size, Viewport};
 use iced_native::mouse;
 
 use core::ffi::c_void;

--- a/graphics/src/window/gl_compositor.rs
+++ b/graphics/src/window/gl_compositor.rs
@@ -1,4 +1,4 @@
-use crate::{Color, Error, Size, Viewport};
+use crate::{Color, Error, Size, Viewport, Rectangle};
 use iced_native::mouse;
 
 use core::ffi::c_void;
@@ -31,7 +31,7 @@ pub trait GLCompositor: Sized {
     type Settings: Default;
 
     /// Creates a new [`GLCompositor`] and [`Renderer`] with the given
-    /// [`Settings`] and an OpenGL address loader function.
+    /// [`Settings`], viewport size and an OpenGL address loader function.
     ///
     /// [`Renderer`]: crate::Renderer
     /// [`Backend`]: crate::Backend
@@ -39,6 +39,7 @@ pub trait GLCompositor: Sized {
     #[allow(unsafe_code)]
     unsafe fn new(
         settings: Self::Settings,
+        viewport_size: Size<u32>,
         loader_function: impl FnMut(&str) -> *const c_void,
     ) -> Result<(Self, Self::Renderer), Error>;
 
@@ -60,4 +61,7 @@ pub trait GLCompositor: Sized {
         output: &<Self::Renderer as iced_native::Renderer>::Output,
         overlay: &[T],
     ) -> mouse::Interaction;
+
+    /// Reads the framebuffer pixels on the provided region into the provided buffer.
+    fn read(&self, region: Rectangle<u32>, buffer: &mut [u8]);
 }

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -24,6 +24,7 @@ farbfeld = ["image_rs/farbfeld"]
 canvas = ["iced_graphics/canvas"]
 qr_code = ["iced_graphics/qr_code"]
 default_system_font = ["iced_graphics/font-source"]
+offscreen = []
 
 [dependencies]
 wgpu = "0.9"

--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -1,7 +1,8 @@
 use crate::{Backend, Color, Error, Renderer, Settings, Viewport};
 
-use futures::task::SpawnExt;
+use futures::{executor::block_on, task::SpawnExt};
 use iced_native::{futures, mouse};
+use iced_graphics::{Size, Rectangle};
 use raw_window_handle::HasRawWindowHandle;
 
 /// A window graphics backend for iced powered by `wgpu`.
@@ -13,6 +14,7 @@ pub struct Compositor {
     queue: wgpu::Queue,
     staging_belt: wgpu::util::StagingBelt,
     local_pool: futures::executor::LocalPool,
+    framebuffer: Option<Framebuffer>,
 }
 
 impl Compositor {
@@ -23,6 +25,7 @@ impl Compositor {
     /// Returns `None` if no compatible graphics adapter could be found.
     pub async fn request<W: HasRawWindowHandle>(
         settings: Settings,
+        viewport_size: Size<u32>,
         compatible_window: Option<&W>,
     ) -> Option<Self> {
         let instance = wgpu::Instance::new(settings.internal_backend);
@@ -59,6 +62,43 @@ impl Compositor {
             .await
             .ok()?;
 
+        #[cfg(feature = "offscreen")]
+        let framebuffer = {
+            let size = BufferDimensions::new(viewport_size.width as usize, viewport_size.height as usize);
+            let output = device.create_buffer(&wgpu::BufferDescriptor{
+                label: None,
+                size: (size.padded_bytes_per_row * size.height) as u64,
+                usage: wgpu::BufferUsage::MAP_READ | wgpu::BufferUsage::COPY_DST,
+                mapped_at_creation: false,
+            });
+
+            let target = device.create_texture(&wgpu::TextureDescriptor{
+                size: wgpu::Extent3d{
+                    width: size.width as u32,
+                    height: size.height as u32,
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                // format: wgpu::TextureFormat::Rgba8UnormSrgb,
+                format: wgpu::TextureFormat::Bgra8UnormSrgb,
+                usage: wgpu::TextureUsage::COPY_SRC | wgpu::TextureUsage::RENDER_ATTACHMENT,
+                label: None,
+            });
+
+            Some(
+                Framebuffer{
+                    target,
+                    output,
+                    size
+                }
+            )
+        };
+
+        #[cfg(not(feature = "offscreen"))]
+        let framebuffer = None;
+
         let staging_belt = wgpu::util::StagingBelt::new(Self::CHUNK_SIZE);
         let local_pool = futures::executor::LocalPool::new();
 
@@ -69,6 +109,7 @@ impl Compositor {
             queue,
             staging_belt,
             local_pool,
+            framebuffer,
         })
     }
 
@@ -86,10 +127,12 @@ impl iced_graphics::window::Compositor for Compositor {
 
     fn new<W: HasRawWindowHandle>(
         settings: Self::Settings,
+        viewport_size: Size<u32>,
         compatible_window: Option<&W>,
     ) -> Result<(Self, Renderer), Error> {
         let compositor = futures::executor::block_on(Self::request(
             settings,
+            viewport_size,
             compatible_window,
         ))
         .ok_or(Error::AdapterNotFound)?;
@@ -136,7 +179,16 @@ impl iced_graphics::window::Compositor for Compositor {
         output: &<Self::Renderer as iced_native::Renderer>::Output,
         overlay: &[T],
     ) -> mouse::Interaction {
+        #[cfg(not(feature = "offscreen"))]
         let frame = swap_chain.get_current_frame().expect("Next frame");
+        #[cfg(feature = "offscreen")]
+        let frame = self.framebuffer.as_ref().expect("No framebuffer");
+        
+        #[cfg(not(feature = "offscreen"))]
+        let view = &frame.output.view;
+
+        #[cfg(feature = "offscreen")]
+        let view = &frame.target.create_view(&wgpu::TextureViewDescriptor::default());
 
         let mut encoder = self.device.create_command_encoder(
             &wgpu::CommandEncoderDescriptor {
@@ -147,7 +199,7 @@ impl iced_graphics::window::Compositor for Compositor {
         let _ = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
             label: Some("iced_wgpu::window::Compositor render pass"),
             color_attachments: &[wgpu::RenderPassColorAttachment {
-                view: &frame.output.view,
+                view,
                 resolve_target: None,
                 ops: wgpu::Operations {
                     load: wgpu::LoadOp::Clear({
@@ -170,10 +222,35 @@ impl iced_graphics::window::Compositor for Compositor {
             &mut self.device,
             &mut self.staging_belt,
             &mut encoder,
-            &frame.output.view,
+            view,
             viewport,
             output,
             overlay,
+        );
+
+        #[cfg(feature = "offscreen")]
+        encoder.copy_texture_to_buffer(
+            wgpu::ImageCopyTexture {
+                texture: &frame.target,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+            },
+            wgpu::ImageCopyBuffer {
+                buffer: &frame.output,
+                layout: wgpu::ImageDataLayout {
+                    offset: 0,
+                    bytes_per_row: Some(
+                        std::num::NonZeroU32::new(frame.size.padded_bytes_per_row as u32)
+                            .unwrap(),
+                    ),
+                    rows_per_image: None,
+                },
+            },
+            wgpu::Extent3d{
+                width: frame.size.width as u32,
+                height: frame.size.height as u32,
+                depth_or_array_layers: 1,
+            },
         );
 
         // Submit work
@@ -189,5 +266,50 @@ impl iced_graphics::window::Compositor for Compositor {
         self.local_pool.run_until_stalled();
 
         mouse_interaction
+    }
+
+    fn read(&self, buffer: &mut [u8]){
+        if let Some(frame) = &self.framebuffer{
+            let buffer_slice = frame.output.slice(..);
+            let buffer_future = buffer_slice.map_async(wgpu::MapMode::Read);
+            self.device.poll(wgpu::Maintain::Wait);
+
+            if let Ok(()) = block_on(buffer_future){
+                buffer.copy_from_slice(&buffer_slice.get_mapped_range());
+            }
+            
+            frame.output.unmap();
+        }
+    }
+}
+
+// TODO: This struct and Swapchain should be interchangeable, maybe an enum?
+struct Framebuffer{
+    target: wgpu::Texture,
+    output: wgpu::Buffer,   
+    size: BufferDimensions,
+}
+
+// from https://github.com/gfx-rs/wgpu-rs/blob/master/examples/capture/main.rs
+struct BufferDimensions {
+    width: usize,
+    height: usize,
+    unpadded_bytes_per_row: usize,
+    padded_bytes_per_row: usize,
+}
+
+impl BufferDimensions {
+    fn new(width: usize, height: usize) -> Self {
+        let bytes_per_pixel = std::mem::size_of::<u32>();
+        let unpadded_bytes_per_row = width * bytes_per_pixel;
+        let align = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT as usize;
+        let padded_bytes_per_row_padding = (align - unpadded_bytes_per_row % align) % align;
+        let padded_bytes_per_row = unpadded_bytes_per_row + padded_bytes_per_row_padding;
+        Self {
+            width,
+            height,
+            unpadded_bytes_per_row,
+            padded_bytes_per_row,
+        }
     }
 }

--- a/winit/Cargo.toml
+++ b/winit/Cargo.toml
@@ -12,11 +12,13 @@ categories = ["gui"]
 
 [features]
 debug = ["iced_native/debug"]
+offscreen = []
 
 [dependencies]
 window_clipboard = "0.2"
 log = "0.4"
 thiserror = "1.0"
+image = "0.23"
 
 [dependencies.winit]
 version = "0.25"

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -157,9 +157,11 @@ where
         .build(&event_loop)
         .map_err(Error::WindowCreationFailed)?;
 
-    let viewport_size = Size::new(window.inner_size().width, window.inner_size().height);
+    let viewport_size =
+        Size::new(window.inner_size().width, window.inner_size().height);
 
-    let (compositor, renderer) = C::new(compositor_settings, viewport_size, Some(&window))?;
+    let (compositor, renderer) =
+        C::new(compositor_settings, viewport_size, Some(&window))?;
 
     let (mut sender, receiver) = mpsc::unbounded();
 
@@ -259,7 +261,13 @@ async fn run_instance<A, E, C>(
     let mut messages = Vec::new();
 
     #[cfg(feature = "offscreen")]
-    let (mut pixels, mut saved) = (Vec::with_capacity(4*state.viewport().physical_width() as usize*state.viewport().physical_height() as usize), false);
+    let (mut pixels, mut saved) = (
+        Vec::with_capacity(
+            4 * state.viewport().physical_width() as usize
+                * state.viewport().physical_height() as usize,
+        ),
+        false,
+    );
 
     debug.startup_finished();
 
@@ -380,12 +388,20 @@ async fn run_instance<A, E, C>(
                     &debug.overlay(),
                 );
 
-                #[cfg(feature = "offscreen")]                
-                if !saved{
-                    let (width, height) = (state.viewport().physical_width(), state.viewport().physical_height());
-                    pixels.resize(4*width as usize*height as usize, 0);                    
-                    compositor.read(&mut pixels);                    
-                    let image = image::RgbaImage::from_raw(width, height, pixels.clone()).unwrap();
+                #[cfg(feature = "offscreen")]
+                if !saved {
+                    let (width, height) = (
+                        state.viewport().physical_width(),
+                        state.viewport().physical_height(),
+                    );
+                    pixels.resize(4 * width as usize * height as usize, 0);
+                    compositor.read(&mut pixels);
+                    let image = image::RgbaImage::from_raw(
+                        width,
+                        height,
+                        pixels.clone(),
+                    )
+                    .unwrap();
                     image.save("framebuffer.png").unwrap();
 
                     saved = true;

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -157,7 +157,9 @@ where
         .build(&event_loop)
         .map_err(Error::WindowCreationFailed)?;
 
-    let (compositor, renderer) = C::new(compositor_settings, Some(&window))?;
+    let viewport_size = Size::new(window.inner_size().width, window.inner_size().height);
+
+    let (compositor, renderer) = C::new(compositor_settings, viewport_size, Some(&window))?;
 
     let (mut sender, receiver) = mpsc::unbounded();
 
@@ -255,6 +257,9 @@ async fn run_instance<A, E, C>(
 
     let mut events = Vec::new();
     let mut messages = Vec::new();
+
+    #[cfg(feature = "offscreen")]
+    let (mut pixels, mut saved) = (Vec::with_capacity(4*state.viewport().physical_width() as usize*state.viewport().physical_height() as usize), false);
 
     debug.startup_finished();
 
@@ -374,6 +379,17 @@ async fn run_instance<A, E, C>(
                     &primitive,
                     &debug.overlay(),
                 );
+
+                #[cfg(feature = "offscreen")]                
+                if !saved{
+                    let (width, height) = (state.viewport().physical_width(), state.viewport().physical_height());
+                    pixels.resize(4*width as usize*height as usize, 0);                    
+                    compositor.read(&mut pixels);                    
+                    let image = image::RgbaImage::from_raw(width, height, pixels.clone()).unwrap();
+                    image.save("framebuffer.png").unwrap();
+
+                    saved = true;
+                }
 
                 debug.render_finished();
 


### PR DESCRIPTION
Allows the application to render in an offscreen buffer instead of the onscreen framebuffer. This would allow the application to render and save the screen content into a file.

I'm not sure how to expose this feature to the application (expose the `&[u8]` to the `Application` trait), so I'm opening a draft PT to get some ideas.
Currently, this is gated under the `offscreen` feature flag, which renders the first frame of the application to a `framebuffer.png` file.

### Some ideas
**New method**
Create a new method on the `Application` trait, something like `frame(&mut self, buffer: &[u8])` and call it on the event loop (`application.frame(&pixels)`). The problem would be gating this through the feature, since we need `offscreen` rendering enabled on the backend to be able to read the content of the buffer.

**New trait**
Almost the same as the **new method** idea, just instead we add it to a new `OffscreenProgram` trait, or later on for example, a `HeadlessApplication` (I'm working on enabling Iced to run headless, and this could be used in conjunction to enable server side rendering).

**Subscription**
Not sure if this is feasible, but we could allow the user to use a `frames` subscription.

**Note:** While rendering to an offscreen buffer you won't see anything on the window.
**Also:** Technically, on OpenGL you can read the framebuffer directly, by using `glReadPixels`, but on `wgpu` the same isn't guaranteed, you'd have to request an extension for that.