### PR TITLE
Remove unnecessary String allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ impl Counter {
             )
             .push(
                 // We show the value of the counter here
-                Text::new(&self.value.to_string()).size(50),
+                Text::new(self.value.to_string()).size(50),
             )
             .push(
                 // The decrement button. We tell it to produce a

--- a/examples/scrollable/src/main.rs
+++ b/examples/scrollable/src/main.rs
@@ -72,7 +72,7 @@ impl Sandbox for ScrollableDemo {
                 column.push(
                     Radio::new(
                         *option,
-                        &format!("{:?}", option),
+                        format!("{:?}", option),
                         Some(*theme),
                         Message::ThemeChanged,
                     )

--- a/examples/styling/src/main.rs
+++ b/examples/styling/src/main.rs
@@ -60,7 +60,7 @@ impl Sandbox for Styling {
                 column.push(
                     Radio::new(
                         *theme,
-                        &format!("{:?}", theme),
+                        format!("{:?}", theme),
                         Some(self.theme),
                         Message::ThemeChanged,
                     )

--- a/examples/todos/src/main.rs
+++ b/examples/todos/src/main.rs
@@ -374,7 +374,7 @@ impl Controls {
             .spacing(20)
             .align_items(Alignment::Center)
             .push(
-                Text::new(&format!(
+                Text::new(format!(
                     "{} {} left",
                     tasks_left,
                     if tasks_left == 1 { "task" } else { "tasks" }
@@ -464,7 +464,7 @@ const ICONS: Font = Font::External {
 };
 
 fn icon(unicode: char) -> Text {
-    Text::new(&unicode.to_string())
+    Text::new(unicode.to_string())
         .font(ICONS)
         .width(Length::Units(20))
         .horizontal_alignment(alignment::Horizontal::Center)

--- a/examples/tour/src/main.rs
+++ b/examples/tour/src/main.rs
@@ -417,7 +417,7 @@ impl<'a> Step {
                 StepMessage::SliderChanged,
             ))
             .push(
-                Text::new(&value.to_string())
+                Text::new(value.to_string())
                     .width(Length::Fill)
                     .horizontal_alignment(alignment::Horizontal::Center),
             )
@@ -464,7 +464,7 @@ impl<'a> Step {
                 StepMessage::SpacingChanged,
             ))
             .push(
-                Text::new(&format!("{} px", spacing))
+                Text::new(format!("{} px", spacing))
                     .width(Length::Fill)
                     .horizontal_alignment(alignment::Horizontal::Center),
             );
@@ -497,7 +497,7 @@ impl<'a> Step {
             .spacing(20)
             .push(Text::new("You can change its size:"))
             .push(
-                Text::new(&format!("This text is {} pixels", size)).size(size),
+                Text::new(format!("This text is {} pixels", size)).size(size),
             )
             .push(Slider::new(
                 size_slider,
@@ -518,7 +518,7 @@ impl<'a> Step {
             .padding(20)
             .spacing(20)
             .push(Text::new("And its color:"))
-            .push(Text::new(&format!("{:?}", color)).color(color))
+            .push(Text::new(format!("{:?}", color)).color(color))
             .push(color_sliders);
 
         Self::container("Text")
@@ -589,7 +589,7 @@ impl<'a> Step {
                 StepMessage::ImageWidthChanged,
             ))
             .push(
-                Text::new(&format!("Width: {} px", width.to_string()))
+                Text::new(format!("Width: {} px", width.to_string()))
                     .width(Length::Fill)
                     .horizontal_alignment(alignment::Horizontal::Center),
             )

--- a/examples/tour/src/main.rs
+++ b/examples/tour/src/main.rs
@@ -496,9 +496,7 @@ impl<'a> Step {
             .padding(20)
             .spacing(20)
             .push(Text::new("You can change its size:"))
-            .push(
-                Text::new(format!("This text is {} pixels", size)).size(size),
-            )
+            .push(Text::new(format!("This text is {} pixels", size)).size(size))
             .push(Slider::new(
                 size_slider,
                 10..=70,


### PR DESCRIPTION
Remove unnecessary `String` allocation by passing `&format!` or `&x.to_string` as `impl Into<String>`