### PR TITLE
Added iced_winit::application::Application::run_with_window_configurator

### DIFF
--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -17,13 +17,13 @@ use iced_graphics::window;
 use iced_native::program::Program;
 use iced_native::{Cache, UserInterface};
 
-use crate::settings::{SettingsWindowConfigurator};
+use crate::settings::SettingsWindowConfigurator;
+use crate::window_configurator::WindowConfigurator;
 use crate::winit::event_loop::EventLoopWindowTarget;
 use crate::winit::platform::run_return::EventLoopExtRunReturn;
 use std::mem::ManuallyDrop;
 use std::ops::Deref;
 use winit::window::WindowBuilder;
-use crate::window_configurator::WindowConfigurator;
 
 /// An interactive, native cross-platform application.
 ///
@@ -121,9 +121,9 @@ where
     let window_configurator = SettingsWindowConfigurator {
         window: settings.window,
         id: settings.id,
-        mode: Mode::Windowed
+        mode: Mode::Windowed,
     };
-    run_with_window_configurator::<A,E,C,_>(
+    run_with_window_configurator::<A, E, C, _>(
         settings.flags,
         compositor_settings,
         window_configurator,
@@ -162,9 +162,7 @@ where
         Runtime::new(executor, proxy)
     };
 
-    let (application, init_command) = {
-        runtime.enter(|| A::new(flags))
-    };
+    let (application, init_command) = { runtime.enter(|| A::new(flags)) };
 
     let subscription = application.subscription();
     let window_builder = WindowBuilder::new()

--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -29,6 +29,7 @@ pub mod clipboard;
 pub mod conversion;
 pub mod settings;
 pub mod window;
+pub mod window_configurator;
 
 mod error;
 mod mode;

--- a/winit/src/window_configurator.rs
+++ b/winit/src/window_configurator.rs
@@ -1,0 +1,29 @@
+//! Configure winit windows
+use std::fmt::Debug;
+use crate::winit::window::WindowBuilder;
+
+/// Allows to perform any custom settings on the winit::WindowBuilder
+///
+/// Is called after all other window settings have been applied
+pub trait WindowConfigurator<A>: Debug {
+    /// Apply custom settings on the window_builder
+    fn configure_builder(
+        self,
+        available_monitors: &winit::event_loop::EventLoopWindowTarget<A>,
+        window_builder: WindowBuilder,
+    ) -> WindowBuilder;
+}
+
+/// A WindowConfigurator that does nothing
+#[derive(Debug)]
+pub struct NoopWindowConfigurator;
+
+impl<A> WindowConfigurator<A> for NoopWindowConfigurator {
+    fn configure_builder(
+        self,
+        _available_monitors: &winit::event_loop::EventLoopWindowTarget<A>,
+        window_builder: WindowBuilder,
+    ) -> WindowBuilder {
+        window_builder
+    }
+}

--- a/winit/src/window_configurator.rs
+++ b/winit/src/window_configurator.rs
@@ -1,6 +1,6 @@
 //! Configure winit windows
-use std::fmt::Debug;
 use crate::winit::window::WindowBuilder;
+use std::fmt::Debug;
 
 /// Allows to perform any custom settings on the winit::WindowBuilder
 ///


### PR DESCRIPTION
Defined a new `WindowConfigurator` trait in iced_winit to configure the `WindowBuilder.`

The `SettingsWindowConfigurator` struct just applies the Window settings.

The new `iced_winit::application::run_with_window_configurator` uses a WindowConfigurator instead of the Settings struct. Except for the name, this makes quite a nice API for run as it avoids the generic Settings struct.