### PR TITLE
feat: Additional actions for window controls

### DIFF
--- a/native/src/window/action.rs
+++ b/native/src/window/action.rs
@@ -20,6 +20,8 @@ pub enum Action<T> {
     },
     /// Sets the window to maximized or back
     Maximize(bool),
+    /// Set the window to minimized or back
+    Minimize(bool),
     /// Move the window.
     ///
     /// Unsupported on Wayland.
@@ -50,6 +52,7 @@ impl<T> Action<T> {
             Self::Drag => Action::Drag,
             Self::Resize { width, height } => Action::Resize { width, height },
             Self::Maximize(bool) => Action::Maximize(bool),
+            Self::Minimize(bool) => Action::Minimize(bool),
             Self::Move { x, y } => Action::Move { x, y },
             Self::SetMode(mode) => Action::SetMode(mode),
             Self::ToggleMaximize => Action::ToggleMaximize,
@@ -68,6 +71,7 @@ impl<T> fmt::Debug for Action<T> {
                 width, height
             ),
             Self::Maximize(value) => write!(f, "Action::Maximize({})", value),
+            Self::Minimize(value) => write!(f, "Action::Minimize({}", value),
             Self::Move { x, y } => {
                 write!(f, "Action::Move {{ x: {}, y: {} }}", x, y)
             }

--- a/native/src/window/action.rs
+++ b/native/src/window/action.rs
@@ -18,6 +18,8 @@ pub enum Action<T> {
         /// The new logical height of the window
         height: u32,
     },
+    /// Sets the window to maximized or back
+    Maximize(bool),
     /// Move the window.
     ///
     /// Unsupported on Wayland.
@@ -29,6 +31,8 @@ pub enum Action<T> {
     },
     /// Set the [`Mode`] of the window.
     SetMode(Mode),
+    /// Sets the window to maximized or back
+    ToggleMaximize,
     /// Fetch the current [`Mode`] of the window.
     FetchMode(Box<dyn FnOnce(Mode) -> T + 'static>),
 }
@@ -45,8 +49,10 @@ impl<T> Action<T> {
         match self {
             Self::Drag => Action::Drag,
             Self::Resize { width, height } => Action::Resize { width, height },
+            Self::Maximize(bool) => Action::Maximize(bool),
             Self::Move { x, y } => Action::Move { x, y },
             Self::SetMode(mode) => Action::SetMode(mode),
+            Self::ToggleMaximize => Action::ToggleMaximize,
             Self::FetchMode(o) => Action::FetchMode(Box::new(move |s| f(o(s)))),
         }
     }
@@ -61,10 +67,12 @@ impl<T> fmt::Debug for Action<T> {
                 "Action::Resize {{ widget: {}, height: {} }}",
                 width, height
             ),
+            Self::Maximize(value) => write!(f, "Action::Maximize({})", value),
             Self::Move { x, y } => {
                 write!(f, "Action::Move {{ x: {}, y: {} }}", x, y)
             }
             Self::SetMode(mode) => write!(f, "Action::SetMode({:?})", mode),
+            Self::ToggleMaximize => write!(f, "Action::ToggleMaximize"),
             Self::FetchMode(_) => write!(f, "Action::FetchMode"),
         }
     }

