### PR TITLE
Combine `glow_default_system_font` and `default_system_font` features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ documentation = "https://docs.rs/iced"
 readme = "README.md"
 keywords = ["gui", "ui", "graphics", "interface", "widgets"]
 categories = ["gui"]
-resolver = "2"
 
 [features]
 default = ["wgpu"]
@@ -25,11 +24,9 @@ qr_code = ["iced_graphics/qr_code"]
 # Enables the `iced_wgpu` renderer
 wgpu = ["iced_wgpu"]
 # Enables using system fonts
-default_system_font = ["iced_wgpu/default_system_font"]
+default_system_font = ["iced_wgpu?/default_system_font", "iced_glow?/default_system_font"]
 # Enables the `iced_glow` renderer. Overrides `iced_wgpu`
 glow = ["iced_glow", "iced_glutin"]
-# Enables using system fonts for `iced_glow`
-glow_default_system_font = ["iced_glow/default_system_font"]
 # Enables a debug view in native platforms (press F12)
 debug = ["iced_winit/debug"]
 # Enables `tokio` as the `executor::Default` on native platforms


### PR DESCRIPTION
Apparently "weak dependency features" have been stable since Rust 1.60.0, allowing a feature to enable a feature of a dependency only if that dependency is enabled elsewhere. So having a separate feature for this with glow is unnecessary now.

Also remove the `resolver` setting which is redundant on edition 2021.