### PR TITLE
Don't constrict tooltip text layout to viewport size

### DIFF
--- a/native/src/widget/tooltip.rs
+++ b/native/src/widget/tooltip.rs
@@ -300,8 +300,13 @@ pub fn draw<Renderer>(
 
         let text_layout = layout_text(
             renderer,
-            &layout::Limits::new(Size::ZERO, viewport.size())
-                .pad(Padding::new(padding)),
+            &layout::Limits::new(
+                Size::ZERO,
+                snap_within_viewport
+                    .then(|| viewport.size())
+                    .unwrap_or(Size::INFINITY),
+            )
+            .pad(Padding::new(padding)),
         );
 
         let padding = f32::from(padding);


### PR DESCRIPTION
Oops, I forgot to remove this constraint. The text layout also shouldn't be constrained to the viewport size (when viewport is set by scrollable). 