### PR TITLE
Make TextInput emit a Submit message when the key NumpadEnter is pressed

### DIFF
--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -519,7 +519,8 @@ where
                 let modifiers = self.state.keyboard_modifiers;
 
                 match key_code {
-                    keyboard::KeyCode::Enter => {
+                    keyboard::KeyCode::Enter
+                    | keyboard::KeyCode::NumpadEnter => {
                         if let Some(on_submit) = self.on_submit.clone() {
                             shell.publish(on_submit);
                         }


### PR DESCRIPTION
Currently `TextInput`s only emit their `on_submit` message when the "main" Enter key is pressed. I believe they should also do so when the Enter key from the numpad is pressed. 