### PR TITLE
`iced_lazy` and `Component` trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ members = [
     "graphics",
     "glow",
     "glutin",
+    "lazy",
     "native",
     "style",
     "web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ members = [
     "examples/bezier_tool",
     "examples/clock",
     "examples/color_palette",
+    "examples/component",
     "examples/counter",
     "examples/custom_widget",
     "examples/download_progress",

--- a/examples/component/Cargo.toml
+++ b/examples/component/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "component"
+version = "0.1.0"
+authors = ["Héctor Ramón Jiménez <hector0193@gmail.com>"]
+edition = "2018"
+publish = false
+
+[dependencies]
+iced = { path = "../..", features = ["debug"] }
+iced_native = { path = "../../native" }
+iced_lazy = { path = "../../lazy" }

--- a/examples/component/src/main.rs
+++ b/examples/component/src/main.rs
@@ -174,7 +174,7 @@ mod numeric_input {
         Renderer: text::Renderer + 'a,
     {
         fn from(numeric_input: NumericInput<'a, Message>) -> Self {
-            component::view(Box::new(numeric_input))
+            component::view(numeric_input)
         }
     }
 }

--- a/examples/component/src/main.rs
+++ b/examples/component/src/main.rs
@@ -1,0 +1,180 @@
+use iced::{Container, Element, Length, Sandbox, Settings};
+use numeric_input::NumericInput;
+
+pub fn main() -> iced::Result {
+    Component::run(Settings::default())
+}
+
+#[derive(Default)]
+struct Component {
+    numeric_input: numeric_input::State,
+    value: Option<u32>,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Message {
+    NumericInputChanged(Option<u32>),
+}
+
+impl Sandbox for Component {
+    type Message = Message;
+
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn title(&self) -> String {
+        String::from("Component - Iced")
+    }
+
+    fn update(&mut self, message: Message) {
+        match message {
+            Message::NumericInputChanged(value) => {
+                self.value = value;
+            }
+        }
+    }
+
+    fn view(&mut self) -> Element<Message> {
+        Container::new(NumericInput::new(
+            &mut self.numeric_input,
+            self.value,
+            Message::NumericInputChanged,
+        ))
+        .padding(20)
+        .height(Length::Fill)
+        .center_y()
+        .into()
+    }
+}
+
+mod numeric_input {
+    use iced_lazy::component::{self, Component};
+    use iced_native::alignment::{self, Alignment};
+    use iced_native::text;
+    use iced_native::widget::button::{self, Button};
+    use iced_native::widget::text_input::{self, TextInput};
+    use iced_native::widget::{Row, Text};
+    use iced_native::{Element, Length};
+
+    pub struct NumericInput<'a, Message> {
+        state: &'a mut State,
+        value: Option<u32>,
+        on_change: Box<dyn Fn(Option<u32>) -> Message>,
+    }
+
+    #[derive(Default)]
+    pub struct State {
+        input: text_input::State,
+        decrement_button: button::State,
+        increment_button: button::State,
+    }
+
+    #[derive(Debug, Clone)]
+    pub enum Event {
+        InputChanged(String),
+        IncrementPressed,
+        DecrementPressed,
+    }
+
+    impl<'a, Message> NumericInput<'a, Message> {
+        pub fn new(
+            state: &'a mut State,
+            value: Option<u32>,
+            on_change: impl Fn(Option<u32>) -> Message + 'static,
+        ) -> Self {
+            Self {
+                state,
+                value,
+                on_change: Box::new(on_change),
+            }
+        }
+    }
+
+    impl<'a, Message, Renderer> Component<Message, Renderer>
+        for NumericInput<'a, Message>
+    where
+        Renderer: 'a + text::Renderer,
+    {
+        type Event = Event;
+
+        fn update(&mut self, event: Event) -> Option<Message> {
+            match event {
+                Event::IncrementPressed => Some((self.on_change)(Some(
+                    self.value.unwrap_or_default().saturating_add(1),
+                ))),
+                Event::DecrementPressed => Some((self.on_change)(Some(
+                    self.value.unwrap_or_default().saturating_sub(1),
+                ))),
+                Event::InputChanged(value) => {
+                    if value.is_empty() {
+                        Some((self.on_change)(None))
+                    } else {
+                        value
+                            .parse()
+                            .ok()
+                            .map(Some)
+                            .map(self.on_change.as_ref())
+                    }
+                }
+            }
+        }
+
+        fn view(&mut self) -> Element<Event, Renderer> {
+            let button = |state, label, on_press| {
+                Button::new(
+                    state,
+                    Text::new(label)
+                        .width(Length::Fill)
+                        .height(Length::Fill)
+                        .horizontal_alignment(alignment::Horizontal::Center)
+                        .vertical_alignment(alignment::Vertical::Center),
+                )
+                .width(Length::Units(50))
+                .on_press(on_press)
+            };
+
+            Row::with_children(vec![
+                button(
+                    &mut self.state.decrement_button,
+                    "-",
+                    Event::DecrementPressed,
+                )
+                .into(),
+                TextInput::new(
+                    &mut self.state.input,
+                    "Type a number",
+                    self.value
+                        .as_ref()
+                        .map(u32::to_string)
+                        .as_ref()
+                        .map(String::as_str)
+                        .unwrap_or(""),
+                    Event::InputChanged,
+                )
+                .padding(10)
+                .into(),
+                button(
+                    &mut self.state.increment_button,
+                    "+",
+                    Event::IncrementPressed,
+                )
+                .into(),
+            ])
+            .align_items(Alignment::Fill)
+            .spacing(10)
+            .into()
+        }
+    }
+
+    impl<'a, Message, Renderer> From<NumericInput<'a, Message>>
+        for Element<'a, Message, Renderer>
+    where
+        Message: 'a,
+        Renderer: text::Renderer + 'a,
+    {
+        fn from(numeric_input: NumericInput<'a, Message>) -> Self {
+            component::view(Box::new(numeric_input))
+        }
+    }
+}

--- a/graphics/src/widget/canvas.rs
+++ b/graphics/src/widget/canvas.rs
@@ -9,8 +9,8 @@ use crate::{Backend, Primitive};
 use iced_native::layout;
 use iced_native::mouse;
 use iced_native::{
-    Clipboard, Element, Hasher, Layout, Length, Point, Rectangle, Size, Vector,
-    Widget,
+    Clipboard, Element, Hasher, Layout, Length, Point, Rectangle, Shell, Size,
+    Vector, Widget,
 };
 use std::hash::Hash;
 use std::marker::PhantomData;
@@ -158,7 +158,7 @@ where
         cursor_position: Point,
         _renderer: &Renderer<B>,
         _clipboard: &mut dyn Clipboard,
-        messages: &mut Vec<Message>,
+        shell: &mut Shell<'_, Message>,
     ) -> event::Status {
         let bounds = layout.bounds();
 
@@ -179,7 +179,7 @@ where
                 self.program.update(canvas_event, bounds, cursor);
 
             if let Some(message) = message {
-                messages.push(message);
+                shell.publish(message);
             }
 
             return event_status;

--- a/lazy/Cargo.toml
+++ b/lazy/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "iced_lazy"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+ouroboros = "0.13"
+
+[dependencies.iced_native]
+version = "0.4"
+path = "../native"

--- a/lazy/src/component.rs
+++ b/lazy/src/component.rs
@@ -1,0 +1,181 @@
+use iced_native::event;
+use iced_native::layout::{self, Layout};
+use iced_native::mouse;
+use iced_native::overlay;
+use iced_native::renderer;
+use iced_native::{
+    Clipboard, Element, Hasher, Length, Point, Rectangle, Widget,
+};
+
+use ouroboros::self_referencing;
+use std::marker::PhantomData;
+
+pub fn view<'a, Event, Message, Renderer>(
+    component: &'a mut dyn Component<Message, Renderer, Event = Event>,
+) -> Element<'a, Message, Renderer>
+where
+    Renderer: iced_native::Renderer,
+{
+    Element::new(Instance {
+        state: Some(
+            StateBuilder {
+                component,
+                cache_builder: |state| Cache {
+                    element: state.view(),
+                    message: PhantomData,
+                },
+            }
+            .build(),
+        ),
+    })
+}
+
+pub trait Component<Message, Renderer> {
+    type Event;
+
+    fn update(&mut self, event: Self::Event) -> Option<Message>;
+
+    fn view(&mut self) -> Element<Self::Event, Renderer>;
+}
+
+struct Instance<'a, Message, Renderer, Event> {
+    state: Option<State<'a, Message, Renderer, Event>>,
+}
+
+#[self_referencing]
+struct State<'a, Message, Renderer, Event> {
+    component: &'a mut dyn Component<Message, Renderer, Event = Event>,
+
+    #[borrows(mut component)]
+    #[covariant]
+    cache: Cache<'this, Message, Renderer, Event>,
+}
+
+struct Cache<'a, Message, Renderer, Event> {
+    element: Element<'a, Event, Renderer>,
+    message: PhantomData<Message>,
+}
+
+impl<'a, Message, Renderer, Event> Widget<Message, Renderer>
+    for Instance<'a, Message, Renderer, Event>
+where
+    Renderer: iced_native::Renderer,
+{
+    fn width(&self) -> Length {
+        self.state.as_ref().unwrap().borrow_cache().element.width()
+    }
+
+    fn height(&self) -> Length {
+        self.state.as_ref().unwrap().borrow_cache().element.width()
+    }
+
+    fn layout(
+        &self,
+        renderer: &Renderer,
+        limits: &layout::Limits,
+    ) -> layout::Node {
+        self.state
+            .as_ref()
+            .unwrap()
+            .borrow_cache()
+            .element
+            .layout(renderer, limits)
+    }
+
+    fn on_event(
+        &mut self,
+        event: iced_native::Event,
+        layout: Layout<'_>,
+        cursor_position: Point,
+        renderer: &Renderer,
+        clipboard: &mut dyn Clipboard,
+        messages: &mut Vec<Message>,
+    ) -> event::Status {
+        let mut local_messages = Vec::new();
+
+        let event_status =
+            self.state.as_mut().unwrap().with_cache_mut(|cache| {
+                cache.element.on_event(
+                    event,
+                    layout,
+                    cursor_position,
+                    renderer,
+                    clipboard,
+                    &mut local_messages,
+                )
+            });
+
+        if !local_messages.is_empty() {
+            let component = self.state.take().unwrap().into_heads().component;
+
+            messages.extend(
+                local_messages
+                    .into_iter()
+                    .filter_map(|message| component.update(message)),
+            );
+
+            self.state = Some(
+                StateBuilder {
+                    component,
+                    cache_builder: |state| Cache {
+                        element: state.view(),
+                        message: PhantomData,
+                    },
+                }
+                .build(),
+            );
+
+            // TODO: Invalidate layout (!)
+        }
+
+        event_status
+    }
+
+    fn draw(
+        &self,
+        renderer: &mut Renderer,
+        style: &renderer::Style,
+        layout: Layout<'_>,
+        cursor_position: Point,
+        viewport: &Rectangle,
+    ) {
+        self.state.as_ref().unwrap().borrow_cache().element.draw(
+            renderer,
+            style,
+            layout,
+            cursor_position,
+            viewport,
+        )
+    }
+
+    fn hash_layout(&self, state: &mut Hasher) {
+        self.state
+            .as_ref()
+            .unwrap()
+            .borrow_cache()
+            .element
+            .hash_layout(state)
+    }
+
+    fn mouse_interaction(
+        &self,
+        layout: Layout<'_>,
+        cursor_position: Point,
+        viewport: &Rectangle,
+    ) -> mouse::Interaction {
+        self.state
+            .as_ref()
+            .unwrap()
+            .borrow_cache()
+            .element
+            .mouse_interaction(layout, cursor_position, viewport)
+    }
+
+    fn overlay(
+        &mut self,
+        _layout: Layout<'_>,
+    ) -> Option<overlay::Element<'_, Message, Renderer>> {
+        // TODO: Rethink overlay composability
+        None
+    }
+}

