### PR TITLE
Constrain padding to resolved inner / outer widget sizes

### DIFF
--- a/core/src/padding.rs
+++ b/core/src/padding.rs
@@ -1,3 +1,5 @@
+use crate::Size;
+
 /// An amount of space to pad for each side of a box
 ///
 /// You can leverage the `From` trait to build [`Padding`] conveniently:
@@ -70,6 +72,18 @@ impl Padding {
     /// Returns the total amount of horizontal [`Padding`].
     pub fn horizontal(self) -> u16 {
         self.left + self.right
+    }
+
+    /// Constrains the padding to fit between the inner & outer [`Size`]
+    pub fn constrain(self, inner: Size, outer: Size) -> Self {
+        let available = (outer - inner).max(Size::ZERO);
+
+        Padding {
+            top: self.top.min((available.height / 2.0) as u16),
+            right: self.right.min((available.width / 2.0) as u16),
+            bottom: self.bottom.min((available.height / 2.0) as u16),
+            left: self.left.min((available.width / 2.0) as u16),
+        }
     }
 }
 

--- a/core/src/padding.rs
+++ b/core/src/padding.rs
@@ -87,7 +87,7 @@ impl Padding {
     }
 }
 
-impl std::convert::From<u16> for Padding {
+impl From<u16> for Padding {
     fn from(p: u16) -> Self {
         Padding {
             top: p,
@@ -98,7 +98,7 @@ impl std::convert::From<u16> for Padding {
     }
 }
 
-impl std::convert::From<[u16; 2]> for Padding {
+impl From<[u16; 2]> for Padding {
     fn from(p: [u16; 2]) -> Self {
         Padding {
             top: p[0],
@@ -109,7 +109,7 @@ impl std::convert::From<[u16; 2]> for Padding {
     }
 }
 
-impl std::convert::From<[u16; 4]> for Padding {
+impl From<[u16; 4]> for Padding {
     fn from(p: [u16; 4]) -> Self {
         Padding {
             top: p[0],

--- a/core/src/padding.rs
+++ b/core/src/padding.rs
@@ -74,8 +74,8 @@ impl Padding {
         self.left + self.right
     }
 
-    /// Constrains the padding to fit between the inner & outer [`Size`]
-    pub fn constrain(self, inner: Size, outer: Size) -> Self {
+    /// Fits the [`Padding`] between the provided `inner` and `outer` [`Size`].
+    pub fn fit(self, inner: Size, outer: Size) -> Self {
         let available = (outer - inner).max(Size::ZERO);
 
         Padding {

--- a/core/src/padding.rs
+++ b/core/src/padding.rs
@@ -79,10 +79,10 @@ impl Padding {
         let available = (outer - inner).max(Size::ZERO);
 
         Padding {
-            top: self.top.min((available.height / 2.0) as u16),
-            right: self.right.min((available.width / 2.0) as u16),
-            bottom: self.bottom.min((available.height / 2.0) as u16),
-            left: self.left.min((available.width / 2.0) as u16),
+            top: self.top.min((available.height as u16) / 2),
+            right: self.right.min((available.width as u16) / 2),
+            bottom: self.bottom.min((available.height as u16) / 2),
+            left: self.left.min((available.width as u16) / 2),
         }
     }
 }

--- a/core/src/size.rs
+++ b/core/src/size.rs
@@ -34,6 +34,22 @@ impl Size {
             height: self.height + padding.vertical() as f32,
         }
     }
+
+    /// Returns the minimum of each component of this size and another
+    pub fn min(self, other: Self) -> Self {
+        Size {
+            width: self.width.min(other.width),
+            height: self.height.min(other.height),
+        }
+    }
+
+    /// Returns the maximum of each component of this size and another
+    pub fn max(self, other: Self) -> Self {
+        Size {
+            width: self.width.max(other.width),
+            height: self.height.max(other.height),
+        }
+    }
 }
 
 impl From<[f32; 2]> for Size {
@@ -66,5 +82,16 @@ impl From<Size> for [f32; 2] {
 impl From<Size> for Vector<f32> {
     fn from(size: Size) -> Self {
         Vector::new(size.width, size.height)
+    }
+}
+
+impl std::ops::Sub for Size {
+    type Output = Size;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Size {
+            width: self.width - rhs.width,
+            height: self.height - rhs.height,
+        }
     }
 }

--- a/native/src/widget/button.rs
+++ b/native/src/widget/button.rs
@@ -430,7 +430,7 @@ pub fn layout<Renderer>(
 
     let mut content = layout_content(renderer, &limits.pad(padding));
 
-    let padding = padding.constrain(content.size(), limits.max());
+    let padding = padding.fit(content.size(), limits.max());
 
     content.move_to(Point::new(padding.left.into(), padding.top.into()));
 

--- a/native/src/widget/button.rs
+++ b/native/src/widget/button.rs
@@ -426,12 +426,15 @@ pub fn layout<Renderer>(
     padding: Padding,
     layout_content: impl FnOnce(&Renderer, &layout::Limits) -> layout::Node,
 ) -> layout::Node {
-    let limits = limits.width(width).height(height).pad(padding);
+    let limits = limits.width(width).height(height);
 
-    let mut content = layout_content(renderer, &limits);
+    let mut content = layout_content(renderer, &limits.pad(padding));
+
+    let padding = padding.constrain(content.size(), limits.max());
+
     content.move_to(Point::new(padding.left.into(), padding.top.into()));
 
-    let size = limits.resolve(content.size()).pad(padding);
+    let size = limits.pad(padding).resolve(content.size()).pad(padding);
 
     layout::Node::with_children(size, vec![content])
 }

--- a/native/src/widget/button.rs
+++ b/native/src/widget/button.rs
@@ -429,12 +429,10 @@ pub fn layout<Renderer>(
     let limits = limits.width(width).height(height);
 
     let mut content = layout_content(renderer, &limits.pad(padding));
-
     let padding = padding.fit(content.size(), limits.max());
+    let size = limits.pad(padding).resolve(content.size()).pad(padding);
 
     content.move_to(Point::new(padding.left.into(), padding.top.into()));
-
-    let size = limits.pad(padding).resolve(content.size()).pad(padding);
 
     layout::Node::with_children(size, vec![content])
 }

--- a/native/src/widget/container.rs
+++ b/native/src/widget/container.rs
@@ -293,11 +293,13 @@ pub fn layout<Renderer>(
         .max_width(max_width)
         .max_height(max_height)
         .width(width)
-        .height(height)
-        .pad(padding);
+        .height(height);
 
-    let mut content = layout_content(renderer, &limits.loose());
-    let size = limits.resolve(content.size());
+    let mut content = layout_content(renderer, &limits.pad(padding).loose());
+
+    let padding = padding.constrain(content.size(), limits.max());
+
+    let size = limits.pad(padding).resolve(content.size());
 
     content.move_to(Point::new(padding.left.into(), padding.top.into()));
     content.align(

--- a/native/src/widget/container.rs
+++ b/native/src/widget/container.rs
@@ -296,9 +296,7 @@ pub fn layout<Renderer>(
         .height(height);
 
     let mut content = layout_content(renderer, &limits.pad(padding).loose());
-
     let padding = padding.fit(content.size(), limits.max());
-
     let size = limits.pad(padding).resolve(content.size());
 
     content.move_to(Point::new(padding.left.into(), padding.top.into()));

--- a/native/src/widget/container.rs
+++ b/native/src/widget/container.rs
@@ -297,7 +297,7 @@ pub fn layout<Renderer>(
 
     let mut content = layout_content(renderer, &limits.pad(padding).loose());
 
-    let padding = padding.constrain(content.size(), limits.max());
+    let padding = padding.fit(content.size(), limits.max());
 
     let size = limits.pad(padding).resolve(content.size());
 

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -357,12 +357,10 @@ where
     let limits = limits.width(width).height(Length::Shrink);
 
     let mut text = layout::Node::new(text_limits.resolve(Size::ZERO));
-
     let padding = padding.fit(text.size(), limits.max());
+    let size = limits.pad(padding).resolve(text.size()).pad(padding);
 
     text.move_to(Point::new(padding.left.into(), padding.top.into()));
-
-    let size = limits.pad(padding).resolve(text.size()).pad(padding);
 
     layout::Node::with_children(size, vec![text])
 }

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -358,7 +358,7 @@ where
 
     let mut text = layout::Node::new(text_limits.resolve(Size::ZERO));
 
-    let padding = padding.constrain(text.size(), limits.max());
+    let padding = padding.fit(text.size(), limits.max());
 
     text.move_to(Point::new(padding.left.into(), padding.top.into()));
 

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -350,15 +350,21 @@ where
 {
     let text_size = size.unwrap_or_else(|| renderer.default_size());
 
-    let limits = limits
+    let text_limits = limits
         .pad(padding)
         .width(width)
         .height(Length::Units(text_size));
+    let limits = limits.width(width).height(Length::Shrink);
 
-    let mut text = layout::Node::new(limits.resolve(Size::ZERO));
+    let mut text = layout::Node::new(text_limits.resolve(Size::ZERO));
+
+    let padding = padding.constrain(text.size(), limits.max());
+
     text.move_to(Point::new(padding.left.into(), padding.top.into()));
 
-    layout::Node::with_children(text.size().pad(padding), vec![text])
+    let size = limits.pad(padding).resolve(text.size()).pad(padding);
+
+    layout::Node::with_children(size, vec![text])
 }
 
 /// Processes an [`Event`] and updates the [`State`] of a [`TextInput`]


### PR DESCRIPTION
During layout, padding isn't constrained to the difference between the child widget and parent widgets max limits. This causes the parent widget to have the wrong resolved size and for the child widget to get offset by `padding` instead of the constrained padding.

This fixes the issue by constraining the padding to the min between itself and `limits.max() - child.size()`. So far I've fixed Container, Button & Text Input as I've seen instances of this for all of them, but haven't combed the other widgets yet for padding.

Below is an example of the fix implemented on `Todos`, where both text input and buttons are bleeding over when their size should be 0. I've tested these fixes on some larger projects I maintain and couldn't find any regression in layout.

Feel free to rename things, not sure `constrain` is the best, I suck at naming :P

| Before | After |
| - | - |
| ![Screenshot from 2022-10-27 12:12:02](https://user-images.githubusercontent.com/10239377/198378271-4e6de297-d118-4f55-99fc-10093b1b400c.png) | ![Screenshot from 2022-10-27 12:11:35](https://user-images.githubusercontent.com/10239377/198378283-51332f71-8d06-46bb-9f24-d38682ead2c0.png) |
