### PR TITLE
Fix memory leak in opengl integration example

### DIFF
--- a/examples/integration_opengl/src/main.rs
+++ b/examples/integration_opengl/src/main.rs
@@ -73,8 +73,9 @@ pub fn main() {
     );
     let mut resized = false;
 
+    let scene = Scene::new(&gl, &shader_version);
+
     event_loop.run(move |event, _, control_flow| {
-        let scene = Scene::new(&gl, &shader_version);
         *control_flow = ControlFlow::Wait;
 
         match event {

--- a/examples/integration_opengl/src/scene.rs
+++ b/examples/integration_opengl/src/scene.rs
@@ -86,6 +86,8 @@ impl Scene {
 
     pub fn draw(&self, gl: &glow::Context) {
         unsafe {
+            gl.bind_vertex_array(Some(self.vertex_array));
+            gl.use_program(Some(self.program));
             gl.draw_arrays(glow::TRIANGLES, 0, 3);
         }
     }


### PR DESCRIPTION
Fixes issue #1087, where any user input in the opengl integration example would leak memory. This was due to creating a new VAO and program for every call to the event handler.