### PR TITLE
Fix wgpu README supported backends 

### DIFF
--- a/wgpu/README.md
+++ b/wgpu/README.md
@@ -6,7 +6,7 @@
 
 `iced_wgpu` is a [`wgpu`] renderer for [`iced_native`]. For now, it is the default renderer of Iced in native platforms.
 
-[`wgpu`] supports most modern graphics backends: Vulkan, Metal, DX11, and DX12 (OpenGL and WebGL are still WIP). Additionally, it will support the incoming [WebGPU API].
+[`wgpu`] supports most modern graphics backends: Vulkan, Metal, and DX12 (OpenGL and WebGL are still WIP). Additionally, it will support the incoming [WebGPU API].
 
 Currently, `iced_wgpu` supports the following primitives:
 - Text, which is rendered using [`wgpu_glyph`]. No shaping at all.

--- a/wgpu/README.md
+++ b/wgpu/README.md
@@ -4,7 +4,7 @@
 [![License](https://img.shields.io/crates/l/iced_wgpu.svg)](https://github.com/iced-rs/iced/blob/master/LICENSE)
 [![Discord Server](https://img.shields.io/discord/628993209984614400?label=&labelColor=6A7EC2&logo=discord&logoColor=ffffff&color=7389D8)](https://discord.gg/3xZJ65GAhd)
 
-`iced_wgpu` is a [`wgpu`] renderer for [`iced_native`]. For now, it is the default renderer of Iced in native platforms.
+`iced_wgpu` is a [`wgpu`] renderer for [`iced_native`]. For now, it is the default renderer of Iced on [native platforms].
 
 [`wgpu`] supports most modern graphics backends: Vulkan, Metal, and DX12 (OpenGL and WebGL are still WIP). Additionally, it will support the incoming [WebGPU API].
 
@@ -22,6 +22,7 @@ Currently, `iced_wgpu` supports the following primitives:
 [documentation]: https://docs.rs/iced_wgpu
 [`iced_native`]: ../native
 [`wgpu`]: https://github.com/gfx-rs/wgpu
+[native platforms]: https://github.com/gfx-rs/wgpu#supported-platforms
 [WebGPU API]: https://gpuweb.github.io/gpuweb/
 [`wgpu_glyph`]: https://github.com/hecrj/wgpu_glyph
 
@@ -39,7 +40,7 @@ you want to learn about a specific release, check out [the release list].
 
 ## Current limitations
 
-The current implementation is quite naive, it uses:
+The current implementation is quite naive; it uses:
 
 - A different pipeline/shader for each primitive
 - A very simplistic layer model: every `Clip` primitive will generate new layers


### PR DESCRIPTION
The main README.md shows that wgpu does not support DX11, but the wgpu README.md says that DX11 is supported. Here is the gfx-rs currently supported platforms: https://github.com/gfx-rs/wgpu#supported-platforms.