--- a/native/src/window/action.rs
+++ b/native/src/window/action.rs
@@ -5,6 +5,12 @@ use std::fmt;
 
 /// An operation to be performed on some window.
 pub enum Action<T> {
+    /// Moves the window with the left mouse button until the button is
+    /// released.
+    ///
+    /// There’s no guarantee that this will work unless the left mouse
+    /// button was pressed immediately before this function is called.
+    Drag,
     /// Resize the window.
     Resize {
         /// The new logical width of the window
@@ -37,6 +43,7 @@ impl<T> Action<T> {
         T: 'static,
     {
         match self {
+            Self::Drag => Action::Drag,
             Self::Resize { width, height } => Action::Resize { width, height },
             Self::Move { x, y } => Action::Move { x, y },
             Self::SetMode(mode) => Action::SetMode(mode),
@@ -48,6 +55,7 @@ impl<T> Action<T> {
 impl<T> fmt::Debug for Action<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::Drag => write!(f, "Action::Drag"),
             Self::Resize { width, height } => write!(
                 f,
                 "Action::Resize {{ widget: {}, height: {} }}",

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -615,6 +615,9 @@ pub fn run_command<A, E>(
                 }
             },
             command::Action::Window(action) => match action {
+                window::Action::Drag => {
+                    let _res = window.drag_window();
+                }
                 window::Action::Resize { width, height } => {
                     window.set_inner_size(winit::dpi::LogicalSize {
                         width,

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -627,6 +627,9 @@ pub fn run_command<A, E>(
                 window::Action::Maximize(value) => {
                     window.set_maximized(value);
                 }
+                window::Action::Minimize(value) => {
+                    window.set_minimized(value);
+                }
                 window::Action::Move { x, y } => {
                     window.set_outer_position(winit::dpi::LogicalPosition {
                         x,

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -624,6 +624,9 @@ pub fn run_command<A, E>(
                         height,
                     });
                 }
+                window::Action::Maximize(value) => {
+                    window.set_maximized(value);
+                }
                 window::Action::Move { x, y } => {
                     window.set_outer_position(winit::dpi::LogicalPosition {
                         x,
@@ -636,6 +639,9 @@ pub fn run_command<A, E>(
                         window.primary_monitor(),
                         mode,
                     ));
+                }
+                window::Action::ToggleMaximize => {
+                    window.set_maximized(!window.is_maximized())
                 }
                 window::Action::FetchMode(tag) => {
                     let mode = if window.is_visible().unwrap_or(true) {

--- a/winit/src/window.rs
+++ b/winit/src/window.rs
@@ -4,6 +4,11 @@ use iced_native::window;
 
 pub use window::{Event, Mode};
 
+/// Begins dragging the window while the left mouse button is held.
+pub fn drag<Message>() -> Command<Message> {
+    Command::single(command::Action::Window(window::Action::Drag))
+}
+
 /// Resizes the window to the given logical dimensions.
 pub fn resize<Message>(width: u32, height: u32) -> Command<Message> {
     Command::single(command::Action::Window(window::Action::Resize {

--- a/winit/src/window.rs
+++ b/winit/src/window.rs
@@ -22,6 +22,11 @@ pub fn maximize<Message>(value: bool) -> Command<Message> {
     Command::single(command::Action::Window(window::Action::Maximize(value)))
 }
 
+/// Set the window to minimized or back.
+pub fn minimize<Message>(value: bool) -> Command<Message> {
+    Command::single(command::Action::Window(window::Action::Minimize(value)))
+}
+
 /// Moves a window to the given logical coordinates.
 pub fn move_to<Message>(x: i32, y: i32) -> Command<Message> {
     Command::single(command::Action::Window(window::Action::Move { x, y }))

--- a/winit/src/window.rs
+++ b/winit/src/window.rs
@@ -17,6 +17,11 @@ pub fn resize<Message>(width: u32, height: u32) -> Command<Message> {
     }))
 }
 
+/// Sets the window to maximized or back.
+pub fn maximize<Message>(value: bool) -> Command<Message> {
+    Command::single(command::Action::Window(window::Action::Maximize(value)))
+}
+
 /// Moves a window to the given logical coordinates.
 pub fn move_to<Message>(x: i32, y: i32) -> Command<Message> {
     Command::single(command::Action::Window(window::Action::Move { x, y }))
@@ -25,6 +30,11 @@ pub fn move_to<Message>(x: i32, y: i32) -> Command<Message> {
 /// Sets the [`Mode`] of the window.
 pub fn set_mode<Message>(mode: Mode) -> Command<Message> {
     Command::single(command::Action::Window(window::Action::SetMode(mode)))
+}
+
+/// Sets the window to maximized or back.
+pub fn toggle_maximize<Message>() -> Command<Message> {
+    Command::single(command::Action::Window(window::Action::ToggleMaximize))
 }
 
 /// Fetches the current [`Mode`] of the window.


### PR DESCRIPTION
Adds new window actions to enable the possibility to create client-side decorations in Iced applications. libcosmic has a functioning headerbar widget which utilizes these actions and their functions. We could add a headerbar widget example for demonstrating the functionality.

- `Action::Drag`
- `Action::Maximize(bool)`
- `Action::Minimize(bool)`
- `Action::ResizeDrag`
- `Action::ToggleMaximize`

`ResizeDrag` is currently a no-op because it requires a patch to winit. I am working on this patch at the moment.

Partially implements #759

Related RFC: https://github.com/iced-rs/rfcs/pull/13