### PR TITLE
Add pane maximize / restore for `PaneGrid`

### DIFF
--- a/native/src/widget/pane_grid.rs
+++ b/native/src/widget/pane_grid.rs
@@ -221,6 +221,12 @@ where
         self.style = style.into();
         self
     }
+
+    fn drag_enabled(&self) -> bool {
+        (!self.elements.is_maximized())
+            .then(|| self.on_drag.is_some())
+            .unwrap_or_default()
+    }
 }
 
 impl<'a, Message, Renderer> Widget<Message, Renderer>
@@ -296,6 +302,11 @@ where
     ) -> event::Status {
         let action = tree.state.downcast_mut::<state::Action>();
 
+        let on_drag = self
+            .drag_enabled()
+            .then_some(&self.on_drag)
+            .unwrap_or(&None);
+
         let event_status = update(
             action,
             self.elements.node(self.state),
@@ -306,7 +317,7 @@ where
             self.spacing,
             self.elements.iter(),
             &self.on_click,
-            &self.on_drag,
+            on_drag,
             &self.on_resize,
         );
 
@@ -361,7 +372,7 @@ where
                         cursor_position,
                         viewport,
                         renderer,
-                        self.on_drag.is_some(),
+                        self.drag_enabled(),
                     )
                 })
                 .max()
@@ -960,5 +971,10 @@ impl<T> Elements<T> {
             Elements::Normal(_) => state.layout(),
             Elements::Maximized(_, _, node) => node,
         }
+    }
+
+    /// TODO
+    pub fn is_maximized(&self) -> bool {
+        matches!(self, Self::Maximized(..))
     }
 }

