### PR TITLE
More pane grid fixes

### DIFF
--- a/native/src/widget/pane_grid.rs
+++ b/native/src/widget/pane_grid.rs
@@ -757,7 +757,12 @@ pub fn draw<Renderer, T>(
         cursor_position
     };
 
-    for ((id, pane), layout) in elements.zip(layout.children()) {
+    // Render picked pane last
+    let mut elements = elements.zip(layout.children()).collect::<Vec<_>>();
+    elements
+        .sort_by_key(|((id, _), _)| picked_pane.map(|(id, _)| id) == Some(*id));
+
+    for ((id, pane), layout) in elements {
         match picked_pane {
             Some((dragging, origin)) if id == dragging => {
                 let bounds = layout.bounds();

--- a/native/src/widget/pane_grid.rs
+++ b/native/src/widget/pane_grid.rs
@@ -341,6 +341,7 @@ where
                         cursor_position,
                         viewport,
                         renderer,
+                        self.on_drag.is_some(),
                     )
                 })
                 .max()
@@ -648,7 +649,7 @@ pub fn mouse_interaction(
     resize_leeway: Option<u16>,
 ) -> Option<mouse::Interaction> {
     if action.picked_pane().is_some() {
-        return Some(mouse::Interaction::Grab);
+        return Some(mouse::Interaction::Grabbing);
     }
 
     let resize_axis =

--- a/native/src/widget/pane_grid/content.rs
+++ b/native/src/widget/pane_grid/content.rs
@@ -238,6 +238,7 @@ where
         cursor_position: Point,
         viewport: &Rectangle,
         renderer: &Renderer,
+        drag_enabled: bool,
     ) -> mouse::Interaction {
         let (body_layout, title_bar_interaction) =
             if let Some(title_bar) = &self.title_bar {
@@ -247,7 +248,7 @@ where
                 let is_over_pick_area = title_bar
                     .is_over_pick_area(title_bar_layout, cursor_position);
 
-                if is_over_pick_area {
+                if is_over_pick_area && drag_enabled {
                     return mouse::Interaction::Grab;
                 }
 


### PR DESCRIPTION
- dca99f3 - Fixes mouse interactions 
- fb03652 - Renders picked pane last. Similar to #1463, if panes have an internal canvas clip / `renderer.with_layer`, it's possible for their content to be drawn on top of the picked / dragging pane if the pane is iterated after the picked pane. This ensures picked pane is always rendered last and will therefore always come on top.