### PR TITLE
Include alignment in the container layout hash

### DIFF
--- a/core/src/alignment.rs
+++ b/core/src/alignment.rs
@@ -37,7 +37,7 @@ impl From<Vertical> for Alignment {
 }
 
 /// The horizontal [`Alignment`] of some resource.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Horizontal {
     /// Align left
     Left,
@@ -50,7 +50,7 @@ pub enum Horizontal {
 }
 
 /// The vertical [`Alignment`] of some resource.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Vertical {
     /// Align top
     Top,

--- a/native/src/widget/container.rs
+++ b/native/src/widget/container.rs
@@ -226,6 +226,8 @@ where
         self.height.hash(state);
         self.max_width.hash(state);
         self.max_height.hash(state);
+        self.horizontal_alignment.hash(state);
+        self.vertical_alignment.hash(state);
 
         self.content.hash_layout(state);
     }


### PR DESCRIPTION
I noticed the layout wasn't updating when I changed the alignment.