### PR TITLE
Expose pure flex module as public

### DIFF
--- a/pure/src/lib.rs
+++ b/pure/src/lib.rs
@@ -87,11 +87,10 @@
 #![forbid(unsafe_code)]
 #![forbid(rust_2018_idioms)]
 
+pub mod flex;
 pub mod helpers;
 pub mod overlay;
 pub mod widget;
-
-pub(crate) mod flex;
 
 mod element;
 


### PR DESCRIPTION
Needed for using `flex` in externally created pure widgets