### PR TITLE
Use `once_cell` instead of `lazy_static`

### DIFF
--- a/examples/todos/Cargo.toml
+++ b/examples/todos/Cargo.toml
@@ -7,9 +7,9 @@ publish = false
 
 [dependencies]
 iced = { path = "../..", features = ["async-std", "debug"] }
-once_cell = "1.15.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+once_cell = "1.15"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 async-std = "1.0"

--- a/examples/todos/Cargo.toml
+++ b/examples/todos/Cargo.toml
@@ -7,9 +7,9 @@ publish = false
 
 [dependencies]
 iced = { path = "../..", features = ["async-std", "debug"] }
+once_cell = "1.15.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-lazy_static = "1.4"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 async-std = "1.0"

--- a/examples/todos/src/main.rs
+++ b/examples/todos/src/main.rs
@@ -11,12 +11,10 @@ use iced::window;
 use iced::{Application, Element};
 use iced::{Color, Command, Font, Length, Settings, Subscription};
 
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 
-lazy_static! {
-    static ref INPUT_ID: text_input::Id = text_input::Id::unique();
-}
+static INPUT_ID: Lazy<text_input::Id> = Lazy::new(text_input::Id::unique);
 
 pub fn main() -> iced::Result {
     Todos::run(Settings {

--- a/examples/websocket/Cargo.toml
+++ b/examples/websocket/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 iced = { path = "../..", features = ["tokio", "debug"] }
 iced_native = { path = "../../native" }
 iced_futures = { path = "../../futures" }
-once_cell = "1.15.0"
+once_cell = "1.15"
 
 [dependencies.async-tungstenite]
 version = "0.16"

--- a/examples/websocket/Cargo.toml
+++ b/examples/websocket/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 iced = { path = "../..", features = ["tokio", "debug"] }
 iced_native = { path = "../../native" }
 iced_futures = { path = "../../futures" }
-lazy_static = "1.4"
+once_cell = "1.15.0"
 
 [dependencies.async-tungstenite]
 version = "0.16"

--- a/examples/websocket/src/main.rs
+++ b/examples/websocket/src/main.rs
@@ -8,6 +8,7 @@ use iced::widget::{
 use iced::{
     Application, Color, Command, Element, Length, Settings, Subscription, Theme,
 };
+use once_cell::sync::Lazy;
 
 pub fn main() -> iced::Result {
     WebSocket::run(Settings::default())
@@ -165,6 +166,4 @@ impl Default for State {
     }
 }
 
-lazy_static::lazy_static! {
-    static ref MESSAGE_LOG: scrollable::Id = scrollable::Id::unique();
-}
+static MESSAGE_LOG: Lazy<scrollable::Id> = Lazy::new(scrollable::Id::unique);

--- a/style/Cargo.toml
+++ b/style/Cargo.toml
@@ -18,5 +18,5 @@ features = ["palette"]
 [dependencies.palette]
 version = "0.6"
 
-[dependencies.lazy_static]
-version = "1.4"
+[dependencies.once_cell]
+version = "1.15"

--- a/style/src/theme/palette.rs
+++ b/style/src/theme/palette.rs
@@ -1,6 +1,6 @@
 use iced_core::Color;
 
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use palette::{FromColor, Hsl, Mix, RelativeContrast, Srgb};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -66,11 +66,10 @@ pub struct Extended {
     pub danger: Danger,
 }
 
-lazy_static! {
-    pub static ref EXTENDED_LIGHT: Extended =
-        Extended::generate(Palette::LIGHT);
-    pub static ref EXTENDED_DARK: Extended = Extended::generate(Palette::DARK);
-}
+pub static EXTENDED_LIGHT: Lazy<Extended> =
+    Lazy::new(|| Extended::generate(Palette::LIGHT));
+pub static EXTENDED_DARK: Lazy<Extended> =
+    Lazy::new(|| Extended::generate(Palette::DARK));
 
 impl Extended {
     pub fn generate(palette: Palette) -> Self {


### PR DESCRIPTION
This seems to be generally considered the preferred, idiomatic solution now. This is in the standard library behind a feature flag (apparently now called `std::sync::LazyLock`).