### PR TITLE
Fix invisible window on Windows

### DIFF
--- a/glutin/src/application.rs
+++ b/glutin/src/application.rs
@@ -54,17 +54,12 @@ where
         runtime.enter(|| A::new(flags))
     };
 
-    let should_be_visible = settings.window.visible;
-
     let context = {
-        let builder = settings
-            .window
-            .into_builder(
-                &application.title(),
-                event_loop.primary_monitor(),
-                settings.id,
-            )
-            .with_visible(false);
+        let builder = settings.window.into_builder(
+            &application.title(),
+            event_loop.primary_monitor(),
+            settings.id,
+        );
 
         log::info!("Window builder: {:#?}", builder);
 
@@ -139,7 +134,6 @@ where
         receiver,
         context,
         init_command,
-        should_be_visible,
         settings.exit_on_close_request,
     ));
 
@@ -192,7 +186,6 @@ async fn run_instance<A, E, C>(
     mut receiver: mpsc::UnboundedReceiver<glutin::event::Event<'_, A::Message>>,
     mut context: glutin::ContextWrapper<glutin::PossiblyCurrent, Window>,
     init_command: Command<A::Message>,
-    should_be_visible: bool,
     exit_on_close_request: bool,
 ) where
     A: Application + 'static,
@@ -206,7 +199,6 @@ async fn run_instance<A, E, C>(
     let mut clipboard = Clipboard::connect(context.window());
     let mut cache = user_interface::Cache::default();
     let mut state = application::State::new(&application, context.window());
-    let mut visible = false;
     let mut viewport_version = state.viewport_version();
 
     application::run_command(
@@ -405,12 +397,6 @@ async fn run_instance<A, E, C>(
                 context.swap_buffers().expect("Swap buffers");
 
                 debug.render_finished();
-
-                if !visible && should_be_visible {
-                    context.window().set_visible(true);
-
-                    visible = true;
-                }
 
                 // TODO: Handle animations!
                 // Maybe we can use `ControlFlow::WaitUntil` for this.

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -137,15 +137,11 @@ where
         runtime.enter(|| A::new(flags))
     };
 
-    let should_be_visible = settings.window.visible;
-    let builder = settings
-        .window
-        .into_builder(
-            &application.title(),
-            event_loop.primary_monitor(),
-            settings.id,
-        )
-        .with_visible(false);
+    let builder = settings.window.into_builder(
+        &application.title(),
+        event_loop.primary_monitor(),
+        settings.id,
+    );
 
     log::info!("Window builder: {:#?}", builder);
 
@@ -182,7 +178,6 @@ where
         receiver,
         init_command,
         window,
-        should_be_visible,
         settings.exit_on_close_request,
     ));
 
@@ -233,7 +228,6 @@ async fn run_instance<A, E, C>(
     mut receiver: mpsc::UnboundedReceiver<winit::event::Event<'_, A::Message>>,
     init_command: Command<A::Message>,
     window: winit::window::Window,
-    should_be_visible: bool,
     exit_on_close_request: bool,
 ) where
     A: Application + 'static,
@@ -247,7 +241,6 @@ async fn run_instance<A, E, C>(
     let mut clipboard = Clipboard::connect(&window);
     let mut cache = user_interface::Cache::default();
     let mut surface = compositor.create_surface(&window);
-    let mut visible = false;
 
     let mut state = State::new(&application, &window);
     let mut viewport_version = state.viewport_version();
@@ -446,12 +439,6 @@ async fn run_instance<A, E, C>(
                 ) {
                     Ok(()) => {
                         debug.render_finished();
-
-                        if !visible && should_be_visible {
-                            window.set_visible(true);
-
-                            visible = true;
-                        }
 
                         // TODO: Handle animations!
                         // Maybe we can use `ControlFlow::WaitUntil` for this.

--- a/winit/src/settings.rs
+++ b/winit/src/settings.rs
@@ -106,7 +106,8 @@ impl Window {
             .with_decorations(self.decorations)
             .with_transparent(self.transparent)
             .with_window_icon(self.icon)
-            .with_always_on_top(self.always_on_top);
+            .with_always_on_top(self.always_on_top)
+            .with_visible(self.visible);
 
         if let Some(position) = conversion::position(
             primary_monitor.as_ref(),


### PR DESCRIPTION
... by reverting the changes that were supposed to hide the window initially and only show it after rendering the first frame.

Fixes #1419.