### PR TITLE
Fix `arc_to`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ members = [
     "examples/tour",
     "examples/url_handler",
     "examples/websocket",
+    "examples/pure/arc",
     "examples/pure/component",
     "examples/pure/counter",
     "examples/pure/game_of_life",

--- a/examples/pure/arc/Cargo.toml
+++ b/examples/pure/arc/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "arc"
+version = "0.1.0"
+authors = ["ThatsNoMoon <git@thatsnomoon.dev>"]
+edition = "2021"
+publish = false
+
+[dependencies]
+iced = { path = "../../..", features = ["pure", "canvas", "tokio", "debug"] }

--- a/examples/pure/arc/README.md
+++ b/examples/pure/arc/README.md
@@ -1,0 +1,14 @@
+## arc_to
+
+An application that uses the `Canvas` widget to draw a rotating arc.
+
+This is a simple demo for https://github.com/iced-rs/iced/pull/1358.
+
+The __[`main`]__ file contains all the code of the example.
+
+You can run it with `cargo run`:
+```
+cargo run --package arc_to
+```
+
+[`main`]: src/main.rs

--- a/examples/pure/arc/README.md
+++ b/examples/pure/arc/README.md
@@ -1,4 +1,4 @@
-## arc_to
+## Arc
 
 An application that uses the `Canvas` widget to draw a rotating arc.
 
@@ -8,7 +8,7 @@ The __[`main`]__ file contains all the code of the example.
 
 You can run it with `cargo run`:
 ```
-cargo run --package arc_to
+cargo run --package arc
 ```
 
 [`main`]: src/main.rs

--- a/examples/pure/arc/src/main.rs
+++ b/examples/pure/arc/src/main.rs
@@ -5,9 +5,7 @@ use iced::pure::widget::canvas::{
     self, Cache, Canvas, Cursor, Geometry, Path, Stroke,
 };
 use iced::pure::{Application, Element};
-use iced::{
-    Color, Command, Length, Point, Rectangle, Settings, Subscription, Theme,
-};
+use iced::{Command, Length, Point, Rectangle, Settings, Subscription, Theme};
 
 pub fn main() -> iced::Result {
     Arc::run(Settings {
@@ -80,6 +78,8 @@ impl<Message> canvas::Program<Message> for Arc {
         _cursor: Cursor,
     ) -> Vec<Geometry> {
         let geometry = self.cache.draw(bounds.size(), |frame| {
+            let palette = theme.palette();
+
             let center = frame.center();
             let radius = frame.width().min(frame.height()) / 5.0;
 
@@ -101,15 +101,13 @@ impl<Message> canvas::Program<Message> for Arc {
                 b.circle(end, 10.0);
             });
 
-            frame.fill(&circles, Color::WHITE);
+            frame.fill(&circles, palette.text);
 
             let path = Path::new(|b| {
                 b.move_to(start);
                 b.arc_to(center, end, 50.0);
                 b.line_to(end);
             });
-
-            let palette = theme.palette();
 
             frame.stroke(
                 &path,

--- a/examples/pure/arc/src/main.rs
+++ b/examples/pure/arc/src/main.rs
@@ -1,0 +1,126 @@
+use std::{f32::consts::PI, time::Instant};
+
+use iced::executor;
+use iced::pure::widget::canvas::{
+    self, Cache, Canvas, Cursor, Geometry, Path, Stroke,
+};
+use iced::pure::{Application, Element};
+use iced::{
+    Color, Command, Length, Point, Rectangle, Settings, Subscription, Theme,
+};
+
+pub fn main() -> iced::Result {
+    Arc::run(Settings {
+        antialiasing: true,
+        ..Settings::default()
+    })
+}
+
+struct Arc {
+    start: Instant,
+    cache: Cache,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Message {
+    Tick,
+}
+
+impl Application for Arc {
+    type Executor = executor::Default;
+    type Message = Message;
+    type Theme = Theme;
+    type Flags = ();
+
+    fn new(_flags: ()) -> (Self, Command<Message>) {
+        (
+            Arc {
+                start: Instant::now(),
+                cache: Default::default(),
+            },
+            Command::none(),
+        )
+    }
+
+    fn title(&self) -> String {
+        String::from("Arc - Iced")
+    }
+
+    fn update(&mut self, _: Message) -> Command<Message> {
+        self.cache.clear();
+
+        Command::none()
+    }
+
+    fn subscription(&self) -> Subscription<Message> {
+        iced::time::every(std::time::Duration::from_millis(10))
+            .map(|_| Message::Tick)
+    }
+
+    fn view(&self) -> Element<Message> {
+        Canvas::new(self)
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .into()
+    }
+
+    fn theme(&self) -> Theme {
+        Theme::Dark
+    }
+}
+
+impl<Message> canvas::Program<Message> for Arc {
+    type State = ();
+
+    fn draw(
+        &self,
+        _state: &Self::State,
+        theme: &Theme,
+        bounds: Rectangle,
+        _cursor: Cursor,
+    ) -> Vec<Geometry> {
+        let geometry = self.cache.draw(bounds.size(), |frame| {
+            let center = frame.center();
+            let radius = frame.width().min(frame.height()) / 5.0;
+
+            let start = Point::new(center.x, center.y - radius);
+
+            let angle = (self.start.elapsed().as_millis() % 10_000) as f32
+                / 10_000.0
+                * 2.0
+                * PI;
+
+            let end = Point::new(
+                center.x + radius * angle.cos(),
+                center.y + radius * angle.sin(),
+            );
+
+            let circles = Path::new(|b| {
+                b.circle(start, 10.0);
+                b.move_to(end);
+                b.circle(end, 10.0);
+            });
+
+            frame.fill(&circles, Color::WHITE);
+
+            let path = Path::new(|b| {
+                b.move_to(start);
+                b.arc_to(center, end, 50.0);
+                b.line_to(end);
+            });
+
+            let palette = theme.palette();
+
+            frame.stroke(
+                &path,
+                Stroke {
+                    color: palette.text,
+                    width: 10.0,
+                    ..Stroke::default()
+                },
+            );
+        });
+
+        vec![geometry]
+    }
+}

--- a/graphics/src/widget/canvas/path/builder.rs
+++ b/graphics/src/widget/canvas/path/builder.rs
@@ -42,9 +42,16 @@ impl Builder {
     /// Adds a circular arc to the [`Path`] with the given control points and
     /// radius.
     ///
-    /// This essentially draws two straight line segments, from the current
-    /// position to `a`, and from `a` to `b`, but smooths out the corner by
-    /// fitting a circular arc of `radius` tangent to both segments.
+    /// This essentially draws a straight line segment from the current
+    /// position to `a`, but fits a circular arc of `radius` tangent to that
+    /// segment and tangent to the line between `a` and `b`.
+    ///
+    /// With another `.line_to(b)`, the result will be a path connecting the
+    /// starting point and `b` with straight line segments towards `a` and a
+    /// circular arc smoothing out the corner at `a`.
+    ///
+    /// See [the HTML5 specification of `arcTo`](https://html.spec.whatwg.org/multipage/canvas.html#building-paths:dom-context-2d-arcto)
+    /// for more details and examples.
     pub fn arc_to(&mut self, a: Point, b: Point, radius: f32) {
         use lyon::{math, path};
 
@@ -53,7 +60,7 @@ impl Builder {
         let end = math::Point::new(b.x, b.y);
 
         if start == mid || mid == end || radius == 0.0 {
-            let _ = self.raw.line_to(end);
+            let _ = self.raw.line_to(mid);
             return;
         }
 
@@ -62,7 +69,7 @@ impl Builder {
             + end.x * (start.y - mid.y);
 
         if double_area == 0.0 {
-            let _ = self.raw.line_to(end);
+            let _ = self.raw.line_to(mid);
             return;
         }
 
@@ -91,8 +98,6 @@ impl Builder {
             },
             arc_end,
         );
-
-        let _ = self.raw.line_to(end);
     }
 
     /// Adds an ellipse to the [`Path`] using a clockwise direction.

--- a/style/src/theme/palette.rs
+++ b/style/src/theme/palette.rs
@@ -5,11 +5,11 @@ use palette::{FromColor, Hsl, Mix, RelativeContrast, Srgb};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Palette {
-    background: Color,
-    text: Color,
-    primary: Color,
-    success: Color,
-    danger: Color,
+    pub background: Color,
+    pub text: Color,
+    pub primary: Color,
+    pub success: Color,
+    pub danger: Color,
 }
 
 impl Palette {


### PR DESCRIPTION
Fixed `iced_graphics::widget::canvas::path::Builder::arc_to` to behave the same as [HTML5's `arcTo`](https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-arcto).

Closes #1357.