### PR TITLE
Don't process captured overlay statuses

### DIFF
--- a/native/src/user_interface.rs
+++ b/native/src/user_interface.rs
@@ -254,6 +254,10 @@ where
             .cloned()
             .zip(overlay_statuses.into_iter())
             .map(|(event, overlay_status)| {
+                if matches!(overlay_status, event::Status::Captured) {
+                    return overlay_status;
+                }
+
                 let mut shell = Shell::new(messages);
 
                 let event_status = self.root.widget.on_event(


### PR DESCRIPTION
Captured events processed by overlays are still getting processed by the widget. This skips processing the event w/ the widget if it was `Captured` by the overlay.