### PR TITLE
Text content by cow

### DIFF
--- a/examples/todos/src/main.rs
+++ b/examples/todos/src/main.rs
@@ -469,7 +469,7 @@ const ICONS: Font = Font::External {
     bytes: include_bytes!("../../todos/fonts/icons.ttf"),
 };
 
-fn icon(unicode: char) -> Text {
+fn icon(unicode: char) -> Text<'static> {
     text(unicode.to_string())
         .font(ICONS)
         .width(Length::Units(20))
@@ -477,11 +477,11 @@ fn icon(unicode: char) -> Text {
         .size(20)
 }
 
-fn edit_icon() -> Text {
+fn edit_icon() -> Text<'static> {
     icon('\u{F303}')
 }
 
-fn delete_icon() -> Text {
+fn delete_icon() -> Text<'static> {
     icon('\u{F1F8}')
 }
 

--- a/native/src/element.rs
+++ b/native/src/element.rs
@@ -91,7 +91,7 @@ impl<'a, Message, Renderer> Element<'a, Message, Renderer> {
     ///
     /// ```
     /// # mod counter {
-    /// #     type Text = iced_native::widget::Text<iced_native::renderer::Null>;
+    /// #     type Text<'a> = iced_native::widget::Text<'a, iced_native::renderer::Null>;
     /// #
     /// #     #[derive(Debug, Clone, Copy)]
     /// #     pub enum Message {}

--- a/native/src/widget/helpers.rs
+++ b/native/src/widget/helpers.rs
@@ -101,18 +101,18 @@ where
     Renderer: crate::text::Renderer,
     Renderer::Theme: widget::container::StyleSheet + widget::text::StyleSheet,
 {
-    widget::Tooltip::new(content, tooltip, position)
+    widget::Tooltip::new(content, tooltip.to_string(), position)
 }
 
 /// Creates a new [`Text`] widget with the provided content.
 ///
 /// [`Text`]: widget::Text
-pub fn text<Renderer>(text: impl ToString) -> widget::Text<Renderer>
+pub fn text<'a, Renderer>(text: impl ToString) -> widget::Text<'a, Renderer>
 where
     Renderer: crate::text::Renderer,
     Renderer::Theme: widget::text::StyleSheet,
 {
-    widget::Text::new(text)
+    widget::Text::new(text.to_string())
 }
 
 /// Creates a new [`Checkbox`].

--- a/native/src/widget/text.rs
+++ b/native/src/widget/text.rs
@@ -6,6 +6,8 @@ use crate::text;
 use crate::widget::Tree;
 use crate::{Element, Layout, Length, Point, Rectangle, Size, Widget};
 
+use std::borrow::Cow;
+
 pub use iced_style::text::{Appearance, StyleSheet};
 
 /// A paragraph of text.
@@ -15,7 +17,7 @@ pub use iced_style::text::{Appearance, StyleSheet};
 /// ```
 /// # use iced_native::Color;
 /// #
-/// # type Text = iced_native::widget::Text<iced_native::renderer::Null>;
+/// # type Text<'a> = iced_native::widget::Text<'a, iced_native::renderer::Null>;
 /// #
 /// Text::new("I <3 iced!")
 ///     .size(40)
@@ -24,12 +26,12 @@ pub use iced_style::text::{Appearance, StyleSheet};
 ///
 /// ![Text drawn by `iced_wgpu`](https://github.com/iced-rs/iced/blob/7760618fb112074bc40b148944521f312152012a/docs/images/text.png?raw=true)
 #[allow(missing_debug_implementations)]
-pub struct Text<Renderer>
+pub struct Text<'a, Renderer>
 where
     Renderer: text::Renderer,
     Renderer::Theme: StyleSheet,
 {
-    content: String,
+    content: Cow<'a, str>,
     size: Option<u16>,
     width: Length,
     height: Length,
@@ -39,15 +41,15 @@ where
     style: <Renderer::Theme as StyleSheet>::Style,
 }
 
-impl<Renderer> Text<Renderer>
+impl<'a, Renderer> Text<'a, Renderer>
 where
     Renderer: text::Renderer,
     Renderer::Theme: StyleSheet,
 {
     /// Create a new fragment of [`Text`] with the given contents.
-    pub fn new<T: ToString>(label: T) -> Self {
+    pub fn new(content: impl Into<Cow<'a, str>>) -> Self {
         Text {
-            content: label.to_string(),
+            content: content.into(),
             size: None,
             font: Default::default(),
             width: Length::Shrink,
@@ -112,7 +114,7 @@ where
     }
 }
 
-impl<Message, Renderer> Widget<Message, Renderer> for Text<Renderer>
+impl<'a, Message, Renderer> Widget<Message, Renderer> for Text<'a, Renderer>
 where
     Renderer: text::Renderer,
     Renderer::Theme: StyleSheet,
@@ -216,18 +218,18 @@ pub fn draw<Renderer>(
     });
 }
 
-impl<'a, Message, Renderer> From<Text<Renderer>>
+impl<'a, Message, Renderer> From<Text<'a, Renderer>>
     for Element<'a, Message, Renderer>
 where
     Renderer: text::Renderer + 'a,
     Renderer::Theme: StyleSheet,
 {
-    fn from(text: Text<Renderer>) -> Element<'a, Message, Renderer> {
+    fn from(text: Text<'a, Renderer>) -> Element<'a, Message, Renderer> {
         Element::new(text)
     }
 }
 
-impl<Renderer> Clone for Text<Renderer>
+impl<'a, Renderer> Clone for Text<'a, Renderer>
 where
     Renderer: text::Renderer,
     Renderer::Theme: StyleSheet,

--- a/native/src/widget/tooltip.rs
+++ b/native/src/widget/tooltip.rs
@@ -13,6 +13,8 @@ use crate::{
     Shell, Size, Vector, Widget,
 };
 
+use std::borrow::Cow;
+
 /// An element to display a widget over another.
 #[allow(missing_debug_implementations)]
 pub struct Tooltip<'a, Message, Renderer: text::Renderer>
@@ -21,7 +23,7 @@ where
     Renderer::Theme: container::StyleSheet + widget::text::StyleSheet,
 {
     content: Element<'a, Message, Renderer>,
-    tooltip: Text<Renderer>,
+    tooltip: Text<'a, Renderer>,
     position: Position,
     gap: u16,
     padding: u16,
@@ -42,12 +44,12 @@ where
     /// [`Tooltip`]: struct.Tooltip.html
     pub fn new(
         content: impl Into<Element<'a, Message, Renderer>>,
-        tooltip: impl ToString,
+        tooltip: impl Into<Cow<'a, str>>,
         position: Position,
     ) -> Self {
         Tooltip {
             content: content.into(),
-            tooltip: Text::new(tooltip.to_string()),
+            tooltip: Text::new(tooltip),
             position,
             gap: 0,
             padding: Self::DEFAULT_PADDING,

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -16,8 +16,8 @@ pub mod text {
     pub use iced_native::widget::text::{Appearance, StyleSheet};
 
     /// A paragraph of text.
-    pub type Text<Renderer = crate::Renderer> =
-        iced_native::widget::Text<Renderer>;
+    pub type Text<'a, Renderer = crate::Renderer> =
+        iced_native::widget::Text<'a, Renderer>;
 }
 
 pub mod button {


### PR DESCRIPTION
#1050
Replace `Text.content` from `String` to `Cow<'a,str>` to reduce `String` allocation.