### PR TITLE
Add clip to canvas

### DIFF
--- a/graphics/src/widget/canvas/frame.rs
+++ b/graphics/src/widget/canvas/frame.rs
@@ -244,6 +244,30 @@ impl Frame {
         self.transforms.current = self.transforms.previous.pop().unwrap();
     }
 
+    /// TODO...
+    #[inline]
+    pub fn with_clip(
+        &mut self,
+        translation: Vector,
+        size: Size,
+        f: impl FnOnce(&mut Frame),
+    ) {
+        let mut frame = Frame::new(self.size());
+        frame.translate(translation);
+
+        f(&mut frame);
+
+        self.primitives.push(Primitive::Clip {
+            bounds: Rectangle {
+                x: translation.x,
+                y: translation.y,
+                width: size.width,
+                height: size.height,
+            },
+            content: Box::new(frame.into_geometry().into_primitive()),
+        });
+    }
+
     /// Applies a translation to the current transform of the [`Frame`].
     #[inline]
     pub fn translate(&mut self, translation: Vector) {

--- a/graphics/src/widget/canvas/frame.rs
+++ b/graphics/src/widget/canvas/frame.rs
@@ -244,7 +244,14 @@ impl Frame {
         self.transforms.current = self.transforms.previous.pop().unwrap();
     }
 
-    /// TODO...
+    /// Stores the current transform of the [`Frame`] and executes the given
+    /// drawing operations within a clipped [`Rectange`] at translation / size,
+    /// restoring the transform afterwards.
+    ///
+    /// This method is userful to perform drawing operations that need to be
+    /// clipped.
+    ///
+    /// [`Rectange`]: crate::Rectangle
     #[inline]
     pub fn with_clip(
         &mut self,


### PR DESCRIPTION
This adds the ability to draw on the canvas within a clip primitive. Similar to `with_save`, it "restores" itself after returning (we never actually modify `&mut self / Frame`). This is very useful when drawing on the canvas with multiple regions that have distinct geometry that can bleed over into the other regions.

Not 100% sure what the API should look like, but it made the most sense to supply a translation and size to define the clipped `Rectangle` relative to the `Frame`.