### PR TITLE
fix: nested component layout invalidation

### DIFF
--- a/lazy/src/component.rs
+++ b/lazy/src/component.rs
@@ -149,6 +149,8 @@ where
             )
         });
 
+        local_shell.with_invalid_layout(|| shell.invalidate_layout());
+
         if !local_messages.is_empty() {
             let mut component = self
                 .state
@@ -372,6 +374,8 @@ where
                 )
             })
             .unwrap_or_else(|| iced_native::event::Status::Ignored);
+
+        local_shell.with_invalid_layout(|| shell.invalidate_layout());
 
         if !local_messages.is_empty() {
             let mut component =


### PR DESCRIPTION
This PR modifies `on_event` for `Component` and its corresponding `Overlay` to also invalidate the layout if that of the `local_shell` is invalidated by the cached element during its processing of events.

Without this, layout invalidation is 'swallowed' in some cases when using nested components, causing potential panics and other weird behavior in subsequent `draw`s. I've put a simple-ish repro case in [this gist](https://gist.github.com/nicksenger/8c065b30b7798d88fa38a73ad50cc1ab)