### PR TITLE
Fix vertical rule helper

### DIFF
--- a/pure/src/helpers.rs
+++ b/pure/src/helpers.rs
@@ -202,7 +202,7 @@ pub fn horizontal_rule<'a>(height: u16) -> widget::Rule<'a> {
 ///
 /// [`Rule`]: widget::Rule
 pub fn vertical_rule<'a>(width: u16) -> widget::Rule<'a> {
-    widget::Rule::horizontal(width)
+    widget::Rule::vertical(width)
 }
 
 /// Creates a new [`ProgressBar`].


### PR DESCRIPTION
`vertical_rule` helper is returning `Rule::horizontal`