### PR TITLE
Make `overlay::menu` accessible

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,6 +174,7 @@ pub mod clipboard;
 pub mod executor;
 pub mod keyboard;
 pub mod mouse;
+pub mod overlay;
 pub mod settings;
 pub mod time;
 pub mod widget;

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -1,0 +1,10 @@
+//! Build and show dropdown menus.
+///
+/// This is an alias of an `iced_native` element with a default `Renderer`.
+pub mod menu {
+    pub use iced_native::overlay::menu::{Appearance, State, StyleSheet};
+
+    /// A widget that produces a message when clicked.
+    pub type Menu<'a, Message, Renderer = crate::Renderer> =
+        iced_native::overlay::Menu<'a, Message, Renderer>;
+}

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -1,7 +1,6 @@
-//! Build and show dropdown menus.
-///
-/// This is an alias of an `iced_native` element with a default `Renderer`.
+//! Display interactive elements on top of other widgets.
 pub mod menu {
+    //! Build and show dropdown menus.
     pub use iced_native::overlay::menu::{Appearance, State, StyleSheet};
 
     /// A widget that produces a message when clicked.

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -1,4 +1,11 @@
 //! Display interactive elements on top of other widgets.
+
+/// A generic [`Overlay`].
+///
+/// This is an alias of an `iced_native` element with a default `Renderer`.
+pub type Element<'a, Message, Renderer = crate::Renderer> =
+    iced_native::overlay::Element<'a, Message, Renderer>;
+
 pub mod menu {
     //! Build and show dropdown menus.
     pub use iced_native::overlay::menu::{Appearance, State, StyleSheet};


### PR DESCRIPTION
Implementing `pick_list::StyleSheet` for a custom `Theme` requires to also implement `menu::StyleSheet` which is currently not accessible.

This pull request creates an alias of `overlay::menu` in the root so you can import it with `use iced::overlay::menu`.

Fixes #1406