--- a/lazy/src/component.rs
+++ b/lazy/src/component.rs
@@ -10,18 +10,18 @@ use iced_native::{
 use ouroboros::self_referencing;
 use std::marker::PhantomData;
 
-pub fn view<'a, Event, Message, Renderer>(
-    component: Box<dyn Component<Message, Renderer, Event = Event> + 'a>,
+pub fn view<'a, C, Message, Renderer>(
+    component: C,
 ) -> Element<'a, Message, Renderer>
 where
+    C: Component<Message, Renderer> + 'a,
     Message: 'a,
-    Event: 'a,
     Renderer: iced_native::Renderer + 'a,
 {
     Element::new(Instance {
         state: Some(
             StateBuilder {
-                component,
+                component: Box::new(component),
                 cache_builder: |state| Cache {
                     element: state.view(),
                     message: PhantomData,

--- a/lazy/src/lib.rs
+++ b/lazy/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod component;
+
+pub use component::Component;

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -53,6 +53,7 @@ pub mod window;
 mod element;
 mod hasher;
 mod runtime;
+mod shell;
 mod user_interface;
 
 // We disable debug capabilities on release builds unless the `debug` feature
@@ -85,6 +86,7 @@ pub use overlay::Overlay;
 pub use program::Program;
 pub use renderer::Renderer;
 pub use runtime::Runtime;
+pub use shell::Shell;
 pub use subscription::Subscription;
 pub use user_interface::{Cache, UserInterface};
 pub use widget::Widget;

--- a/native/src/overlay.rs
+++ b/native/src/overlay.rs
@@ -10,7 +10,7 @@ use crate::event::{self, Event};
 use crate::layout;
 use crate::mouse;
 use crate::renderer;
-use crate::{Clipboard, Hasher, Layout, Point, Rectangle, Size};
+use crate::{Clipboard, Hasher, Layout, Point, Rectangle, Shell, Size};
 
 /// An interactive component that can be displayed on top of other widgets.
 pub trait Overlay<Message, Renderer>
@@ -71,7 +71,7 @@ where
         _cursor_position: Point,
         _renderer: &Renderer,
         _clipboard: &mut dyn Clipboard,
-        _messages: &mut Vec<Message>,
+        _shell: &mut Shell<'_, Message>,
     ) -> event::Status {
         event::Status::Ignored
     }

--- a/native/src/overlay/element.rs
+++ b/native/src/overlay/element.rs
@@ -25,6 +25,11 @@ where
         Self { position, overlay }
     }
 
+    /// Returns the position of the [`Element`].
+    pub fn position(&self) -> Point {
+        self.position
+    }
+
     /// Translates the [`Element`].
     pub fn translate(mut self, translation: Vector) -> Self {
         self.position = self.position + translation;

--- a/native/src/overlay/element.rs
+++ b/native/src/overlay/element.rs
@@ -4,7 +4,7 @@ use crate::event::{self, Event};
 use crate::layout;
 use crate::mouse;
 use crate::renderer;
-use crate::{Clipboard, Hasher, Layout, Point, Rectangle, Size, Vector};
+use crate::{Clipboard, Hasher, Layout, Point, Rectangle, Shell, Size, Vector};
 
 /// A generic [`Overlay`].
 #[allow(missing_debug_implementations)]
@@ -62,7 +62,7 @@ where
         cursor_position: Point,
         renderer: &Renderer,
         clipboard: &mut dyn Clipboard,
-        messages: &mut Vec<Message>,
+        shell: &mut Shell<'_, Message>,
     ) -> event::Status {
         self.overlay.on_event(
             event,
@@ -70,7 +70,7 @@ where
             cursor_position,
             renderer,
             clipboard,
-            messages,
+            shell,
         )
     }
 
@@ -136,9 +136,10 @@ where
         cursor_position: Point,
         renderer: &Renderer,
         clipboard: &mut dyn Clipboard,
-        messages: &mut Vec<B>,
+        shell: &mut Shell<'_, B>,
     ) -> event::Status {
-        let mut original_messages = Vec::new();
+        let mut local_messages = Vec::new();
+        let mut local_shell = Shell::new(&mut local_messages);
 
         let event_status = self.content.on_event(
             event,
@@ -146,12 +147,10 @@ where
             cursor_position,
             renderer,
             clipboard,
-            &mut original_messages,
+            &mut local_shell,
         );
 
-        original_messages
-            .drain(..)
-            .for_each(|message| messages.push((self.mapper)(message)));
+        shell.merge(local_shell, self.mapper);
 
         event_status
     }

--- a/native/src/overlay/menu.rs
+++ b/native/src/overlay/menu.rs
@@ -11,7 +11,7 @@ use crate::widget::scrollable::{self, Scrollable};
 use crate::widget::Container;
 use crate::{
     Clipboard, Color, Element, Hasher, Layout, Length, Padding, Point,
-    Rectangle, Size, Vector, Widget,
+    Rectangle, Shell, Size, Vector, Widget,
 };
 
 pub use iced_style::menu::Style;
@@ -222,7 +222,7 @@ where
         cursor_position: Point,
         renderer: &Renderer,
         clipboard: &mut dyn Clipboard,
-        messages: &mut Vec<Message>,
+        shell: &mut Shell<'_, Message>,
     ) -> event::Status {
         self.container.on_event(
             event.clone(),
@@ -230,7 +230,7 @@ where
             cursor_position,
             renderer,
             clipboard,
-            messages,
+            shell,
         )
     }
 
@@ -333,7 +333,7 @@ where
         cursor_position: Point,
         renderer: &Renderer,
         _clipboard: &mut dyn Clipboard,
-        _messages: &mut Vec<Message>,
+        _shell: &mut Shell<'_, Message>,
     ) -> event::Status {
         match event {
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) => {

--- a/native/src/shell.rs
+++ b/native/src/shell.rs
@@ -1,0 +1,54 @@
+/// A connection to the state of a shell.
+///
+/// A [`Widget`] can leverage a [`Shell`] to trigger changes in an application,
+/// like publishing messages or invalidating the current layout.
+///
+/// [`Widget`]: crate::Widget
+#[derive(Debug)]
+pub struct Shell<'a, Message> {
+    messages: &'a mut Vec<Message>,
+    is_layout_invalid: bool,
+}
+
+impl<'a, Message> Shell<'a, Message> {
+    /// Creates a new [`Shell`] with the provided buffer of messages.
+    pub fn new(messages: &'a mut Vec<Message>) -> Self {
+        Self {
+            messages,
+            is_layout_invalid: false,
+        }
+    }
+
+    /// Triggers the given function if the layout is invalid, cleaning it in the
+    /// process.
+    pub fn with_invalid_layout(&mut self, f: impl FnOnce()) {
+        if self.is_layout_invalid {
+            self.is_layout_invalid = false;
+
+            f()
+        }
+    }
+
+    /// Publish the given `Message` for an application to process it.
+    pub fn publish(&mut self, message: Message) {
+        self.messages.push(message);
+    }
+
+    /// Invalidates the current application layout.
+    ///
+    /// The shell will relayout the application widgets.
+    pub fn invalidate_layout(&mut self) {
+        self.is_layout_invalid = true;
+    }
+
+    /// Merges the current [`Shell`] with another one by applying the given
+    /// function to the messages of the latter.
+    ///
+    /// This method is useful for composition.
+    pub fn merge<B>(&mut self, other: Shell<'_, B>, f: impl Fn(B) -> Message) {
+        self.messages.extend(other.messages.drain(..).map(f));
+
+        self.is_layout_invalid =
+            self.is_layout_invalid || other.is_layout_invalid;
+    }
+}

--- a/native/src/widget.rs
+++ b/native/src/widget.rs
@@ -75,7 +75,7 @@ use crate::layout;
 use crate::mouse;
 use crate::overlay;
 use crate::renderer;
-use crate::{Clipboard, Hasher, Layout, Length, Point, Rectangle};
+use crate::{Clipboard, Hasher, Layout, Length, Point, Rectangle, Shell};
 
 /// A component that displays information and allows interaction.
 ///
@@ -163,7 +163,7 @@ where
         _cursor_position: Point,
         _renderer: &Renderer,
         _clipboard: &mut dyn Clipboard,
-        _messages: &mut Vec<Message>,
+        _shell: &mut Shell<'_, Message>,
     ) -> event::Status {
         event::Status::Ignored
     }

--- a/native/src/widget/button.rs
+++ b/native/src/widget/button.rs
@@ -9,7 +9,7 @@ use crate::renderer;
 use crate::touch;
 use crate::{
     Background, Clipboard, Color, Element, Hasher, Layout, Length, Padding,
-    Point, Rectangle, Vector, Widget,
+    Point, Rectangle, Shell, Vector, Widget,
 };
 
 use std::hash::Hash;
@@ -197,7 +197,7 @@ where
         cursor_position: Point,
         renderer: &Renderer,
         clipboard: &mut dyn Clipboard,
-        messages: &mut Vec<Message>,
+        shell: &mut Shell<'_, Message>,
     ) -> event::Status {
         if let event::Status::Captured = self.content.on_event(
             event.clone(),
@@ -205,7 +205,7 @@ where
             cursor_position,
             renderer,
             clipboard,
-            messages,
+            shell,
         ) {
             return event::Status::Captured;
         }
@@ -232,7 +232,7 @@ where
                         self.state.is_pressed = false;
 
                         if bounds.contains(cursor_position) {
-                            messages.push(on_press);
+                            shell.publish(on_press);
                         }
 
                         return event::Status::Captured;

--- a/native/src/widget/checkbox.rs
+++ b/native/src/widget/checkbox.rs
@@ -11,7 +11,7 @@ use crate::touch;
 use crate::widget::{self, Row, Text};
 use crate::{
     Alignment, Clipboard, Color, Element, Hasher, Layout, Length, Point,
-    Rectangle, Widget,
+    Rectangle, Shell, Widget,
 };
 
 pub use iced_style::checkbox::{Style, StyleSheet};
@@ -171,7 +171,7 @@ where
         cursor_position: Point,
         _renderer: &Renderer,
         _clipboard: &mut dyn Clipboard,
-        messages: &mut Vec<Message>,
+        shell: &mut Shell<'_, Message>,
     ) -> event::Status {
         match event {
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
@@ -179,7 +179,7 @@ where
                 let mouse_over = layout.bounds().contains(cursor_position);
 
                 if mouse_over {
-                    messages.push((self.on_toggle)(!self.is_checked));
+                    shell.publish((self.on_toggle)(!self.is_checked));
 
                     return event::Status::Captured;
                 }

--- a/native/src/widget/column.rs
+++ b/native/src/widget/column.rs
@@ -8,7 +8,7 @@ use crate::overlay;
 use crate::renderer;
 use crate::{
     Alignment, Clipboard, Element, Hasher, Layout, Length, Padding, Point,
-    Rectangle, Widget,
+    Rectangle, Shell, Widget,
 };
 
 use std::u32;
@@ -146,7 +146,7 @@ where
         cursor_position: Point,
         renderer: &Renderer,
         clipboard: &mut dyn Clipboard,
-        messages: &mut Vec<Message>,
+        shell: &mut Shell<'_, Message>,
     ) -> event::Status {
         self.children
             .iter_mut()
@@ -158,7 +158,7 @@ where
                     cursor_position,
                     renderer,
                     clipboard,
-                    messages,
+                    shell,
                 )
             })
             .fold(event::Status::Ignored, event::Status::merge)

