### PR TITLE
Gate non-wasm32 winit features behind flags.

### DIFF
--- a/winit/Cargo.toml
+++ b/winit/Cargo.toml
@@ -11,10 +11,11 @@ keywords = ["gui", "ui", "graphics", "interface", "widgets"]
 categories = ["gui"]
 
 [features]
+default = ["window_clipboard"]
 debug = ["iced_native/debug"]
 
 [dependencies]
-window_clipboard = "0.2"
+window_clipboard = { version = "0.2", optional = true }
 log = "0.4"
 thiserror = "1.0"
 

--- a/winit/src/clipboard.rs
+++ b/winit/src/clipboard.rs
@@ -1,71 +1,11 @@
 //! Access the clipboard.
-pub use iced_native::clipboard::Action;
 
-use crate::command::{self, Command};
+#[cfg(feature = "window_clipboard")]
+mod window_clipboard;
+#[cfg(feature = "window_clipboard")]
+pub use self::window_clipboard::*;
 
-/// A buffer for short-term storage and transfer within and between
-/// applications.
-#[allow(missing_debug_implementations)]
-pub struct Clipboard {
-    state: State,
-}
-
-enum State {
-    Connected(window_clipboard::Clipboard),
-    Unavailable,
-}
-
-impl Clipboard {
-    /// Creates a new [`Clipboard`] for the given window.
-    pub fn connect(window: &winit::window::Window) -> Clipboard {
-        let state = window_clipboard::Clipboard::connect(window)
-            .ok()
-            .map(State::Connected)
-            .unwrap_or(State::Unavailable);
-
-        Clipboard { state }
-    }
-
-    /// Reads the current content of the [`Clipboard`] as text.
-    pub fn read(&self) -> Option<String> {
-        match &self.state {
-            State::Connected(clipboard) => clipboard.read().ok(),
-            State::Unavailable => None,
-        }
-    }
-
-    /// Writes the given text contents to the [`Clipboard`].
-    pub fn write(&mut self, contents: String) {
-        match &mut self.state {
-            State::Connected(clipboard) => match clipboard.write(contents) {
-                Ok(()) => {}
-                Err(error) => {
-                    log::warn!("error writing to clipboard: {}", error)
-                }
-            },
-            State::Unavailable => {}
-        }
-    }
-}
-
-impl iced_native::Clipboard for Clipboard {
-    fn read(&self) -> Option<String> {
-        self.read()
-    }
-
-    fn write(&mut self, contents: String) {
-        self.write(contents)
-    }
-}
-
-/// Read the current contents of the clipboard.
-pub fn read<Message>(
-    f: impl Fn(Option<String>) -> Message + 'static,
-) -> Command<Message> {
-    Command::single(command::Action::Clipboard(Action::Read(Box::new(f))))
-}
-
-/// Write the given contents to the clipboard.
-pub fn write<Message>(contents: String) -> Command<Message> {
-    Command::single(command::Action::Clipboard(Action::Write(contents)))
-}
+#[cfg(not(feature = "window_clipboard"))]
+mod null_clipboard;
+#[cfg(not(feature = "window_clipboard"))]
+pub use null_clipboard::*;

--- a/winit/src/clipboard/null_clipboard.rs
+++ b/winit/src/clipboard/null_clipboard.rs
@@ -1,0 +1,48 @@
+//! Access the clipboard.
+pub use iced_native::clipboard::Action;
+
+use crate::command::{self, Command};
+
+/// A buffer for short-term storage and transfer within and between
+/// applications.
+#[derive(Debug)]
+pub struct Clipboard;
+
+impl Clipboard {
+    /// Creates a new [`Clipboard`] for the given window.
+    pub fn new() -> Clipboard {
+        Clipboard
+    }
+
+    /// Reads the current content of the [`Clipboard`] as text.
+    pub fn read(&self) -> Option<String> {
+        None
+    }
+
+    /// Writes the given text contents to the [`Clipboard`].
+    pub fn write(&mut self, _contents: String) {
+        log::warn!("cannot write to null clipboard");
+    }
+}
+
+impl iced_native::Clipboard for Clipboard {
+    fn read(&self) -> Option<String> {
+        self.read()
+    }
+
+    fn write(&mut self, contents: String) {
+        self.write(contents)
+    }
+}
+
+/// Read the current contents of the clipboard.
+pub fn read<Message>(
+    f: impl Fn(Option<String>) -> Message + 'static,
+) -> Command<Message> {
+    Command::single(command::Action::Clipboard(Action::Read(Box::new(f))))
+}
+
+/// Write the given contents to the clipboard.
+pub fn write<Message>(contents: String) -> Command<Message> {
+    Command::single(command::Action::Clipboard(Action::Write(contents)))
+}

