### PR TITLE
Application::run returns on native platforms

### DIFF
--- a/glutin/src/application.rs
+++ b/glutin/src/application.rs
@@ -11,7 +11,6 @@ use iced_winit::futures;
 use iced_winit::futures::channel::mpsc;
 use iced_winit::{Cache, Clipboard, Debug, Proxy, Settings};
 
-use crate::glutin::platform::run_return::EventLoopExtRunReturn;
 use glutin::window::Window;
 use std::mem::ManuallyDrop;
 
@@ -29,6 +28,7 @@ where
     use futures::task;
     use futures::Future;
     use glutin::event_loop::EventLoop;
+    use glutin::platform::run_return::EventLoopExtRunReturn;
     use glutin::ContextBuilder;
 
     let mut debug = Debug::new();

--- a/glutin/src/application.rs
+++ b/glutin/src/application.rs
@@ -11,6 +11,7 @@ use iced_winit::futures;
 use iced_winit::futures::channel::mpsc;
 use iced_winit::{Cache, Clipboard, Debug, Proxy, Settings};
 
+use crate::glutin::platform::run_return::EventLoopExtRunReturn;
 use glutin::window::Window;
 use std::mem::ManuallyDrop;
 
@@ -33,7 +34,7 @@ where
     let mut debug = Debug::new();
     debug.startup_started();
 
-    let event_loop = EventLoop::with_user_event();
+    let mut event_loop = EventLoop::with_user_event();
     let mut proxy = event_loop.create_proxy();
 
     let mut runtime = {
@@ -115,7 +116,7 @@ where
 
     let mut context = task::Context::from_waker(task::noop_waker_ref());
 
-    event_loop.run(move |event, _, control_flow| {
+    event_loop.run_return(move |event, _, control_flow| {
         use glutin::event_loop::ControlFlow;
 
         if let ControlFlow::Exit = control_flow {
@@ -148,6 +149,8 @@ where
             };
         }
     });
+
+    Ok(())
 }
 
 async fn run_instance<A, E, C>(

--- a/src/application.rs
+++ b/src/application.rs
@@ -188,9 +188,10 @@ pub trait Application: Sized {
     /// Runs the [`Application`].
     ///
     /// On native platforms, this method will take control of the current thread
-    /// until the event loop of the main window exits.
+    /// until the [`Application`] exits.
     ///
-    /// Does never return on the web platform
+    /// On the web platform, this method __will NOT return__ unless there is an
+    /// [`Error`] during startup.
     ///
     /// [`Error`]: crate::Error
     fn run(settings: Settings<Self::Flags>) -> crate::Result

--- a/src/application.rs
+++ b/src/application.rs
@@ -188,9 +188,9 @@ pub trait Application: Sized {
     /// Runs the [`Application`].
     ///
     /// On native platforms, this method will take control of the current thread
-    /// and __will NOT return__ unless there is an [`Error`] during startup.
+    /// until the event loop of the main window exits.
     ///
-    /// It should probably be that last thing you call in your `main` function.
+    /// Does never return on the web platform
     ///
     /// [`Error`]: crate::Error
     fn run(settings: Settings<Self::Flags>) -> crate::Result

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -17,7 +17,6 @@ use iced_graphics::window;
 use iced_native::program::Program;
 use iced_native::{Cache, UserInterface};
 
-use crate::winit::platform::run_return::EventLoopExtRunReturn;
 use std::mem::ManuallyDrop;
 
 /// An interactive, native cross-platform application.
@@ -116,6 +115,7 @@ where
     use futures::task;
     use futures::Future;
     use winit::event_loop::EventLoop;
+    use winit::platform::run_return::EventLoopExtRunReturn;
 
     let mut debug = Debug::new();
     debug.startup_started();

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -17,6 +17,7 @@ use iced_graphics::window;
 use iced_native::program::Program;
 use iced_native::{Cache, UserInterface};
 
+use crate::winit::platform::run_return::EventLoopExtRunReturn;
 use std::mem::ManuallyDrop;
 
 /// An interactive, native cross-platform application.
@@ -119,7 +120,7 @@ where
     let mut debug = Debug::new();
     debug.startup_started();
 
-    let event_loop = EventLoop::with_user_event();
+    let mut event_loop = EventLoop::with_user_event();
     let mut proxy = event_loop.create_proxy();
 
     let mut runtime = {
@@ -178,7 +179,7 @@ where
 
     let mut context = task::Context::from_waker(task::noop_waker_ref());
 
-    event_loop.run(move |event, _, control_flow| {
+    event_loop.run_return(move |event, _, control_flow| {
         use winit::event_loop::ControlFlow;
 
         if let ControlFlow::Exit = control_flow {
@@ -211,6 +212,8 @@ where
             };
         }
     });
+
+    Ok(())
 }
 
 async fn run_instance<A, E, C>(
@@ -401,7 +404,7 @@ async fn run_instance<A, E, C>(
                     Err(error) => match error {
                         // This is an unrecoverable error.
                         window::SurfaceError::OutOfMemory => {
-                            panic!("{}", error);
+                            panic!("{:?}", error);
                         }
                         _ => {
                             debug.render_finished();


### PR DESCRIPTION
Added an `on_exit() -> Option<Box<dyn FnOnce>>` function to the iced::Application trait that provides that callback.

When the returned closure does not actually exit the application then `iced::Application::run()` can return as well, allowing the program to continue when the main window is closed.

For iced_web it could make sense to invoke the on_exit() closure when unloading the page, did not try to implement that though.

The main use-case for this is to allow to change the exit code of the application.