--- a/native/src/widget/container.rs
+++ b/native/src/widget/container.rs
@@ -9,7 +9,7 @@ use crate::overlay;
 use crate::renderer;
 use crate::{
     Background, Clipboard, Color, Element, Hasher, Layout, Length, Padding,
-    Point, Rectangle, Widget,
+    Point, Rectangle, Shell, Widget,
 };
 
 use std::u32;
@@ -167,7 +167,7 @@ where
         cursor_position: Point,
         renderer: &Renderer,
         clipboard: &mut dyn Clipboard,
-        messages: &mut Vec<Message>,
+        shell: &mut Shell<'_, Message>,
     ) -> event::Status {
         self.content.widget.on_event(
             event,
@@ -175,7 +175,7 @@ where
             cursor_position,
             renderer,
             clipboard,
-            messages,
+            shell,
         )
     }
 

--- a/native/src/widget/image/viewer.rs
+++ b/native/src/widget/image/viewer.rs
@@ -5,8 +5,8 @@ use crate::layout;
 use crate::mouse;
 use crate::renderer;
 use crate::{
-    Clipboard, Element, Hasher, Layout, Length, Point, Rectangle, Size, Vector,
-    Widget,
+    Clipboard, Element, Hasher, Layout, Length, Point, Rectangle, Shell, Size,
+    Vector, Widget,
 };
 
 use std::hash::Hash;
