### PR TITLE
Allow specification of `border_radius` for `pick_list::Menu`

### DIFF
--- a/native/src/overlay/menu.rs
+++ b/native/src/overlay/menu.rs
@@ -273,7 +273,7 @@ where
                 },
                 border_color: appearance.border_color,
                 border_width: appearance.border_width,
-                border_radius: 0.0,
+                border_radius: appearance.border_radius,
             },
             appearance.background,
         );
@@ -461,7 +461,7 @@ where
                         bounds,
                         border_color: Color::TRANSPARENT,
                         border_width: 0.0,
-                        border_radius: 0.0,
+                        border_radius: appearance.border_radius,
                     },
                     appearance.selected_background,
                 );

--- a/style/src/menu.rs
+++ b/style/src/menu.rs
@@ -6,6 +6,7 @@ pub struct Appearance {
     pub text_color: Color,
     pub background: Background,
     pub border_width: f32,
+    pub border_radius: f32,
     pub border_color: Color,
     pub selected_text_color: Color,
     pub selected_background: Background,

--- a/style/src/theme.rs
+++ b/style/src/theme.rs
@@ -366,6 +366,7 @@ impl menu::StyleSheet for Theme {
             text_color: palette.background.weak.text,
             background: palette.background.weak.color.into(),
             border_width: 1.0,
+            border_radius: 0.0,
             border_color: palette.background.strong.color,
             selected_text_color: palette.primary.strong.text,
             selected_background: palette.primary.strong.color.into(),


### PR DESCRIPTION
Currently a `border_radius` may be applied to the pick list button, but not its menu. This PR updates the menu to support border radius.