### PR TITLE
Allow overriding pure text_input value during draw

### DIFF
--- a/pure/src/widget/text_input.rs
+++ b/pure/src/widget/text_input.rs
@@ -121,6 +121,32 @@ where
         self.style_sheet = style_sheet.into();
         self
     }
+
+    /// Draws the [`TextInput`] with the given [`Renderer`], overriding its
+    /// [`text_input::Value`] if provided.
+    ///
+    /// [`Renderer`]: text::Renderer
+    pub fn draw(
+        &self,
+        tree: &Tree,
+        renderer: &mut Renderer,
+        layout: Layout<'_>,
+        cursor_position: Point,
+        value: Option<&text_input::Value>,
+    ) {
+        text_input::draw(
+            renderer,
+            layout,
+            cursor_position,
+            tree.state.downcast_ref::<text_input::State>(),
+            value.unwrap_or(&self.value),
+            &self.placeholder,
+            self.size,
+            &self.font,
+            self.is_secure,
+            self.style_sheet.as_ref(),
+        )
+    }
 }
 
 impl<'a, Message, Renderer> Widget<Message, Renderer>


### PR DESCRIPTION
`iced_native::widget::TextInput` defines a `draw` method to override it's `Value` when drawn. This adds the same functionality to the pure version.

Difference here is caller must provide the `Tree` with associated state in it for the text input and it's up to them to make sure this is safe.