### PR TITLE
Remove old pure feature from docs.rs build metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ iced_wgpu = { version = "0.5", path = "wgpu", features = ["webgl"], optional = t
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
-features = ["image", "svg", "canvas", "qr_code", "pure"]
+features = ["image", "svg", "canvas", "qr_code"]
 
 [profile.release-opt]
 inherits = "release"


### PR DESCRIPTION
It looks like the `pure` feature was removed in #1393 