### PR TITLE
Native web fixes.

### DIFF
--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -37,33 +37,58 @@ pub mod time;
 
 pub use command::Command;
 pub use executor::Executor;
+pub use platform::*;
 pub use runtime::Runtime;
 pub use subscription::Subscription;
 
-/// A boxed static future.
-///
-/// - On native platforms, it needs a `Send` requirement.
-/// - On the Web platform, it does not need a `Send` requirement.
 #[cfg(not(target_arch = "wasm32"))]
-pub type BoxFuture<T> = futures::future::BoxFuture<'static, T>;
+mod platform {
+    /// A boxed static future.
+    ///
+    /// - On native platforms, it needs a `Send` requirement.
+    /// - On the Web platform, it does not need a `Send` requirement.
+    pub type BoxFuture<T> = futures::future::BoxFuture<'static, T>;
 
-/// A boxed static future.
-///
-/// - On native platforms, it needs a `Send` requirement.
-/// - On the Web platform, it does not need a `Send` requirement.
+    /// A boxed static stream.
+    ///
+    /// - On native platforms, it needs a `Send` requirement.
+    /// - On the Web platform, it does not need a `Send` requirement.
+    pub type BoxStream<T> = futures::stream::BoxStream<'static, T>;
+
+    /// Boxes a stream.
+    ///
+    /// - On native platforms, it needs a `Send` requirement.
+    /// - On the Web platform, it does not need a `Send` requirement.
+    pub fn boxed_stream<T, S>(stream: S) -> BoxStream<T>
+    where
+        S: futures::Stream<Item = T> + Send + 'static,
+    {
+        futures::stream::StreamExt::boxed(stream)
+    }
+}
+
 #[cfg(target_arch = "wasm32")]
-pub type BoxFuture<T> = futures::future::LocalBoxFuture<'static, T>;
+mod platform {
+    /// A boxed static future.
+    ///
+    /// - On native platforms, it needs a `Send` requirement.
+    /// - On the Web platform, it does not need a `Send` requirement.
+    pub type BoxFuture<T> = futures::future::LocalBoxFuture<'static, T>;
 
-/// A boxed static stream.
-///
-/// - On native platforms, it needs a `Send` requirement.
-/// - On the Web platform, it does not need a `Send` requirement.
-#[cfg(not(target_arch = "wasm32"))]
-pub type BoxStream<T> = futures::stream::BoxStream<'static, T>;
+    /// A boxed static stream.
+    ///
+    /// - On native platforms, it needs a `Send` requirement.
+    /// - On the Web platform, it does not need a `Send` requirement.
+    pub type BoxStream<T> = futures::stream::LocalBoxStream<'static, T>;
 
-/// A boxed static stream.
-///
-/// - On native platforms, it needs a `Send` requirement.
-/// - On the Web platform, it does not need a `Send` requirement.
-#[cfg(target_arch = "wasm32")]
-pub type BoxStream<T> = futures::stream::LocalBoxStream<'static, T>;
+    /// Boxes a stream.
+    ///
+    /// - On native platforms, it needs a `Send` requirement.
+    /// - On the Web platform, it does not need a `Send` requirement.
+    pub fn boxed_stream<T, S>(stream: S) -> BoxStream<T>
+    where
+        S: futures::Stream<Item = T> + 'static,
+    {
+        futures::stream::StreamExt::boxed_local(stream)
+    }
+}

--- a/native/src/subscription.rs
+++ b/native/src/subscription.rs
@@ -1,7 +1,7 @@
 //! Listen to external events in your application.
 use crate::event::{self, Event};
 use crate::Hasher;
-use iced_futures::futures::stream::BoxStream;
+use iced_futures::BoxStream;
 
 /// A request to listen to external events.
 ///
@@ -21,7 +21,7 @@ pub type Subscription<T> =
 /// A stream of runtime events.
 ///
 /// It is the input of a [`Subscription`] in the native runtime.
-pub type EventStream = BoxStream<'static, (Event, event::Status)>;
+pub type EventStream = BoxStream<(Event, event::Status)>;
 
 /// A native [`Subscription`] tracker.
 pub type Tracker =

--- a/native/src/subscription/events.rs
+++ b/native/src/subscription/events.rs
@@ -27,10 +27,9 @@ where
         self: Box<Self>,
         event_stream: EventStream,
     ) -> BoxStream<Self::Output> {
-        event_stream
-            .filter_map(move |(event, status)| {
-                future::ready((self.f)(event, status))
-            })
-            .boxed()
+        let stream = event_stream.filter_map(move |(event, status)| {
+            future::ready((self.f)(event, status))
+        });
+        iced_futures::boxed_stream(stream)
     }
 }


### PR DESCRIPTION
`iced_futures`
* Since there are several "platform-specific" type aliases (and a new function), I moved them into their own `mod`. Just makes it easier to read and minimizes the number of `#[cfg(...)]` annotations.
* Added a new function `boxed_stream` that takes a stream of the type supported by the target architecture and boxes it accordingly.

`iced_native`
* Use the `iced_futures` types and functions to allow the `iced_native` to compile on the `wasm32-unknown-unknown` target.
