### PR TITLE
feat(pick_list): seperate menu width, text font & color

### DIFF
--- a/examples/pick_list/src/main.rs
+++ b/examples/pick_list/src/main.rs
@@ -45,6 +45,8 @@ impl Sandbox for Example {
             self.selected_language,
             Message::LanguageSelected,
         )
+        // Menu width can be made independent from PickList width
+        // .menu_width(pick_list::MenuWidth::Independent)
         .placeholder("Choose a language...");
 
         let mut content = Scrollable::new(&mut self.scroll)

--- a/graphics/src/widget/pick_list.rs
+++ b/graphics/src/widget/pick_list.rs
@@ -7,7 +7,7 @@ use iced_native::{
 };
 use iced_style::menu;
 
-pub use iced_native::pick_list::State;
+pub use iced_native::pick_list::{MenuWidth, State};
 pub use iced_style::pick_list::{Style, StyleSheet};
 
 /// A widget allowing the selection of a single value from a list of options.

--- a/native/src/overlay/menu.rs
+++ b/native/src/overlay/menu.rs
@@ -202,10 +202,7 @@ where
                 labels.map(|label| measure(&label)).max().unwrap_or(100)
             };
 
-            max_width as u16
-                + text_size
-                + self.padding.left
-                + self.padding.horizontal()
+            max_width as u16 + text_size + self.padding.horizontal()
         });
 
         let space_below = bounds.height - (position.y + self.target_height);

--- a/wgpu/src/widget/pick_list.rs
+++ b/wgpu/src/widget/pick_list.rs
@@ -1,5 +1,5 @@
 //! Display a dropdown list of selectable values.
-pub use iced_native::pick_list::State;
+pub use iced_native::pick_list::{MenuWidth, State};
 
 pub use iced_graphics::overlay::menu::Style as Menu;
 pub use iced_graphics::pick_list::{Style, StyleSheet};


### PR DESCRIPTION
This fixes #918, and also adds the ability to change menu entries' font, text size and menu width seperately.