### PR TITLE
Power and Limits Auto configure and setting.

### DIFF
--- a/wgpu/src/settings.rs
+++ b/wgpu/src/settings.rs
@@ -83,6 +83,7 @@ fn backend_from_env() -> Option<wgpu::Backends> {
             "gl" => wgpu::Backends::GL,
             "webgpu" => wgpu::Backends::BROWSER_WEBGPU,
             "primary" => wgpu::Backends::PRIMARY,
+            "secondary" => wgpu::Backends::SECONDARY,
             other => panic!("Unknown backend: {}", other),
         }
     })


### PR DESCRIPTION
Adjusted Limits so it uses what the adapter allows also changed the Power settings so it checks for High powered adapters first and then low powered.

This will attempt to use high powered GPU first <PCIe> if it fails to find any it will then use Low Powered GPU's 2nd Processor embedded and software based. 

It will pull the required limits for None WASM to what the default adapter supports rather than setting it all to the lowest of low.
Should fix some issues with #1232 .  We might also be able to add a 3rd check for fallback software devices which might allow WSL to work better when neither GPU are pass-thru acceptable. But will need to test that too. 