### PR TITLE
Fix drop down not closing when inside scrollable

### DIFF
--- a/native/src/widget/pick_list.rs
+++ b/native/src/widget/pick_list.rs
@@ -348,9 +348,9 @@ where
             let state = state();
 
             let event_status = if state.is_open {
-                // TODO: Encode cursor availability in the type system
-                state.is_open =
-                    cursor_position.x < 0.0 || cursor_position.y < 0.0;
+                // Event wasn't processed by overlay, so cursor was clicked either outside it's
+                // bounds or on the drop-down, either way we close the overlay.
+                state.is_open = false;
 
                 event::Status::Captured
             } else if layout.bounds().contains(cursor_position) {


### PR DESCRIPTION
Fix drop down not closing when inside scrollable and user clicks outside the scrollable. This is because the scrollable sets -1.0 on cursor.y for any events where cursor is outside it's bounds. I'm not sure why picklist had this logic to stay open on -1.0 / -1.0, any click outside the overlay should close it.