### PR TITLE
Update docs for renamed integration examples

### DIFF
--- a/native/src/user_interface.rs
+++ b/native/src/user_interface.rs
@@ -15,10 +15,11 @@ use crate::{Clipboard, Element, Layout, Point, Rectangle, Shell, Size};
 /// charge of using this type in your system in any way you want.
 ///
 /// # Example
-/// The [`integration` example] uses a [`UserInterface`] to integrate Iced in
-/// an existing graphical application.
+/// The [`integration_opengl`] & [`integration_wgpu`] examples use a
+/// [`UserInterface`] to integrate Iced in an existing graphical application.
 ///
-/// [`integration` example]: https://github.com/iced-rs/iced/tree/0.4/examples/integration
+/// [`integration_opengl`]: https://github.com/iced-rs/iced/tree/0.4/examples/integration_opengl
+/// [`integration_wgpu`]: https://github.com/iced-rs/iced/tree/0.4/examples/integration_wgpu
 #[allow(missing_debug_implementations)]
 pub struct UserInterface<'a, Message, Renderer> {
     root: Element<'a, Message, Renderer>,


### PR DESCRIPTION
The integration examples were renamed in
77a0b68aa176782e95048795aec15c20a3e60ec6 , this just updates the docs to point to the updates links.