### PR TITLE
Update import path in pure canvas example

### DIFF
--- a/graphics/src/widget/pure/canvas.rs
+++ b/graphics/src/widget/pure/canvas.rs
@@ -28,7 +28,9 @@ use std::marker::PhantomData;
 /// ```no_run
 /// # mod iced {
 /// #     pub mod pure {
-/// #         pub use iced_graphics::pure::canvas;
+/// #         pub mod widget {
+/// #             pub use iced_graphics::pure::canvas;
+/// #         }
 /// #     }
 /// #     pub use iced_native::{Color, Rectangle, Theme};
 /// # }

--- a/graphics/src/widget/pure/canvas.rs
+++ b/graphics/src/widget/pure/canvas.rs
@@ -32,7 +32,7 @@ use std::marker::PhantomData;
 /// #     }
 /// #     pub use iced_native::{Color, Rectangle, Theme};
 /// # }
-/// use iced::pure::canvas::{self, Canvas, Cursor, Fill, Frame, Geometry, Path, Program};
+/// use iced::pure::widget::canvas::{self, Canvas, Cursor, Fill, Frame, Geometry, Path, Program};
 /// use iced::{Color, Rectangle, Theme};
 ///
 /// // First, we define the data we need for drawing


### PR DESCRIPTION
In current version, `iced::pure::canvas` would be unresolved.
It should be `iced::pure::widget::canvas`.