### PR TITLE
Expose touch events in canvas

### DIFF
--- a/graphics/src/widget/canvas.rs
+++ b/graphics/src/widget/canvas.rs
@@ -166,6 +166,9 @@ where
             iced_native::Event::Mouse(mouse_event) => {
                 Some(Event::Mouse(mouse_event))
             }
+            iced_native::Event::Touch(touch_event) => {
+                Some(Event::Touch(touch_event))
+            }
             iced_native::Event::Keyboard(keyboard_event) => {
                 Some(Event::Keyboard(keyboard_event))
             }

--- a/graphics/src/widget/canvas/event.rs
+++ b/graphics/src/widget/canvas/event.rs
@@ -1,6 +1,7 @@
 //! Handle events of a canvas.
 use iced_native::keyboard;
 use iced_native::mouse;
+use iced_native::touch;
 
 pub use iced_native::event::Status;
 
@@ -11,6 +12,9 @@ pub use iced_native::event::Status;
 pub enum Event {
     /// A mouse event.
     Mouse(mouse::Event),
+
+    /// A touch event.
+    Touch(touch::Event),
 
     /// A keyboard event.
     Keyboard(keyboard::Event),


### PR DESCRIPTION
This exposes `iced_native::Event::Touch` in `canvas::on_event`. Currently it's not possible to handle touchscreen interactions in canvas code, the way a lot of builtin widgets do (`slider`, `button`, etc).

I tested the examples that use canvas (`bezier_tool`, `solar_system`, `game_of_life`) and this doesn't break any of them.