### PR TITLE
Fix Tooltip inside Scrollable

### DIFF
--- a/native/src/widget/tooltip.rs
+++ b/native/src/widget/tooltip.rs
@@ -349,7 +349,7 @@ pub fn draw<Renderer>(
                 viewport.y + viewport.height - tooltip_bounds.height;
         }
 
-        renderer.with_layer(*viewport, |renderer| {
+        renderer.with_layer(Rectangle::with_size(Size::INFINITY), |renderer| {
             container::draw_background(renderer, &style, tooltip_bounds);
 
             draw_text(

--- a/native/src/widget/tooltip.rs
+++ b/native/src/widget/tooltip.rs
@@ -25,6 +25,7 @@ where
     position: Position,
     gap: u16,
     padding: u16,
+    snap_within_viewport: bool,
     style: <Renderer::Theme as container::StyleSheet>::Style,
 }
 
@@ -50,6 +51,7 @@ where
             position,
             gap: 0,
             padding: Self::DEFAULT_PADDING,
+            snap_within_viewport: true,
             style: Default::default(),
         }
     }
@@ -77,6 +79,12 @@ where
     /// Sets the padding of the [`Tooltip`].
     pub fn padding(mut self, padding: u16) -> Self {
         self.padding = padding;
+        self
+    }
+
+    /// Sets whether the [`Tooltip`] is snapped within the viewport.
+    pub fn snap_within_viewport(mut self, snap: bool) -> Self {
+        self.snap_within_viewport = snap;
         self
     }
 
@@ -190,6 +198,7 @@ where
             self.position,
             self.gap,
             self.padding,
+            self.snap_within_viewport,
             self.style,
             |renderer, limits| {
                 Widget::<(), Renderer>::layout(tooltip, renderer, limits)
@@ -263,6 +272,7 @@ pub fn draw<Renderer>(
     position: Position,
     gap: u16,
     padding: u16,
+    snap_within_viewport: bool,
     style: <Renderer::Theme as container::StyleSheet>::Style,
     layout_text: impl FnOnce(&Renderer, &layout::Limits) -> layout::Node,
     draw_text: impl FnOnce(
@@ -331,22 +341,24 @@ pub fn draw<Renderer>(
             }
         };
 
-        if tooltip_bounds.x < viewport.x {
-            tooltip_bounds.x = viewport.x;
-        } else if viewport.x + viewport.width
-            < tooltip_bounds.x + tooltip_bounds.width
-        {
-            tooltip_bounds.x =
-                viewport.x + viewport.width - tooltip_bounds.width;
-        }
+        if snap_within_viewport {
+            if tooltip_bounds.x < viewport.x {
+                tooltip_bounds.x = viewport.x;
+            } else if viewport.x + viewport.width
+                < tooltip_bounds.x + tooltip_bounds.width
+            {
+                tooltip_bounds.x =
+                    viewport.x + viewport.width - tooltip_bounds.width;
+            }
 
-        if tooltip_bounds.y < viewport.y {
-            tooltip_bounds.y = viewport.y;
-        } else if viewport.y + viewport.height
-            < tooltip_bounds.y + tooltip_bounds.height
-        {
-            tooltip_bounds.y =
-                viewport.y + viewport.height - tooltip_bounds.height;
+            if tooltip_bounds.y < viewport.y {
+                tooltip_bounds.y = viewport.y;
+            } else if viewport.y + viewport.height
+                < tooltip_bounds.y + tooltip_bounds.height
+            {
+                tooltip_bounds.y =
+                    viewport.y + viewport.height - tooltip_bounds.height;
+            }
         }
 
         renderer.with_layer(Rectangle::with_size(Size::INFINITY), |renderer| {


### PR DESCRIPTION
`Tooltip` inside `Scrollable` is currently broken since the `viewport` passed to the `Tooltip` is modified by `Scrollable` to be it's visible bounds instead of the application viewport bounds. This causes the `Tooltip` to position itself within these bounds.

I've added a builder to `Tooltip` to disable the positioning adjustment that ensures its always inside the `viewport` with `snap_within_viewport(bool)`. I've then also removed the layer clip when drawing the tooltip so it's not clipped by the scrollable bounds (tooltip is effectively an overlay and should never be clipped).

Commit b3f5f74 shows the bug and 046e7e0 shows it being fixed. These commits can get dropped.


I realize this is a hacky solution, since `snap_within_viewport` shouldn't be something that's exposed or even considered and isn't really honest about why it's there. However, since we don't get the _actual_ window viewport in the widget, we have no way of know when or when not to adjust to the viewport.

Should we do something like the following, so there is a `window` bounds that can be used that we know is unchanged during `draw`. `Tooltip` can then use this for it's positioning adjustment to the window bounds.

```rs
fn draw<'a>(
    &'a self,
    ...,
    viewport: &Rectangle,
    window: &'a Rectangle,
)
```