### PR TITLE
Don't rebroadcast redundant slider messages

### DIFF
--- a/native/src/widget/slider.rs
+++ b/native/src/widget/slider.rs
@@ -144,7 +144,7 @@ where
 }
 
 /// The local state of a [`Slider`].
-#[derive(Debug, Clone, Copy, PartialEq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct State {
     is_dragging: bool,
 }

--- a/native/src/widget/slider.rs
+++ b/native/src/widget/slider.rs
@@ -147,7 +147,6 @@ where
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub struct State {
     is_dragging: bool,
-    previous: Option<f64>,
 }
 
 impl State {
@@ -220,14 +219,10 @@ where
                 }
             };
 
-            if let Some(previous) = self.state.previous {
-                if (new_value.into() - previous).abs() > f64::EPSILON {
-                    messages.push((self.on_change)(new_value));
-                    self.state.previous = Some(new_value.into());
-                }
-            } else {
+            if (self.value.into() - new_value.into()).abs() > f64::EPSILON {
                 messages.push((self.on_change)(new_value));
-                self.state.previous = Some(new_value.into());
+
+                self.value = new_value;
             }
         };
 


### PR DESCRIPTION
Updates `Slider` to only broadcast `on_change` when the `Slider` value actually changes from it's previous value. I noticed a ton of redundant messages being broadcast for the same slider value (probably due to high DPI mouse). This causes the slider to become very laggy when driving a computationally heavy change.

`Slider` is now buttery smooth!