### PR TITLE
Widget states storage

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -28,6 +28,7 @@ mod point;
 mod rectangle;
 mod size;
 mod vector;
+// mod hash_states;
 
 pub use alignment::Alignment;
 pub use background::Background;
@@ -39,3 +40,4 @@ pub use point::Point;
 pub use rectangle::Rectangle;
 pub use size::Size;
 pub use vector::Vector;
+// pub use hash_states::HashStates;

--- a/examples/todos/src/main.rs
+++ b/examples/todos/src/main.rs
@@ -101,9 +101,10 @@ impl Application for Todos {
                     }
                     Message::TaskMessage(i, task_message) => {
                         if let Some(task) = state.tasks.get_mut(i) {
-                            states.enter(&format!("task_{}", i));
-                            task.update(task_message, states);
-                            states.exit();
+                            task.update(
+                                task_message, 
+                                &mut states.enter(&format!("task_{}", i))
+                            );
                         }
                     }
                     Message::Saved(_) => {

--- a/graphics/src/widget/slider.rs
+++ b/graphics/src/widget/slider.rs
@@ -13,8 +13,8 @@ pub use iced_style::slider::{Handle, HandleShape, Style, StyleSheet};
 /// values.
 ///
 /// This is an alias of an `iced_native` slider with an `iced_wgpu::Renderer`.
-pub type Slider<'a, T, Message, Backend> =
-    iced_native::Slider<'a, T, Message, Renderer<Backend>>;
+pub type Slider<T, Message, Backend> =
+    iced_native::Slider<T, Message, Renderer<Backend>>;
 
 impl<B> slider::Renderer for Renderer<B>
 where

--- a/graphics/src/widget/text_input.rs
+++ b/graphics/src/widget/text_input.rs
@@ -18,8 +18,8 @@ pub use iced_style::text_input::{Style, StyleSheet};
 /// A field that can be filled with text.
 ///
 /// This is an alias of an `iced_native` text input with an `iced_wgpu::Renderer`.
-pub type TextInput<'a, Message, Backend> =
-    iced_native::TextInput<'a, Message, Renderer<Backend>>;
+pub type TextInput<Message, Backend> =
+    iced_native::TextInput<Message, Renderer<Backend>>;
 
 impl<B> text_input::Renderer for Renderer<B>
 where

--- a/native/src/element.rs
+++ b/native/src/element.rs
@@ -268,22 +268,18 @@ where
     /// Making State Array of Widget for saving
     pub fn into_states(self, hash: Hasher, states: &mut StateStorage) {
         if let Some(id) = &self.root_id {
-            states.enter(&id);
-        }
-        self.widget.into_states(hash, states);
-        if self.root_id.is_some() {
-            states.exit();
+            self.widget.into_states(hash, &mut states.enter(&id));
+        } else {
+            self.widget.into_states(hash, states);
         }
     }
     
     /// Apply States for widget
     pub fn apply_states(&mut self, hash: Hasher, states: &mut StateStorage) {
         if let Some(id) = &self.root_id {
-            states.enter(&id);
-        }
-        self.widget.apply_states(hash, states);
-        if self.root_id.is_some() {
-            states.exit();
+            self.widget.apply_states(hash, &mut states.enter(&id));
+        } else {
+            self.widget.apply_states(hash, states);
         }
     }
 

--- a/native/src/hasher.rs
+++ b/native/src/hasher.rs
@@ -1,5 +1,5 @@
 /// The hasher used to compare layouts.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Hasher(twox_hash::XxHash64);
 
 impl Default for Hasher {

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -46,6 +46,7 @@ pub mod subscription;
 pub mod touch;
 pub mod widget;
 pub mod window;
+pub mod state_storage;
 
 mod element;
 mod hasher;
@@ -85,3 +86,4 @@ pub use runtime::Runtime;
 pub use subscription::Subscription;
 pub use user_interface::{Cache, UserInterface};
 pub use widget::*;
+pub use state_storage::StateStorage;

--- a/native/src/overlay/menu.rs
+++ b/native/src/overlay/menu.rs
@@ -15,7 +15,6 @@ use crate::{
 /// A list of selectable options.
 #[allow(missing_debug_implementations)]
 pub struct Menu<'a, T, Renderer: self::Renderer> {
-    state: &'a mut State,
     options: &'a [T],
     hovered_option: &'a mut Option<usize>,
     last_selection: &'a mut Option<T>,
@@ -34,13 +33,11 @@ where
     /// Creates a new [`Menu`] with the given [`State`], a list of options, and
     /// the message to produced when an option is selected.
     pub fn new(
-        state: &'a mut State,
         options: &'a [T],
         hovered_option: &'a mut Option<usize>,
         last_selection: &'a mut Option<T>,
     ) -> Self {
         Menu {
-            state,
             options,
             hovered_option,
             last_selection,
@@ -103,19 +100,6 @@ where
     }
 }
 
-/// The local state of a [`Menu`].
-#[derive(Debug, Clone, Default)]
-pub struct State {
-    scrollable: scrollable::State,
-}
-
-impl State {
-    /// Creates a new [`State`] for a [`Menu`].
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 struct Overlay<'a, Message, Renderer: self::Renderer> {
     container: Container<'a, Message, Renderer>,
     width: u16,
@@ -133,7 +117,6 @@ where
         T: Clone + ToString,
     {
         let Menu {
-            state,
             options,
             hovered_option,
             last_selection,
@@ -145,7 +128,7 @@ where
         } = menu;
 
         let container =
-            Container::new(Scrollable::new(&mut state.scrollable).push(List {
+            Container::new(Scrollable::new().push(List {
                 options,
                 hovered_option,
                 last_selection,

--- a/native/src/program.rs
+++ b/native/src/program.rs
@@ -1,5 +1,5 @@
 //! Build interactive programs using The Elm Architecture.
-use crate::{Command, Element, Renderer};
+use crate::{Command, Element, Renderer, StateStorage};
 
 mod state;
 
@@ -21,10 +21,10 @@ pub trait Program: Sized {
     ///
     /// Any [`Command`] returned will be executed immediately in the
     /// background by shells.
-    fn update(&mut self, message: Self::Message) -> Command<Self::Message>;
+    fn update(&mut self, message: Self::Message, states: &mut StateStorage) -> Command<Self::Message>;
 
     /// Returns the widgets to display in the [`Program`].
     ///
     /// These widgets can produce __messages__ based on user interaction.
-    fn view(&mut self) -> Element<'_, Self::Message, Self::Renderer>;
+    fn view(&self) -> Element<'_, Self::Message, Self::Renderer>;
 }

--- a/native/src/program/state.rs
+++ b/native/src/program/state.rs
@@ -129,14 +129,14 @@ where
         } else {
             // When there are messages, we are forced to rebuild twice
             // for now :^)
-            let temp_cache = user_interface.into_cache();
+            let mut temp_cache = user_interface.into_cache();
 
             let commands =
                 Command::batch(messages.into_iter().map(|message| {
                     debug.log_message(&message);
 
                     debug.update_started();
-                    let command = self.program.update(message);
+                    let command = self.program.update(message, temp_cache.widget_states_storage());
                     debug.update_finished();
 
                     command

--- a/native/src/state_storage.rs
+++ b/native/src/state_storage.rs
@@ -1,0 +1,77 @@
+//! Use storage state of widgets
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::any::Any;
+
+type StateBox = Box<dyn Any>;
+
+/// Structure for storing widget states
+#[derive(Debug, Default)]
+pub struct StateStorage {
+    states: HashMap<PathBuf, StateBox>,
+    path: PathBuf,
+}
+
+impl StateStorage {
+    /// Insert a state from widget. 
+    /// Used for Widhet::into_states function
+    #[track_caller]
+    pub fn insert(&mut self, id: &str, state: StateBox) {
+//         println!("insert: {}", id);
+        if let Some(_s) = self.states.insert(self.path.join(id), state) {
+            panic!("The state by ({}) already exists", id);
+        }
+    }
+    
+    /// Take the state by id
+    pub fn take(&mut self, id: &str) -> Option<StateBox> {
+        self.states.remove(&self.path.join(id))
+    }
+    
+    /// Take the state by id and convert type
+    pub fn take_state<S: Any>(&mut self, id: &str) -> Option<Box<S>> {
+        self.states.remove(&self.path.join(id))
+            .and_then(|s| s.downcast().ok())
+    }
+    
+    /// Get the state ref by id
+    pub fn get_ref<S: Any>(&self, id: &str) -> Option<&S> {
+        self.states.get(&self.path.join(id))
+            .and_then(|s| s.downcast_ref())
+//             .as_ref()
+    }
+    
+    /// Get the state mutable ref by id
+    pub fn get_mut<S: Any>(&mut self, id: &str) -> Option<&mut S> {
+        self.states.get_mut(&self.path.join(id))
+            .and_then(|s| s.downcast_mut())
+//             .as_mut()
+    }
+    
+    /// Get the state mutable ref by id, or insert the default state
+    pub fn get_mut_or_default<S: Any>(&mut self, id: &str) -> Option<&mut S> 
+        where S: Default
+    {
+        self.states.entry(self.path.join(id))
+            .or_insert(Box::new(S::default()))
+            .downcast_mut()
+    }
+    
+    /// Get the state mutable ref by id, or insert the new state
+    pub fn get_mut_or_insert<S: Any>(&mut self, id: &str, s: S) -> Option<&mut S> 
+    {
+        self.states.entry(self.path.join(id))
+            .or_insert(Box::new(s))
+            .downcast_mut()
+    }
+    
+    /// Entering a state group
+    pub fn enter(&mut self, id: &str) {
+        self.path.push(id);
+    }
+    /// Exit from the group
+    pub fn exit(&mut self) {
+        let _ = self.path.pop();
+    }
+}

--- a/native/src/widget.rs
+++ b/native/src/widget.rs
@@ -81,7 +81,7 @@ pub use tooltip::Tooltip;
 use crate::event::{self, Event};
 use crate::layout;
 use crate::overlay;
-use crate::{Clipboard, Hasher, Layout, Length, Point, Rectangle};
+use crate::{Clipboard, Hasher, Layout, Length, Point, Rectangle, StateStorage};
 
 /// A component that displays information and allows interaction.
 ///
@@ -149,6 +149,16 @@ where
     ///
     /// [`Text`]: crate::widget::Text
     fn hash_layout(&self, state: &mut Hasher);
+
+    /// Making the [`StateStorage`] of the [`Widget`] for saving
+    fn into_states(self: Box<Self>, _hash: Hasher, _states: &mut StateStorage) {
+    
+    }
+    
+    /// Apply States for the [`Widget`]
+    fn apply_states(&mut self, _hash: Hasher, _states: &mut StateStorage) {
+        
+    }
 
     /// Processes a runtime [`Event`].
     ///

--- a/native/src/widget/column.rs
+++ b/native/src/widget/column.rs
@@ -6,7 +6,7 @@ use crate::layout;
 use crate::overlay;
 use crate::{
     Alignment, Clipboard, Element, Hasher, Layout, Length, Padding, Point,
-    Rectangle, Widget,
+    Rectangle, Widget, StateStorage,
 };
 
 use std::u32;
@@ -99,6 +99,16 @@ impl<'a, Message, Renderer> Column<'a, Message, Renderer> {
     {
         self.children.push(child.into());
         self
+    }
+    
+    pub(crate) fn into_states(self, hash: Hasher, states: &mut StateStorage)
+        where Renderer: self::Renderer
+    {
+        for (i, child) in self.children.into_iter().enumerate() {
+            let mut h = hash.clone();
+            i.hash(&mut h);
+            child.into_states(h, states);
+        }
     }
 }
 
@@ -193,6 +203,21 @@ where
 
         for child in &self.children {
             child.widget.hash_layout(state);
+        }
+    }
+    
+    fn into_states(self: Box<Self>, hash: Hasher, states: &mut StateStorage) {
+        for (i, child) in self.children.into_iter().enumerate() {
+            let mut h = hash.clone();
+            i.hash(&mut h);
+            child.into_states(h, states);
+        }
+    }
+    fn apply_states(&mut self, hash: Hasher, states: &mut StateStorage) {
+        for (i, child) in self.children.iter_mut().enumerate() {
+            let mut h = hash.clone();
+            i.hash(&mut h);
+            child.apply_states(h, states);
         }
     }
 

--- a/native/src/widget/container.rs
+++ b/native/src/widget/container.rs
@@ -6,8 +6,8 @@ use crate::event::{self, Event};
 use crate::layout;
 use crate::overlay;
 use crate::{
-    Clipboard, Element, Hasher, Layout, Length, Padding, Point, Rectangle,
-    Widget,
+    Clipboard, Element, Hasher, Layout, Length, Padding, Point,
+    Rectangle, Widget, StateStorage,
 };
 
 use std::u32;
@@ -202,6 +202,13 @@ where
         self.max_height.hash(state);
 
         self.content.hash_layout(state);
+    }
+    
+    fn into_states(self: Box<Self>, hash: Hasher, states: &mut StateStorage) {
+        self.content.widget.into_states(hash, states);
+    }
+    fn apply_states(&mut self, hash: Hasher, states: &mut StateStorage) {
+        self.content.widget.apply_states(hash, states);
     }
 
     fn overlay(

--- a/native/src/widget/pane_grid/content.rs
+++ b/native/src/widget/pane_grid/content.rs
@@ -3,7 +3,7 @@ use crate::event::{self, Event};
 use crate::layout;
 use crate::overlay;
 use crate::pane_grid::{self, TitleBar};
-use crate::{Clipboard, Element, Hasher, Layout, Point, Rectangle, Size};
+use crate::{Clipboard, Element, Hasher, StateStorage, Layout, Point, Rectangle, Size};
 
 /// The content of a [`Pane`].
 ///
@@ -192,6 +192,13 @@ where
         }
 
         self.body.hash_layout(state);
+    }
+    
+    pub(crate) fn into_states(self, hash: Hasher, states: &mut StateStorage) {
+        self.body.into_states(hash, states);
+    }
+    pub(crate) fn apply_states(&mut self, hash: Hasher, states: &mut StateStorage) {
+        self.body.apply_states(hash, states);
     }
 
     pub(crate) fn overlay(

--- a/native/src/widget/pick_list.rs
+++ b/native/src/widget/pick_list.rs
@@ -20,7 +20,6 @@ pub struct PickList<'a, T, Message, Renderer: self::Renderer>
 where
     [T]: ToOwned<Owned = Vec<T>>,
 {
-    menu: &'a mut menu::State,
     keyboard_modifiers: &'a mut keyboard::Modifiers,
     is_open: &'a mut bool,
     hovered_option: &'a mut Option<usize>,
@@ -39,7 +38,6 @@ where
 /// The local state of a [`PickList`].
 #[derive(Debug, Clone)]
 pub struct State<T> {
-    menu: menu::State,
     keyboard_modifiers: keyboard::Modifiers,
     is_open: bool,
     hovered_option: Option<usize>,
@@ -49,7 +47,6 @@ pub struct State<T> {
 impl<T> Default for State<T> {
     fn default() -> Self {
         Self {
-            menu: menu::State::default(),
             keyboard_modifiers: keyboard::Modifiers::default(),
             is_open: bool::default(),
             hovered_option: Option::default(),
@@ -74,7 +71,6 @@ where
         on_selected: impl Fn(T) -> Message + 'static,
     ) -> Self {
         let State {
-            menu,
             keyboard_modifiers,
             is_open,
             hovered_option,
@@ -82,7 +78,6 @@ where
         } = state;
 
         Self {
-            menu,
             keyboard_modifiers,
             is_open,
             hovered_option,
@@ -349,7 +344,6 @@ where
             let bounds = layout.bounds();
 
             let mut menu = Menu::new(
-                &mut self.menu,
                 &self.options,
                 &mut self.hovered_option,
                 &mut self.last_selection,

--- a/native/src/widget/row.rs
+++ b/native/src/widget/row.rs
@@ -4,7 +4,7 @@ use crate::layout;
 use crate::overlay;
 use crate::{
     Alignment, Clipboard, Element, Hasher, Layout, Length, Padding, Point,
-    Rectangle, Widget,
+    Rectangle, Widget, StateStorage,
 };
 
 use std::hash::Hash;
@@ -195,6 +195,21 @@ where
         }
     }
 
+    fn into_states(self: Box<Self>, hash: Hasher, states: &mut StateStorage) {
+        for (i, child) in self.children.into_iter().enumerate() {
+            let mut h = hash.clone();
+            i.hash(&mut h);
+            child.widget.into_states(h, states);
+        }
+    }
+    fn apply_states(&mut self, hash: Hasher, states: &mut StateStorage) {
+        for (i, child) in self.children.iter_mut().enumerate() {
+            let mut h = hash.clone();
+            i.hash(&mut h);
+            child.widget.apply_states(h, states);
+        }
+    }
+    
     fn overlay(
         &mut self,
         layout: Layout<'_>,

--- a/src/application.rs
+++ b/src/application.rs
@@ -1,5 +1,5 @@
 use crate::window;
-use crate::{Color, Command, Element, Executor, Settings, Subscription};
+use crate::{Color, Command, StateStorage, Element, Executor, Settings, Subscription};
 
 /// An interactive cross-platform application.
 ///
@@ -127,7 +127,7 @@ pub trait Application: Sized {
     /// this method.
     ///
     /// Any [`Command`] returned will be executed immediately in the background.
-    fn update(&mut self, message: Self::Message) -> Command<Self::Message>;
+    fn update(&mut self, message: Self::Message, states: &mut StateStorage) -> Command<Self::Message>;
 
     /// Returns the event [`Subscription`] for the current state of the
     /// application.
@@ -144,7 +144,7 @@ pub trait Application: Sized {
     /// Returns the widgets to display in the [`Application`].
     ///
     /// These widgets can produce __messages__ based on user interaction.
-    fn view(&mut self) -> Element<'_, Self::Message>;
+    fn view(&self) -> Element<'_, Self::Message>;
 
     /// Returns the current [`Application`] mode.
     ///
@@ -237,11 +237,11 @@ where
     type Renderer = crate::renderer::Renderer;
     type Message = A::Message;
 
-    fn update(&mut self, message: Self::Message) -> Command<Self::Message> {
-        self.0.update(message)
+    fn update(&mut self, message: Self::Message, states: &mut StateStorage) -> Command<Self::Message> {
+        self.0.update(message, states)
     }
 
-    fn view(&mut self) -> Element<'_, Self::Message> {
+    fn view(&self) -> Element<'_, Self::Message> {
         self.0.view()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,5 +249,5 @@ pub use runtime::alignment;
 pub use runtime::futures;
 pub use runtime::{
     Alignment, Background, Color, Command, Font, Length, Point, Rectangle,
-    Size, Subscription, Vector,
+    Size, Subscription, Vector, StateStorage,
 };

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Application, Color, Command, Element, Error, Settings, Subscription,
+    Application, Color, Command, Element, Error, Settings, Subscription, StateStorage,
 };
 
 /// A sandboxed [`Application`].
@@ -109,7 +109,7 @@ pub trait Sandbox {
     /// Returns the widgets to display in the [`Sandbox`].
     ///
     /// These widgets can produce __messages__ based on user interaction.
-    fn view(&mut self) -> Element<'_, Self::Message>;
+    fn view(&self) -> Element<'_, Self::Message>;
 
     /// Returns the background color of the [`Sandbox`].
     ///
@@ -161,7 +161,7 @@ where
         T::title(self)
     }
 
-    fn update(&mut self, message: T::Message) -> Command<T::Message> {
+    fn update(&mut self, message: T::Message, _states: &mut StateStorage) -> Command<T::Message> {
         T::update(self, message);
 
         Command::none()
@@ -171,7 +171,7 @@ where
         Subscription::none()
     }
 
-    fn view(&mut self) -> Element<'_, T::Message> {
+    fn view(&self) -> Element<'_, T::Message> {
         T::view(self)
     }
 

--- a/wgpu/src/widget/slider.rs
+++ b/wgpu/src/widget/slider.rs
@@ -10,4 +10,4 @@ pub use iced_native::slider::State;
 /// values.
 ///
 /// This is an alias of an `iced_native` slider with an `iced_wgpu::Renderer`.
-pub type Slider<'a, T, Message> = iced_native::Slider<'a, T, Message, Renderer>;
+pub type Slider<T, Message> = iced_native::Slider<T, Message, Renderer>;

--- a/wgpu/src/widget/text_input.rs
+++ b/wgpu/src/widget/text_input.rs
@@ -9,4 +9,4 @@ pub use iced_native::text_input::State;
 /// A field that can be filled with text.
 ///
 /// This is an alias of an `iced_native` text input with an `iced_wgpu::Renderer`.
-pub type TextInput<'a, Message> = iced_native::TextInput<'a, Message, Renderer>;
+pub type TextInput<Message> = iced_native::TextInput<Message, Renderer>;


### PR DESCRIPTION
I have been using iced for my projects  for a year now. My concern is that the Application::view function is mutable. I don't know, maybe you have your own solution, but I decided to offer my own. I know that you don't like to go to the code without a preliminary discussion, but my English is bad.

This is my first PR not only in this project, but also my first contribution to open source in general. So do not judge strictly.
This PR allows you to get rid of the changeable Application function::view, by storing states in a special WidgetStateStorage struct. This storage is formed during the deletion of the current Element tree and before creating a new Element tree, during the Application::view call. StateStorage is temporarily stored in the Cache and is used inside the UserInterface::builder.
Since widgets themselves store their state, now there is no longer a need to store widget states inside the Application, and therefore there is no need inside the Application::view function to pass a mutable reference to the state.
But what if you need to change the state of some widget inside the Application::update function? Then it is possible to use a mutable reference to StateStorage, which is passed to the argument of the update function.
Each State has its own ID, which is manually specified or automatically generated. To get a mutable reference to the state of a specific widget inside the Application::update function, you must assign an ID to this widget in advance.
A tree of elements of great depth is sometimes divided into several "components", and in this case, an ID conflict may occur. To avoid this, a multi-level ID in the form of PathBuf is used.

Two functions have been added for the widget function. "into_states" - the widget is deleted and returns its state, "apply_status" - the widget finds and assigns its state.
