### PR TITLE
wgpu: Do not offset `_position_in_atlas` and `_size_in_atlas`

### DIFF
--- a/wgpu/src/image.rs
+++ b/wgpu/src/image.rs
@@ -550,12 +550,12 @@ fn add_instance(
         _position: position,
         _size: size,
         _position_in_atlas: [
-            (x as f32 + 0.5) / atlas::SIZE as f32,
-            (y as f32 + 0.5) / atlas::SIZE as f32,
+            x as f32 / atlas::SIZE as f32,
+            y as f32 / atlas::SIZE as f32,
         ],
         _size_in_atlas: [
-            (width as f32 - 1.0) / atlas::SIZE as f32,
-            (height as f32 - 1.0) / atlas::SIZE as f32,
+            width as f32 / atlas::SIZE as f32,
+            height as f32 / atlas::SIZE as f32,
         ],
         _layer: layer as u32,
     };


### PR DESCRIPTION
Based on my testing, removing the `+ 0.5` and `- 1.0` here makes off-screen rendering of an image primitive output exactly the same data as the input image. Changing to `Nearest` interpolation has the same impact. Previously this resulted in a somewhat blurred output.

Unless there's some subtle issue I'm missing when there are more images in the atlas, this seems to be correct.