### PR TITLE
Fix alpha blending for wgpu msaa

### DIFF
--- a/examples/solar_system/src/main.rs
+++ b/examples/solar_system/src/main.rs
@@ -48,6 +48,10 @@ impl Application for SolarSystem {
         String::from("Solar system - Iced")
     }
 
+    fn background_color(&self) -> Color {
+        Color::BLACK
+    }
+
     fn update(&mut self, message: Message) -> Command<Message> {
         match message {
             Message::Tick(instant) => {
@@ -137,15 +141,11 @@ impl<Message> canvas::Program<Message> for State {
         use std::f32::consts::PI;
 
         let background = self.space_cache.draw(bounds.size(), |frame| {
-            let space = Path::rectangle(Point::new(0.0, 0.0), frame.size());
-
             let stars = Path::new(|path| {
                 for (p, size) in &self.stars {
                     path.rectangle(*p, Size::new(*size, *size));
                 }
             });
-
-            frame.fill(&space, Color::BLACK);
 
             frame.translate(frame.center() - Point::ORIGIN);
             frame.fill(&stars, Color::WHITE);

--- a/wgpu/src/triangle.rs
+++ b/wgpu/src/triangle.rs
@@ -162,18 +162,7 @@ impl Pipeline {
                     entry_point: "fs_main",
                     targets: &[wgpu::ColorTargetState {
                         format,
-                        blend: Some(wgpu::BlendState {
-                            color: wgpu::BlendComponent {
-                                src_factor: wgpu::BlendFactor::SrcAlpha,
-                                dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
-                                operation: wgpu::BlendOperation::Add,
-                            },
-                            alpha: wgpu::BlendComponent {
-                                src_factor: wgpu::BlendFactor::One,
-                                dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
-                                operation: wgpu::BlendOperation::Add,
-                            },
-                        }),
+                        blend: Some(wgpu::BlendState::ALPHA_BLENDING),
                         write_mask: wgpu::ColorWrites::ALL,
                     }],
                 }),

--- a/wgpu/src/triangle/msaa.rs
+++ b/wgpu/src/triangle/msaa.rs
@@ -95,18 +95,9 @@ impl Blit {
                     entry_point: "fs_main",
                     targets: &[wgpu::ColorTargetState {
                         format,
-                        blend: Some(wgpu::BlendState {
-                            color: wgpu::BlendComponent {
-                                src_factor: wgpu::BlendFactor::SrcAlpha,
-                                dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
-                                operation: wgpu::BlendOperation::Add,
-                            },
-                            alpha: wgpu::BlendComponent {
-                                src_factor: wgpu::BlendFactor::One,
-                                dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
-                                operation: wgpu::BlendOperation::Add,
-                            },
-                        }),
+                        blend: Some(
+                            wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING,
+                        ),
                         write_mask: wgpu::ColorWrites::ALL,
                     }],
                 }),


### PR DESCRIPTION
Alpha is not blended correctly when using MSAA on wgpu. When the fragments are stored to the multisampled color attachment, the color components are multiplied by alpha. When they are sampled and then stored to the non-multisampled resolve attachment, they are getting multiplied by alpha again. Using `PREMULTIPLIED_ALPHA_BLENDING` for the resolve attachment fixes this since it uses a `src_factor` of `One`.

This is evident when adding a background color to the `solar_system` example and removing the `frame.fill` call to cover the canvas in a background color. The orbit, which has a small alpha value to begin with, becomes nearly fully transparent due to the double alpha blending. This fixes it so the orbit looks identical in alpha to the example without anti-aliasing enabled. 