@@ -169,7 +169,7 @@ where
         cursor_position: Point,
         renderer: &Renderer,
         _clipboard: &mut dyn Clipboard,
-        _messages: &mut Vec<Message>,
+        _shell: &mut Shell<'_, Message>,
     ) -> event::Status {
         let bounds = layout.bounds();
         let is_mouse_over = bounds.contains(cursor_position);

--- a/native/src/widget/pane_grid/content.rs
+++ b/native/src/widget/pane_grid/content.rs
@@ -5,7 +5,9 @@ use crate::overlay;
 use crate::renderer;
 use crate::widget::container;
 use crate::widget::pane_grid::TitleBar;
-use crate::{Clipboard, Element, Hasher, Layout, Point, Rectangle, Size};
+use crate::{
+    Clipboard, Element, Hasher, Layout, Point, Rectangle, Shell, Size,
+};
 
 /// The content of a [`Pane`].
 ///
@@ -160,7 +162,7 @@ where
         cursor_position: Point,
         renderer: &Renderer,
         clipboard: &mut dyn Clipboard,
-        messages: &mut Vec<Message>,
+        shell: &mut Shell<'_, Message>,
         is_picked: bool,
     ) -> event::Status {
         let mut event_status = event::Status::Ignored;
@@ -174,7 +176,7 @@ where
                 cursor_position,
                 renderer,
                 clipboard,
-                messages,
+                shell,
             );
 
             children.next().unwrap()
