### PR TITLE
Glow image rendering support; move image/svg code to iced_graphics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ resolver = "2"
 [features]
 default = ["wgpu"]
 # Enables the `Image` widget
-image = ["iced_wgpu/image", "image_rs"]
+image = ["iced_wgpu?/image", "iced_glow?/image", "image_rs"]
 # Enables the `Svg` widget
-svg = ["iced_wgpu/svg"]
+svg = ["iced_wgpu?/svg", "iced_glow?/svg"]
 # Enables the `Canvas` widget
 canvas = ["iced_graphics/canvas"]
 # Enables the `QRCode` widget

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ iced_glow = { version = "0.3", path = "glow", optional = true }
 thiserror = "1.0"
 
 [dependencies.image_rs]
-version = "0.23"
+version = "0.24"
 package = "image"
 optional = true
 

--- a/glow/Cargo.toml
+++ b/glow/Cargo.toml
@@ -33,8 +33,6 @@ glyph_brush = "0.7"
 euclid = "0.22"
 bytemuck = "1.4"
 log = "0.4"
-kamadak-exif = "0.5"
-bitflags = "1.2"
 
 [dependencies.iced_native]
 version = "0.5"

--- a/glow/Cargo.toml
+++ b/glow/Cargo.toml
@@ -8,12 +8,23 @@ license = "MIT AND OFL-1.1"
 repository = "https://github.com/iced-rs/iced"
 
 [features]
+svg = ["iced_graphics/svg"]
+image = ["image_rs", "iced_graphics/image", "png", "jpeg", "jpeg_rayon", "gif", "webp", "bmp"]
+image_rs = ["iced_graphics/image_rs"]
+png = ["iced_graphics/png"]
+jpeg = ["iced_graphics/jpeg"]
+jpeg_rayon = ["iced_graphics/jpeg_rayon"]
+gif = ["iced_graphics/gif"]
+webp = ["iced_graphics/webp"]
+pnm = ["iced_graphics/pnm"]
+ico = ["iced_graphics/ico"]
+bmp = ["iced_graphics/bmp"]
+hdr = ["iced_graphics/hdr"]
+dds = ["iced_graphics/dds"]
+farbfeld = ["iced_graphics/farbfeld"]
 canvas = ["iced_graphics/canvas"]
 qr_code = ["iced_graphics/qr_code"]
 default_system_font = ["iced_graphics/font-source"]
-# Not supported yet!
-image = []
-svg = []
 
 [dependencies]
 glow = "0.11.1"
@@ -22,6 +33,8 @@ glyph_brush = "0.7"
 euclid = "0.22"
 bytemuck = "1.4"
 log = "0.4"
+kamadak-exif = "0.5"
+bitflags = "1.2"
 
 [dependencies.iced_native]
 version = "0.5"

--- a/glow/Cargo.toml
+++ b/glow/Cargo.toml
@@ -9,8 +9,7 @@ repository = "https://github.com/iced-rs/iced"
 
 [features]
 svg = ["iced_graphics/svg"]
-image = ["image_rs", "iced_graphics/image", "png", "jpeg", "jpeg_rayon", "gif", "webp", "bmp"]
-image_rs = ["iced_graphics/image_rs"]
+image = ["iced_graphics/image"]
 png = ["iced_graphics/png"]
 jpeg = ["iced_graphics/jpeg"]
 jpeg_rayon = ["iced_graphics/jpeg_rayon"]

