### PR TITLE
fix: sync size of window and viewport

### DIFF
--- a/winit/src/application/state.rs
+++ b/winit/src/application/state.rs
@@ -3,7 +3,6 @@ use crate::conversion;
 use crate::{Application, Color, Debug, Point, Size, Viewport};
 
 use std::marker::PhantomData;
-use winit::dpi::PhysicalSize;
 use winit::event::{Touch, WindowEvent};
 use winit::window::Window;
 
@@ -193,18 +192,15 @@ where
 
         // Update scale factor and size
         let new_scale_factor = application.scale_factor();
-        let Size { width, height } = self.viewport.physical_size();
-        let PhysicalSize {
-            width: w_width,
-            height: w_height,
-        } = window.inner_size();
-        if self.scale_factor != new_scale_factor
-            || (width, height) != (w_width, w_height)
-        {
-            let size = window.inner_size();
+        let new_size = window.inner_size();
+        let current_size = self.viewport.physical_size();
 
+        if self.scale_factor != new_scale_factor
+            || (current_size.width, current_size.height)
+                != (new_size.width, new_size.height)
+        {
             self.viewport = Viewport::with_physical_size(
-                Size::new(size.width, size.height),
+                Size::new(new_size.width, new_size.height),
                 window.scale_factor() * new_scale_factor,
             );
             self.viewport_version = self.viewport_version.wrapping_add(1);

--- a/winit/src/application/state.rs
+++ b/winit/src/application/state.rs
@@ -194,8 +194,13 @@ where
         // Update scale factor and size
         let new_scale_factor = application.scale_factor();
         let Size { width, height } = self.viewport.physical_size();
-        let PhysicalSize { width: w_width, height: w_height} = window.inner_size();
-        if self.scale_factor != new_scale_factor || (width, height) != (w_width, w_height) {
+        let PhysicalSize {
+            width: w_width,
+            height: w_height,
+        } = window.inner_size();
+        if self.scale_factor != new_scale_factor
+            || (width, height) != (w_width, w_height)
+        {
             let size = window.inner_size();
 
             self.viewport = Viewport::with_physical_size(

--- a/winit/src/application/state.rs
+++ b/winit/src/application/state.rs
@@ -3,6 +3,7 @@ use crate::conversion;
 use crate::{Application, Color, Debug, Point, Size, Viewport};
 
 use std::marker::PhantomData;
+use winit::dpi::PhysicalSize;
 use winit::event::{Touch, WindowEvent};
 use winit::window::Window;
 
@@ -190,16 +191,18 @@ where
             self.title = new_title;
         }
 
-        // Update scale factor
+        // Update scale factor and size
         let new_scale_factor = application.scale_factor();
-
-        if self.scale_factor != new_scale_factor {
+        let Size { width, height } = self.viewport.physical_size();
+        let PhysicalSize { width: w_width, height: w_height} = window.inner_size();
+        if self.scale_factor != new_scale_factor || (width, height) != (w_width, w_height) {
             let size = window.inner_size();
 
             self.viewport = Viewport::with_physical_size(
                 Size::new(size.width, size.height),
                 window.scale_factor() * new_scale_factor,
             );
+            self.viewport_version = self.viewport_version.wrapping_add(1);
 
             self.scale_factor = new_scale_factor;
         }


### PR DESCRIPTION
I noticed that `iced::window::resize` did change the size of the window, but didn't sync with the viewport size, like how a user resize would. This syncs the size of the window and viewport.