@@ -191,7 +193,7 @@ where
                 cursor_position,
                 renderer,
                 clipboard,
-                messages,
+                shell,
             )
         };
 

--- a/native/src/widget/pane_grid/title_bar.rs
+++ b/native/src/widget/pane_grid/title_bar.rs
@@ -5,7 +5,7 @@ use crate::overlay;
 use crate::renderer;
 use crate::widget::container;
 use crate::{
-    Clipboard, Element, Hasher, Layout, Padding, Point, Rectangle, Size,
+    Clipboard, Element, Hasher, Layout, Padding, Point, Rectangle, Shell, Size,
 };
 
 /// The title bar of a [`Pane`].
@@ -218,7 +218,7 @@ where
         cursor_position: Point,
         renderer: &Renderer,
         clipboard: &mut dyn Clipboard,
-        messages: &mut Vec<Message>,
+        shell: &mut Shell<'_, Message>,
     ) -> event::Status {
         let mut children = layout.children();
         let padded = children.next().unwrap();
@@ -235,7 +235,7 @@ where
                 cursor_position,
                 renderer,
                 clipboard,
-                messages,
+                shell,
             )
         } else {
             event::Status::Ignored
@@ -247,7 +247,7 @@ where
             cursor_position,
             renderer,
             clipboard,
-            messages,
+            shell,
         );
 
         control_status.merge(title_status)

