### PR TITLE
Fix image/svg widget size allocation to use `full_size`, not `raw_size`

### DIFF
--- a/native/src/widget/image.rs
+++ b/native/src/widget/image.rs
@@ -100,11 +100,11 @@ where
     let final_size = Size {
         width: match width {
             Length::Shrink => f32::min(raw_size.width, full_size.width),
-            _ => raw_size.width,
+            _ => full_size.width,
         },
         height: match height {
             Length::Shrink => f32::min(raw_size.height, full_size.height),
-            _ => raw_size.height,
+            _ => full_size.height,
         },
     };
 

--- a/native/src/widget/svg.rs
+++ b/native/src/widget/svg.rs
@@ -99,11 +99,11 @@ where
         let final_size = Size {
             width: match self.width {
                 Length::Shrink => f32::min(raw_size.width, full_size.width),
-                _ => raw_size.width,
+                _ => full_size.width,
             },
             height: match self.height {
                 Length::Shrink => f32::min(raw_size.height, full_size.height),
-                _ => raw_size.height,
+                _ => full_size.height,
             },
         };
 


### PR DESCRIPTION
Previously only had an impact on the final size of dimensions set to `Shrink`. I'm guessing this was a mistake but anyway...

Before this change, setting `Fill` for height and width of an image, with `ContentFit::Contain`, caused it to take all available space in both dimensions. Where the ratio of the images differs from that of the space it has available, it preserves the ratio and centers along the dimension with extra space. I want to to allocate only the space it needs, without centering, and I don't see a way to do that currently.

The centering may be useful in some cases but should involve another property or widget.