### PR TITLE
Update docs for running `integration_wgpu` example

### DIFF
--- a/examples/integration_wgpu/README.md
+++ b/examples/integration_wgpu/README.md
@@ -12,7 +12,7 @@ The __[`main`]__ file contains all the code of the example.
 
 You can run it with `cargo run`:
 ```
-cargo run --package integration
+cargo run --package integration_wgpu
 ```
 
 ### How to run this example with WebGL backend


### PR DESCRIPTION
The package should be `integration_wgpu`