### PR TITLE
Allow Sandbox applications to exit.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ members = [
     "examples/custom_widget",
     "examples/download_progress",
     "examples/events",
+    "examples/exit",
     "examples/game_of_life",
     "examples/geometry",
     "examples/integration_opengl",

--- a/examples/exit/Cargo.toml
+++ b/examples/exit/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "exit"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+iced = { path = "../.." }

--- a/examples/exit/README.md
+++ b/examples/exit/README.md
@@ -1,0 +1,12 @@
+## Exit
+
+How to exit an application based on user input.
+
+The __[`main`]__ file contains all the code of the example.
+
+You can run it with `cargo run`:
+```
+cargo run --package exit
+```
+
+[`main`]: src/main.rs

--- a/examples/exit/src/main.rs
+++ b/examples/exit/src/main.rs
@@ -1,5 +1,6 @@
 use iced::{
-    button, Alignment, Button, Column, Element, Sandbox, Settings, Text,
+    button, Alignment, Button, Column, Container, Element, Length, Sandbox,
+    Settings, Text,
 };
 
 pub fn main() -> iced::Result {
@@ -47,9 +48,9 @@ impl Sandbox for Exit {
     }
 
     fn view(&mut self) -> Element<Message> {
-        if self.show_confirm {
+        let content = if self.show_confirm {
             Column::new()
-                .padding(20)
+                .spacing(10)
                 .align_items(Alignment::Center)
                 .push(Text::new("Are you sure you want to exit?"))
                 .push(
@@ -57,19 +58,27 @@ impl Sandbox for Exit {
                         &mut self.confirm_button,
                         Text::new("Yes, exit now"),
                     )
+                    .padding([10, 20])
                     .on_press(Message::Confirm),
                 )
-                .into()
         } else {
             Column::new()
-                .padding(20)
+                .spacing(10)
                 .align_items(Alignment::Center)
                 .push(Text::new("Click the button to exit"))
                 .push(
                     Button::new(&mut self.exit_button, Text::new("Exit"))
+                        .padding([10, 20])
                         .on_press(Message::Exit),
                 )
-                .into()
-        }
+        };
+
+        Container::new(content)
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .padding(20)
+            .center_x()
+            .center_y()
+            .into()
     }
 }

--- a/examples/exit/src/main.rs
+++ b/examples/exit/src/main.rs
@@ -1,0 +1,75 @@
+use iced::{
+    button, Alignment, Button, Column, Element, Sandbox, Settings, Text,
+};
+
+pub fn main() -> iced::Result {
+    Exit::run(Settings::default())
+}
+
+#[derive(Default)]
+struct Exit {
+    show_confirm: bool,
+    exit: bool,
+    confirm_button: button::State,
+    exit_button: button::State,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Message {
+    Confirm,
+    Exit,
+}
+
+impl Sandbox for Exit {
+    type Message = Message;
+
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn title(&self) -> String {
+        String::from("Exit - Iced")
+    }
+
+    fn should_exit(&self) -> bool {
+        self.exit
+    }
+
+    fn update(&mut self, message: Message) {
+        match message {
+            Message::Confirm => {
+                self.exit = true;
+            }
+            Message::Exit => {
+                self.show_confirm = true;
+            }
+        }
+    }
+
+    fn view(&mut self) -> Element<Message> {
+        if self.show_confirm {
+            Column::new()
+                .padding(20)
+                .align_items(Alignment::Center)
+                .push(Text::new("Are you sure you want to exit?"))
+                .push(
+                    Button::new(
+                        &mut self.confirm_button,
+                        Text::new("Yes, exit now"),
+                    )
+                    .on_press(Message::Confirm),
+                )
+                .into()
+        } else {
+            Column::new()
+                .padding(20)
+                .align_items(Alignment::Center)
+                .push(Text::new("Click the button to exit"))
+                .push(
+                    Button::new(&mut self.exit_button, Text::new("Exit"))
+                        .on_press(Message::Exit),
+                )
+                .into()
+        }
+    }
+}

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -131,6 +131,13 @@ pub trait Sandbox {
         1.0
     }
 
+    /// Returns whether the [`Sandbox`] should be terminated.
+    ///
+    /// By default, it returns `false`.
+    fn should_exit(&self) -> bool {
+        false
+    }
+
     /// Runs the [`Sandbox`].
     ///
     /// On native platforms, this method will take control of the current thread
@@ -181,5 +188,9 @@ where
 
     fn scale_factor(&self) -> f64 {
         T::scale_factor(self)
+    }
+
+    fn should_exit(&self) -> bool {
+        T::should_exit(self)
     }
 }


### PR DESCRIPTION
I noticed that when using the `Sandbox` its not possible to graceful tell iced to quit. Although I understand that `Sandbox` is a simplified alternative to `Application`, it seemed to me that `Sandbox` users may still want the ability to exit.

To make it possible for `Sandbox` programs to quit, this PR adds a `fn should_exit(&self) -> bool` method to the `Sandbox`  trait. The `Sandbox` trait defines the default implementation of `should_exit` to return false, just like `Application` does, so `Sandbox` users who do not care about the ability to exit should notice no difference.