### PR TITLE
Prevent pane grid title bar content and controls from overlapping

### DIFF
--- a/native/src/widget/pane_grid/title_bar.rs
+++ b/native/src/widget/pane_grid/title_bar.rs
@@ -105,19 +105,17 @@ where
 
         let mut children = padded.children();
         let title_layout = children.next().unwrap();
-
-        self.content.draw(
-            renderer,
-            &inherited_style,
-            title_layout,
-            cursor_position,
-            viewport,
-        );
+        let mut show_title = true;
 
         if let Some(controls) = &self.controls {
             let controls_layout = children.next().unwrap();
 
             if show_controls || self.always_show_controls {
+                if title_layout.bounds().width + controls_layout.bounds().width
+                    > padded.bounds().width
+                {
+                    show_title = false;
+                }
                 controls.draw(
                     renderer,
                     &inherited_style,
@@ -126,6 +124,16 @@ where
                     viewport,
                 );
             }
+        }
+
+        if show_title {
+            self.content.draw(
+                renderer,
+                &inherited_style,
+                title_layout,
+                cursor_position,
+                viewport,
+            );
         }
     }
 
@@ -214,9 +222,15 @@ where
 
         let mut children = padded.children();
         let title_layout = children.next().unwrap();
+        let mut show_title = true;
 
         let control_status = if let Some(controls) = &mut self.controls {
             let controls_layout = children.next().unwrap();
+            if title_layout.bounds().width + controls_layout.bounds().width
+                > padded.bounds().width
+            {
+                show_title = false;
+            }
 
             controls.on_event(
                 event.clone(),
@@ -230,14 +244,18 @@ where
             event::Status::Ignored
         };
 
-        let title_status = self.content.on_event(
-            event,
-            title_layout,
-            cursor_position,
-            renderer,
-            clipboard,
-            shell,
-        );
+        let title_status = if show_title {
+            self.content.on_event(
+                event,
+                title_layout,
+                cursor_position,
+                renderer,
+                clipboard,
+                shell,
+            )
+        } else {
+            event::Status::Ignored
+        };
 
         control_status.merge(title_status)
     }
@@ -264,15 +282,20 @@ where
 
         if let Some(controls) = &self.controls {
             let controls_layout = children.next().unwrap();
+            let controls_interaction = controls.mouse_interaction(
+                controls_layout,
+                cursor_position,
+                viewport,
+                renderer,
+            );
 
-            controls
-                .mouse_interaction(
-                    controls_layout,
-                    cursor_position,
-                    viewport,
-                    renderer,
-                )
-                .max(title_interaction)
+            if title_layout.bounds().width + controls_layout.bounds().width
+                > padded.bounds().width
+            {
+                controls_interaction
+            } else {
+                controls_interaction.max(title_interaction)
+            }
         } else {
             title_interaction
         }


### PR DESCRIPTION
This fixes the content/controls becoming unreadable when they overlap in narrow panes.

Should this be configurable? For example:

```rust
enum Overlap {
    Allow, // existing behavior
    HideContent, // proposed behavior
    HideControls,
}
```

### Before
https://user-images.githubusercontent.com/4934192/172265902-715c0a3f-bab7-41d9-8ad5-1fcbd6dc214a.mp4

### After
https://user-images.githubusercontent.com/4934192/172265908-66f7ec7e-2121-4c82-9f4a-fa12f663cb7a.mp4
