### PR TITLE
Remove ambiguous `text_color` attributes for `Checkbox` and `Radio`

### DIFF
--- a/examples/scrollable/src/style.rs
+++ b/examples/scrollable/src/style.rs
@@ -116,6 +116,7 @@ mod dark {
                 dot_color: ACTIVE,
                 border_width: 1.0,
                 border_color: ACTIVE,
+                text_color: None,
             }
         }
 

--- a/examples/styling/src/main.rs
+++ b/examples/styling/src/main.rs
@@ -343,6 +343,7 @@ mod style {
                     dot_color: ACTIVE,
                     border_width: 1.0,
                     border_color: ACTIVE,
+                    text_color: None,
                 }
             }
 
@@ -528,10 +529,10 @@ mod style {
                     background: if is_checked { ACTIVE } else { SURFACE }
                         .into(),
                     checkmark_color: Color::WHITE,
-                    text_color: Color::BLACK,
                     border_radius: 2.0,
                     border_width: 1.0,
                     border_color: ACTIVE,
+                    text_color: None,
                 }
             }
 

--- a/native/src/widget/checkbox.rs
+++ b/native/src/widget/checkbox.rs
@@ -10,8 +10,8 @@ use crate::text;
 use crate::touch;
 use crate::widget::{self, Row, Text};
 use crate::{
-    Alignment, Clipboard, Color, Element, Hasher, Layout, Length, Point,
-    Rectangle, Shell, Widget,
+    Alignment, Clipboard, Element, Hasher, Layout, Length, Point, Rectangle,
+    Shell, Widget,
 };
 
 pub use iced_style::checkbox::{Style, StyleSheet};
@@ -43,7 +43,6 @@ pub struct Checkbox<'a, Message, Renderer: text::Renderer> {
     spacing: u16,
     text_size: Option<u16>,
     font: Renderer::Font,
-    text_color: Option<Color>,
     style_sheet: Box<dyn StyleSheet + 'a>,
 }
 
@@ -75,7 +74,6 @@ impl<'a, Message, Renderer: text::Renderer> Checkbox<'a, Message, Renderer> {
             spacing: Self::DEFAULT_SPACING,
             text_size: None,
             font: Renderer::Font::default(),
-            text_color: None,
             style_sheet: Default::default(),
         }
     }
@@ -109,12 +107,6 @@ impl<'a, Message, Renderer: text::Renderer> Checkbox<'a, Message, Renderer> {
     /// [`Font`]: crate::widget::text::Renderer::Font
     pub fn font(mut self, font: Renderer::Font) -> Self {
         self.font = font;
-        self
-    }
-
-    /// Sets the text color of the [`Checkbox`] button.
-    pub fn text_color(mut self, color: Color) -> Self {
-        self.text_color = Some(color);
         self
     }
 
@@ -264,7 +256,7 @@ where
                 &self.label,
                 self.font.clone(),
                 self.text_size,
-                self.text_color.or(Some(custom_style.text_color)),
+                custom_style.text_color,
                 alignment::Horizontal::Left,
                 alignment::Vertical::Center,
             );

--- a/native/src/widget/radio.rs
+++ b/native/src/widget/radio.rs
@@ -51,7 +51,6 @@ pub struct Radio<'a, Message, Renderer: text::Renderer> {
     size: u16,
     spacing: u16,
     text_size: Option<u16>,
-    text_color: Option<Color>,
     font: Renderer::Font,
     style_sheet: Box<dyn StyleSheet + 'a>,
 }
@@ -92,7 +91,6 @@ where
             size: Self::DEFAULT_SIZE,
             spacing: Self::DEFAULT_SPACING, //15
             text_size: None,
-            text_color: None,
             font: Default::default(),
             style_sheet: Default::default(),
         }
@@ -119,12 +117,6 @@ where
     /// Sets the text size of the [`Radio`] button.
     pub fn text_size(mut self, text_size: u16) -> Self {
         self.text_size = Some(text_size);
-        self
-    }
-
-    /// Sets the text color of the [`Radio`] button.
-    pub fn text_color(mut self, color: Color) -> Self {
-        self.text_color = Some(color);
         self
     }
 
@@ -231,6 +223,12 @@ where
 
         let mut children = layout.children();
 
+        let custom_style = if is_mouse_over {
+            self.style_sheet.hovered()
+        } else {
+            self.style_sheet.active()
+        };
+
         {
             let layout = children.next().unwrap();
             let bounds = layout.bounds();
@@ -238,20 +236,14 @@ where
             let size = bounds.width;
             let dot_size = size / 2.0;
 
-            let style = if is_mouse_over {
-                self.style_sheet.hovered()
-            } else {
-                self.style_sheet.active()
-            };
-
             renderer.fill_quad(
                 renderer::Quad {
                     bounds,
                     border_radius: size / 2.0,
-                    border_width: style.border_width,
-                    border_color: style.border_color,
+                    border_width: custom_style.border_width,
+                    border_color: custom_style.border_color,
                 },
-                style.background,
+                custom_style.background,
             );
 
             if self.is_selected {
@@ -267,7 +259,7 @@ where
                         border_width: 0.0,
                         border_color: Color::TRANSPARENT,
                     },
-                    style.dot_color,
+                    custom_style.dot_color,
                 );
             }
         }
@@ -282,7 +274,7 @@ where
                 &self.label,
                 self.font.clone(),
                 self.text_size,
-                self.text_color,
+                custom_style.text_color,
                 alignment::Horizontal::Left,
                 alignment::Vertical::Center,
             );

--- a/style/src/checkbox.rs
+++ b/style/src/checkbox.rs
@@ -6,10 +6,10 @@ use iced_core::{Background, Color};
 pub struct Style {
     pub background: Background,
     pub checkmark_color: Color,
-    pub text_color: Color,
     pub border_radius: f32,
     pub border_width: f32,
     pub border_color: Color,
+    pub text_color: Option<Color>,
 }
 
 /// A set of rules that dictate the style of a checkbox.
@@ -26,10 +26,10 @@ impl StyleSheet for Default {
         Style {
             background: Background::Color(Color::from_rgb(0.95, 0.95, 0.95)),
             checkmark_color: Color::from_rgb(0.3, 0.3, 0.3),
-            text_color: Color::BLACK,
             border_radius: 5.0,
             border_width: 1.0,
             border_color: Color::from_rgb(0.6, 0.6, 0.6),
+            text_color: None,
         }
     }
 

--- a/style/src/radio.rs
+++ b/style/src/radio.rs
@@ -8,6 +8,7 @@ pub struct Style {
     pub dot_color: Color,
     pub border_width: f32,
     pub border_color: Color,
+    pub text_color: Option<Color>,
 }
 
 /// A set of rules that dictate the style of a radio button.
@@ -26,6 +27,7 @@ impl StyleSheet for Default {
             dot_color: Color::from_rgb(0.3, 0.3, 0.3),
             border_width: 1.0,
             border_color: Color::from_rgb(0.6, 0.6, 0.6),
+            text_color: None,
         }
     }
 


### PR DESCRIPTION
Instead, always use a `StyleSheet`.