### PR TITLE
Fix overflow of graphics primitives in overlays

### DIFF
--- a/native/src/user_interface.rs
+++ b/native/src/user_interface.rs
@@ -409,7 +409,7 @@ where
 
                     let overlay_bounds = layer.layout.bounds();
 
-                    renderer.with_layer(viewport, |renderer| {
+                    renderer.with_layer(overlay_bounds, |renderer| {
                         overlay.draw(
                             renderer,
                             &renderer::Style::default(),


### PR DESCRIPTION
... by using `overlay_bounds` instead of `viewport` as clip bounds for overlay layer in `UserInterface::draw`.

Closes #1123.