### PR TITLE
Expose touch events in canvas widget

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ members = [
     "examples/geometry",
     "examples/integration_opengl",
     "examples/integration_wgpu",
+    "examples/multitouch",
     "examples/pane_grid",
     "examples/pick_list",
     "examples/pokedex",

--- a/examples/game_of_life/src/main.rs
+++ b/examples/game_of_life/src/main.rs
@@ -204,6 +204,7 @@ fn view_controls<'a>(
 
 mod grid {
     use crate::Preset;
+    use iced::touch;
     use iced::widget::canvas;
     use iced::widget::canvas::event::{self, Event};
     use iced::widget::canvas::{
@@ -423,6 +424,22 @@ mod grid {
             };
 
             match event {
+                Event::Touch(touch_event) => match touch_event {
+                    touch::Event::FingerMoved { .. } => {
+                        let message = {
+                            *interaction = if is_populated {
+                                Interaction::Erasing
+                            } else {
+                                Interaction::Drawing
+                            };
+
+                            populate.or(unpopulate)
+                        };
+
+                        (event::Status::Captured, message)
+                    }
+                    _ => (event::Status::Ignored, None),
+                },
                 Event::Mouse(mouse_event) => match mouse_event {
                     mouse::Event::ButtonPressed(button) => {
                         let message = match button {

--- a/examples/game_of_life/src/main.rs
+++ b/examples/game_of_life/src/main.rs
@@ -424,22 +424,19 @@ mod grid {
             };
 
             match event {
-                Event::Touch(touch_event) => match touch_event {
-                    touch::Event::FingerMoved { .. } => {
-                        let message = {
-                            *interaction = if is_populated {
-                                Interaction::Erasing
-                            } else {
-                                Interaction::Drawing
-                            };
-
-                            populate.or(unpopulate)
+                Event::Touch(touch::Event::FingerMoved { .. }) => {
+                    let message = {
+                        *interaction = if is_populated {
+                            Interaction::Erasing
+                        } else {
+                            Interaction::Drawing
                         };
 
-                        (event::Status::Captured, message)
-                    }
-                    _ => (event::Status::Ignored, None),
-                },
+                        populate.or(unpopulate)
+                    };
+
+                    (event::Status::Captured, message)
+                }
                 Event::Mouse(mouse_event) => match mouse_event {
                     mouse::Event::ButtonPressed(button) => {
                         let message = match button {

--- a/examples/multitouch/Cargo.toml
+++ b/examples/multitouch/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "multitouch"
+version = "0.1.0"
+authors = ["Artur Sapek <artur@kraken.com>"]
+edition = "2021"
+publish = false
+
+[dependencies]
+iced = { path = "../..", features = ["canvas", "tokio", "debug"] }
+tokio = { version = "1.0", features = ["sync"] }
+env_logger = "0.9"

--- a/examples/multitouch/Cargo.toml
+++ b/examples/multitouch/Cargo.toml
@@ -9,4 +9,4 @@ publish = false
 iced = { path = "../..", features = ["canvas", "tokio", "debug"] }
 tokio = { version = "1.0", features = ["sync"] }
 env_logger = "0.9"
-voronoi = "0.1.4"
+voronator = "0.2"

--- a/examples/multitouch/Cargo.toml
+++ b/examples/multitouch/Cargo.toml
@@ -9,3 +9,4 @@ publish = false
 iced = { path = "../..", features = ["canvas", "tokio", "debug"] }
 tokio = { version = "1.0", features = ["sync"] }
 env_logger = "0.9"
+voronoi = "0.1.4"

--- a/examples/multitouch/src/main.rs
+++ b/examples/multitouch/src/main.rs
@@ -70,7 +70,7 @@ impl Application for Multitouch {
     fn update(&mut self, message: Message) -> Command<Message> {
         match message {
             Message::FingerPressed { id, position } => {
-                self.state.fingers.insert(id, position.clone());
+                self.state.fingers.insert(id, position);
                 self.state.cache.clear();
             }
             Message::FingerLifted { id } => {
@@ -94,7 +94,7 @@ impl Application for Multitouch {
     }
 }
 
-impl<'a> canvas::Program<Message> for State {
+impl canvas::Program<Message> for State {
     type State = ();
 
     fn update(
@@ -134,11 +134,8 @@ impl<'a> canvas::Program<Message> for State {
             }
 
             // Collect tuples of (id, point);
-            let mut zones: Vec<(u64, Point)> = self
-                .fingers
-                .iter()
-                .map(|(id, pt)| (id.0, pt.clone()))
-                .collect();
+            let mut zones: Vec<(u64, Point)> =
+                self.fingers.iter().map(|(id, pt)| (id.0, *pt)).collect();
 
             // Sort by ID
             zones.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());

--- a/examples/multitouch/src/main.rs
+++ b/examples/multitouch/src/main.rs
@@ -9,6 +9,7 @@ use iced::{
 };
 
 use std::collections::HashMap;
+use voronoi;
 
 pub fn main() -> iced::Result {
     env_logger::builder().format_timestamp(None).init();
@@ -126,16 +127,77 @@ impl<'a> canvas::Program<Message> for State {
         _state: &Self::State,
         _theme: &Theme,
         bounds: Rectangle,
-        _cursor: Cursor,
+        cursor: Cursor,
     ) -> Vec<Geometry> {
         let fingerweb = self.cache.draw(bounds.size(), |frame| {
-            for finger in &self.fingers {
-                dbg!(&finger);
+            let mut fingers = HashMap::new();
 
-                let circle = Path::new(|p| p.circle(*finger.1, 50.0));
+            // TODO delete fake fingers
+            fingers.insert(1, Point { x: 50.0, y: 50.0 });
+            fingers.insert(2, Point { x: 250.0, y: 400.0 });
+            fingers.insert(3, Point { x: 650.0, y: 120.0 });
+            fingers.insert(4, Point { x: 750.0, y: 520.0 });
+
+            match cursor {
+                canvas::Cursor::Available(pt) => {
+                    dbg!(&pt);
+                    fingers.insert(5, pt);
+                }
+                _ => {}
+            }
+
+            // Collect tuples of (id, point);
+            let mut zones: Vec<(i32, Point)> = fingers
+                .iter()
+                .map(|(id, pt)| (id.clone(), pt.clone()))
+                .collect();
+
+            // Sort by ID
+            zones.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+
+            // Generate sorted list of points
+            let vpoints: Vec<voronoi::Point> = zones
+                .iter()
+                .map(|zone| iced_point_to_voronoi_point(&zone.1))
+                .collect();
+
+            let diagram = voronoi::voronoi(vpoints, 700.0);
+            let polys = voronoi::make_polygons(&diagram);
+
+            for i in 0..polys.len() {
+                let mut builder = canvas::path::Builder::new();
+                let zone = &zones[i];
+                let poly = &polys[i];
+
+                for (index, pt) in poly.iter().enumerate() {
+                    let pt = voronoi_point_to_iced_point(pt);
+
+                    match index {
+                        0 => builder.move_to(pt),
+                        _ => builder.line_to(pt),
+                    }
+                }
+
+                let path = builder.build();
+
+                let zone = &zones[i];
+
+                let color_r = (10 % zone.0) as f32 / 20.0;
+                let color_g = (10 % (zone.0 + 8)) as f32 / 20.0;
+                let color_b = (10 % (zone.0 + 3)) as f32 / 20.0;
+
+                frame.fill(
+                    &path,
+                    Color {
+                        r: color_r,
+                        g: color_g,
+                        b: color_b,
+                        a: 1.0,
+                    },
+                );
 
                 frame.stroke(
-                    &circle,
+                    &path,
                     Stroke {
                         color: Color::BLACK,
                         width: 3.0,
@@ -146,5 +208,18 @@ impl<'a> canvas::Program<Message> for State {
         });
 
         vec![fingerweb]
+    }
+}
+
+fn iced_point_to_voronoi_point(pt: &iced::Point) -> voronoi::Point {
+    voronoi::Point::new(pt.x.into(), pt.y.into())
+}
+
+fn voronoi_point_to_iced_point(pt: &voronoi::Point) -> iced::Point {
+    let x: f64 = pt.x.into();
+    let y: f64 = pt.y.into();
+    Point {
+        x: x as f32,
+        y: y as f32,
     }
 }

--- a/examples/multitouch/src/main.rs
+++ b/examples/multitouch/src/main.rs
@@ -1,0 +1,150 @@
+//! This example shows how to use touch events in `Canvas` to draw
+//! a circle around each fingertip. This only works on touch-enabled
+//! computers like Microsoft Surface.
+use iced::widget::canvas::event;
+use iced::widget::canvas::{self, Canvas, Cursor, Geometry, Path, Stroke};
+use iced::{
+    executor, touch, window, Application, Color, Command, Element, Length,
+    Point, Rectangle, Settings, Subscription, Theme,
+};
+
+use std::collections::HashMap;
+
+pub fn main() -> iced::Result {
+    env_logger::builder().format_timestamp(None).init();
+
+    Multitouch::run(Settings {
+        antialiasing: true,
+        window: window::Settings {
+            position: window::Position::Centered,
+            ..window::Settings::default()
+        },
+        ..Settings::default()
+    })
+}
+
+struct Multitouch {
+    state: State,
+}
+
+#[derive(Debug)]
+struct State {
+    cache: canvas::Cache,
+    fingers: HashMap<touch::Finger, Point>,
+}
+
+impl State {
+    fn new() -> Self {
+        Self {
+            cache: canvas::Cache::new(),
+            fingers: HashMap::new(),
+        }
+    }
+}
+
+#[derive(Debug)]
+enum Message {
+    FingerPressed { id: touch::Finger, position: Point },
+    FingerLifted { id: touch::Finger },
+}
+
+impl Application for Multitouch {
+    type Executor = executor::Default;
+    type Message = Message;
+    type Theme = Theme;
+    type Flags = ();
+
+    fn new(_flags: ()) -> (Self, Command<Message>) {
+        (
+            Multitouch {
+                state: State::new(),
+            },
+            Command::none(),
+        )
+    }
+
+    fn title(&self) -> String {
+        String::from("Multitouch - Iced")
+    }
+
+    fn update(&mut self, message: Message) -> Command<Message> {
+        match message {
+            Message::FingerPressed { id, position } => {
+                self.state.fingers.insert(id, position.clone());
+                self.state.cache.clear();
+            }
+            Message::FingerLifted { id } => {
+                self.state.fingers.remove(&id);
+                self.state.cache.clear();
+            }
+        }
+
+        Command::none()
+    }
+
+    fn subscription(&self) -> Subscription<Message> {
+        Subscription::none()
+    }
+
+    fn view(&self) -> Element<Message> {
+        Canvas::new(&self.state)
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .into()
+    }
+}
+
+impl<'a> canvas::Program<Message> for State {
+    type State = ();
+
+    fn update(
+        &self,
+        _state: &mut Self::State,
+        event: event::Event,
+        _bounds: Rectangle,
+        _cursor: Cursor,
+    ) -> (event::Status, Option<Message>) {
+        match event {
+            event::Event::Touch(touch_event) => match touch_event {
+                touch::Event::FingerPressed { id, position }
+                | touch::Event::FingerMoved { id, position } => (
+                    event::Status::Captured,
+                    Some(Message::FingerPressed { id, position }),
+                ),
+                touch::Event::FingerLifted { id, .. }
+                | touch::Event::FingerLost { id, .. } => (
+                    event::Status::Captured,
+                    Some(Message::FingerLifted { id }),
+                ),
+            },
+            _ => (event::Status::Ignored, None),
+        }
+    }
+
+    fn draw(
+        &self,
+        _state: &Self::State,
+        _theme: &Theme,
+        bounds: Rectangle,
+        _cursor: Cursor,
+    ) -> Vec<Geometry> {
+        let fingerweb = self.cache.draw(bounds.size(), |frame| {
+            for finger in &self.fingers {
+                dbg!(&finger);
+
+                let circle = Path::new(|p| p.circle(*finger.1, 50.0));
+
+                frame.stroke(
+                    &circle,
+                    Stroke {
+                        color: Color::BLACK,
+                        width: 3.0,
+                        ..Stroke::default()
+                    },
+                );
+            }
+        });
+
+        vec![fingerweb]
+    }
+}

--- a/graphics/src/widget/canvas.rs
+++ b/graphics/src/widget/canvas.rs
@@ -173,6 +173,9 @@ where
             iced_native::Event::Mouse(mouse_event) => {
                 Some(Event::Mouse(mouse_event))
             }
+            iced_native::Event::Touch(touch_event) => {
+                Some(Event::Touch(touch_event))
+            }
             iced_native::Event::Keyboard(keyboard_event) => {
                 Some(Event::Keyboard(keyboard_event))
             }

--- a/graphics/src/widget/canvas/event.rs
+++ b/graphics/src/widget/canvas/event.rs
@@ -1,6 +1,7 @@
 //! Handle events of a canvas.
 use iced_native::keyboard;
 use iced_native::mouse;
+use iced_native::touch;
 
 pub use iced_native::event::Status;
 
@@ -11,6 +12,9 @@ pub use iced_native::event::Status;
 pub enum Event {
     /// A mouse event.
     Mouse(mouse::Event),
+
+    /// A touch event.
+    Touch(touch::Event),
 
     /// A keyboard event.
     Keyboard(keyboard::Event),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,6 +177,7 @@ pub mod mouse;
 pub mod overlay;
 pub mod settings;
 pub mod time;
+pub mod touch;
 pub mod widget;
 pub mod window;
 

--- a/src/touch.rs
+++ b/src/touch.rs
@@ -1,0 +1,2 @@
+//! Listen and react to touch events.
+pub use crate::runtime::touch::{Event, Finger};


### PR DESCRIPTION
This exposes `iced_native::Event::Touch` in `canvas::on_event`. Currently it's not possible to handle touchscreen interactions in canvas code, the way a lot of builtin widgets do (`slider`, `button`, etc).

I tested the examples that use canvas (`bezier_tool`, `solar_system`, `game_of_life`) and this doesn't break any of them.