### PR TITLE
Add application feature, which allows to build freestanding wgpu app

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,7 @@ categories = ["gui"]
 resolver = "2"
 
 [features]
-default = ["wgpu", "application"]
-# Enables the building the application modules
-application = ["iced_winit/application"]
+default = ["wgpu"]
 # Enables the `Image` widget
 image = ["iced_wgpu/image", "image_rs"]
 # Enables the `Svg` widget
@@ -98,7 +96,7 @@ iced_core = { version = "0.5", path = "core" }
 iced_futures = { version = "0.4", path = "futures" }
 iced_native = { version = "0.5", path = "native" }
 iced_graphics = { version = "0.3", path = "graphics" }
-iced_winit = { version = "0.4", path = "winit" }
+iced_winit = { version = "0.4", path = "winit", features = ["application"] }
 iced_glutin = { version = "0.3", path = "glutin", optional = true }
 iced_glow = { version = "0.3", path = "glow", optional = true }
 thiserror = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,9 @@ categories = ["gui"]
 resolver = "2"
 
 [features]
-default = ["wgpu"]
+default = ["wgpu", "application"]
+# Enables the building the application modules
+application = ["iced_winit/application"]
 # Enables the `Image` widget
 image = ["iced_wgpu/image", "image_rs"]
 # Enables the `Svg` widget

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,8 +167,10 @@
 mod element;
 mod error;
 mod result;
+#[cfg(feature = "application")]
 mod sandbox;
 
+#[cfg(feature = "application")]
 pub mod application;
 pub mod clipboard;
 pub mod executor;
@@ -196,6 +198,7 @@ pub use iced_native::theme;
 pub use runtime::event;
 pub use runtime::subscription;
 
+#[cfg(feature = "application")]
 pub use application::Application;
 pub use element::Element;
 pub use error::Error;
@@ -203,6 +206,7 @@ pub use event::Event;
 pub use executor::Executor;
 pub use renderer::Renderer;
 pub use result::Result;
+#[cfg(feature = "application")]
 pub use sandbox::Sandbox;
 pub use settings::Settings;
 pub use subscription::Subscription;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,10 +167,8 @@
 mod element;
 mod error;
 mod result;
-#[cfg(feature = "application")]
 mod sandbox;
 
-#[cfg(feature = "application")]
 pub mod application;
 pub mod clipboard;
 pub mod executor;
@@ -198,7 +196,6 @@ pub use iced_native::theme;
 pub use runtime::event;
 pub use runtime::subscription;
 
-#[cfg(feature = "application")]
 pub use application::Application;
 pub use element::Element;
 pub use error::Error;
@@ -206,7 +203,6 @@ pub use event::Event;
 pub use executor::Executor;
 pub use renderer::Renderer;
 pub use result::Result;
-#[cfg(feature = "application")]
 pub use sandbox::Sandbox;
 pub use settings::Settings;
 pub use subscription::Subscription;

--- a/winit/Cargo.toml
+++ b/winit/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["gui"]
 [features]
 debug = ["iced_native/debug"]
 system = ["sysinfo"]
+application = []
 
 [dependencies]
 window_clipboard = "0.2"

--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -35,6 +35,7 @@
 pub use iced_native::*;
 pub use winit;
 
+#[cfg(feature = "application")]
 pub mod application;
 pub mod clipboard;
 pub mod conversion;
@@ -48,6 +49,7 @@ mod error;
 mod position;
 mod proxy;
 
+#[cfg(feature = "application")]
 pub use application::Application;
 pub use clipboard::Clipboard;
 pub use error::Error;


### PR DESCRIPTION
This PR adds new "application" feature, which is default. When user builds with:

```
cargo build --no-default-features --features "wgpu"
```

it allows to user to build "freestanding" app, with all the nice building blocks of iced, but user responsible for window creation, and rendering.

This also fixes building for iOS, for example, because user can turn off application, and put together pieces they need, similar to integration example.

We can also reduce other dependencies in parts of the workspace I think -- make them optional as example--, to decrease compile time of iced and codegen in this case, but I leave it here for now, for @hecrj to consider. We can do such things in future if desired.

Thank you for your time!

I think this is a better answer than #1190 