### PR TITLE
Don't double translate text clip inside canvas

### DIFF
--- a/graphics/src/widget/canvas/frame.rs
+++ b/graphics/src/widget/canvas/frame.rs
@@ -280,7 +280,7 @@ impl Frame {
                 Primitive::Translate {
                     translation,
                     content: Box::new(Primitive::Clip {
-                        bounds: region,
+                        bounds: Rectangle::with_size(region.size()),
                         content: Box::new(Primitive::Group {
                             primitives: text,
                         }),


### PR DESCRIPTION
The clip bounds is already inside a `Translate`, so using `region` offsets the clip bounds by translate again. Clip within the translate should start at origin w/ region size.