### PR TITLE
Forward overlay() calls in iced_pure::element::Map

### DIFF
--- a/native/src/overlay/element.rs
+++ b/native/src/overlay/element.rs
@@ -41,7 +41,7 @@ where
     where
         Message: 'a,
         Renderer: 'a,
-        B: 'static,
+        B: 'a,
     {
         Element {
             position: self.position,

--- a/native/src/widget/scrollable.rs
+++ b/native/src/widget/scrollable.rs
@@ -33,7 +33,7 @@ pub struct Scrollable<'a, Message, Renderer> {
     scrollbar_margin: u16,
     scroller_width: u16,
     content: Column<'a, Message, Renderer>,
-    on_scroll: Option<Box<dyn Fn(f32) -> Message>>,
+    on_scroll: Option<Box<dyn Fn(f32) -> Message + 'a>>,
     style_sheet: Box<dyn StyleSheet + 'a>,
 }
 
@@ -181,7 +181,7 @@ pub fn update<Message>(
     scrollbar_width: u16,
     scrollbar_margin: u16,
     scroller_width: u16,
-    on_scroll: &Option<Box<dyn Fn(f32) -> Message>>,
+    on_scroll: &Option<Box<dyn Fn(f32) -> Message + '_>>,
     update_content: impl FnOnce(
         Event,
         Layout<'_>,
@@ -597,7 +597,7 @@ fn scrollbar(
 
 fn notify_on_scroll<Message>(
     state: &State,
-    on_scroll: &Option<Box<dyn Fn(f32) -> Message>>,
+    on_scroll: &Option<Box<dyn Fn(f32) -> Message + '_>>,
     bounds: Rectangle,
     content_bounds: Rectangle,
     shell: &mut Shell<'_, Message>,

--- a/pure/src/element.rs
+++ b/pure/src/element.rs
@@ -1,3 +1,4 @@
+use crate::overlay;
 use crate::widget::tree::{self, Tree};
 use crate::widget::Widget;
 
@@ -33,7 +34,7 @@ impl<'a, Message, Renderer> Element<'a, Message, Renderer> {
     where
         Message: 'a,
         Renderer: iced_native::Renderer + 'a,
-        B: 'a,
+        B: 'static,
     {
         Element::new(Map::new(self.widget, f))
     }
@@ -63,7 +64,7 @@ impl<'a, A, B, Renderer> Widget<B, Renderer> for Map<'a, A, B, Renderer>
 where
     Renderer: iced_native::Renderer + 'a,
     A: 'a,
-    B: 'a,
+    B: 'static,
 {
     fn tag(&self) -> tree::Tag {
         self.widget.tag()
@@ -159,5 +160,18 @@ where
             viewport,
             renderer,
         )
+    }
+
+    fn overlay<'b>(
+        &'b self,
+        tree: &'b mut Tree,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+    ) -> Option<overlay::Element<'b, B, Renderer>> {
+        let mapper = &self.mapper;
+
+        self.widget
+            .overlay(tree, layout, renderer)
+            .map(move |overlay| overlay.map(mapper))
     }
 }

--- a/pure/src/element.rs
+++ b/pure/src/element.rs
@@ -34,7 +34,7 @@ impl<'a, Message, Renderer> Element<'a, Message, Renderer> {
     where
         Message: 'a,
         Renderer: iced_native::Renderer + 'a,
-        B: 'static,
+        B: 'a,
     {
         Element::new(Map::new(self.widget, f))
     }
@@ -64,7 +64,7 @@ impl<'a, A, B, Renderer> Widget<B, Renderer> for Map<'a, A, B, Renderer>
 where
     Renderer: iced_native::Renderer + 'a,
     A: 'a,
-    B: 'static,
+    B: 'a,
 {
     fn tag(&self) -> tree::Tag {
         self.widget.tag()

--- a/pure/src/lib.rs
+++ b/pure/src/lib.rs
@@ -23,8 +23,8 @@ pub struct Pure<'a, Message, Renderer> {
 
 impl<'a, Message, Renderer> Pure<'a, Message, Renderer>
 where
-    Message: 'static,
-    Renderer: iced_native::Renderer + 'static,
+    Message: 'a,
+    Renderer: iced_native::Renderer + 'a,
 {
     pub fn new(
         state: &'a mut State,

--- a/pure/src/widget/button.rs
+++ b/pure/src/widget/button.rs
@@ -75,8 +75,8 @@ impl<'a, Message, Renderer> Button<'a, Message, Renderer> {
 impl<'a, Message, Renderer> Widget<Message, Renderer>
     for Button<'a, Message, Renderer>
 where
-    Message: 'static + Clone,
-    Renderer: 'static + iced_native::Renderer,
+    Message: 'a + Clone,
+    Renderer: 'a + iced_native::Renderer,
 {
     fn tag(&self) -> tree::Tag {
         tree::Tag::of::<State>()
@@ -216,8 +216,8 @@ where
 impl<'a, Message, Renderer> Into<Element<'a, Message, Renderer>>
     for Button<'a, Message, Renderer>
 where
-    Message: Clone + 'static,
-    Renderer: iced_native::Renderer + 'static,
+    Message: Clone + 'a,
+    Renderer: iced_native::Renderer + 'a,
 {
     fn into(self) -> Element<'a, Message, Renderer> {
         Element::new(self)

--- a/pure/src/widget/column.rs
+++ b/pure/src/widget/column.rs
@@ -216,8 +216,8 @@ where
 impl<'a, Message, Renderer> Into<Element<'a, Message, Renderer>>
     for Column<'a, Message, Renderer>
 where
-    Message: 'static,
-    Renderer: iced_native::Renderer + 'static,
+    Message: 'a,
+    Renderer: iced_native::Renderer + 'a,
 {
     fn into(self) -> Element<'a, Message, Renderer> {
         Element::new(self)

--- a/pure/src/widget/pick_list.rs
+++ b/pure/src/widget/pick_list.rs
@@ -109,7 +109,7 @@ impl<'a, T: 'a, Message, Renderer> Widget<Message, Renderer>
 where
     T: Clone + ToString + Eq + 'static,
     [T]: ToOwned<Owned = Vec<T>>,
-    Message: 'static,
+    Message: 'a,
     Renderer: text::Renderer + 'a,
 {
     fn tag(&self) -> tree::Tag {
@@ -226,7 +226,7 @@ where
     T: Clone + ToString + Eq + 'static,
     [T]: ToOwned<Owned = Vec<T>>,
     Renderer: text::Renderer + 'a,
-    Message: 'static,
+    Message: 'a,
 {
     fn into(self) -> Element<'a, Message, Renderer> {
         Element::new(self)

--- a/pure/src/widget/row.rs
+++ b/pure/src/widget/row.rs
@@ -203,8 +203,8 @@ where
 impl<'a, Message, Renderer> Into<Element<'a, Message, Renderer>>
     for Row<'a, Message, Renderer>
 where
-    Message: 'static,
-    Renderer: iced_native::Renderer + 'static,
+    Message: 'a,
+    Renderer: iced_native::Renderer + 'a,
 {
     fn into(self) -> Element<'a, Message, Renderer> {
         Element::new(self)

--- a/pure/src/widget/scrollable.rs
+++ b/pure/src/widget/scrollable.rs
@@ -19,7 +19,7 @@ pub struct Scrollable<'a, Message, Renderer> {
     scrollbar_width: u16,
     scrollbar_margin: u16,
     scroller_width: u16,
-    on_scroll: Option<Box<dyn Fn(f32) -> Message>>,
+    on_scroll: Option<Box<dyn Fn(f32) -> Message + 'a>>,
     style_sheet: Box<dyn StyleSheet + 'a>,
     content: Element<'a, Message, Renderer>,
 }
@@ -71,7 +71,7 @@ impl<'a, Message, Renderer: iced_native::Renderer>
     ///
     /// The function takes the new relative offset of the [`Scrollable`]
     /// (e.g. `0` means top, while `1` means bottom).
-    pub fn on_scroll(mut self, f: impl Fn(f32) -> Message + 'static) -> Self {
+    pub fn on_scroll(mut self, f: impl Fn(f32) -> Message + 'a) -> Self {
         self.on_scroll = Some(Box::new(f));
         self
     }

--- a/pure/src/widget/text.rs
+++ b/pure/src/widget/text.rs
@@ -53,7 +53,7 @@ where
 impl<'a, Message, Renderer> Into<Element<'a, Message, Renderer>>
     for Text<Renderer>
 where
-    Renderer: text::Renderer + 'static,
+    Renderer: text::Renderer + 'a,
 {
     fn into(self) -> Element<'a, Message, Renderer> {
         Element::new(self)
@@ -62,7 +62,7 @@ where
 
 impl<'a, Message, Renderer> Into<Element<'a, Message, Renderer>> for &'a str
 where
-    Renderer: text::Renderer + 'static,
+    Renderer: text::Renderer + 'a,
 {
     fn into(self) -> Element<'a, Message, Renderer> {
         Text::new(self).into()


### PR DESCRIPTION
If Map does not override overlay(), calling map() on a pure Element
breaks any pick_list inside it (its overlay does not appear).

Fix it by implementing overlay() the same way iced_native::element::Map
does.