### PR TITLE
Disable default features in twox-hash dependency.

### DIFF
--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/hecrj/iced"
 debug = []
 
 [dependencies]
-twox-hash = "1.5"
+twox-hash = { version = "1.5", default-features = false }
 unicode-segmentation = "1.6"
 num-traits = "0.2"
 


### PR DESCRIPTION
We don't use twox-hash's random seeding features. Removing them makes
this crate leaner and also more portable (specifically for web).