### PR TITLE
fix: tree node passed in `component::OverlayInstance::on_event`

### DIFF
--- a/lazy/src/pure/component.rs
+++ b/lazy/src/pure/component.rs
@@ -470,7 +470,7 @@ where
                             .as_ref()
                             .unwrap()
                             .as_widget()
-                            .overlay(tree, layout, renderer)
+                            .overlay(&mut tree.children[0], layout, renderer)
                     },
                 }
                 .build(),


### PR DESCRIPTION
I was seeing some strange behavior when using overlays inside of components. Currently when rebuilding the overlay in `on_event` of `OverlayInstance`, the widget tree node for the component itself is being used rather than the tree node for the cached element. In `Instance::overlay`, the correct tree node is already being used, so no change is required there.