### PR TITLE
Iced fixes for trade activity

### DIFF
--- a/native/src/overlay/menu.rs
+++ b/native/src/overlay/menu.rs
@@ -273,7 +273,7 @@ where
                 },
                 border_color: appearance.border_color,
                 border_width: appearance.border_width,
-                border_radius: 0.0,
+                border_radius: appearance.border_radius,
             },
             appearance.background,
         );
@@ -457,7 +457,7 @@ where
                         bounds,
                         border_color: Color::TRANSPARENT,
                         border_width: 0.0,
-                        border_radius: 0.0,
+                        border_radius: appearance.border_radius,
                     },
                     appearance.selected_background,
                 );

--- a/native/src/widget/container.rs
+++ b/native/src/widget/container.rs
@@ -127,12 +127,20 @@ pub fn layout<Renderer>(
     limits: &layout::Limits,
     width: Length,
     height: Length,
+    max_width: u32,
+    max_height: u32,
     padding: Padding,
     horizontal_alignment: alignment::Horizontal,
     vertical_alignment: alignment::Vertical,
     layout_content: impl FnOnce(&Renderer, &layout::Limits) -> layout::Node,
 ) -> layout::Node {
-    let limits = limits.loose().width(width).height(height).pad(padding);
+    let limits = limits
+        .loose()
+        .max_width(max_width)
+        .max_height(max_height)
+        .width(width)
+        .height(height)
+        .pad(padding);
 
     let mut content = layout_content(renderer, &limits.loose());
     let size = limits.resolve(content.size());
@@ -171,6 +179,8 @@ where
             limits,
             self.width,
             self.height,
+            self.max_width,
+            self.max_height,
             self.padding,
             self.horizontal_alignment,
             self.vertical_alignment,

--- a/pure/src/widget/container.rs
+++ b/pure/src/widget/container.rs
@@ -156,6 +156,8 @@ where
             limits,
             self.width,
             self.height,
+            self.max_width,
+            self.max_height,
             self.padding,
             self.horizontal_alignment,
             self.vertical_alignment,

--- a/pure/src/widget/tooltip.rs
+++ b/pure/src/widget/tooltip.rs
@@ -153,7 +153,7 @@ where
     ) -> mouse::Interaction {
         self.content.as_widget().mouse_interaction(
             &tree.children[0],
-            layout.children().next().unwrap(),
+            layout,
             cursor_position,
             viewport,
             renderer,

--- a/style/src/menu.rs
+++ b/style/src/menu.rs
@@ -6,6 +6,7 @@ pub struct Appearance {
     pub text_color: Color,
     pub background: Background,
     pub border_width: f32,
+    pub border_radius: f32,
     pub border_color: Color,
     pub selected_text_color: Color,
     pub selected_background: Background,

--- a/style/src/theme.rs
+++ b/style/src/theme.rs
@@ -366,6 +366,7 @@ impl menu::StyleSheet for Theme {
             text_color: palette.background.weak.text,
             background: palette.background.weak.color.into(),
             border_width: 1.0,
+            border_radius: 0.0,
             border_color: palette.background.strong.color,
             selected_text_color: palette.primary.strong.text,
             selected_background: palette.primary.strong.color.into(),


### PR DESCRIPTION
This brings over some post-impure-removal fixes needed for trade activity. Included are:

- Border radius for the pick_list menu
- Max width/height for container
- Pure tooltip mouse interaction