### PR TITLE
fix: prevent building component overlay with stale layout

### DIFF
--- a/lazy/src/component.rs
+++ b/lazy/src/component.rs
@@ -376,38 +376,6 @@ where
         let mut local_messages = Vec::new();
         let mut local_shell = Shell::new(&mut local_messages);
 
-        if self
-            .instance
-            .state
-            .borrow()
-            .as_ref()
-            .and_then(|state| state.borrow_cache().as_ref())
-            .and_then(|cache| cache.borrow_overlay().as_ref())
-            .is_none()
-        {
-            let component =
-                self.instance.state.take().unwrap().into_heads().component;
-
-            self.instance.state = RefCell::new(Some(
-                StateBuilder {
-                    component,
-                    message: PhantomData,
-                    cache_builder: |state| {
-                        Some(
-                            CacheBuilder {
-                                element: state.view(),
-                                overlay_builder: |element| {
-                                    element.overlay(layout, renderer)
-                                },
-                            }
-                            .build(),
-                        )
-                    },
-                }
-                .build(),
-            ));
-        }
-
         let event_status = self
             .with_overlay_mut_maybe(|overlay| {
                 overlay.on_event(
@@ -442,7 +410,9 @@ where
                         Some(
                             CacheBuilder {
                                 element: state.view(),
-                                overlay_builder: |_| None,
+                                overlay_builder: |element| {
+                                    element.overlay(layout, renderer)
+                                },
                             }
                             .build(),
                         )

--- a/lazy/src/component.rs
+++ b/lazy/src/component.rs
@@ -410,9 +410,7 @@ where
                         Some(
                             CacheBuilder {
                                 element: state.view(),
-                                overlay_builder: |element| {
-                                    element.overlay(layout, renderer)
-                                },
+                                overlay_builder: |_| None,
                             }
                             .build(),
                         )

--- a/lazy/src/component.rs
+++ b/lazy/src/component.rs
@@ -376,6 +376,38 @@ where
         let mut local_messages = Vec::new();
         let mut local_shell = Shell::new(&mut local_messages);
 
+        if self
+            .instance
+            .state
+            .borrow()
+            .as_ref()
+            .and_then(|state| state.borrow_cache().as_ref())
+            .and_then(|cache| cache.borrow_overlay().as_ref())
+            .is_none()
+        {
+            let component =
+                self.instance.state.take().unwrap().into_heads().component;
+
+            self.instance.state = RefCell::new(Some(
+                StateBuilder {
+                    component,
+                    message: PhantomData,
+                    cache_builder: |state| {
+                        Some(
+                            CacheBuilder {
+                                element: state.view(),
+                                overlay_builder: |element| {
+                                    element.overlay(layout, renderer)
+                                },
+                            }
+                            .build(),
+                        )
+                    },
+                }
+                .build(),
+            ));
+        }
+
         let event_status = self
             .with_overlay_mut_maybe(|overlay| {
                 overlay.on_event(
@@ -410,9 +442,7 @@ where
                         Some(
                             CacheBuilder {
                                 element: state.view(),
-                                overlay_builder: |element| {
-                                    element.overlay(layout, renderer)
-                                },
+                                overlay_builder: |_| None,
                             }
                             .build(),
                         )

--- a/lazy/src/pure/component.rs
+++ b/lazy/src/pure/component.rs
@@ -415,6 +415,35 @@ where
         let mut local_messages = Vec::new();
         let mut local_shell = Shell::new(&mut local_messages);
 
+        if self
+            .overlay
+            .as_ref()
+            .and_then(|overlay| overlay.borrow_overlay().as_ref())
+            .is_none()
+        {
+            let overlay = self.overlay.take().unwrap().into_heads();
+
+            self.overlay = Some(
+                OverlayBuilder {
+                    instance: overlay.instance,
+                    instance_ref_builder: |instance| instance.state.borrow(),
+                    tree: overlay.tree,
+                    types: PhantomData,
+                    overlay_builder: |instance, tree| {
+                        instance
+                            .as_ref()
+                            .unwrap()
+                            .borrow_element()
+                            .as_ref()
+                            .unwrap()
+                            .as_widget()
+                            .overlay(&mut tree.children[0], layout, renderer)
+                    },
+                }
+                .build(),
+            );
+        }
+
         let event_status = self
             .with_overlay_mut_maybe(|overlay| {
                 overlay.on_event(
@@ -464,16 +493,7 @@ where
                     instance_ref_builder: |instance| instance.state.borrow(),
                     tree: overlay.tree,
                     types: PhantomData,
-                    overlay_builder: |instance, tree| {
-                        instance
-                            .as_ref()
-                            .unwrap()
-                            .borrow_element()
-                            .as_ref()
-                            .unwrap()
-                            .as_widget()
-                            .overlay(&mut tree.children[0], layout, renderer)
-                    },
+                    overlay_builder: |_, _| None,
                 }
                 .build(),
             );

--- a/lazy/src/pure/component.rs
+++ b/lazy/src/pure/component.rs
@@ -464,16 +464,7 @@ where
                     instance_ref_builder: |instance| instance.state.borrow(),
                     tree: overlay.tree,
                     types: PhantomData,
-                    overlay_builder: |instance, tree| {
-                        instance
-                            .as_ref()
-                            .unwrap()
-                            .borrow_element()
-                            .as_ref()
-                            .unwrap()
-                            .as_widget()
-                            .overlay(&mut tree.children[0], layout, renderer)
-                    },
+                    overlay_builder: |_, _| None,
                 }
                 .build(),
             );

--- a/lazy/src/pure/component.rs
+++ b/lazy/src/pure/component.rs
@@ -415,35 +415,6 @@ where
         let mut local_messages = Vec::new();
         let mut local_shell = Shell::new(&mut local_messages);
 
-        if self
-            .overlay
-            .as_ref()
-            .and_then(|overlay| overlay.borrow_overlay().as_ref())
-            .is_none()
-        {
-            let overlay = self.overlay.take().unwrap().into_heads();
-
-            self.overlay = Some(
-                OverlayBuilder {
-                    instance: overlay.instance,
-                    instance_ref_builder: |instance| instance.state.borrow(),
-                    tree: overlay.tree,
-                    types: PhantomData,
-                    overlay_builder: |instance, tree| {
-                        instance
-                            .as_ref()
-                            .unwrap()
-                            .borrow_element()
-                            .as_ref()
-                            .unwrap()
-                            .as_widget()
-                            .overlay(&mut tree.children[0], layout, renderer)
-                    },
-                }
-                .build(),
-            );
-        }
-
         let event_status = self
             .with_overlay_mut_maybe(|overlay| {
                 overlay.on_event(
@@ -493,7 +464,16 @@ where
                     instance_ref_builder: |instance| instance.state.borrow(),
                     tree: overlay.tree,
                     types: PhantomData,
-                    overlay_builder: |_, _| None,
+                    overlay_builder: |instance, tree| {
+                        instance
+                            .as_ref()
+                            .unwrap()
+                            .borrow_element()
+                            .as_ref()
+                            .unwrap()
+                            .as_widget()
+                            .overlay(&mut tree.children[0], layout, renderer)
+                    },
                 }
                 .build(),
             );

--- a/native/src/shell.rs
+++ b/native/src/shell.rs
@@ -31,6 +31,11 @@ impl<'a, Message> Shell<'a, Message> {
         }
     }
 
+    /// Returns whether the current layout is invalid or not.
+    pub fn is_layout_invalid(&self) -> bool {
+        self.is_layout_invalid
+    }
+
     /// Publish the given `Message` for an application to process it.
     pub fn publish(&mut self, message: Message) {
         self.messages.push(message);


### PR DESCRIPTION
In the implementation of `on_event` for a component's overlay (both pure and impure), after processing local messages which may mutate the state and in turn alter the output of `Component::view`, the cached element and overlay must be rebuilt. Currently, it is rebuilt with a layout tree which is potentially stale, because the shape of the layout tree is dependent upon the cached element which may have changed.

I've added a preliminary fix here, which is to rebuild the cached element only after processing any local messages, then attempt to rebuild the overlay at the beginning of `on_event` if it is absent.

I'll open this as a draft because it feels a bit odd to intentionally leave the cached overlay element as `None` after `on_event`. I haven't yet thought of another way to resolve this though.