### PR TITLE
`is_selected` property for `Radio` `StyleSheet`

### DIFF
--- a/native/src/widget/radio.rs
+++ b/native/src/widget/radio.rs
@@ -230,9 +230,9 @@ where
         let mut children = layout.children();
 
         let custom_style = if is_mouse_over {
-            theme.hovered(self.style)
+            theme.hovered(self.style, self.is_selected)
         } else {
-            theme.active(self.style)
+            theme.active(self.style, self.is_selected)
         };
 
         {

--- a/style/src/radio.rs
+++ b/style/src/radio.rs
@@ -15,7 +15,7 @@ pub struct Appearance {
 pub trait StyleSheet {
     type Style: Default + Copy;
 
-    fn active(&self, style: Self::Style) -> Appearance;
+    fn active(&self, style: Self::Style, is_selected: bool) -> Appearance;
 
-    fn hovered(&self, style: Self::Style) -> Appearance;
+    fn hovered(&self, style: Self::Style, is_selected: bool) -> Appearance;
 }

--- a/style/src/theme.rs
+++ b/style/src/theme.rs
@@ -415,7 +415,11 @@ impl pick_list::StyleSheet for Theme {
 impl radio::StyleSheet for Theme {
     type Style = ();
 
-    fn active(&self, _style: Self::Style) -> radio::Appearance {
+    fn active(
+        &self,
+        _style: Self::Style,
+        _is_selected: bool,
+    ) -> radio::Appearance {
         let palette = self.extended_palette();
 
         radio::Appearance {
@@ -427,8 +431,12 @@ impl radio::StyleSheet for Theme {
         }
     }
 
-    fn hovered(&self, style: Self::Style) -> radio::Appearance {
-        let active = self.active(style);
+    fn hovered(
+        &self,
+        style: Self::Style,
+        is_selected: bool,
+    ) -> radio::Appearance {
+        let active = self.active(style, is_selected);
         let palette = self.extended_palette();
 
         radio::Appearance {

--- a/style/src/toggler.rs
+++ b/style/src/toggler.rs
@@ -2,7 +2,7 @@
 use iced_core::Color;
 
 /// The appearance of a toggler.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct Appearance {
     pub background: Color,
     pub background_border: Option<Color>,


### PR DESCRIPTION
Added an `is_selected` property to the `Radio`'s `StyleSheet` to allow setting a custom border color and hover background for the selected `Radio` widget.

before:
![изображение](https://user-images.githubusercontent.com/49415741/166727384-2809294f-68e0-4cc0-b116-2a37d6fe1ab2.png)

after:
![изображение](https://user-images.githubusercontent.com/49415741/166727366-db562ddb-426d-4772-907a-39d2ae1a71a9.png)
