### PR TITLE
Fix `Widget::tag` implementation of `pure::Canvas`

### DIFF
--- a/graphics/src/widget/pure/canvas.rs
+++ b/graphics/src/widget/pure/canvas.rs
@@ -109,7 +109,8 @@ where
     B: Backend,
 {
     fn tag(&self) -> tree::Tag {
-        tree::Tag::of::<P::State>()
+        struct Tag<T>(T);
+        tree::Tag::of::<Tag<P::State>>()
     }
 
     fn state(&self) -> tree::State {

--- a/lazy/src/pure/component.rs
+++ b/lazy/src/pure/component.rs
@@ -70,8 +70,6 @@ where
     })
 }
 
-struct Tag<T>(T);
-
 struct Instance<'a, Message, Renderer, Event, S> {
     state: RefCell<Option<State<'a, Message, Renderer, Event, S>>>,
 }
@@ -132,6 +130,7 @@ where
     Renderer: iced_native::Renderer,
 {
     fn tag(&self) -> tree::Tag {
+        struct Tag<T>(T);
         tree::Tag::of::<Tag<S>>()
     }
 


### PR DESCRIPTION
Using `P::State` can cause a panic if the `Canvas` has `()` as `P::State` and replaces a stateless widget in a future `view` call.

Related to #1309.