### PR TITLE
Change uses of BGRA for images to RGBA and use image-rs 0.24

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ iced_glow = { version = "0.3", path = "glow", optional = true }
 thiserror = "1.0"
 
 [dependencies.image_rs]
-version = "0.23"
+version = "0.24"
 package = "image"
 optional = true
 

--- a/native/src/image.rs
+++ b/native/src/image.rs
@@ -21,12 +21,12 @@ impl Handle {
     }
 
     /// Creates an image [`Handle`] containing the image pixels directly. This
-    /// function expects the input data to be provided as a `Vec<u8>` of BGRA
+    /// function expects the input data to be provided as a `Vec<u8>` of RGBA
     /// pixels.
     ///
     /// This is useful if you have already decoded your image.
-    pub fn from_pixels(width: u32, height: u32, pixels: Vec<u8>) -> Handle {
-        Self::from_data(Data::Pixels {
+    pub fn from_rgba(width: u32, height: u32, pixels: Vec<u8>) -> Handle {
+        Self::from_data(Data::Rgba {
             width,
             height,
             pixels,
@@ -88,8 +88,8 @@ pub enum Data {
     /// In-memory data
     Bytes(Vec<u8>),
 
-    /// Decoded image pixels in BGRA format.
-    Pixels {
+    /// Decoded image pixels in RGBA format.
+    Rgba {
         /// The width of the image.
         width: u32,
         /// The height of the image.
@@ -104,8 +104,8 @@ impl std::fmt::Debug for Data {
         match self {
             Data::Path(path) => write!(f, "Path({:?})", path),
             Data::Bytes(_) => write!(f, "Bytes(...)"),
-            Data::Pixels { width, height, .. } => {
-                write!(f, "Pixels({} * {})", width, height)
+            Data::Rgba { width, height, .. } => {
+                write!(f, "Rgba({} * {})", width, height)
             }
         }
     }

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -52,7 +52,7 @@ path = "../graphics"
 features = ["font-fallback", "font-icons"]
 
 [dependencies.image_rs]
-version = "0.23"
+version = "0.24"
 package = "image"
 default-features = false
 optional = true

--- a/wgpu/src/image/atlas.rs
+++ b/wgpu/src/image/atlas.rs
@@ -35,7 +35,7 @@ impl Atlas {
             mip_level_count: 1,
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
-            format: wgpu::TextureFormat::Bgra8UnormSrgb,
+            format: wgpu::TextureFormat::Rgba8UnormSrgb,
             usage: wgpu::TextureUsages::COPY_DST
                 | wgpu::TextureUsages::COPY_SRC
                 | wgpu::TextureUsages::TEXTURE_BINDING,
@@ -336,7 +336,7 @@ impl Atlas {
             mip_level_count: 1,
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
-            format: wgpu::TextureFormat::Bgra8UnormSrgb,
+            format: wgpu::TextureFormat::Rgba8UnormSrgb,
             usage: wgpu::TextureUsages::COPY_DST
                 | wgpu::TextureUsages::COPY_SRC
                 | wgpu::TextureUsages::TEXTURE_BINDING,

--- a/wgpu/src/image/raster.rs
+++ b/wgpu/src/image/raster.rs
@@ -6,7 +6,7 @@ use bitflags::bitflags;
 
 #[derive(Debug)]
 pub enum Memory {
-    Host(::image_rs::ImageBuffer<::image_rs::Bgra<u8>, Vec<u8>>),
+    Host(::image_rs::ImageBuffer<::image_rs::Rgba<u8>, Vec<u8>>),
     Device(atlas::Entry),
     NotFound,
     Invalid,
@@ -53,7 +53,7 @@ impl Cache {
                         })
                         .unwrap_or_else(Operation::empty);
 
-                    Memory::Host(operation.perform(image.to_bgra8()))
+                    Memory::Host(operation.perform(image.to_rgba8()))
                 } else {
                     Memory::NotFound
                 }
@@ -65,12 +65,12 @@ impl Cache {
                             .ok()
                             .unwrap_or_else(Operation::empty);
 
-                    Memory::Host(operation.perform(image.to_bgra8()))
+                    Memory::Host(operation.perform(image.to_rgba8()))
                 } else {
                     Memory::Invalid
                 }
             }
-            image::Data::Pixels {
+            image::Data::Rgba {
                 width,
                 height,
                 pixels,

--- a/wgpu/src/image/vector.rs
+++ b/wgpu/src/image/vector.rs
@@ -122,13 +122,10 @@ impl Cache {
                     img.as_mut(),
                 )?;
 
-                let mut rgba = img.take();
-                rgba.chunks_exact_mut(4).for_each(|rgba| rgba.swap(0, 2));
-
                 let allocation = texture_atlas.upload(
                     width,
                     height,
-                    bytemuck::cast_slice(rgba.as_slice()),
+                    bytemuck::cast_slice(img.data()),
                     device,
                     encoder,
                 )?;


### PR DESCRIPTION
Is there a reason this was using BGRA? RGBA is more common, though BGR was historically popular at one point. `image` 0.24 has removed support for BGR images.

`image::Handle::from_pixels()` is renamed to `image::Handle::from_rgba()` to be more descriptive, and force any users to use RGBA instead of silently interpreting their pixels incorrectly.