--- a/native/src/widget/pick_list.rs
+++ b/native/src/widget/pick_list.rs
@@ -11,7 +11,7 @@ use crate::text::{self, Text};
 use crate::touch;
 use crate::{
     Clipboard, Element, Hasher, Layout, Length, Padding, Point, Rectangle,
-    Size, Widget,
+    Shell, Size, Widget,
 };
 use std::borrow::Cow;
 
@@ -245,7 +245,7 @@ where
         cursor_position: Point,
         _renderer: &Renderer,
         _clipboard: &mut dyn Clipboard,
-        messages: &mut Vec<Message>,
+        shell: &mut Shell<'_, Message>,
     ) -> event::Status {
         match event {
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
@@ -271,7 +271,7 @@ where
                 };
 
                 if let Some(last_selection) = self.last_selection.take() {
-                    messages.push((self.on_selected)(last_selection));
+                    shell.publish((self.on_selected)(last_selection));
 
                     *self.is_open = false;
 
@@ -312,7 +312,7 @@ where
                 };
 
                 if let Some(next_option) = next_option {
-                    messages.push((self.on_selected)(next_option.clone()));
+                    shell.publish((self.on_selected)(next_option.clone()));
                 }
 
                 event::Status::Captured

--- a/native/src/widget/radio.rs
+++ b/native/src/widget/radio.rs
@@ -11,7 +11,7 @@ use crate::touch;
 use crate::widget::{self, Row, Text};
 use crate::{
     Alignment, Clipboard, Color, Element, Hasher, Layout, Length, Point,
-    Rectangle, Widget,
+    Rectangle, Shell, Widget,
 };
 
 pub use iced_style::radio::{Style, StyleSheet};
@@ -187,13 +187,13 @@ where
         cursor_position: Point,
         _renderer: &Renderer,
         _clipboard: &mut dyn Clipboard,
-        messages: &mut Vec<Message>,
+        shell: &mut Shell<'_, Message>,
     ) -> event::Status {
         match event {
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
             | Event::Touch(touch::Event::FingerPressed { .. }) => {
                 if layout.bounds().contains(cursor_position) {
-                    messages.push(self.on_click.clone());
+                    shell.publish(self.on_click.clone());
 
                     return event::Status::Captured;
                 }

--- a/native/src/widget/row.rs
+++ b/native/src/widget/row.rs
@@ -6,7 +6,7 @@ use crate::overlay;
 use crate::renderer;
 use crate::{
     Alignment, Clipboard, Element, Hasher, Layout, Length, Padding, Point,
-    Rectangle, Widget,
+    Rectangle, Shell, Widget,
 };
 
 use std::hash::Hash;
@@ -145,7 +145,7 @@ where
         cursor_position: Point,
         renderer: &Renderer,
         clipboard: &mut dyn Clipboard,
-        messages: &mut Vec<Message>,
+        shell: &mut Shell<'_, Message>,
     ) -> event::Status {
         self.children
             .iter_mut()
@@ -157,7 +157,7 @@ where
                     cursor_position,
                     renderer,
                     clipboard,
-                    messages,
+                    shell,
                 )
             })
             .fold(event::Status::Ignored, event::Status::merge)

