### PR TITLE
Document that `window::Action::Move` is unsupported on Wayland

### DIFF
--- a/native/src/window/action.rs
+++ b/native/src/window/action.rs
@@ -13,6 +13,8 @@ pub enum Action<T> {
         height: u32,
     },
     /// Move the window.
+    ///
+    /// Unsupported on Wayland.
     Move {
         /// The new logical x location of the window
         x: i32,


### PR DESCRIPTION
https://docs.rs/winit/latest/winit/window/struct.Window.html#method.set_outer_position notes that this isn't supported on Wayland.

Wayland by design doesn't allow applications to position windows arbitrarily. GTK4 in comparison removed `gtk_window_move()` (which naturally didn't work on Wayland).