--- a/glow/src/backend.rs
+++ b/glow/src/backend.rs
@@ -258,7 +258,7 @@ impl backend::Text for Backend {
 
 #[cfg(feature = "image_rs")]
 impl backend::Image for Backend {
-    fn dimensions(&self, handle: &iced_native::image::Handle) -> (u32, u32) {
+    fn dimensions(&self, handle: &iced_native::image::Handle) -> Size<u32> {
         self.image_pipeline.dimensions(handle)
     }
 }
@@ -267,8 +267,8 @@ impl backend::Image for Backend {
 impl backend::Svg for Backend {
     fn viewport_dimensions(
         &self,
-        _handle: &iced_native::svg::Handle,
-    ) -> (u32, u32) {
-        (50, 50)
+        handle: &iced_native::svg::Handle,
+    ) -> Size<u32> {
+        self.image_pipeline.viewport_dimensions(handle)
     }
 }

--- a/glow/src/backend.rs
+++ b/glow/src/backend.rs
@@ -1,3 +1,5 @@
+#[cfg(any(feature = "image_rs", feature = "svg"))]
+use crate::image;
 use crate::quad;
 use crate::text;
 use crate::{program, triangle};
@@ -15,6 +17,8 @@ use iced_native::{Font, Size};
 /// [`iced`]: https://github.com/iced-rs/iced
 #[derive(Debug)]
 pub struct Backend {
+    #[cfg(any(feature = "image_rs", feature = "svg"))]
+    image_pipeline: image::Pipeline,
     quad_pipeline: quad::Pipeline,
     text_pipeline: text::Pipeline,
     triangle_pipeline: triangle::Pipeline,
@@ -32,10 +36,14 @@ impl Backend {
 
         let shader_version = program::Version::new(gl);
 
+        #[cfg(any(feature = "image_rs", feature = "svg"))]
+        let image_pipeline = image::Pipeline::new(gl, &shader_version);
         let quad_pipeline = quad::Pipeline::new(gl, &shader_version);
         let triangle_pipeline = triangle::Pipeline::new(gl, &shader_version);
 
         Self {
+            #[cfg(any(feature = "image_rs", feature = "svg"))]
+            image_pipeline,
             quad_pipeline,
             text_pipeline,
             triangle_pipeline,
@@ -70,6 +78,9 @@ impl Backend {
                 viewport_size.height,
             );
         }
+
+        #[cfg(any(feature = "image_rs", feature = "svg"))]
+        self.image_pipeline.trim_cache(gl);
     }
 
     fn flush(
@@ -110,6 +121,15 @@ impl Backend {
                 scaled,
                 scale_factor,
             );
+        }
+
+        #[cfg(any(feature = "image_rs", feature = "svg"))]
+        if !layer.images.is_empty() {
+            let scaled = transformation
+                * Transformation::scale(scale_factor, scale_factor);
+
+            self.image_pipeline
+                .draw(gl, scaled, scale_factor, &layer.images);
         }
 
         if !layer.text.is_empty() {
@@ -236,10 +256,10 @@ impl backend::Text for Backend {
     }
 }
 
-#[cfg(feature = "image")]
+#[cfg(feature = "image_rs")]
 impl backend::Image for Backend {
-    fn dimensions(&self, _handle: &iced_native::image::Handle) -> (u32, u32) {
-        (50, 50)
+    fn dimensions(&self, handle: &iced_native::image::Handle) -> (u32, u32) {
+        self.image_pipeline.dimensions(handle)
     }
 }
 

--- a/glow/src/backend.rs
+++ b/glow/src/backend.rs
@@ -1,4 +1,4 @@
-#[cfg(any(feature = "image_rs", feature = "svg"))]
+#[cfg(any(feature = "image", feature = "svg"))]
 use crate::image;
 use crate::quad;
 use crate::text;
@@ -17,7 +17,7 @@ use iced_native::{Font, Size};
 /// [`iced`]: https://github.com/iced-rs/iced
 #[derive(Debug)]
 pub struct Backend {
-    #[cfg(any(feature = "image_rs", feature = "svg"))]
+    #[cfg(any(feature = "image", feature = "svg"))]
     image_pipeline: image::Pipeline,
     quad_pipeline: quad::Pipeline,
     text_pipeline: text::Pipeline,
@@ -36,13 +36,13 @@ impl Backend {
 
         let shader_version = program::Version::new(gl);
 
-        #[cfg(any(feature = "image_rs", feature = "svg"))]
+        #[cfg(any(feature = "image", feature = "svg"))]
         let image_pipeline = image::Pipeline::new(gl, &shader_version);
         let quad_pipeline = quad::Pipeline::new(gl, &shader_version);
         let triangle_pipeline = triangle::Pipeline::new(gl, &shader_version);
 
         Self {
-            #[cfg(any(feature = "image_rs", feature = "svg"))]
+            #[cfg(any(feature = "image", feature = "svg"))]
             image_pipeline,
             quad_pipeline,
             text_pipeline,
@@ -79,7 +79,7 @@ impl Backend {
             );
         }
 
-        #[cfg(any(feature = "image_rs", feature = "svg"))]
+        #[cfg(any(feature = "image", feature = "svg"))]
         self.image_pipeline.trim_cache(gl);
     }
 
@@ -123,7 +123,7 @@ impl Backend {
             );
         }
 
-        #[cfg(any(feature = "image_rs", feature = "svg"))]
+        #[cfg(any(feature = "image", feature = "svg"))]
         if !layer.images.is_empty() {
             let scaled = transformation
                 * Transformation::scale(scale_factor, scale_factor);
@@ -256,7 +256,7 @@ impl backend::Text for Backend {
     }
 }
 
-#[cfg(feature = "image_rs")]
+#[cfg(feature = "image")]
 impl backend::Image for Backend {
     fn dimensions(&self, handle: &iced_native::image::Handle) -> Size<u32> {
         self.image_pipeline.dimensions(handle)

--- a/glow/src/image.rs
+++ b/glow/src/image.rs
@@ -1,0 +1,212 @@
+use crate::program::{self, Shader};
+use crate::Transformation;
+use glow::HasContext;
+use iced_graphics::layer;
+#[cfg(feature = "image_rs")]
+use std::cell::RefCell;
+
+pub use iced_graphics::triangle::{Mesh2D, Vertex2D};
+
+#[cfg(feature = "image_rs")]
+use iced_graphics::image::raster;
+
+#[cfg(feature = "svg")]
+use iced_graphics::image::vector;
+
+mod textures;
+use textures::{Entry, Textures};
+
+#[derive(Debug)]
+pub(crate) struct Pipeline {
+    program: <glow::Context as HasContext>::Program,
+    vertex_array: <glow::Context as HasContext>::VertexArray,
+    vertex_buffer: <glow::Context as HasContext>::Buffer,
+    transform_location: <glow::Context as HasContext>::UniformLocation,
+    textures: Textures,
+    #[cfg(feature = "image_rs")]
+    raster_cache: RefCell<raster::Cache<Textures>>,
+    #[cfg(feature = "svg")]
+    vector_cache: vector::Cache<Textures>,
+}
+
+impl Pipeline {
+    pub fn new(
+        gl: &glow::Context,
+        shader_version: &program::Version,
+    ) -> Pipeline {
+        let program = unsafe {
+            let vertex_shader = Shader::vertex(
+                gl,
+                shader_version,
+                include_str!("shader/common/image.vert"),
+            );
+            let fragment_shader = Shader::fragment(
+                gl,
+                shader_version,
+                include_str!("shader/common/image.frag"),
+            );
+
+            program::create(
+                gl,
+                &[vertex_shader, fragment_shader],
+                &[(0, "i_Position")],
+            )
+        };
+
+        let transform_location =
+            unsafe { gl.get_uniform_location(program, "u_Transform") }
+                .expect("Get transform location");
+
+        unsafe {
+            gl.use_program(Some(program));
+
+            let transform: [f32; 16] = Transformation::identity().into();
+            gl.uniform_matrix_4_f32_slice(
+                Some(&transform_location),
+                false,
+                &transform,
+            );
+
+            gl.use_program(None);
+        }
+
+        let vertex_buffer =
+            unsafe { gl.create_buffer().expect("Create vertex buffer") };
+        let vertex_array =
+            unsafe { gl.create_vertex_array().expect("Create vertex array") };
+
+        unsafe {
+            gl.bind_vertex_array(Some(vertex_array));
+            gl.bind_buffer(glow::ARRAY_BUFFER, Some(vertex_buffer));
+
+            let vertices = &[0u8, 0, 1, 0, 0, 1, 1, 1];
+            gl.buffer_data_size(
+                glow::ARRAY_BUFFER,
+                vertices.len() as i32,
+                glow::STATIC_DRAW,
+            );
+            gl.buffer_sub_data_u8_slice(
+                glow::ARRAY_BUFFER,
+                0,
+                bytemuck::cast_slice(vertices),
+            );
+
+            gl.enable_vertex_attrib_array(0);
+            gl.vertex_attrib_pointer_f32(
+                0,
+                2,
+                glow::UNSIGNED_BYTE,
+                false,
+                0,
+                0,
+            );
+
+            gl.bind_buffer(glow::ARRAY_BUFFER, None);
+            gl.bind_vertex_array(None);
+        }
+
+        Pipeline {
+            program,
+            vertex_array,
+            vertex_buffer,
+            transform_location,
+            textures: Textures::new(),
+            #[cfg(feature = "image_rs")]
+            raster_cache: RefCell::new(raster::Cache::default()),
+            #[cfg(feature = "svg")]
+            vector_cache: vector::Cache::default(),
+        }
+    }
+
+    #[cfg(feature = "image_rs")]
+    pub fn dimensions(
+        &self,
+        handle: &iced_native::image::Handle,
+    ) -> (u32, u32) {
+        self.raster_cache.borrow_mut().load(handle).dimensions()
+    }
+
+    pub fn draw(
+        &mut self,
+        mut gl: &glow::Context,
+        transformation: Transformation,
+        _scale_factor: f32,
+        images: &[layer::Image],
+    ) {
+        unsafe {
+            gl.use_program(Some(self.program));
+            gl.bind_vertex_array(Some(self.vertex_array));
+            gl.bind_buffer(glow::ARRAY_BUFFER, Some(self.vertex_buffer));
+        }
+
+        #[cfg(feature = "image_rs")]
+        let mut raster_cache = self.raster_cache.borrow_mut();
+        for image in images {
+            let (entry, bounds) = match &image {
+                #[cfg(feature = "image_rs")]
+                layer::Image::Raster { handle, bounds } => (
+                    raster_cache.upload(handle, &mut gl, &mut self.textures),
+                    bounds,
+                ),
+                #[cfg(not(feature = "image_rs"))]
+                layer::Image::Raster { handle: _, bounds } => (None, bounds),
+
+                #[cfg(feature = "svg")]
+                layer::Image::Vector { handle, bounds } => {
+                    let size = [bounds.width, bounds.height];
+                    (
+                        self.vector_cache.upload(
+                            handle,
+                            size,
+                            _scale_factor,
+                            &mut gl,
+                            &mut self.textures,
+                        ),
+                        bounds,
+                    )
+                }
+
+                #[cfg(not(feature = "svg"))]
+                layer::Image::Vector { handle: _, bounds } => (None, bounds),
+            };
+
+            unsafe {
+                if let Some(Entry { texture, .. }) = entry {
+                    gl.bind_texture(glow::TEXTURE_2D, Some(*texture))
+                } else {
+                    continue;
+                }
+
+                let translate = Transformation::translate(bounds.x, bounds.y);
+                let scale = Transformation::scale(bounds.width, bounds.height);
+                let transformation = transformation * translate * scale;
+                let matrix: [f32; 16] = transformation.into();
+                gl.uniform_matrix_4_f32_slice(
+                    Some(&self.transform_location),
+                    false,
+                    &matrix,
+                );
+
+                gl.draw_arrays(glow::TRIANGLE_STRIP, 0, 4);
+
+                gl.bind_texture(glow::TEXTURE_2D, None);
+            }
+        }
+
+        unsafe {
+            gl.bind_buffer(glow::ARRAY_BUFFER, None);
+            gl.bind_vertex_array(None);
+            gl.use_program(None);
+        }
+    }
+
+    pub fn trim_cache(&mut self, mut gl: &glow::Context) {
+        #[cfg(feature = "image_rs")]
+        self.raster_cache
+            .borrow_mut()
+            .trim(&mut self.textures, &mut gl);
+
+        #[cfg(feature = "svg")]
+        self.vector_cache.trim(&mut self.textures, &mut gl);
+    }
+}

--- a/glow/src/image.rs
+++ b/glow/src/image.rs
@@ -7,7 +7,7 @@ pub use iced_graphics::triangle::{Mesh2D, Vertex2D};
 use crate::program::{self, Shader};
 use crate::Transformation;
 
-#[cfg(feature = "image_rs")]
+#[cfg(feature = "image")]
 use iced_graphics::image::raster;
 
 #[cfg(feature = "svg")]
@@ -27,7 +27,7 @@ pub(crate) struct Pipeline {
     vertex_buffer: <glow::Context as HasContext>::Buffer,
     transform_location: <glow::Context as HasContext>::UniformLocation,
     storage: Storage,
-    #[cfg(feature = "image_rs")]
+    #[cfg(feature = "image")]
     raster_cache: RefCell<raster::Cache<Storage>>,
     #[cfg(feature = "svg")]
     vector_cache: RefCell<vector::Cache<Storage>>,
@@ -115,14 +115,14 @@ impl Pipeline {
             vertex_buffer,
             transform_location,
             storage: Storage::default(),
-            #[cfg(feature = "image_rs")]
+            #[cfg(feature = "image")]
             raster_cache: RefCell::new(raster::Cache::default()),
             #[cfg(feature = "svg")]
             vector_cache: RefCell::new(vector::Cache::default()),
         }
     }
 
-    #[cfg(feature = "image_rs")]
+    #[cfg(feature = "image")]
     pub fn dimensions(&self, handle: &iced_native::image::Handle) -> Size<u32> {
         self.raster_cache.borrow_mut().load(handle).dimensions()
     }
@@ -151,7 +151,7 @@ impl Pipeline {
             gl.bind_buffer(glow::ARRAY_BUFFER, Some(self.vertex_buffer));
         }
 
-        #[cfg(feature = "image_rs")]
+        #[cfg(feature = "image")]
         let mut raster_cache = self.raster_cache.borrow_mut();
 
         #[cfg(feature = "svg")]
@@ -159,12 +159,12 @@ impl Pipeline {
 
         for image in images {
             let (entry, bounds) = match &image {
-                #[cfg(feature = "image_rs")]
+                #[cfg(feature = "image")]
                 layer::Image::Raster { handle, bounds } => (
                     raster_cache.upload(handle, &mut gl, &mut self.storage),
                     bounds,
                 ),
-                #[cfg(not(feature = "image_rs"))]
+                #[cfg(not(feature = "image"))]
                 layer::Image::Raster { handle: _, bounds } => (None, bounds),
 
                 #[cfg(feature = "svg")]
@@ -217,7 +217,7 @@ impl Pipeline {
     }
 
     pub fn trim_cache(&mut self, mut gl: &glow::Context) {
-        #[cfg(feature = "image_rs")]
+        #[cfg(feature = "image")]
         self.raster_cache
             .borrow_mut()
             .trim(&mut self.storage, &mut gl);

--- a/glow/src/image/storage.rs
+++ b/glow/src/image/storage.rs
@@ -1,16 +1,12 @@
+use iced_graphics::image;
+use iced_graphics::Size;
+
 use glow::HasContext;
-use iced_graphics::image::{TextureStore, TextureStoreEntry};
 
-#[derive(Debug)]
-pub struct Textures;
+#[derive(Debug, Default)]
+pub struct Storage;
 
-impl Textures {
-    pub fn new() -> Self {
-        Self
-    }
-}
-
-impl TextureStore for Textures {
+impl image::Storage for Storage {
     type Entry = Entry;
     type State<'a> = &'a glow::Context;
 
@@ -58,7 +54,7 @@ impl TextureStore for Textures {
             gl.bind_texture(glow::TEXTURE_2D, None);
 
             Some(Entry {
-                size: (width, height),
+                size: Size::new(width, height),
                 texture,
             })
         }
@@ -71,12 +67,12 @@ impl TextureStore for Textures {
 
 #[derive(Debug)]
 pub struct Entry {
-    size: (u32, u32),
-    pub texture: glow::NativeTexture,
+    size: Size<u32>,
+    pub(super) texture: glow::NativeTexture,
 }
 
-impl TextureStoreEntry for Entry {
-    fn size(&self) -> (u32, u32) {
+impl image::storage::Entry for Entry {
+    fn size(&self) -> Size<u32> {
         self.size
     }
 }

--- a/glow/src/image/storage.rs
+++ b/glow/src/image/storage.rs
@@ -27,7 +27,7 @@ impl image::Storage for Storage {
                 width as i32,
                 height as i32,
                 0,
-                glow::BGRA,
+                glow::RGBA,
                 glow::UNSIGNED_BYTE,
                 Some(data),
             );

--- a/glow/src/image/textures.rs
+++ b/glow/src/image/textures.rs
@@ -1,0 +1,82 @@
+use glow::HasContext;
+use iced_graphics::image::{TextureStore, TextureStoreEntry};
+
+#[derive(Debug)]
+pub struct Textures;
+
+impl Textures {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl TextureStore for Textures {
+    type Entry = Entry;
+    type State<'a> = &'a glow::Context;
+
+    fn upload(
+        &mut self,
+        width: u32,
+        height: u32,
+        data: &[u8],
+        gl: &mut &glow::Context,
+    ) -> Option<Self::Entry> {
+        unsafe {
+            let texture = gl.create_texture().expect("create texture");
+            gl.bind_texture(glow::TEXTURE_2D, Some(texture));
+            gl.tex_image_2d(
+                glow::TEXTURE_2D,
+                0,
+                glow::SRGB8_ALPHA8 as i32,
+                width as i32,
+                height as i32,
+                0,
+                glow::BGRA,
+                glow::UNSIGNED_BYTE,
+                Some(data),
+            );
+            gl.tex_parameter_i32(
+                glow::TEXTURE_2D,
+                glow::TEXTURE_WRAP_S,
+                glow::CLAMP_TO_EDGE as _,
+            );
+            gl.tex_parameter_i32(
+                glow::TEXTURE_2D,
+                glow::TEXTURE_WRAP_T,
+                glow::CLAMP_TO_EDGE as _,
+            );
+            gl.tex_parameter_i32(
+                glow::TEXTURE_2D,
+                glow::TEXTURE_MIN_FILTER,
+                glow::LINEAR as _,
+            );
+            gl.tex_parameter_i32(
+                glow::TEXTURE_2D,
+                glow::TEXTURE_MAG_FILTER,
+                glow::LINEAR as _,
+            );
+            gl.bind_texture(glow::TEXTURE_2D, None);
+
+            Some(Entry {
+                size: (width, height),
+                texture,
+            })
+        }
+    }
+
+    fn remove(&mut self, entry: &Entry, gl: &mut &glow::Context) {
+        unsafe { gl.delete_texture(entry.texture) }
+    }
+}
+
+#[derive(Debug)]
+pub struct Entry {
+    size: (u32, u32),
+    pub texture: glow::NativeTexture,
+}
+
+impl TextureStoreEntry for Entry {
+    fn size(&self) -> (u32, u32) {
+        self.size
+    }
+}

--- a/glow/src/lib.rs
+++ b/glow/src/lib.rs
@@ -24,7 +24,7 @@
 pub use glow;
 
 mod backend;
-#[cfg(any(feature = "image_rs", feature = "svg"))]
+#[cfg(any(feature = "image", feature = "svg"))]
 mod image;
 mod program;
 mod quad;

--- a/glow/src/lib.rs
+++ b/glow/src/lib.rs
@@ -24,6 +24,8 @@
 pub use glow;
 
 mod backend;
+#[cfg(any(feature = "image_rs", feature = "svg"))]
+mod image;
 mod program;
 mod quad;
 mod text;

--- a/glow/src/shader/common/image.frag
+++ b/glow/src/shader/common/image.frag
@@ -1,0 +1,22 @@
+#ifdef GL_ES
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+precision highp float;
+#else
+precision mediump float;
+#endif
+#endif
+
+uniform sampler2D tex;
+in vec2 tex_pos;
+
+#ifdef HIGHER_THAN_300
+out vec4 fragColor;
+#define gl_FragColor fragColor
+#endif
+#ifdef GL_ES
+#define texture texture2D
+#endif
+
+void main() {
+    gl_FragColor = texture(tex, tex_pos);
+}

--- a/glow/src/shader/common/image.vert
+++ b/glow/src/shader/common/image.vert
@@ -1,0 +1,9 @@
+uniform mat4 u_Transform;
+
+in vec2 i_Position;
+out vec2 tex_pos;
+
+void main() {
+    gl_Position = u_Transform * vec4(i_Position, 0.0, 1.0);
+    tex_pos = i_Position;
+}

--- a/graphics/Cargo.toml
+++ b/graphics/Cargo.toml
@@ -11,17 +11,33 @@ keywords = ["gui", "ui", "graphics", "interface", "widgets"]
 categories = ["gui"]
 
 [features]
+svg = ["resvg", "usvg", "tiny-skia"]
+image = ["png", "jpeg", "jpeg_rayon", "gif", "webp", "bmp"]
+png = ["image_rs/png"]
+jpeg = ["image_rs/jpeg"]
+jpeg_rayon = ["image_rs/jpeg_rayon"]
+gif = ["image_rs/gif"]
+webp = ["image_rs/webp"]
+pnm = ["image_rs/pnm"]
+ico = ["image_rs/ico"]
+bmp = ["image_rs/bmp"]
+hdr = ["image_rs/hdr"]
+dds = ["image_rs/dds"]
+farbfeld = ["image_rs/farbfeld"]
 canvas = ["lyon"]
 qr_code = ["qrcode", "canvas"]
 font-source = ["font-kit"]
 font-fallback = []
 font-icons = []
 opengl = []
+image_rs = ["kamadak-exif"]
 
 [dependencies]
 glam = "0.21.3"
+log = "0.4"
 raw-window-handle = "0.5"
 thiserror = "1.0"
+bitflags = "1.2"
 
 [dependencies.bytemuck]
 version = "1.4"
@@ -46,6 +62,28 @@ default-features = false
 
 [dependencies.font-kit]
 version = "0.10"
+optional = true
+
+[dependencies.image_rs]
+version = "0.23"
+package = "image"
+default-features = false
+optional = true
+
+[dependencies.resvg]
+version = "0.18"
+optional = true
+
+[dependencies.usvg]
+version = "0.18"
+optional = true
+
+[dependencies.tiny-skia]
+version = "0.6"
+optional = true
+
+[dependencies.kamadak-exif]
+version = "0.5"
 optional = true
 
 [package.metadata.docs.rs]

--- a/graphics/Cargo.toml
+++ b/graphics/Cargo.toml
@@ -65,7 +65,7 @@ version = "0.10"
 optional = true
 
 [dependencies.image_rs]
-version = "0.23"
+version = "0.24"
 package = "image"
 default-features = false
 optional = true

--- a/graphics/src/backend.rs
+++ b/graphics/src/backend.rs
@@ -66,11 +66,11 @@ pub trait Text {
 /// A graphics backend that supports image rendering.
 pub trait Image {
     /// Returns the dimensions of the provided image.
-    fn dimensions(&self, handle: &image::Handle) -> (u32, u32);
+    fn dimensions(&self, handle: &image::Handle) -> Size<u32>;
 }
 
 /// A graphics backend that supports SVG rendering.
 pub trait Svg {
     /// Returns the viewport dimensions of the provided SVG.
-    fn viewport_dimensions(&self, handle: &svg::Handle) -> (u32, u32);
+    fn viewport_dimensions(&self, handle: &svg::Handle) -> Size<u32>;
 }

--- a/graphics/src/image.rs
+++ b/graphics/src/image.rs
@@ -1,34 +1,10 @@
-//! Image loading and caching
-
-use std::fmt::Debug;
-
+//! Render images.
 #[cfg(feature = "image_rs")]
 pub mod raster;
 
 #[cfg(feature = "svg")]
 pub mod vector;
 
-/// Entry in the texture store
-pub trait TextureStoreEntry: Debug {
-    /// Width and height of the entry
-    fn size(&self) -> (u32, u32);
-}
+pub mod storage;
 
-/// Stores cached image data for use in rendering
-pub trait TextureStore {
-    /// Entry in the texture store
-    type Entry: TextureStoreEntry;
-    /// State passed to upload/remove
-    type State<'a>;
-
-    /// Upload image data
-    fn upload(
-        &mut self,
-        width: u32,
-        height: u32,
-        data: &[u8],
-        state: &mut Self::State<'_>,
-    ) -> Option<Self::Entry>;
-    /// Remome image from store
-    fn remove(&mut self, entry: &Self::Entry, state: &mut Self::State<'_>);
-}
+pub use storage::Storage;

--- a/graphics/src/image.rs
+++ b/graphics/src/image.rs
@@ -1,0 +1,34 @@
+//! Image loading and caching
+
+use std::fmt::Debug;
+
+#[cfg(feature = "image_rs")]
+pub mod raster;
+
+#[cfg(feature = "svg")]
+pub mod vector;
+
+/// Entry in the texture store
+pub trait TextureStoreEntry: Debug {
+    /// Width and height of the entry
+    fn size(&self) -> (u32, u32);
+}
+
+/// Stores cached image data for use in rendering
+pub trait TextureStore {
+    /// Entry in the texture store
+    type Entry: TextureStoreEntry;
+    /// State passed to upload/remove
+    type State<'a>;
+
+    /// Upload image data
+    fn upload(
+        &mut self,
+        width: u32,
+        height: u32,
+        data: &[u8],
+        state: &mut Self::State<'_>,
+    ) -> Option<Self::Entry>;
+    /// Remome image from store
+    fn remove(&mut self, entry: &Self::Entry, state: &mut Self::State<'_>);
+}

--- a/graphics/src/image/raster.rs
+++ b/graphics/src/image/raster.rs
@@ -80,7 +80,7 @@ impl<T: Storage> Cache<T> {
                     Memory::Invalid
                 }
             }
-            image::Data::Pixels {
+            image::Data::Rgba {
                 width,
                 height,
                 pixels,

--- a/graphics/src/image/raster.rs
+++ b/graphics/src/image/raster.rs
@@ -12,7 +12,7 @@ use std::collections::{HashMap, HashSet};
 pub enum Memory<T: Storage> {
     /// Image data on host
     Host(::image_rs::ImageBuffer<::image_rs::Rgba<u8>, Vec<u8>>),
-    /// Texture store entry
+    /// Storage entry
     Device(T::Entry),
     /// Image not found
     NotFound,
@@ -106,14 +106,14 @@ impl<T: Storage> Cache<T> {
         &mut self,
         handle: &image::Handle,
         state: &mut T::State<'_>,
-        store: &mut T,
+        storage: &mut T,
     ) -> Option<&T::Entry> {
         let memory = self.load(handle);
 
         if let Memory::Host(image) = memory {
             let (width, height) = image.dimensions();
 
-            let entry = store.upload(width, height, image, state)?;
+            let entry = storage.upload(width, height, image, state)?;
 
             *memory = Memory::Device(entry);
         }
@@ -126,7 +126,7 @@ impl<T: Storage> Cache<T> {
     }
 
     /// Trim cache misses from cache
-    pub fn trim(&mut self, store: &mut T, state: &mut T::State<'_>) {
+    pub fn trim(&mut self, storage: &mut T, state: &mut T::State<'_>) {
         let hits = &self.hits;
 
         self.map.retain(|k, memory| {
@@ -134,7 +134,7 @@ impl<T: Storage> Cache<T> {
 
             if !retain {
                 if let Memory::Device(entry) = memory {
-                    store.remove(entry, state);
+                    storage.remove(entry, state);
                 }
             }
 

--- a/graphics/src/image/storage.rs
+++ b/graphics/src/image/storage.rs
@@ -1,0 +1,31 @@
+//! Store images.
+use crate::Size;
+
+use std::fmt::Debug;
+
+/// Stores cached image data for use in rendering
+pub trait Storage {
+    /// The type of an [`Entry`] in the [`Storage`].
+    type Entry: Entry;
+
+    /// State provided to upload or remove a [`Self::Entry`].
+    type State<'a>;
+
+    /// Upload the image data of a [`Self::Entry`].
+    fn upload(
+        &mut self,
+        width: u32,
+        height: u32,
+        data: &[u8],
+        state: &mut Self::State<'_>,
+    ) -> Option<Self::Entry>;
+
+    /// Romve a [`Self::Entry`] from the [`Storage`].
+    fn remove(&mut self, entry: &Self::Entry, state: &mut Self::State<'_>);
+}
+
+/// An entry in some [`Storage`],
+pub trait Entry: Debug {
+    /// The [`Size`] of the [`Entry`].
+    fn size(&self) -> Size<u32>;
+}

--- a/graphics/src/image/vector.rs
+++ b/graphics/src/image/vector.rs
@@ -1,11 +1,11 @@
 //! Vector image loading and caching
+use crate::image::Storage;
 
 use iced_native::svg;
+use iced_native::Size;
 
 use std::collections::{HashMap, HashSet};
 use std::fs;
-
-use super::TextureStore;
 
 /// Entry in cache corresponding to an svg handle
 pub enum Svg {
@@ -17,28 +17,28 @@ pub enum Svg {
 
 impl Svg {
     /// Viewport width and height
-    pub fn viewport_dimensions(&self) -> (u32, u32) {
+    pub fn viewport_dimensions(&self) -> Size<u32> {
         match self {
             Svg::Loaded(tree) => {
                 let size = tree.svg_node().size;
 
-                (size.width() as u32, size.height() as u32)
+                Size::new(size.width() as u32, size.height() as u32)
             }
-            Svg::NotFound => (1, 1),
+            Svg::NotFound => Size::new(1, 1),
         }
     }
 }
 
 /// Caches svg vector and raster data
 #[derive(Debug)]
-pub struct Cache<T: TextureStore> {
+pub struct Cache<T: Storage> {
     svgs: HashMap<u64, Svg>,
     rasterized: HashMap<(u64, u32, u32), T::Entry>,
     svg_hits: HashSet<u64>,
     rasterized_hits: HashSet<(u64, u32, u32)>,
 }
 
-impl<T: TextureStore> Cache<T> {
+impl<T: Storage> Cache<T> {
     /// Load svg
     pub fn load(&mut self, handle: &svg::Handle) -> &Svg {
         if self.svgs.contains_key(&handle.id()) {
@@ -162,7 +162,7 @@ impl<T: TextureStore> Cache<T> {
     }
 }
 
-impl<T: TextureStore> Default for Cache<T> {
+impl<T: Storage> Default for Cache<T> {
     fn default() -> Self {
         Self {
             svgs: HashMap::new(),

--- a/graphics/src/image/vector.rs
+++ b/graphics/src/image/vector.rs
@@ -79,7 +79,7 @@ impl<T: Storage> Cache<T> {
         [width, height]: [f32; 2],
         scale: f32,
         state: &mut T::State<'_>,
-        texture_store: &mut T,
+        storage: &mut T,
     ) -> Option<&T::Entry> {
         let id = handle.id();
 
@@ -124,7 +124,7 @@ impl<T: Storage> Cache<T> {
                 let mut rgba = img.take();
                 rgba.chunks_exact_mut(4).for_each(|rgba| rgba.swap(0, 2));
 
-                let allocation = texture_store.upload(
+                let allocation = storage.upload(
                     width,
                     height,
                     bytemuck::cast_slice(rgba.as_slice()),
@@ -143,7 +143,7 @@ impl<T: Storage> Cache<T> {
     }
 
     /// Load svg and upload raster data
-    pub fn trim(&mut self, texture_store: &mut T, state: &mut T::State<'_>) {
+    pub fn trim(&mut self, storage: &mut T, state: &mut T::State<'_>) {
         let svg_hits = &self.svg_hits;
         let rasterized_hits = &self.rasterized_hits;
 
@@ -152,7 +152,7 @@ impl<T: Storage> Cache<T> {
             let retain = rasterized_hits.contains(k);
 
             if !retain {
-                texture_store.remove(entry, state);
+                storage.remove(entry, state);
             }
 
             retain

--- a/graphics/src/image/vector.rs
+++ b/graphics/src/image/vector.rs
@@ -1,16 +1,22 @@
-use crate::image::atlas::{self, Atlas};
+//! Vector image loading and caching
 
 use iced_native::svg;
 
 use std::collections::{HashMap, HashSet};
 use std::fs;
 
+use super::TextureStore;
+
+/// Entry in cache corresponding to an svg handle
 pub enum Svg {
+    /// Parsed svg
     Loaded(usvg::Tree),
+    /// Svg not found or failed to parse
     NotFound,
 }
 
 impl Svg {
+    /// Viewport width and height
     pub fn viewport_dimensions(&self) -> (u32, u32) {
         match self {
             Svg::Loaded(tree) => {
@@ -23,24 +29,17 @@ impl Svg {
     }
 }
 
+/// Caches svg vector and raster data
 #[derive(Debug)]
-pub struct Cache {
+pub struct Cache<T: TextureStore> {
     svgs: HashMap<u64, Svg>,
-    rasterized: HashMap<(u64, u32, u32), atlas::Entry>,
+    rasterized: HashMap<(u64, u32, u32), T::Entry>,
     svg_hits: HashSet<u64>,
     rasterized_hits: HashSet<(u64, u32, u32)>,
 }
 
-impl Cache {
-    pub fn new() -> Self {
-        Self {
-            svgs: HashMap::new(),
-            rasterized: HashMap::new(),
-            svg_hits: HashSet::new(),
-            rasterized_hits: HashSet::new(),
-        }
-    }
-
+impl<T: TextureStore> Cache<T> {
+    /// Load svg
     pub fn load(&mut self, handle: &svg::Handle) -> &Svg {
         if self.svgs.contains_key(&handle.id()) {
             return self.svgs.get(&handle.id()).unwrap();
@@ -73,15 +72,15 @@ impl Cache {
         self.svgs.get(&handle.id()).unwrap()
     }
 
+    /// Load svg and upload raster data
     pub fn upload(
         &mut self,
         handle: &svg::Handle,
         [width, height]: [f32; 2],
         scale: f32,
-        device: &wgpu::Device,
-        encoder: &mut wgpu::CommandEncoder,
-        texture_atlas: &mut Atlas,
-    ) -> Option<&atlas::Entry> {
+        state: &mut T::State<'_>,
+        texture_store: &mut T,
+    ) -> Option<&T::Entry> {
         let id = handle.id();
 
         let (width, height) = (
@@ -125,12 +124,11 @@ impl Cache {
                 let mut rgba = img.take();
                 rgba.chunks_exact_mut(4).for_each(|rgba| rgba.swap(0, 2));
 
-                let allocation = texture_atlas.upload(
+                let allocation = texture_store.upload(
                     width,
                     height,
                     bytemuck::cast_slice(rgba.as_slice()),
-                    device,
-                    encoder,
+                    state,
                 )?;
                 log::debug!("allocating {} {}x{}", id, width, height);
 
@@ -144,7 +142,8 @@ impl Cache {
         }
     }
 
-    pub fn trim(&mut self, atlas: &mut Atlas) {
+    /// Load svg and upload raster data
+    pub fn trim(&mut self, texture_store: &mut T, state: &mut T::State<'_>) {
         let svg_hits = &self.svg_hits;
         let rasterized_hits = &self.rasterized_hits;
 
@@ -153,13 +152,24 @@ impl Cache {
             let retain = rasterized_hits.contains(k);
 
             if !retain {
-                atlas.remove(entry);
+                texture_store.remove(entry, state);
             }
 
             retain
         });
         self.svg_hits.clear();
         self.rasterized_hits.clear();
+    }
+}
+
+impl<T: TextureStore> Default for Cache<T> {
+    fn default() -> Self {
+        Self {
+            svgs: HashMap::new(),
+            rasterized: HashMap::new(),
+            svg_hits: HashSet::new(),
+            rasterized_hits: HashSet::new(),
+        }
     }
 }
 

--- a/graphics/src/lib.rs
+++ b/graphics/src/lib.rs
@@ -30,6 +30,7 @@ mod viewport;
 pub mod backend;
 pub mod font;
 pub mod gradient;
+pub mod image;
 pub mod layer;
 pub mod overlay;
 pub mod renderer;

--- a/graphics/src/renderer.rs
+++ b/graphics/src/renderer.rs
@@ -183,7 +183,7 @@ where
 {
     type Handle = image::Handle;
 
-    fn dimensions(&self, handle: &image::Handle) -> (u32, u32) {
+    fn dimensions(&self, handle: &image::Handle) -> Size<u32> {
         self.backend().dimensions(handle)
     }
 
@@ -196,7 +196,7 @@ impl<B, T> svg::Renderer for Renderer<B, T>
 where
     B: Backend + backend::Svg,
 {
-    fn dimensions(&self, handle: &svg::Handle) -> (u32, u32) {
+    fn dimensions(&self, handle: &svg::Handle) -> Size<u32> {
         self.backend().viewport_dimensions(handle)
     }
 

--- a/native/src/image.rs
+++ b/native/src/image.rs
@@ -1,5 +1,5 @@
 //! Load and draw raster graphics.
-use crate::{Hasher, Rectangle};
+use crate::{Hasher, Rectangle, Size};
 
 use std::borrow::Cow;
 use std::hash::{Hash, Hasher as _};
@@ -126,7 +126,7 @@ pub trait Renderer: crate::Renderer {
     type Handle: Clone + Hash;
 
     /// Returns the dimensions of an image for the given [`Handle`].
-    fn dimensions(&self, handle: &Self::Handle) -> (u32, u32);
+    fn dimensions(&self, handle: &Self::Handle) -> Size<u32>;
 
     /// Draws an image with the given [`Handle`] and inside the provided
     /// `bounds`.

--- a/native/src/image.rs
+++ b/native/src/image.rs
@@ -22,7 +22,7 @@ impl Handle {
     }
 
     /// Creates an image [`Handle`] containing the image pixels directly. This
-    /// function expects the input data to be provided as a `Vec<u8>` of BGRA
+    /// function expects the input data to be provided as a `Vec<u8>` of RGBA
     /// pixels.
     ///
     /// This is useful if you have already decoded your image.
@@ -31,7 +31,7 @@ impl Handle {
         height: u32,
         pixels: impl Into<Cow<'static, [u8]>>,
     ) -> Handle {
-        Self::from_data(Data::Pixels {
+        Self::from_data(Data::Rgba {
             width,
             height,
             pixels: pixels.into(),
@@ -93,8 +93,8 @@ pub enum Data {
     /// In-memory data
     Bytes(Cow<'static, [u8]>),
 
-    /// Decoded image pixels in BGRA format.
-    Pixels {
+    /// Decoded image pixels in RGBA format.
+    Rgba {
         /// The width of the image.
         width: u32,
         /// The height of the image.
@@ -109,7 +109,7 @@ impl std::fmt::Debug for Data {
         match self {
             Data::Path(path) => write!(f, "Path({:?})", path),
             Data::Bytes(_) => write!(f, "Bytes(...)"),
-            Data::Pixels { width, height, .. } => {
+            Data::Rgba { width, height, .. } => {
                 write!(f, "Pixels({} * {})", width, height)
             }
         }

--- a/native/src/svg.rs
+++ b/native/src/svg.rs
@@ -1,5 +1,5 @@
 //! Load and draw vector graphics.
-use crate::{Hasher, Rectangle};
+use crate::{Hasher, Rectangle, Size};
 
 use std::borrow::Cow;
 use std::hash::{Hash, Hasher as _};
@@ -82,7 +82,7 @@ impl std::fmt::Debug for Data {
 /// [renderer]: crate::renderer
 pub trait Renderer: crate::Renderer {
     /// Returns the default dimensions of an SVG for the given [`Handle`].
-    fn dimensions(&self, handle: &Handle) -> (u32, u32);
+    fn dimensions(&self, handle: &Handle) -> Size<u32>;
 
     /// Draws an SVG with the given [`Handle`] and inside the provided `bounds`.
     fn draw(&mut self, handle: Handle, bounds: Rectangle);

--- a/native/src/widget/image.rs
+++ b/native/src/widget/image.rs
@@ -85,7 +85,7 @@ where
 {
     // The raw w/h of the underlying image
     let image_size = {
-        let (width, height) = renderer.dimensions(handle);
+        let Size { width, height } = renderer.dimensions(handle);
 
         Size::new(width as f32, height as f32)
     };
@@ -149,7 +149,7 @@ where
         _cursor_position: Point,
         _viewport: &Rectangle,
     ) {
-        let (width, height) = renderer.dimensions(&self.handle);
+        let Size { width, height } = renderer.dimensions(&self.handle);
         let image_size = Size::new(width as f32, height as f32);
 
         let bounds = layout.bounds();

--- a/native/src/widget/image/viewer.rs
+++ b/native/src/widget/image/viewer.rs
@@ -108,7 +108,7 @@ where
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
-        let (width, height) = renderer.dimensions(&self.handle);
+        let Size { width, height } = renderer.dimensions(&self.handle);
 
         let mut size = limits
             .width(self.width)
@@ -409,7 +409,7 @@ pub fn image_size<Renderer>(
 where
     Renderer: image::Renderer,
 {
-    let (width, height) = renderer.dimensions(handle);
+    let Size { width, height } = renderer.dimensions(handle);
 
     let (width, height) = {
         let dimensions = (width as f32, height as f32);

--- a/native/src/widget/svg.rs
+++ b/native/src/widget/svg.rs
@@ -83,7 +83,7 @@ where
         limits: &layout::Limits,
     ) -> layout::Node {
         // The raw w/h of the underlying image
-        let (width, height) = renderer.dimensions(&self.handle);
+        let Size { width, height } = renderer.dimensions(&self.handle);
         let image_size = Size::new(width as f32, height as f32);
 
         // The size to be available to the widget prior to `Shrink`ing
@@ -120,7 +120,7 @@ where
         _cursor_position: Point,
         _viewport: &Rectangle,
     ) {
-        let (width, height) = renderer.dimensions(&self.handle);
+        let Size { width, height } = renderer.dimensions(&self.handle);
         let image_size = Size::new(width as f32, height as f32);
 
         let bounds = layout.bounds();

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -9,8 +9,7 @@ repository = "https://github.com/iced-rs/iced"
 
 [features]
 svg = ["iced_graphics/svg"]
-image = ["image_rs", "iced_graphics/image", "png", "jpeg", "jpeg_rayon", "gif", "webp", "bmp"]
-image_rs = ["iced_graphics/image_rs"]
+image = ["iced_graphics/image"]
 png = ["iced_graphics/png"]
 jpeg = ["iced_graphics/jpeg"]
 jpeg_rayon = ["iced_graphics/jpeg_rayon"]

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -8,19 +8,20 @@ license = "MIT AND OFL-1.1"
 repository = "https://github.com/iced-rs/iced"
 
 [features]
-svg = ["resvg", "usvg", "tiny-skia"]
-image = ["png", "jpeg", "jpeg_rayon", "gif", "webp", "bmp"]
-png = ["image_rs/png"]
-jpeg = ["image_rs/jpeg"]
-jpeg_rayon = ["image_rs/jpeg_rayon"]
-gif = ["image_rs/gif"]
-webp = ["image_rs/webp"]
-pnm = ["image_rs/pnm"]
-ico = ["image_rs/ico"]
-bmp = ["image_rs/bmp"]
-hdr = ["image_rs/hdr"]
-dds = ["image_rs/dds"]
-farbfeld = ["image_rs/farbfeld"]
+svg = ["iced_graphics/svg"]
+image = ["image_rs", "iced_graphics/image", "png", "jpeg", "jpeg_rayon", "gif", "webp", "bmp"]
+image_rs = ["iced_graphics/image_rs"]
+png = ["iced_graphics/png"]
+jpeg = ["iced_graphics/jpeg"]
+jpeg_rayon = ["iced_graphics/jpeg_rayon"]
+gif = ["iced_graphics/gif"]
+webp = ["iced_graphics/webp"]
+pnm = ["iced_graphics/pnm"]
+ico = ["iced_graphics/ico"]
+bmp = ["iced_graphics/bmp"]
+hdr = ["iced_graphics/hdr"]
+dds = ["iced_graphics/dds"]
+farbfeld = ["iced_graphics/farbfeld"]
 canvas = ["iced_graphics/canvas"]
 qr_code = ["iced_graphics/qr_code"]
 default_system_font = ["iced_graphics/font-source"]
@@ -35,7 +36,6 @@ raw-window-handle = "0.5"
 log = "0.4"
 guillotiere = "0.6"
 futures = "0.3"
-kamadak-exif = "0.5"
 bitflags = "1.2"
 
 [dependencies.bytemuck]
@@ -50,24 +50,6 @@ path = "../native"
 version = "0.3"
 path = "../graphics"
 features = ["font-fallback", "font-icons"]
-
-[dependencies.image_rs]
-version = "0.23"
-package = "image"
-default-features = false
-optional = true
-
-[dependencies.resvg]
-version = "0.18"
-optional = true
-
-[dependencies.usvg]
-version = "0.18"
-optional = true
-
-[dependencies.tiny-skia]
-version = "0.6"
-optional = true
 
 [dependencies.encase]
 version = "0.3.0"

--- a/wgpu/src/backend.rs
+++ b/wgpu/src/backend.rs
@@ -296,7 +296,7 @@ impl backend::Text for Backend {
 
 #[cfg(feature = "image_rs")]
 impl backend::Image for Backend {
-    fn dimensions(&self, handle: &iced_native::image::Handle) -> (u32, u32) {
+    fn dimensions(&self, handle: &iced_native::image::Handle) -> Size<u32> {
         self.image_pipeline.dimensions(handle)
     }
 }
@@ -306,7 +306,7 @@ impl backend::Svg for Backend {
     fn viewport_dimensions(
         &self,
         handle: &iced_native::svg::Handle,
-    ) -> (u32, u32) {
+    ) -> Size<u32> {
         self.image_pipeline.viewport_dimensions(handle)
     }
 }

--- a/wgpu/src/backend.rs
+++ b/wgpu/src/backend.rs
@@ -10,7 +10,7 @@ use iced_graphics::{Primitive, Viewport};
 use iced_native::alignment;
 use iced_native::{Font, Size};
 
-#[cfg(any(feature = "image_rs", feature = "svg"))]
+#[cfg(any(feature = "image", feature = "svg"))]
 use crate::image;
 
 /// A [`wgpu`] graphics backend for [`iced`].
@@ -23,7 +23,7 @@ pub struct Backend {
     text_pipeline: text::Pipeline,
     triangle_pipeline: triangle::Pipeline,
 
-    #[cfg(any(feature = "image_rs", feature = "svg"))]
+    #[cfg(any(feature = "image", feature = "svg"))]
     image_pipeline: image::Pipeline,
 
     default_text_size: u16,
@@ -47,7 +47,7 @@ impl Backend {
         let triangle_pipeline =
             triangle::Pipeline::new(device, format, settings.antialiasing);
 
-        #[cfg(any(feature = "image_rs", feature = "svg"))]
+        #[cfg(any(feature = "image", feature = "svg"))]
         let image_pipeline = image::Pipeline::new(device, format);
 
         Self {
@@ -55,7 +55,7 @@ impl Backend {
             text_pipeline,
             triangle_pipeline,
 
-            #[cfg(any(feature = "image_rs", feature = "svg"))]
+            #[cfg(any(feature = "image", feature = "svg"))]
             image_pipeline,
 
             default_text_size: settings.default_text_size,
@@ -98,7 +98,7 @@ impl Backend {
             );
         }
 
-        #[cfg(any(feature = "image_rs", feature = "svg"))]
+        #[cfg(any(feature = "image", feature = "svg"))]
         self.image_pipeline.trim_cache(device, encoder);
     }
 
@@ -148,7 +148,7 @@ impl Backend {
             );
         }
 
-        #[cfg(any(feature = "image_rs", feature = "svg"))]
+        #[cfg(any(feature = "image", feature = "svg"))]
         {
             if !layer.images.is_empty() {
                 let scaled = transformation
@@ -294,7 +294,7 @@ impl backend::Text for Backend {
     }
 }
 
-#[cfg(feature = "image_rs")]
+#[cfg(feature = "image")]
 impl backend::Image for Backend {
     fn dimensions(&self, handle: &iced_native::image::Handle) -> Size<u32> {
         self.image_pipeline.dimensions(handle)

--- a/wgpu/src/backend.rs
+++ b/wgpu/src/backend.rs
@@ -99,7 +99,7 @@ impl Backend {
         }
 
         #[cfg(any(feature = "image_rs", feature = "svg"))]
-        self.image_pipeline.trim_cache();
+        self.image_pipeline.trim_cache(device, encoder);
     }
 
     fn flush(

--- a/wgpu/src/image.rs
+++ b/wgpu/src/image.rs
@@ -1,6 +1,6 @@
 mod atlas;
 
-#[cfg(feature = "image_rs")]
+#[cfg(feature = "image")]
 use iced_graphics::image::raster;
 
 #[cfg(feature = "svg")]
@@ -17,7 +17,7 @@ use std::mem;
 
 use bytemuck::{Pod, Zeroable};
 
-#[cfg(feature = "image_rs")]
+#[cfg(feature = "image")]
 use iced_native::image;
 
 #[cfg(feature = "svg")]
@@ -25,7 +25,7 @@ use iced_native::svg;
 
 #[derive(Debug)]
 pub struct Pipeline {
-    #[cfg(feature = "image_rs")]
+    #[cfg(feature = "image")]
     raster_cache: RefCell<raster::Cache<Atlas>>,
     #[cfg(feature = "svg")]
     vector_cache: RefCell<vector::Cache<Atlas>>,
@@ -243,7 +243,7 @@ impl Pipeline {
         });
 
         Pipeline {
-            #[cfg(feature = "image_rs")]
+            #[cfg(feature = "image")]
             raster_cache: RefCell::new(raster::Cache::default()),
 
             #[cfg(feature = "svg")]
@@ -262,7 +262,7 @@ impl Pipeline {
         }
     }
 
-    #[cfg(feature = "image_rs")]
+    #[cfg(feature = "image")]
     pub fn dimensions(&self, handle: &image::Handle) -> Size<u32> {
         let mut cache = self.raster_cache.borrow_mut();
         let memory = cache.load(handle);
@@ -291,7 +291,7 @@ impl Pipeline {
     ) {
         let instances: &mut Vec<Instance> = &mut Vec::new();
 
-        #[cfg(feature = "image_rs")]
+        #[cfg(feature = "image")]
         let mut raster_cache = self.raster_cache.borrow_mut();
 
         #[cfg(feature = "svg")]
@@ -299,7 +299,7 @@ impl Pipeline {
 
         for image in images {
             match &image {
-                #[cfg(feature = "image_rs")]
+                #[cfg(feature = "image")]
                 layer::Image::Raster { handle, bounds } => {
                     if let Some(atlas_entry) = raster_cache.upload(
                         handle,
@@ -314,7 +314,7 @@ impl Pipeline {
                         );
                     }
                 }
-                #[cfg(not(feature = "image_rs"))]
+                #[cfg(not(feature = "image"))]
                 layer::Image::Raster { .. } => {}
 
                 #[cfg(feature = "svg")]
@@ -450,7 +450,7 @@ impl Pipeline {
         device: &wgpu::Device,
         encoder: &mut wgpu::CommandEncoder,
     ) {
-        #[cfg(feature = "image_rs")]
+        #[cfg(feature = "image")]
         self.raster_cache
             .borrow_mut()
             .trim(&mut self.texture_atlas, &mut (device, encoder));

--- a/wgpu/src/image.rs
+++ b/wgpu/src/image.rs
@@ -10,7 +10,8 @@ use crate::Transformation;
 use atlas::Atlas;
 
 use iced_graphics::layer;
-use iced_native::Rectangle;
+use iced_native::{Rectangle, Size};
+
 use std::cell::RefCell;
 use std::mem;
 
@@ -262,7 +263,7 @@ impl Pipeline {
     }
 
     #[cfg(feature = "image_rs")]
-    pub fn dimensions(&self, handle: &image::Handle) -> (u32, u32) {
+    pub fn dimensions(&self, handle: &image::Handle) -> Size<u32> {
         let mut cache = self.raster_cache.borrow_mut();
         let memory = cache.load(handle);
 
@@ -270,7 +271,7 @@ impl Pipeline {
     }
 
     #[cfg(feature = "svg")]
-    pub fn viewport_dimensions(&self, handle: &svg::Handle) -> (u32, u32) {
+    pub fn viewport_dimensions(&self, handle: &svg::Handle) -> Size<u32> {
         let mut cache = self.vector_cache.borrow_mut();
         let svg = cache.load(handle);
 
@@ -515,15 +516,18 @@ fn add_instances(
             add_instance(image_position, image_size, allocation, instances);
         }
         atlas::Entry::Fragmented { fragments, size } => {
-            let scaling_x = image_size[0] / size.0 as f32;
-            let scaling_y = image_size[1] / size.1 as f32;
+            let scaling_x = image_size[0] / size.width as f32;
+            let scaling_y = image_size[1] / size.height as f32;
 
             for fragment in fragments {
                 let allocation = &fragment.allocation;
 
                 let [x, y] = image_position;
                 let (fragment_x, fragment_y) = fragment.position;
-                let (fragment_width, fragment_height) = allocation.size();
+                let Size {
+                    width: fragment_width,
+                    height: fragment_height,
+                } = allocation.size();
 
                 let position = [
                     x + fragment_x as f32 * scaling_x,
@@ -549,7 +553,7 @@ fn add_instance(
     instances: &mut Vec<Instance>,
 ) {
     let (x, y) = allocation.position();
-    let (width, height) = allocation.size();
+    let Size { width, height } = allocation.size();
     let layer = allocation.layer();
 
     let instance = Instance {

--- a/wgpu/src/image/atlas.rs
+++ b/wgpu/src/image/atlas.rs
@@ -4,9 +4,6 @@ mod allocation;
 mod allocator;
 mod layer;
 
-use iced_graphics::image::TextureStore;
-use std::num::NonZeroU32;
-
 pub use allocation::Allocation;
 pub use entry::Entry;
 pub use layer::Layer;
@@ -14,6 +11,11 @@ pub use layer::Layer;
 use allocator::Allocator;
 
 pub const SIZE: u32 = 2048;
+
+use iced_graphics::image;
+use iced_graphics::Size;
+
+use std::num::NonZeroU32;
 
 #[derive(Debug)]
 pub struct Atlas {
@@ -112,7 +114,7 @@ impl Atlas {
             }
 
             return Some(Entry::Fragmented {
-                size: (width, height),
+                size: Size::new(width, height),
                 fragments,
             });
         }
@@ -192,7 +194,7 @@ impl Atlas {
         encoder: &mut wgpu::CommandEncoder,
     ) {
         let (x, y) = allocation.position();
-        let (width, height) = allocation.size();
+        let Size { width, height } = allocation.size();
         let layer = allocation.layer();
 
         let extent = wgpu::Extent3d {
@@ -297,7 +299,7 @@ impl Atlas {
     }
 }
 
-impl TextureStore for Atlas {
+impl image::Storage for Atlas {
     type Entry = Entry;
     type State<'a> = (&'a wgpu::Device, &'a mut wgpu::CommandEncoder);
 

--- a/wgpu/src/image/atlas.rs
+++ b/wgpu/src/image/atlas.rs
@@ -38,7 +38,7 @@ impl Atlas {
             mip_level_count: 1,
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
-            format: wgpu::TextureFormat::Bgra8UnormSrgb,
+            format: wgpu::TextureFormat::Rgba8UnormSrgb,
             usage: wgpu::TextureUsages::COPY_DST
                 | wgpu::TextureUsages::COPY_SRC
                 | wgpu::TextureUsages::TEXTURE_BINDING,
@@ -246,7 +246,7 @@ impl Atlas {
             mip_level_count: 1,
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
-            format: wgpu::TextureFormat::Bgra8UnormSrgb,
+            format: wgpu::TextureFormat::Rgba8UnormSrgb,
             usage: wgpu::TextureUsages::COPY_DST
                 | wgpu::TextureUsages::COPY_SRC
                 | wgpu::TextureUsages::TEXTURE_BINDING,

--- a/wgpu/src/image/atlas/allocation.rs
+++ b/wgpu/src/image/atlas/allocation.rs
@@ -1,5 +1,7 @@
 use crate::image::atlas::{self, allocator};
 
+use iced_graphics::Size;
+
 #[derive(Debug)]
 pub enum Allocation {
     Partial {
@@ -19,10 +21,10 @@ impl Allocation {
         }
     }
 
-    pub fn size(&self) -> (u32, u32) {
+    pub fn size(&self) -> Size<u32> {
         match self {
             Allocation::Partial { region, .. } => region.size(),
-            Allocation::Full { .. } => (atlas::SIZE, atlas::SIZE),
+            Allocation::Full { .. } => Size::new(atlas::SIZE, atlas::SIZE),
         }
     }
 

--- a/wgpu/src/image/atlas/allocator.rs
+++ b/wgpu/src/image/atlas/allocator.rs
@@ -46,10 +46,10 @@ impl Region {
         (rectangle.min.x as u32, rectangle.min.y as u32)
     }
 
-    pub fn size(&self) -> (u32, u32) {
+    pub fn size(&self) -> iced_graphics::Size<u32> {
         let size = self.allocation.rectangle.size();
 
-        (size.width as u32, size.height as u32)
+        iced_graphics::Size::new(size.width as u32, size.height as u32)
     }
 }
 

--- a/wgpu/src/image/atlas/entry.rs
+++ b/wgpu/src/image/atlas/entry.rs
@@ -1,4 +1,5 @@
 use crate::image::atlas;
+use iced_graphics::image::TextureStoreEntry;
 
 #[derive(Debug)]
 pub enum Entry {
@@ -9,9 +10,8 @@ pub enum Entry {
     },
 }
 
-impl Entry {
-    #[cfg(feature = "image_rs")]
-    pub fn size(&self) -> (u32, u32) {
+impl TextureStoreEntry for Entry {
+    fn size(&self) -> (u32, u32) {
         match self {
             Entry::Contiguous(allocation) => allocation.size(),
             Entry::Fragmented { size, .. } => *size,

--- a/wgpu/src/image/atlas/entry.rs
+++ b/wgpu/src/image/atlas/entry.rs
@@ -1,17 +1,19 @@
 use crate::image::atlas;
-use iced_graphics::image::TextureStoreEntry;
+
+use iced_graphics::image;
+use iced_graphics::Size;
 
 #[derive(Debug)]
 pub enum Entry {
     Contiguous(atlas::Allocation),
     Fragmented {
-        size: (u32, u32),
+        size: Size<u32>,
         fragments: Vec<Fragment>,
     },
 }
 
-impl TextureStoreEntry for Entry {
-    fn size(&self) -> (u32, u32) {
+impl image::storage::Entry for Entry {
+    fn size(&self) -> Size<u32> {
         match self {
             Entry::Contiguous(allocation) => allocation.size(),
             Entry::Fragmented { size, .. } => *size,

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -56,7 +56,7 @@ pub use settings::Settings;
 
 pub(crate) use iced_graphics::Transformation;
 
-#[cfg(any(feature = "image_rs", feature = "svg"))]
+#[cfg(any(feature = "image", feature = "svg"))]
 mod image;
 
 /// A [`wgpu`] graphics renderer for [`iced`].


### PR DESCRIPTION
Fixes https://github.com/iced-rs/iced/issues/674 and closes #1489.

This works, but duplicates code from `iced_wgpu` that should ideally be shared, and the cache never evicts.

The next step here is to work on an API design to move some of the image loading and caching logic from the backend to `iced_graphics` (or elsewhere?).