### PR TITLE
Allow use of `pure::Component` within `pure::Responsive`

### DIFF
--- a/examples/pure/component/src/main.rs
+++ b/examples/pure/component/src/main.rs
@@ -1,7 +1,6 @@
 use iced::pure::container;
 use iced::pure::{Element, Sandbox};
 use iced::{Length, Settings};
-use iced_lazy::pure::responsive;
 
 use numeric_input::numeric_input;
 
@@ -39,14 +38,11 @@ impl Sandbox for Component {
     }
 
     fn view(&self) -> Element<Message> {
-        responsive(|_| {
-            container(numeric_input(self.value, Message::NumericInputChanged))
-                .padding(20)
-                .height(Length::Fill)
-                .center_y()
-                .into()
-        })
-        .into()
+        container(numeric_input(self.value, Message::NumericInputChanged))
+            .padding(20)
+            .height(Length::Fill)
+            .center_y()
+            .into()
     }
 }
 

--- a/examples/pure/component/src/main.rs
+++ b/examples/pure/component/src/main.rs
@@ -1,6 +1,7 @@
 use iced::pure::container;
 use iced::pure::{Element, Sandbox};
 use iced::{Length, Settings};
+use iced_lazy::pure::responsive;
 
 use numeric_input::numeric_input;
 
@@ -38,11 +39,14 @@ impl Sandbox for Component {
     }
 
     fn view(&self) -> Element<Message> {
-        container(numeric_input(self.value, Message::NumericInputChanged))
-            .padding(20)
-            .height(Length::Fill)
-            .center_y()
-            .into()
+        responsive(|_| {
+            container(numeric_input(self.value, Message::NumericInputChanged))
+                .padding(20)
+                .height(Length::Fill)
+                .center_y()
+                .into()
+        })
+        .into()
     }
 }
 

--- a/lazy/src/pure/responsive.rs
+++ b/lazy/src/pure/responsive.rs
@@ -67,12 +67,13 @@ impl<'a, Message, Renderer> Content<'a, Message, Renderer> {
 
         self.element = view(new_size);
         self.size = new_size;
+
+        tree.diff(&self.element);
+
         self.layout = self
             .element
             .as_widget()
             .layout(renderer, &layout::Limits::new(Size::ZERO, self.size));
-
-        tree.diff(&self.element);
     }
 
     fn resolve<R, T>(


### PR DESCRIPTION
Currently, using an `iced_lazy::pure::Component` within the closure provided to an `iced_lazy::pure::Responsive` will cause the application to panic. This is because `layout` on the component is invoked before the widget tree is diffed, so the component's cache has not yet been populated. It's straightforward to reproduce by wrapping the pure/component example in a responsive.

Simply moving the call to diff the widget tree up a couple lines so that it happens before producing the layout appears to resolve the issue.