### PR TITLE
Update `winit` and `glutin` forks

### DIFF
--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -14,9 +14,9 @@ categories = ["gui"]
 debug = ["iced_winit/debug"]
 
 [dependencies.glutin]
-version = "0.27"
+version = "0.28"
 git = "https://github.com/iced-rs/glutin"
-rev = "492c20605907accf2b5dc2da52284305fd128346"
+rev = "7a0ee02782eb2bf059095e0c953c4bb53f1eef0e"
 
 [dependencies.iced_native]
 version = "0.4"

--- a/winit/Cargo.toml
+++ b/winit/Cargo.toml
@@ -19,9 +19,9 @@ log = "0.4"
 thiserror = "1.0"
 
 [dependencies.winit]
-version = "0.25"
+version = "0.26"
 git = "https://github.com/iced-rs/winit"
-rev = "1e6623c4d06d110e5408dcbdf1edebd07e6a200e"
+rev = "02a12380960cec2f351c09a33d6a7cc2789d96a6"
 
 [dependencies.iced_native]
 version = "0.4"


### PR DESCRIPTION
The forks in `iced-rs` have been rebased on top of the latest releases.