### PR TITLE
Remove unused fields

### DIFF
--- a/examples/pokedex/src/main.rs
+++ b/examples/pokedex/src/main.rs
@@ -15,7 +15,6 @@ enum Pokedex {
         search: button::State,
     },
     Errored {
-        error: Error,
         try_again: button::State,
     },
 }
@@ -58,9 +57,8 @@ impl Application for Pokedex {
 
                 Command::none()
             }
-            Message::PokemonFound(Err(error)) => {
+            Message::PokemonFound(Err(_error)) => {
                 *self = Pokedex::Errored {
-                    error,
                     try_again: button::State::new(),
                 };
 
@@ -155,7 +153,6 @@ impl Pokemon {
 
         #[derive(Debug, Deserialize)]
         struct Entry {
-            id: u32,
             name: String,
             flavor_text_entries: Vec<FlavorText>,
         }

--- a/examples/solar_system/src/main.rs
+++ b/examples/solar_system/src/main.rs
@@ -75,7 +75,6 @@ impl Application for SolarSystem {
 struct State {
     space_cache: canvas::Cache,
     system_cache: canvas::Cache,
-    cursor_position: Point,
     start: Instant,
     now: Instant,
     stars: Vec<(Point, f32)>,
@@ -95,7 +94,6 @@ impl State {
         State {
             space_cache: Default::default(),
             system_cache: Default::default(),
-            cursor_position: Point::ORIGIN,
             start: now,
             now,
             stars: Self::generate_stars(width, height),

--- a/native/src/widget/scrollable.rs
+++ b/native/src/widget/scrollable.rs
@@ -199,7 +199,6 @@ impl<'a, Message, Renderer: crate::Renderer> Scrollable<'a, Message, Renderer> {
             Some(Scrollbar {
                 outer_bounds,
                 bounds: scrollbar_bounds,
-                margin: self.scrollbar_margin,
                 scroller: Scroller {
                     bounds: scroller_bounds,
                 },
@@ -719,9 +718,6 @@ struct Scrollbar {
 
     /// The bounds of the [`Scrollbar`].
     bounds: Rectangle,
-
-    /// The margin within the [`Scrollbar`].
-    margin: u16,
 
     /// The bounds of the [`Scroller`].
     scroller: Scroller,

--- a/wgpu/src/backend.rs
+++ b/wgpu/src/backend.rs
@@ -27,7 +27,6 @@ pub struct Backend {
     image_pipeline: image::Pipeline,
 
     default_text_size: u16,
-    primitive: Primitive,
 }
 
 impl Backend {
@@ -60,7 +59,6 @@ impl Backend {
             image_pipeline,
 
             default_text_size: settings.default_text_size,
-            primitive: Primitive::None,
         }
     }
 


### PR DESCRIPTION
This PR fixes a bunch of new warnings issued by Rust 1.57 about unused fields.