--- a/winit/src/clipboard/window_clipboard.rs
+++ b/winit/src/clipboard/window_clipboard.rs
@@ -1,0 +1,71 @@
+//! Access the clipboard.
+pub use iced_native::clipboard::Action;
+
+use crate::command::{self, Command};
+
+/// A buffer for short-term storage and transfer within and between
+/// applications.
+#[allow(missing_debug_implementations)]
+pub struct Clipboard {
+    state: State,
+}
+
+enum State {
+    Connected(window_clipboard::Clipboard),
+    Unavailable,
+}
+
+impl Clipboard {
+    /// Creates a new [`Clipboard`] for the given window.
+    pub fn connect(window: &winit::window::Window) -> Clipboard {
+        let state = window_clipboard::Clipboard::connect(window)
+            .ok()
+            .map(State::Connected)
+            .unwrap_or(State::Unavailable);
+
+        Clipboard { state }
+    }
+
+    /// Reads the current content of the [`Clipboard`] as text.
+    pub fn read(&self) -> Option<String> {
+        match &self.state {
+            State::Connected(clipboard) => clipboard.read().ok(),
+            State::Unavailable => None,
+        }
+    }
+
+    /// Writes the given text contents to the [`Clipboard`].
+    pub fn write(&mut self, contents: String) {
+        match &mut self.state {
+            State::Connected(clipboard) => match clipboard.write(contents) {
+                Ok(()) => {}
+                Err(error) => {
+                    log::warn!("error writing to clipboard: {}", error)
+                }
+            },
+            State::Unavailable => {}
+        }
+    }
+}
+
+impl iced_native::Clipboard for Clipboard {
+    fn read(&self) -> Option<String> {
+        self.read()
+    }
+
+    fn write(&mut self, contents: String) {
+        self.write(contents)
+    }
+}
+
+/// Read the current contents of the clipboard.
+pub fn read<Message>(
+    f: impl Fn(Option<String>) -> Message + 'static,
+) -> Command<Message> {
+    Command::single(command::Action::Clipboard(Action::Read(Box::new(f))))
+}
+
+/// Write the given contents to the clipboard.
+pub fn write<Message>(contents: String) -> Command<Message> {
+    Command::single(command::Action::Clipboard(Action::Write(contents)))
+}

--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -27,6 +27,7 @@
 pub use iced_native::*;
 pub use winit;
 
+#[cfg(not(target_arch = "wasm32"))]
 pub mod application;
 pub mod clipboard;
 pub mod conversion;
@@ -38,6 +39,7 @@ mod mode;
 mod position;
 mod proxy;
 
+#[cfg(not(target_arch = "wasm32"))]
 pub use application::Application;
 pub use clipboard::Clipboard;
 pub use error::Error;


### PR DESCRIPTION
Let me state, up front, that I would not be upset if this PR were declined. I recognize that it makes some decisions that I did not consult anyone on.

Motivation: these changes (along with #1117 and #1118) allow the winit "native" shell to compile and run on the `wasm32-unknown-unknown` target. This presents a homogeneous and, IMO, very pleasant development target for native/web cross-platform Iced GUIs. 

It requires that a custom event loop is run on wasm32 platforms. Personally, I think that that is acceptable. Winit's basic event loop does work on `wasm32-unknown-unknown` but it is not particularly pretty and `EventLoopExtRunReturn` is not implemented (on which Iced currently depends) is not implemented. I'm of the opinion that this is fine: the requirement that users implement their own event loop on web seems like a reasonable tradeoff for using a native shell on a platform that is not really native.

It does not introduce any changes to existing users of the crate on non wasm platforms.