### PR TITLE
Simplify code, avoid unstable function

### DIFF
--- a/native/src/program/state.rs
+++ b/native/src/program/state.rs
@@ -119,8 +119,9 @@ where
             .queued_events
             .iter()
             .zip(event_statuses)
-            .filter_map(|(event, status)| {
-                matches!(status, event::Status::Ignored).then_some(event)
+            .filter_map(|(event, status)| match status {
+                event::Status::Ignored => Some(event),
+                _ => None,
             })
             .cloned()
             .collect();

--- a/native/src/user_interface.rs
+++ b/native/src/user_interface.rs
@@ -269,7 +269,7 @@ where
             .cloned()
             .zip(overlay_statuses.into_iter())
             .map(|(event, overlay_status)| {
-                if matches!(overlay_status, event::Status::Captured) {
+                if overlay_status == event::Status::Captured {
                     return overlay_status;
                 }
 


### PR DESCRIPTION
Makes code more obvious by reducing usage of an uncommon macro and an unstable feature.

While this is a tiny change, I believe it's nicer to use "more standard" (e.g. more common) code. I always like to believe obvious code should be preferred, especially when coding as a community.

Here we sacrifice close to nothing in terms of character count, while avoiding the use of an uncommonly used macro (avoiding this pattern is a personal opinion)
and avoiding an _unstable_ standard-library feature: https://doc.rust-lang.org/std/primitive.bool.html#method.then_some