--- a/native/src/widget/pane_grid.rs
+++ b/native/src/widget/pane_grid.rs
@@ -85,7 +85,7 @@ use crate::{
 /// let (mut state, _) = pane_grid::State::new(PaneState::SomePane);
 ///
 /// let pane_grid =
-///     PaneGrid::new(&state, |pane, state| {
+///     PaneGrid::new(&state, |pane, state, is_maximized| {
 ///         pane_grid::Content::new(match state {
 ///             PaneState::SomePane => text("This is some pane"),
 ///             PaneState::AnotherKindOfPane => text("This is another kind of pane"),
@@ -302,10 +302,11 @@ where
     ) -> event::Status {
         let action = tree.state.downcast_mut::<state::Action>();
 
-        let on_drag = self
-            .drag_enabled()
-            .then_some(&self.on_drag)
-            .unwrap_or(&None);
+        let on_drag = if self.drag_enabled() {
+            &self.on_drag
+        } else {
+            &None
+        };
 
         let event_status = update(
             action,

--- a/native/src/widget/pane_grid/state.rs
+++ b/native/src/widget/pane_grid/state.rs
@@ -214,12 +214,16 @@ impl<T> State<T> {
 
     /// Maximize the given [`Pane`]. Only this pane will be rendered by the
     /// [`PaneGrid`] until [`Self::restore()`] is called.
+    ///
+    /// [`PaneGrid`]: crate::widget::PaneGrid
     pub fn maximize(&mut self, pane: &Pane) {
         self.maximized = Some(*pane);
     }
 
     /// Restore the currently maximized [`Pane`] to it's normal size. All panes
-    /// will be rendered by the [`PaneGrid`]
+    /// will be rendered by the [`PaneGrid`].
+    ///
+    /// [`PaneGrid`]: crate::widget::PaneGrid
     pub fn restore(&mut self) {
         let _ = self.maximized.take();
     }
@@ -282,6 +286,8 @@ impl Internal {
 }
 
 /// The scoped internal state of the [`PaneGrid`]
+///
+/// [`PaneGrid`]: crate::widget::PaneGrid
 #[derive(Debug)]
 pub enum Scoped<'a> {
     /// The state when all panes are visible
@@ -338,7 +344,7 @@ impl Action {
 }
 
 impl<'a> Scoped<'a> {
-    /// The layout [`Node`] of the [`Scope`] state
+    /// The layout [`Node`] of the [`Scoped`] state
     pub fn layout(&self) -> &Node {
         match self {
             Scoped::All(Internal { layout, .. }) => layout,

--- a/native/src/widget/pane_grid/state.rs
+++ b/native/src/widget/pane_grid/state.rs
@@ -228,6 +228,13 @@ impl<T> State<T> {
     pub fn restore(&mut self) {
         let _ = self.maximized.take();
     }
+
+    /// Returns the maximized [`Pane`] of the [`PaneGrid`].
+    ///
+    /// [`PaneGrid`]: crate::widget::PaneGrid
+    pub fn maximized(&self) -> Option<Pane> {
+        self.maximized
+    }
 }
 
 /// The internal state of a [`PaneGrid`].

--- a/native/src/widget/pane_grid/state.rs
+++ b/native/src/widget/pane_grid/state.rs
@@ -4,9 +4,9 @@
 use crate::widget::pane_grid::{
     Axis, Configuration, Direction, Node, Pane, Split,
 };
-use crate::{Point, Rectangle, Size};
+use crate::{Point, Size};
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 
 /// The state of a [`PaneGrid`].
 ///
@@ -31,6 +31,9 @@ pub struct State<T> {
     ///
     /// [`PaneGrid`]: crate::widget::PaneGrid
     pub internal: Internal,
+
+    /// The maximized [`Pane`] of the [`PaneGrid`]
+    pub(super) maximized: Option<Pane>,
 }
 
 impl<T> State<T> {
@@ -52,7 +55,11 @@ impl<T> State<T> {
         let internal =
             Internal::from_configuration(&mut panes, config.into(), 0);
 
-        State { panes, internal }
+        State {
+            panes,
+            internal,
+            maximized: None,
+        }
     }
 
     /// Returns the total amount of panes in the [`State`].
@@ -194,11 +201,27 @@ impl<T> State<T> {
     /// Closes the given [`Pane`] and returns its internal state and its closest
     /// sibling, if it exists.
     pub fn close(&mut self, pane: &Pane) -> Option<(T, Pane)> {
+        if self.maximized == Some(*pane) {
+            let _ = self.maximized.take();
+        }
+
         if let Some(sibling) = self.internal.layout.remove(pane) {
             self.panes.remove(pane).map(|state| (state, sibling))
         } else {
             None
         }
+    }
+
+    /// Maximize the given [`Pane`]. Only this pane will be rendered by the
+    /// [`PaneGrid`] until [`Self::restore()`] is called.
+    pub fn maximize(&mut self, pane: &Pane) {
+        self.maximized = Some(*pane);
+    }
+
+    /// Restore the currently maximized [`Pane`] to it's normal size. All panes
+    /// will be rendered by the [`PaneGrid`]
+    pub fn restore(&mut self) {
+        let _ = self.maximized.take();
     }
 }
 
@@ -226,11 +249,13 @@ impl Internal {
                 let Internal {
                     layout: a,
                     last_id: next_id,
+                    ..
                 } = Self::from_configuration(panes, *a, next_id);
 
                 let Internal {
                     layout: b,
                     last_id: next_id,
+                    ..
                 } = Self::from_configuration(panes, *b, next_id);
 
                 (
@@ -304,25 +329,8 @@ impl Action {
 }
 
 impl Internal {
-    /// Calculates the current [`Pane`] regions from the [`PaneGrid`] layout.
-    ///
-    /// [`PaneGrid`]: crate::widget::PaneGrid
-    pub fn pane_regions(
-        &self,
-        spacing: f32,
-        size: Size,
-    ) -> BTreeMap<Pane, Rectangle> {
-        self.layout.pane_regions(spacing, size)
-    }
-
-    /// Calculates the current [`Split`] regions from the [`PaneGrid`] layout.
-    ///
-    /// [`PaneGrid`]: crate::widget::PaneGrid
-    pub fn split_regions(
-        &self,
-        spacing: f32,
-        size: Size,
-    ) -> BTreeMap<Split, (Axis, Rectangle, f32)> {
-        self.layout.split_regions(spacing, size)
+    /// The layout [`Node`] of the [`Internal`] state
+    pub fn layout(&self) -> &Node {
+        &self.layout
     }
 }

--- a/native/src/widget/pane_grid/state.rs
+++ b/native/src/widget/pane_grid/state.rs
@@ -281,6 +281,15 @@ impl Internal {
     }
 }
 
+/// The scoped internal state of the [`PaneGrid`]
+#[derive(Debug)]
+pub enum Scoped<'a> {
+    /// The state when all panes are visible
+    All(&'a Internal),
+    /// The state when a pane is maximized
+    Maximized(Node),
+}
+
 /// The current action of a [`PaneGrid`].
 ///
 /// [`PaneGrid`]: crate::widget::PaneGrid
@@ -328,9 +337,12 @@ impl Action {
     }
 }
 
-impl Internal {
-    /// The layout [`Node`] of the [`Internal`] state
+impl<'a> Scoped<'a> {
+    /// The layout [`Node`] of the [`Scope`] state
     pub fn layout(&self) -> &Node {
-        &self.layout
+        match self {
+            Scoped::All(Internal { layout, .. }) => layout,
+            Scoped::Maximized(layout) => layout,
+        }
     }
 }

--- a/native/src/widget/pane_grid/state.rs
+++ b/native/src/widget/pane_grid/state.rs
@@ -293,17 +293,6 @@ impl Internal {
     }
 }
 
-/// The scoped internal state of the [`PaneGrid`]
-///
-/// [`PaneGrid`]: crate::widget::PaneGrid
-#[derive(Debug)]
-pub enum Scoped<'a> {
-    /// The state when all panes are visible
-    All(&'a Internal),
-    /// The state when a pane is maximized
-    Maximized(Node),
-}
-
 /// The current action of a [`PaneGrid`].
 ///
 /// [`PaneGrid`]: crate::widget::PaneGrid
@@ -351,12 +340,9 @@ impl Action {
     }
 }
 
-impl<'a> Scoped<'a> {
-    /// The layout [`Node`] of the [`Scoped`] state
+impl Internal {
+    /// The layout [`Node`] of the [`Internal`] state
     pub fn layout(&self) -> &Node {
-        match self {
-            Scoped::All(Internal { layout, .. }) => layout,
-            Scoped::Maximized(layout) => layout,
-        }
+        &self.layout
     }
 }

--- a/native/src/widget/pane_grid/state.rs
+++ b/native/src/widget/pane_grid/state.rs
@@ -160,6 +160,7 @@ impl<T> State<T> {
         node.split(new_split, axis, new_pane);
 
         let _ = self.panes.insert(new_pane, state);
+        let _ = self.maximized.take();
 
         Some((new_pane, new_split))
     }


### PR DESCRIPTION
Adds the ability to maximize / restore a pane in the pane grid. When maximized, dragging is disabled (we can remove this, since dragging is enabled when only 1 pane exists currently).

### API

Two new methods are exposed on `State` to allow the user control of maximizing and restoring a pane:

```rs
/// Maximize the given [`Pane`]. Only this pane will be rendered by the
/// [`PaneGrid`] until [`Self::restore()`] is called.
pub fn maximize(&mut self, pane: &Pane);

/// Restore the currently maximized [`Pane`] to it's normal size. All panes
/// will be rendered by the [`PaneGrid`]
pub fn restore(&mut self);
```

Once a pane is maximized, a new `bool` is passed on the `view` function to specify if the pane is maximized or not. Maybe we create an enum here for a stronger type since the closure is not descriptive:

```rs
PaneGrid::new(&self.panes, |id, pane, is_maximized| {
    ..
})
```

### Implementation 

`State` stores the maximized pane in a new field: `maximized: Option<Pane>` and is set by the above API.

Instead of storing `Vec<Content>` in the `PaneGrid`, I've created a new helper `Contents` that is built considering the maximized pane. This can be iterated over for building the widget tree & layout.

```rs
pub enum Contents<T> {
    All(Vec<(Pane, T)>),
    Maximized(Pane, T),
}
```

A new `state::Scoped` has been added which either wraps the internal state when no field is maximized, or specifies the maximized pane. The widget methods now take this for determining the layout Node of the `PaneGrid`.

```rs
/// The scoped internal state of the [`PaneGrid`]
pub enum Scoped<'a> {
    /// The state when all panes are visible
    All(&'a Internal),
    /// The state when a pane is maximized
    Maximized(Node),
}

impl<'a> Scoped<'a> {
    /// The layout [`Node`] of the [`Scope`] state
    pub fn layout(&self) -> &Node {
        match self {
            Scoped::Normal(Internal { layout, .. }) => layout,
            Scoped::Maximized(layout) => layout,
        }
    }
}
```

Iterating on `Contents` and calling `Scoped::layout` allowed for very minimal adjustments of the existing widget implementation code.

### Demo

https://user-images.githubusercontent.com/10239377/199626412-7507c106-185f-4d64-8e93-b55943abae49.mp4

