### PR TITLE
Render pane grid titlebar after body

### DIFF
--- a/native/src/widget/pane_grid/content.rs
+++ b/native/src/widget/pane_grid/content.rs
@@ -115,6 +115,16 @@ where
 
             let show_controls = bounds.contains(cursor_position);
 
+            self.body.as_widget().draw(
+                &tree.children[0],
+                renderer,
+                theme,
+                style,
+                body_layout,
+                cursor_position,
+                viewport,
+            );
+
             title_bar.draw(
                 &tree.children[1],
                 renderer,
@@ -124,16 +134,6 @@ where
                 cursor_position,
                 viewport,
                 show_controls,
-            );
-
-            self.body.as_widget().draw(
-                &tree.children[0],
-                renderer,
-                theme,
-                style,
-                body_layout,
-                cursor_position,
-                viewport,
             );
         } else {
             self.body.as_widget().draw(


### PR DESCRIPTION
Super edge case fix, but it's not uncommon to draw something with `renderer.with_layer` (either manually or via canvas `frame.with_clip`) in the body of a pane, while at the same time having tooltips on something in the titlebar. Since tooltip uses `with_layer` instead of `Overlay`, but it's drawn _before_ the body, this causes the tooltips to to be behind what's drawn on the pane body (no ideal).

I propose this is a fine solution until we have better layering support. I think it's way more likely that titlebar has some tooltip / layer that needs to be drawn over body than the other way around.