### PR TITLE
Allow the creation of a clipboard without a window.

### DIFF
--- a/winit/src/clipboard.rs
+++ b/winit/src/clipboard.rs
@@ -26,6 +26,14 @@ impl Clipboard {
         Clipboard { state }
     }
 
+    /// Creates a new [`Clipboard`] that isn't associated with a window.
+    /// This clipboard will never contain a copied value.
+    pub fn unconnected() -> Clipboard {
+        Clipboard {
+            state: State::Unavailable,
+        }
+    }
+
     /// Reads the current content of the [`Clipboard`] as text.
     pub fn read(&self) -> Option<String> {
         match &self.state {


### PR DESCRIPTION
I've been testing the recent wasm32 "native" shell changes and they work marvelously! It would be useful to me if we could create the "unavailable" clipboard without needing a `Window`.

The motivation is that I prefer to (on web) use iced without winit's event loop because of how implements the "does not return" behaviour via an uncaught exception. As such I also forgo their Window object.

Everything else is working exceptionally well! Thank you!