### PR TITLE
Fix `canvas::Frame` issuing a new layer for `Mesh2D` in `with_clip`

### DIFF
--- a/graphics/src/widget/canvas/geometry.rs
+++ b/graphics/src/widget/canvas/geometry.rs
@@ -22,9 +22,3 @@ impl Geometry {
         self.0
     }
 }
-
-impl From<Geometry> for Primitive {
-    fn from(geometry: Geometry) -> Primitive {
-        geometry.0
-    }
-}


### PR DESCRIPTION
Text will still be rendered in its own layer, until we fix the composition bottleneck in `glyph-brush`.