--- a/native/src/widget/scrollable.rs
+++ b/native/src/widget/scrollable.rs
@@ -8,7 +8,7 @@ use crate::touch;
 use crate::widget::Column;
 use crate::{
     Alignment, Background, Clipboard, Color, Element, Hasher, Layout, Length,
-    Padding, Point, Rectangle, Size, Vector, Widget,
+    Padding, Point, Rectangle, Shell, Size, Vector, Widget,
 };
 
 use std::{f32, hash::Hash, u32};
@@ -144,14 +144,14 @@ impl<'a, Message, Renderer: crate::Renderer> Scrollable<'a, Message, Renderer> {
         &self,
         bounds: Rectangle,
         content_bounds: Rectangle,
-        messages: &mut Vec<Message>,
+        shell: &mut Shell<'_, Message>,
     ) {
         if content_bounds.height <= bounds.height {
             return;
         }
 
         if let Some(on_scroll) = &self.on_scroll {
-            messages.push(on_scroll(
+            shell.publish(on_scroll(
                 self.state.offset.absolute(bounds, content_bounds)
                     / (content_bounds.height - bounds.height),
             ));
@@ -251,7 +251,7 @@ where
         cursor_position: Point,
         renderer: &Renderer,
         clipboard: &mut dyn Clipboard,
-        messages: &mut Vec<Message>,
+        shell: &mut Shell<'_, Message>,
     ) -> event::Status {
         let bounds = layout.bounds();
         let is_mouse_over = bounds.contains(cursor_position);
@@ -286,7 +286,7 @@ where
                 cursor_position,
                 renderer,
                 clipboard,
-                messages,
+                shell,
             )
         };
 
@@ -307,7 +307,7 @@ where
                         }
                     }
 
-                    self.notify_on_scroll(bounds, content_bounds, messages);
+                    self.notify_on_scroll(bounds, content_bounds, shell);
 
                     return event::Status::Captured;
                 }
@@ -336,7 +336,7 @@ where
                                 self.notify_on_scroll(
                                     bounds,
                                     content_bounds,
-                                    messages,
+                                    shell,
                                 );
                             }
                         }
@@ -377,7 +377,7 @@ where
                             content_bounds,
                         );
 
-                        self.notify_on_scroll(bounds, content_bounds, messages);
+                        self.notify_on_scroll(bounds, content_bounds, shell);
 
                         return event::Status::Captured;
                     }
@@ -409,7 +409,7 @@ where
                             self.notify_on_scroll(
                                 bounds,
                                 content_bounds,
-                                messages,
+                                shell,
                             );
 
                             return event::Status::Captured;

--- a/native/src/widget/slider.rs
+++ b/native/src/widget/slider.rs
@@ -8,7 +8,7 @@ use crate::renderer;
 use crate::touch;
 use crate::{
     Background, Clipboard, Color, Element, Hasher, Layout, Length, Point,
-    Rectangle, Size, Widget,
+    Rectangle, Shell, Size, Widget,
 };
 
 use std::hash::Hash;
@@ -191,7 +191,7 @@ where
         cursor_position: Point,
         _renderer: &Renderer,
         _clipboard: &mut dyn Clipboard,
-        messages: &mut Vec<Message>,
+        shell: &mut Shell<'_, Message>,
     ) -> event::Status {
         let is_dragging = self.state.is_dragging;
 
@@ -220,7 +220,7 @@ where
             };
 
             if (self.value.into() - new_value.into()).abs() > f64::EPSILON {
-                messages.push((self.on_change)(new_value));
+                shell.publish((self.on_change)(new_value));
 
                 self.value = new_value;
             }
