### PR TITLE
Fix `Widget::height` for `Component`

### DIFF
--- a/lazy/src/component.rs
+++ b/lazy/src/component.rs
@@ -68,7 +68,7 @@ where
     }
 
     fn height(&self) -> Length {
-        self.state.as_ref().unwrap().borrow_cache().element.width()
+        self.state.as_ref().unwrap().borrow_cache().element.height()
     }
 
     fn layout(


### PR DESCRIPTION
This updates `Widget:height` for `Component` to use `height` rather than `width` of the cached element. 