### PR TITLE
Add note about resolver requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ Add `iced` as a dependency in your `Cargo.toml`:
 iced = "0.4"
 ```
 
+If your project is using a Rust edition older than 2021, then you will need to
+set `resolver = "2"` in the `[package]` section as well.
+
 __Iced moves fast and the `master` branch can contain breaking changes!__ If
 you want to learn about a specific release, check out [the release list].
 


### PR DESCRIPTION
If you forget to do this and you're not on Mac (I'm using Windows), you get some nasty errors about Metal being unavailable when you use the default features:

```
   Compiling wgpu-hal v0.12.5
error: Metal API enabled on non-Apple OS. If your project is not using resolver="2" in Cargo.toml, it should.
  --> C:\Users\mtken\.cargo\registry\src\github.com-1ecc6299db9ec823\wgpu-hal-0.12.5\src\lib.rs:51:1
   |
51 | compile_error!("Metal API enabled on non-Apple OS. If your project is not using resolver=\"2\" in Cargo.toml, it should.");
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error[E0432]: unresolved import `mtl`
 --> C:\Users\mtken\.cargo\registry\src\github.com-1ecc6299db9ec823\wgpu-hal-0.12.5\src\metal\adapter.rs:1:5
  |
1 | use mtl::{MTLFeatureSet, MTLGPUFamily, MTLLanguageVersion};
  |     ^^^ use of undeclared crate or module `mtl`

[snip]
```