@@ -241,7 +241,7 @@ where
             | Event::Touch(touch::Event::FingerLost { .. }) => {
                 if is_dragging {
                     if let Some(on_release) = self.on_release.clone() {
-                        messages.push(on_release);
+                        shell.publish(on_release);
                     }
                     self.state.is_dragging = false;
 

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -21,7 +21,7 @@ use crate::text::{self, Text};
 use crate::touch;
 use crate::{
     Clipboard, Color, Element, Hasher, Layout, Length, Padding, Point,
-    Rectangle, Size, Vector, Widget,
+    Rectangle, Shell, Size, Vector, Widget,
 };
 
 use std::u32;
@@ -384,7 +384,7 @@ where
         cursor_position: Point,
         renderer: &Renderer,
         clipboard: &mut dyn Clipboard,
-        messages: &mut Vec<Message>,
+        shell: &mut Shell<'_, Message>,
     ) -> event::Status {
         match event {
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
@@ -509,7 +509,7 @@ where
                 editor.insert(c);
 
                 let message = (self.on_change)(editor.contents());
-                messages.push(message);
+                shell.publish(message);
 
                 return event::Status::Captured;
             }
@@ -521,7 +521,7 @@ where
                 match key_code {
                     keyboard::KeyCode::Enter => {
                         if let Some(on_submit) = self.on_submit.clone() {
-                            messages.push(on_submit);
+                            shell.publish(on_submit);
                         }
                     }
                     keyboard::KeyCode::Backspace => {
@@ -551,7 +551,7 @@ where
                         editor.backspace();
 
                         let message = (self.on_change)(editor.contents());
-                        messages.push(message);
+                        shell.publish(message);
                     }
                     keyboard::KeyCode::Delete => {
                         if platform::is_jump_modifier_pressed(modifiers)
@@ -582,7 +582,7 @@ where
                         editor.delete();
 
                         let message = (self.on_change)(editor.contents());
-                        messages.push(message);
+                        shell.publish(message);
                     }
                     keyboard::KeyCode::Left => {
                         if platform::is_jump_modifier_pressed(modifiers)
@@ -674,7 +674,7 @@ where
                         editor.delete();
 
                         let message = (self.on_change)(editor.contents());
-                        messages.push(message);
+                        shell.publish(message);
                     }
                     keyboard::KeyCode::V => {
                         if self.state.keyboard_modifiers.command() {
@@ -700,7 +700,7 @@ where
                             editor.paste(content.clone());
 
                             let message = (self.on_change)(editor.contents());
-                            messages.push(message);
+                            shell.publish(message);
 
                             self.state.is_pasting = Some(content);
                         } else {

--- a/native/src/widget/toggler.rs
+++ b/native/src/widget/toggler.rs
@@ -10,7 +10,7 @@ use crate::text;
 use crate::widget::{Row, Text};
 use crate::{
     Alignment, Clipboard, Element, Event, Hasher, Layout, Length, Point,
-    Rectangle, Widget,
+    Rectangle, Shell, Widget,
 };
 
 pub use iced_style::toggler::{Style, StyleSheet};
@@ -173,14 +173,14 @@ where
         cursor_position: Point,
         _renderer: &Renderer,
         _clipboard: &mut dyn Clipboard,
-        messages: &mut Vec<Message>,
+        shell: &mut Shell<'_, Message>,
     ) -> event::Status {
         match event {
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) => {
                 let mouse_over = layout.bounds().contains(cursor_position);
 
                 if mouse_over {
-                    messages.push((self.on_toggle)(!self.is_active));
+                    shell.publish((self.on_toggle)(!self.is_active));
 
                     event::Status::Captured
                 } else {

--- a/native/src/widget/tooltip.rs
+++ b/native/src/widget/tooltip.rs
@@ -11,8 +11,8 @@ use crate::text;
 use crate::widget::container;
 use crate::widget::text::Text;
 use crate::{
-    Clipboard, Element, Event, Hasher, Layout, Length, Padding, Point, Size,
-    Vector, Widget,
+    Clipboard, Element, Event, Hasher, Layout, Length, Padding, Point, Shell,
+    Size, Vector, Widget,
 };
 
 /// An element to display a widget over another.
@@ -130,7 +130,7 @@ where
         cursor_position: Point,
         renderer: &Renderer,
         clipboard: &mut dyn Clipboard,
-        messages: &mut Vec<Message>,
+        shell: &mut Shell<'_, Message>,
     ) -> event::Status {
         self.content.widget.on_event(
             event,
@@ -138,7 +138,7 @@ where
             cursor_position,
             renderer,
             clipboard,
-            messages,
+            shell,
         )
     }
 


### PR DESCRIPTION
This PR introduces a new crate: `iced_lazy`.

`iced_lazy` is meant to contain types that are, in one way or another, related to _laziness_. A container widget is considered lazy when its contents are not strictly computed during an `Application::view` call. Instead, a lazy widget may choose the compute the contents beforehand, or only when necessary!

Currently, `iced_lazy` only exposes a new `Component` trait:

```rust
pub trait Component<Message, Renderer> {
    type Event;

    fn update(&mut self, event: Self::Event) -> Option<Message>;

    fn view(&mut self) -> Element<Self::Event, Renderer>;
}
```

Basically, a `Component` can be viewed with `view`, returning widgets that produce some specific `Event`. A `Component` can process an `Event` with `update`, which may change its internal state and optionally return an application `Message`.

In other words, a `Component` can be seen as a sub-application that follows The Elm Architecture, processing internal events and producing messages for the parent application when needed!

The usefulness of this trait becomes apparent when we learn how to use it! The new `component::view` function has the following signature:

```rust
pub fn view<'a, C, Message, Renderer>(
    component: C,
) -> Element<'a, Message, Renderer>
where
    C: Component<Message, Renderer> + 'a,
    Message: 'a,
    Renderer: iced_native::Renderer + 'a,
```

Any `Component` implementor can be turned into an `Element`! This means it is now possible to build custom widgets with its own internal mutable state by leveraging The Elm Architecture. These custom widgets can then be embedded in any `iced` application without additional wiring.

The new `component` example uses this new trait to build a `NumericInput` widget by leveraging composition of the `Button` and `TextInput` widgets.