### PR TITLE
Implement `Default` for `pure::State`

### DIFF
--- a/pure/src/lib.rs
+++ b/pure/src/lib.rs
@@ -41,6 +41,14 @@ pub struct State {
     state_tree: widget::Tree,
 }
 
+impl Default for State {
+    fn default() -> Self {
+        Self {
+            state_tree: widget::Tree::empty(),
+        }
+    }
+}
+
 impl State {
     pub fn new() -> Self {
         Self {

--- a/pure/src/lib.rs
+++ b/pure/src/lib.rs
@@ -43,9 +43,7 @@ pub struct State {
 
 impl Default for State {
     fn default() -> Self {
-        Self {
-            state_tree: widget::Tree::empty(),
-        }
+        Self::new()
     }
 }
 


### PR DESCRIPTION
Allow to use a `pure::State` in a struct deriving Default

This PR set default to `pure::State::new()`