### PR TITLE
Fix `PickList` text wrapping

### DIFF
--- a/native/src/widget/pick_list.rs
+++ b/native/src/widget/pick_list.rs
@@ -402,16 +402,18 @@ pub fn draw<T, Renderer>(
     if let Some(label) =
         label.as_ref().map(String::as_str).or_else(|| placeholder)
     {
+        let text_size = f32::from(text_size.unwrap_or(renderer.default_size()));
+
         renderer.fill_text(Text {
             content: label,
-            size: f32::from(text_size.unwrap_or(renderer.default_size())),
+            size: text_size,
             font: font.clone(),
             color: is_selected
                 .then(|| style.text_color)
                 .unwrap_or(style.placeholder_color),
             bounds: Rectangle {
                 x: bounds.x + f32::from(padding.left),
-                y: bounds.center_y(),
+                y: bounds.center_y() - text_size / 2.0,
                 ..bounds
             },
             horizontal_alignment: alignment::Horizontal::Left,

--- a/native/src/widget/pick_list.rs
+++ b/native/src/widget/pick_list.rs
@@ -414,7 +414,8 @@ pub fn draw<T, Renderer>(
             bounds: Rectangle {
                 x: bounds.x + f32::from(padding.left),
                 y: bounds.center_y() - text_size / 2.0,
-                ..bounds
+                width: bounds.width - f32::from(padding.horizontal()),
+                height: text_size,
             },
             horizontal_alignment: alignment::Horizontal::Left,
             vertical_alignment: alignment::Vertical::Top,

--- a/native/src/widget/pick_list.rs
+++ b/native/src/widget/pick_list.rs
@@ -402,22 +402,24 @@ pub fn draw<T, Renderer>(
     if let Some(label) =
         label.as_ref().map(String::as_str).or_else(|| placeholder)
     {
-        renderer.fill_text(Text {
-            content: label,
-            size: f32::from(text_size.unwrap_or(renderer.default_size())),
-            font: font.clone(),
-            color: is_selected
-                .then(|| style.text_color)
-                .unwrap_or(style.placeholder_color),
-            bounds: Rectangle {
-                x: bounds.x + f32::from(padding.left),
-                y: bounds.center_y(),
-                width: f32::INFINITY,
-                ..bounds
-            },
-            horizontal_alignment: alignment::Horizontal::Left,
-            vertical_alignment: alignment::Vertical::Center,
-        })
+        renderer.with_layer(bounds, |layer| {
+            layer.fill_text(Text {
+                content: label,
+                size: f32::from(text_size.unwrap_or(layer.default_size())),
+                font: font.clone(),
+                color: is_selected
+                    .then(|| style.text_color)
+                    .unwrap_or(style.placeholder_color),
+                bounds: Rectangle {
+                    x: bounds.x + f32::from(padding.left),
+                    y: bounds.center_y(),
+                    width: f32::INFINITY,
+                    ..bounds
+                },
+                horizontal_alignment: alignment::Horizontal::Left,
+                vertical_alignment: alignment::Vertical::Center,
+            })
+        });
     }
 }
 

--- a/native/src/widget/pick_list.rs
+++ b/native/src/widget/pick_list.rs
@@ -402,23 +402,20 @@ pub fn draw<T, Renderer>(
     if let Some(label) =
         label.as_ref().map(String::as_str).or_else(|| placeholder)
     {
-        renderer.with_layer(bounds, |layer| {
-            layer.fill_text(Text {
-                content: label,
-                size: f32::from(text_size.unwrap_or(layer.default_size())),
-                font: font.clone(),
-                color: is_selected
-                    .then(|| style.text_color)
-                    .unwrap_or(style.placeholder_color),
-                bounds: Rectangle {
-                    x: bounds.x + f32::from(padding.left),
-                    y: bounds.center_y(),
-                    width: f32::INFINITY,
-                    ..bounds
-                },
-                horizontal_alignment: alignment::Horizontal::Left,
-                vertical_alignment: alignment::Vertical::Center,
-            })
+        renderer.fill_text(Text {
+            content: label,
+            size: f32::from(text_size.unwrap_or(renderer.default_size())),
+            font: font.clone(),
+            color: is_selected
+                .then(|| style.text_color)
+                .unwrap_or(style.placeholder_color),
+            bounds: Rectangle {
+                x: bounds.x + f32::from(padding.left),
+                y: bounds.center_y(),
+                ..bounds
+            },
+            horizontal_alignment: alignment::Horizontal::Left,
+            vertical_alignment: alignment::Vertical::Top,
         });
     }
 }

--- a/native/src/widget/pick_list.rs
+++ b/native/src/widget/pick_list.rs
@@ -412,6 +412,7 @@ pub fn draw<T, Renderer>(
             bounds: Rectangle {
                 x: bounds.x + f32::from(padding.left),
                 y: bounds.center_y(),
+                width: f32::INFINITY,
                 ..bounds
             },
             horizontal_alignment: alignment::Horizontal::Left,


### PR DESCRIPTION
PickList text is wrapped if the pick list is set to a fixed width and the selected text is wider than the fixed width. This resolves the issue by giving the rendered text bounds an infinite width so it doesn't wrap. A layer / clip needs to be provided to prevent text overflow.

I can't imagine wrapping is intended since the height is fixed to `text_size` and 2 lines of wrapped text inside `text_size` doesn't look good at all. This seems like a more sane default to handle text overflow.