### PR TITLE
Correct 0.3 docs to reference 0.3 source

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //! [windowing shell]: https://github.com/hecrj/iced/tree/master/winit
 //! [`dodrio`]: https://github.com/fitzgen/dodrio
 //! [web runtime]: https://github.com/hecrj/iced/tree/master/web
-//! [examples]: https://github.com/hecrj/iced/tree/0.2/examples
+//! [examples]: https://github.com/hecrj/iced/tree/0.3/examples
 //! [repository]: https://github.com/hecrj/iced
 //!
 //! # Overview


### PR DESCRIPTION
Previously, the docs for version 0.3 would point to the source code on
branch 0.2. This corrects the link to point to the 0.3 source.

I had initially seen this behavior from the docs.rs page:

https://docs.rs/iced/0.3.0/iced/index.html