### PR TITLE
Conditionally allow mainline winit for external integration purposes

### DIFF
--- a/winit/Cargo.toml
+++ b/winit/Cargo.toml
@@ -20,8 +20,6 @@ thiserror = "1.0"
 
 [dependencies.winit]
 version = "0.26"
-git = "https://github.com/iced-rs/winit"
-rev = "02a12380960cec2f351c09a33d6a7cc2789d96a6"
 
 [dependencies.iced_native]
 version = "0.4"

--- a/winit/Cargo.toml
+++ b/winit/Cargo.toml
@@ -9,17 +9,26 @@ repository = "https://github.com/hecrj/iced"
 documentation = "https://docs.rs/iced_winit"
 keywords = ["gui", "ui", "graphics", "interface", "widgets"]
 categories = ["gui"]
+resolver = "2"
 
 [features]
 debug = ["iced_native/debug"]
+mainline_winit = ["winit_mainline"]
+forked_winit = ["winit_fork"]
+default = ["mainline_winit"]
 
 [dependencies]
 window_clipboard = "0.2"
 log = "0.4"
 thiserror = "1.0"
 
-[dependencies.winit]
-version = "0.26"
+[dependencies.winit_mainline]
+path = "./winit_mainline"
+optional = true
+
+[dependencies.winit_fork]
+path = "./winit_fork"
+optional = true
 
 [dependencies.iced_native]
 version = "0.4"

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -10,6 +10,7 @@ use crate::{
     Color, Command, Debug, Error, Executor, Mode, Proxy, Runtime, Settings,
     Size, Subscription,
 };
+use crate::winit;
 
 use iced_futures::futures;
 use iced_futures::futures::channel::mpsc;
@@ -333,6 +334,7 @@ async fn run_instance<A, E, C>(
 
                 window.request_redraw();
             }
+            #[cfg(feature = "forked_winit")]
             event::Event::PlatformSpecific(event::PlatformSpecific::MacOS(
                 event::MacOS::ReceivedUrl(url),
             )) => {

--- a/winit/src/application/state.rs
+++ b/winit/src/application/state.rs
@@ -2,6 +2,7 @@ use crate::conversion;
 use crate::{Application, Color, Debug, Mode, Point, Size, Viewport};
 
 use std::marker::PhantomData;
+use crate::winit;
 use winit::event::{Touch, WindowEvent};
 use winit::window::Window;
 

--- a/winit/src/clipboard.rs
+++ b/winit/src/clipboard.rs
@@ -2,6 +2,7 @@
 pub use iced_native::clipboard::Action;
 
 use crate::command::{self, Command};
+use crate::winit;
 
 /// A buffer for short-term storage and transfer within and between
 /// applications.

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -6,7 +6,7 @@ use crate::keyboard;
 use crate::mouse;
 use crate::touch;
 use crate::window;
-use crate::{Event, Mode, Point, Position};
+use crate::{Event, Mode, Point, Position, winit};
 
 /// Converts a winit window event into an iced event.
 pub fn window_event(

--- a/winit/src/error.rs
+++ b/winit/src/error.rs
@@ -1,4 +1,5 @@
 use iced_futures::futures;
+use crate::winit;
 
 /// An error that occurred while running an application.
 #[derive(Debug, thiserror::Error)]

--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -25,7 +25,13 @@
 
 #[doc(no_inline)]
 pub use iced_native::*;
-pub use winit;
+
+// #[cfg(all(feature = ""))]
+
+#[cfg(feature = "mainline_winit")]
+pub use winit_mainline::winit as winit;
+#[cfg(feature = "forked_winit")]
+pub use winit_fork::winit as winit;
 
 pub mod application;
 pub mod clipboard;

--- a/winit/src/proxy.rs
+++ b/winit/src/proxy.rs
@@ -4,6 +4,7 @@ use iced_native::futures::{
     Sink,
 };
 use std::pin::Pin;
+use crate::winit;
 
 /// An event loop proxy that implements `Sink`.
 #[derive(Debug)]

--- a/winit/src/settings.rs
+++ b/winit/src/settings.rs
@@ -15,6 +15,7 @@ pub use platform::PlatformSpecific;
 
 use crate::conversion;
 use crate::{Mode, Position};
+use crate::winit;
 use winit::monitor::MonitorHandle;
 use winit::window::WindowBuilder;
 
@@ -123,7 +124,7 @@ impl Window {
             target_os = "openbsd"
         ))]
         {
-            use ::winit::platform::unix::WindowBuilderExtUnix;
+            use winit::platform::unix::WindowBuilderExtUnix;
 
             if let Some(id) = _id {
                 window_builder = window_builder.with_app_id(id);

--- a/winit/winit_fork/Cargo.toml
+++ b/winit/winit_fork/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "winit_fork"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies.winit]
+version = "0.26"
+git = "https://github.com/iced-rs/winit"
+rev = "02a12380960cec2f351c09a33d6a7cc2789d96a6"

--- a/winit/winit_fork/src/lib.rs
+++ b/winit/winit_fork/src/lib.rs
@@ -1,0 +1,1 @@
+pub use winit;

--- a/winit/winit_mainline/Cargo.toml
+++ b/winit/winit_mainline/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "winit_mainline"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+winit = "0.26"

--- a/winit/winit_mainline/src/lib.rs
+++ b/winit/winit_mainline/src/lib.rs
@@ -1,0 +1,1 @@
+pub use winit;


### PR DESCRIPTION
I'd like to integrate iced UI rendering in other projects, however the usage of the forked winit can break some dependency handling. I've made it so that users can toggle between it and the mainline version through a feature (defaulting to the forked version).