### PR TITLE
fix: corrected images in `README.md` to be similar height.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,27 +18,28 @@ Inspired by [Elm].
   <img src="https://thumbs.gfycat.com/LittleSaneHalicore-small.gif" height="350px">
 </a>
 <a href="https://gfycat.com/politeadorableiberianmole">
-  <img src="https://thumbs.gfycat.com/PoliteAdorableIberianmole-small.gif">
+  <img src="https://thumbs.gfycat.com/PoliteAdorableIberianmole-small.gif" height="350px">
 </a>
 
 </div>
 
 ## Features
-  * Simple, easy-to-use, batteries-included API
-  * Type-safe, reactive programming model
-  * [Cross-platform support] (Windows, macOS, Linux, and [the Web])
-  * Responsive layout
-  * Built-in widgets (including [text inputs], [scrollables], and more!)
-  * Custom widget support (create your own!)
-  * [Debug overlay with performance metrics]
-  * First-class support for async actions (use futures!)
-  * [Modular ecosystem] split into reusable parts:
-    * A [renderer-agnostic native runtime] enabling integration with existing systems
-    * Two [built-in renderers] leveraging [`wgpu`] and [`glow`]
-      * [`iced_wgpu`] supporting Vulkan, Metal and DX12
-      * [`iced_glow`] supporting OpenGL 2.1+ and OpenGL ES 2.0+
-    * A [windowing shell]
-    * A [web runtime] leveraging the DOM
+
+* Simple, easy-to-use, batteries-included API
+* Type-safe, reactive programming model
+* [Cross-platform support] (Windows, macOS, Linux, and [the Web])
+* Responsive layout
+* Built-in widgets (including [text inputs], [scrollables], and more!)
+* Custom widget support (create your own!)
+* [Debug overlay with performance metrics]
+* First-class support for async actions (use futures!)
+* [Modular ecosystem] split into reusable parts:
+  * A [renderer-agnostic native runtime] enabling integration with existing systems
+  * Two [built-in renderers] leveraging [`wgpu`] and [`glow`]
+    * [`iced_wgpu`] supporting Vulkan, Metal and DX12
+    * [`iced_glow`] supporting OpenGL 2.1+ and OpenGL ES 2.0+
+  * A [windowing shell]
+  * A [web runtime] leveraging the DOM
 
 __Iced is currently experimental software.__ [Take a look at the roadmap],
 [check out the issues], and [feel free to contribute!]
@@ -63,6 +64,7 @@ __Iced is currently experimental software.__ [Take a look at the roadmap],
 [feel free to contribute!]: #contributing--feedback
 
 ## Installation
+
 Add `iced` as a dependency in your `Cargo.toml`:
 
 ```toml
@@ -78,15 +80,16 @@ you want to learn about a specific release, check out [the release list].
 [the release list]: https://github.com/iced-rs/iced/releases
 
 ## Overview
+
 Inspired by [The Elm Architecture], Iced expects you to split user interfaces
 into four different concepts:
 
-  * __State__ — the state of your application
-  * __Messages__ — user interactions or meaningful events that you care
+* __State__ — the state of your application
+* __Messages__ — user interactions or meaningful events that you care
   about
-  * __View logic__ — a way to display your __state__ as widgets that
+* __View logic__ — a way to display your __state__ as widgets that
   may produce __messages__ on user interaction
-  * __Update logic__ — a way to react to __messages__ and update your
+* __Update logic__ — a way to react to __messages__ and update your
   __state__
 
 We can build something to see how this works! Let's say we want a simple counter
@@ -179,6 +182,7 @@ to:
 Browse the [documentation] and the [examples] to learn more!
 
 ## Implementation details
+
 Iced was originally born as an attempt at bringing the simplicity of [Elm] and
 [The Elm Architecture] into [Coffee], a 2D game engine I am working on.
 
@@ -204,7 +208,9 @@ end-user-oriented GUI library, while keeping [the ecosystem] modular:
 [the ecosystem]: ECOSYSTEM.md
 
 ## Troubleshooting
+
 ### `GraphicsAdapterNotFound`
+
 This occurs when the selected [built-in renderer] is not able to create a context.
 
 Often this will occur while using [`iced_wgpu`] as the renderer without
@@ -212,22 +218,25 @@ supported hardware (needs Vulkan, Metal or DX12). In this case, you could try us
 [`iced_glow`] renderer:
 
 First, check if it works with
+
 ```console
-$ cargo run --features iced/glow --package game_of_life
+cargo run --features iced/glow --package game_of_life
 ```
 
 and then use it in your project with
+
 ```toml
 iced = { version = "0.4", default-features = false, features = ["glow"] }
 ```
 
-**NOTE:** Chances are you have hardware that supports at least OpenGL 2.1 or OpenGL ES 2.0,
+__NOTE:__ Chances are you have hardware that supports at least OpenGL 2.1 or OpenGL ES 2.0,
 but if you don't, right now there's no software fallback, so it means your hardware
 doesn't support Iced.
 
 [built-in renderer]: https://github.com/iced-rs/iced/blob/master/ECOSYSTEM.md#Renderers
 
 ## Contributing / Feedback
+
 Contributions are greatly appreciated! If you want to contribute, please
 read our [contributing guidelines] for more details.
 
@@ -237,6 +246,7 @@ awesome folks) over the `#games-and-graphics` and `#gui-and-ui` channels in
 the [Rust Community Discord]. I go by `lone_scientist#9554` there.
 
 ## Sponsors
+
 The development of Iced is sponsored by the [Cryptowatch] team at [Kraken.com]
 
 [documentation]: https://docs.rs/iced/


### PR DESCRIPTION
This is just a tiny PR which ensures the two gifs in the README is equal heights. It looks a lot better, when Github is switched to Dark. I also took the liberty to correct a few markdown lints.

<img width="991" alt="Screenshot 2022-06-02 at 10 11 52 AM" src="https://user-images.githubusercontent.com/2248455/171585458-1856d94e-47d2-441f-9e10-96bd357bb77d.png">

