### PR TITLE
Decouple `image::Handle` from `iced_native` and lower trait bound on `text::Renderer::Font`

### DIFF
--- a/graphics/src/widget/image.rs
+++ b/graphics/src/widget/image.rs
@@ -13,6 +13,8 @@ impl<B> image::Renderer for Renderer<B>
 where
     B: Backend + backend::Image,
 {
+    type Handle = image::Handle;
+
     fn dimensions(&self, handle: &image::Handle) -> (u32, u32) {
         self.backend().dimensions(handle)
     }

--- a/native/src/image.rs
+++ b/native/src/image.rs
@@ -115,10 +115,15 @@ impl std::fmt::Debug for Data {
 ///
 /// [renderer]: crate::renderer
 pub trait Renderer: crate::Renderer {
+    /// The image Handle to be displayed. Iced exposes its own default implementation of a [`Handle`]
+    ///
+    /// [`Handle`]: Self::Handle
+    type Handle: Clone + Hash;
+
     /// Returns the dimensions of an image for the given [`Handle`].
-    fn dimensions(&self, handle: &Handle) -> (u32, u32);
+    fn dimensions(&self, handle: &Self::Handle) -> (u32, u32);
 
     /// Draws an image with the given [`Handle`] and inside the provided
     /// `bounds`.
-    fn draw(&mut self, handle: Handle, bounds: Rectangle);
+    fn draw(&mut self, handle: Self::Handle, bounds: Rectangle);
 }

--- a/native/src/overlay/menu.rs
+++ b/native/src/overlay/menu.rs
@@ -454,7 +454,7 @@ where
                     ..bounds
                 },
                 size: f32::from(text_size),
-                font: self.font,
+                font: self.font.clone(),
                 color: if is_selected {
                     self.style.selected_text_color
                 } else {

--- a/native/src/text.rs
+++ b/native/src/text.rs
@@ -57,7 +57,7 @@ impl Hit {
 /// A renderer capable of measuring and drawing [`Text`].
 pub trait Renderer: crate::Renderer {
     /// The font type used.
-    type Font: Default + Copy;
+    type Font: Default + Clone;
 
     /// The icon font of the backend.
     const ICON_FONT: Self::Font;

--- a/native/src/widget/checkbox.rs
+++ b/native/src/widget/checkbox.rs
@@ -157,7 +157,7 @@ where
             )
             .push(
                 Text::new(&self.label)
-                    .font(self.font)
+                    .font(self.font.clone())
                     .width(self.width)
                     .size(self.text_size.unwrap_or(renderer.default_size())),
             )
@@ -261,7 +261,7 @@ where
                 style,
                 label_layout,
                 &self.label,
-                self.font,
+                self.font.clone(),
                 self.text_size,
                 self.text_color.or(Some(custom_style.text_color)),
                 alignment::Horizontal::Left,

--- a/native/src/widget/image.rs
+++ b/native/src/widget/image.rs
@@ -2,7 +2,7 @@
 pub mod viewer;
 pub use viewer::Viewer;
 
-use crate::image::{self, Handle};
+use crate::image;
 use crate::layout;
 use crate::renderer;
 use crate::{Element, Hasher, Layout, Length, Point, Rectangle, Size, Widget};
@@ -15,19 +15,20 @@ use std::hash::Hash;
 ///
 /// ```
 /// # use iced_native::widget::Image;
+/// # use iced_native::image;
 /// #
-/// let image = Image::new("resources/ferris.png");
+/// let image = Image::<image::Handle>::new("resources/ferris.png");
 /// ```
 ///
 /// <img src="https://github.com/hecrj/iced/blob/9712b319bb7a32848001b96bd84977430f14b623/examples/resources/ferris.png?raw=true" width="300">
 #[derive(Debug, Hash)]
-pub struct Image {
+pub struct Image<Handle> {
     handle: Handle,
     width: Length,
     height: Length,
 }
 
-impl Image {
+impl<Handle> Image<Handle> {
     /// Creates a new [`Image`] with the given path.
     pub fn new<T: Into<Handle>>(handle: T) -> Self {
         Image {
@@ -50,9 +51,10 @@ impl Image {
     }
 }
 
-impl<Message, Renderer> Widget<Message, Renderer> for Image
+impl<Message, Renderer, Handle> Widget<Message, Renderer> for Image<Handle>
 where
-    Renderer: image::Renderer,
+    Renderer: image::Renderer<Handle = Handle>,
+    Handle: Clone + Hash,
 {
     fn width(&self) -> Length {
         self.width
@@ -108,11 +110,13 @@ where
     }
 }
 
-impl<'a, Message, Renderer> From<Image> for Element<'a, Message, Renderer>
+impl<'a, Message, Renderer, Handle> From<Image<Handle>>
+    for Element<'a, Message, Renderer>
 where
-    Renderer: image::Renderer,
+    Renderer: image::Renderer<Handle = Handle>,
+    Handle: Clone + Hash + 'a,
 {
-    fn from(image: Image) -> Element<'a, Message, Renderer> {
+    fn from(image: Image<Handle>) -> Element<'a, Message, Renderer> {
         Element::new(image)
     }
 }

--- a/native/src/widget/image/viewer.rs
+++ b/native/src/widget/image/viewer.rs
@@ -13,7 +13,7 @@ use std::hash::Hash;
 
 /// A frame that displays an image with the ability to zoom in/out and pan.
 #[allow(missing_debug_implementations)]
-pub struct Viewer<'a> {
+pub struct Viewer<'a, Handle> {
     state: &'a mut State,
     padding: u16,
     width: Length,
@@ -21,14 +21,12 @@ pub struct Viewer<'a> {
     min_scale: f32,
     max_scale: f32,
     scale_step: f32,
-    handle: image::Handle,
+    handle: Handle,
 }
 
-impl<'a> Viewer<'a> {
-    /// Creates a new [`Viewer`] with the given [`State`] and [`Handle`].
-    ///
-    /// [`Handle`]: image::Handle
-    pub fn new(state: &'a mut State, handle: image::Handle) -> Self {
+impl<'a, Handle> Viewer<'a, Handle> {
+    /// Creates a new [`Viewer`] with the given [`State`].
+    pub fn new(state: &'a mut State, handle: Handle) -> Self {
         Viewer {
             state,
             padding: 0,
@@ -89,7 +87,7 @@ impl<'a> Viewer<'a> {
     /// will be respected.
     fn image_size<Renderer>(&self, renderer: &Renderer, bounds: Size) -> Size
     where
-        Renderer: image::Renderer,
+        Renderer: image::Renderer<Handle = Handle>,
     {
         let (width, height) = renderer.dimensions(&self.handle);
 
@@ -114,9 +112,11 @@ impl<'a> Viewer<'a> {
     }
 }
 
-impl<'a, Message, Renderer> Widget<Message, Renderer> for Viewer<'a>
+impl<'a, Message, Renderer, Handle> Widget<Message, Renderer>
+    for Viewer<'a, Handle>
 where
-    Renderer: image::Renderer,
+    Renderer: image::Renderer<Handle = Handle>,
+    Handle: Clone + Hash,
 {
     fn width(&self) -> Length {
         self.width
@@ -394,12 +394,14 @@ impl State {
     }
 }
 
-impl<'a, Message, Renderer> From<Viewer<'a>> for Element<'a, Message, Renderer>
+impl<'a, Message, Renderer, Handle> From<Viewer<'a, Handle>>
+    for Element<'a, Message, Renderer>
 where
-    Renderer: 'a + image::Renderer,
+    Renderer: 'a + image::Renderer<Handle = Handle>,
     Message: 'a,
+    Handle: Clone + Hash + 'a,
 {
-    fn from(viewer: Viewer<'a>) -> Element<'a, Message, Renderer> {
+    fn from(viewer: Viewer<'a, Handle>) -> Element<'a, Message, Renderer> {
         Element::new(viewer)
     }
 }

--- a/native/src/widget/pick_list.rs
+++ b/native/src/widget/pick_list.rs
@@ -174,7 +174,7 @@ where
             .pad(self.padding);
 
         let text_size = self.text_size.unwrap_or(renderer.default_size());
-        let font = self.font;
+        let font = self.font.clone();
 
         let max_width = match self.width {
             Length::Shrink => {
@@ -182,7 +182,7 @@ where
                     let (width, _) = renderer.measure(
                         label,
                         text_size,
-                        font,
+                        font.clone(),
                         Size::new(f32::INFINITY, f32::INFINITY),
                     );
 
@@ -397,7 +397,7 @@ where
                 size: f32::from(
                     self.text_size.unwrap_or(renderer.default_size()),
                 ),
-                font: self.font,
+                font: self.font.clone(),
                 color: is_selected
                     .then(|| style.text_color)
                     .unwrap_or(style.placeholder_color),
@@ -427,7 +427,7 @@ where
             )
             .width(bounds.width.round() as u16)
             .padding(self.padding)
-            .font(self.font)
+            .font(self.font.clone())
             .style(self.style_sheet.menu());
 
             if let Some(text_size) = self.text_size {

--- a/native/src/widget/radio.rs
+++ b/native/src/widget/radio.rs
@@ -279,7 +279,7 @@ where
                 style,
                 label_layout,
                 &self.label,
-                self.font,
+                self.font.clone(),
                 self.text_size,
                 self.text_color,
                 alignment::Horizontal::Left,

--- a/native/src/widget/text.rs
+++ b/native/src/widget/text.rs
@@ -124,7 +124,7 @@ where
         let bounds = limits.max();
 
         let (width, height) =
-            renderer.measure(&self.content, size, self.font, bounds);
+            renderer.measure(&self.content, size, self.font.clone(), bounds);
 
         let size = limits.resolve(Size::new(width, height));
 
@@ -144,7 +144,7 @@ where
             style,
             layout,
             &self.content,
-            self.font,
+            self.font.clone(),
             self.size,
             self.color,
             self.horizontal_alignment,
@@ -227,7 +227,7 @@ impl<Renderer: text::Renderer> Clone for Text<Renderer> {
             content: self.content.clone(),
             size: self.size,
             color: self.color,
-            font: self.font,
+            font: self.font.clone(),
             width: self.width,
             height: self.height,
             horizontal_alignment: self.horizontal_alignment,

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -219,7 +219,7 @@ where
                             &value,
                             size,
                             position,
-                            self.font,
+                            self.font.clone(),
                         );
 
                     (
@@ -251,7 +251,7 @@ where
                             &value,
                             size,
                             left,
-                            self.font,
+                            self.font.clone(),
                         );
 
                     let (right_position, right_offset) =
@@ -261,7 +261,7 @@ where
                             &value,
                             size,
                             right,
-                            self.font,
+                            self.font.clone(),
                         );
 
                     let width = right_position - left_position;
@@ -300,7 +300,7 @@ where
                 &text
             },
             size,
-            self.font,
+            self.font.clone(),
         );
 
         let render = |renderer: &mut Renderer| {
@@ -319,7 +319,7 @@ where
                 } else {
                     self.style_sheet.value_color()
                 },
-                font: self.font,
+                font: self.font.clone(),
                 bounds: Rectangle {
                     y: text_bounds.center_y(),
                     width: f32::INFINITY,
@@ -414,7 +414,7 @@ where
                                 find_cursor_position(
                                     renderer,
                                     text_layout.bounds(),
-                                    self.font,
+                                    self.font.clone(),
                                     self.size,
                                     &value,
                                     &self.state,
@@ -434,7 +434,7 @@ where
                                 let position = find_cursor_position(
                                     renderer,
                                     text_layout.bounds(),
-                                    self.font,
+                                    self.font.clone(),
                                     self.size,
                                     &self.value,
                                     &self.state,
@@ -481,7 +481,7 @@ where
                     let position = find_cursor_position(
                         renderer,
                         text_layout.bounds(),
-                        self.font,
+                        self.font.clone(),
                         self.size,
                         &value,
                         &self.state,
@@ -962,13 +962,14 @@ where
 {
     let size = size.unwrap_or(renderer.default_size());
 
-    let offset = offset(renderer, text_bounds, font, size, &value, &state);
+    let offset =
+        offset(renderer, text_bounds, font.clone(), size, &value, &state);
 
     renderer
         .hit_test(
             &value.to_string(),
             size.into(),
-            font,
+            font.clone(),
             Size::INFINITY,
             Point::new(x + offset, text_bounds.height / 2.0),
             true,

--- a/native/src/widget/toggler.rs
+++ b/native/src/widget/toggler.rs
@@ -151,7 +151,7 @@ where
             row = row.push(
                 Text::new(label)
                     .horizontal_alignment(self.text_alignment)
-                    .font(self.font)
+                    .font(self.font.clone())
                     .width(self.width)
                     .size(self.text_size.unwrap_or(renderer.default_size())),
             );
@@ -229,7 +229,7 @@ where
                 style,
                 label_layout,
                 &label,
-                self.font,
+                self.font.clone(),
                 self.text_size,
                 None,
                 self.text_alignment,


### PR DESCRIPTION
As discussed on discord, the goal of this PR is to make `iced_native`'s widgets usable in more contexts (including potentially a Backend for a well-known Rust game engine, who knows :eyes: ) by : 

* Making the image renderer use an associated type `Handle` instead of relying on `iced_native`'s `image::Handle` which is impractical for custom backends 
* Lowering the bound of a Font handle from `Copy` to `Clone`   

This is a breaking change for `iced_native` because any custom renderer will need to add the associated type `Handle` to the `text::Renderer` implementation.