### PR TITLE
CI: Run a Windows application without starting the shell too

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,9 @@ jobs:
         mkdir .cargo
         echo '[target.x86_64-pc-windows-msvc]' >> .cargo/config
         echo 'rustflags = ["-Ctarget-feature=+crt-static"]' >> .cargo/config
+    - name: Run the application without starting the shell
+      run: |
+        sed -i '1 i\#![windows_subsystem = \"windows\"]' examples/todos/src/main.rs
     - name: Build todos binary
       run: cargo build --verbose --release --package todos
     - name: Archive todos binary


### PR DESCRIPTION
When an application is executed on Windows, alongside with that, it also starts the shell. This PR adds to the CI a way not to run a shell through the use of a specific Rust attribute.

Thanks in advance for your review! :)