### PR TITLE
Use `Cow<'static, [u8]>` in image/svg, add constructors taking &[u8]`

### DIFF
--- a/native/src/image.rs
+++ b/native/src/image.rs
@@ -26,26 +26,15 @@ impl Handle {
     /// pixels.
     ///
     /// This is useful if you have already decoded your image.
-    pub fn from_pixels(width: u32, height: u32, pixels: Vec<u8>) -> Handle {
-        Self::from_data(Data::Pixels {
-            width,
-            height,
-            pixels: Cow::Owned(pixels),
-        })
-    }
-
-    /// Like [`Handle::from_pixels`], but from static pixel data.
-    ///
-    /// Useful for images included in binary, for instance with [`include_bytes!`].
-    pub fn from_static_pixels(
+    pub fn from_pixels(
         width: u32,
         height: u32,
-        pixels: &'static [u8],
+        pixels: impl Into<Cow<'static, [u8]>>,
     ) -> Handle {
         Self::from_data(Data::Pixels {
             width,
             height,
-            pixels: Cow::Borrowed(pixels),
+            pixels: pixels.into(),
         })
     }
 
@@ -55,15 +44,8 @@ impl Handle {
     ///
     /// This is useful if you already have your image loaded in-memory, maybe
     /// because you downloaded or generated it procedurally.
-    pub fn from_memory(bytes: Vec<u8>) -> Handle {
-        Self::from_data(Data::Bytes(Cow::Owned(bytes)))
-    }
-
-    /// Like [`Handle::from_memory`], but from static image data.
-    ///
-    /// Useful for images included in binary, for instance with [`include_bytes!`].
-    pub fn from_static_memory(bytes: &'static [u8]) -> Handle {
-        Self::from_data(Data::Bytes(Cow::Borrowed(bytes)))
+    pub fn from_memory(bytes: impl Into<Cow<'static, [u8]>>) -> Handle {
+        Self::from_data(Data::Bytes(bytes.into()))
     }
 
     fn from_data(data: Data) -> Handle {

--- a/native/src/svg.rs
+++ b/native/src/svg.rs
@@ -1,6 +1,7 @@
 //! Load and draw vector graphics.
 use crate::{Hasher, Rectangle};
 
+use std::borrow::Cow;
 use std::hash::{Hash, Hasher as _};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -25,7 +26,14 @@ impl Handle {
     /// This is useful if you already have your SVG data in-memory, maybe
     /// because you downloaded or generated it procedurally.
     pub fn from_memory(bytes: impl Into<Vec<u8>>) -> Handle {
-        Self::from_data(Data::Bytes(bytes.into()))
+        Self::from_data(Data::Bytes(Cow::Owned(bytes.into())))
+    }
+
+    /// Like [`Handle::from_memory`], but from static image data.
+    ///
+    /// Useful for images included in binary, for instance with [`include_bytes!`].
+    pub fn from_static_memory(bytes: &'static [u8]) -> Handle {
+        Self::from_data(Data::Bytes(Cow::Borrowed(bytes)))
     }
 
     fn from_data(data: Data) -> Handle {
@@ -64,7 +72,7 @@ pub enum Data {
     /// In-memory data
     ///
     /// Can contain an SVG string or a gzip compressed data.
-    Bytes(Vec<u8>),
+    Bytes(Cow<'static, [u8]>),
 }
 
 impl std::fmt::Debug for Data {

--- a/native/src/svg.rs
+++ b/native/src/svg.rs
@@ -25,15 +25,8 @@ impl Handle {
     ///
     /// This is useful if you already have your SVG data in-memory, maybe
     /// because you downloaded or generated it procedurally.
-    pub fn from_memory(bytes: impl Into<Vec<u8>>) -> Handle {
-        Self::from_data(Data::Bytes(Cow::Owned(bytes.into())))
-    }
-
-    /// Like [`Handle::from_memory`], but from static image data.
-    ///
-    /// Useful for images included in binary, for instance with [`include_bytes!`].
-    pub fn from_static_memory(bytes: &'static [u8]) -> Handle {
-        Self::from_data(Data::Bytes(Cow::Borrowed(bytes)))
+    pub fn from_memory(bytes: impl Into<Cow<'static, [u8]>>) -> Handle {
+        Self::from_data(Data::Bytes(bytes.into()))
     }
 
     fn from_data(data: Data) -> Handle {


### PR DESCRIPTION
This should resolve https://github.com/iced-rs/iced/issues/580 by providing a way to use an image included with `include_bytes!` without needing to copy it to a `Vec` to create an image handle.

It would be nice if these methods could also be `const`, but that isn't possible due to the hashing being done.

This is technically a breaking change since `Handle::data()` is public. But if that is used, it's most likely in used somewhere that only relies on the type derefing to `&[u8]`.