### PR TITLE
Release `0.5` — Stabilization of stateless widgets, first-class theming, widget operations, `Lazy` widget, and more!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- __[Stabilization of stateless widgets][stateless]__ (#1393)  
+  The old widget API has been completely replaced by stateless widgets (introduced in #1284). Alongside the new API, there are a bunch of new helper functions and macros for easily describing view logic (like `row!` and `column!`).
+
+- __[First-class theming][theming]__ (#1362)  
+  A complete overhaul of our styling primitives, introducing a `Theme` as a first-class concept of the library.
+
+- __[Widget operations][operations]__ (#1399)  
+  An abstraction that can be used to traverse (and operate on) the widget tree of an application in order to query or update some widget state.
+
+- __[`Lazy` widget][lazy]__ (#1400)  
+  A widget that can call some view logic lazily only when some data has changed. Thanks to @nicksenger!
+
+- __[Linear gradient support for `Canvas`][gradient]__ (#1448)  
+  The `Canvas` widget can draw linear gradients now. Thanks to @bungoboingo!
+
+- __[Touch support for `Canvas`][touch]__ (#1305)  
+  The `Canvas` widget now supports touch events. Thanks to @artursapek!
+
+- __[`Image` and `Svg` support for `iced_glow`][image]__ (#1485)  
+  Our OpenGL renderer now is capable of rendering both the `Image` and `Svg` widgets. Thanks to @ids1024!
+
+[stateless]: https://github.com/iced-rs/iced/pull/1393
+[theming]: https://github.com/iced-rs/iced/pull/1362
+[operations]: https://github.com/iced-rs/iced/pull/1399
+[lazy]: https://github.com/iced-rs/iced/pull/1400
+[gradient]: https://github.com/iced-rs/iced/pull/1448
+[touch]: https://github.com/iced-rs/iced/pull/1305
+[image]: https://github.com/iced-rs/iced/pull/1485
 
 ## [0.4.2] - 2022-05-03
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iced"
-version = "0.4.2"
+version = "0.5.0"
 authors = ["Héctor Ramón Jiménez <hector0193@gmail.com>"]
 edition = "2021"
 description = "A cross-platform GUI library inspired by Elm"
@@ -91,13 +91,13 @@ members = [
 ]
 
 [dependencies]
-iced_core = { version = "0.5", path = "core" }
-iced_futures = { version = "0.4", path = "futures" }
-iced_native = { version = "0.5", path = "native" }
-iced_graphics = { version = "0.3", path = "graphics" }
-iced_winit = { version = "0.4", path = "winit", features = ["application"] }
-iced_glutin = { version = "0.3", path = "glutin", optional = true }
-iced_glow = { version = "0.3", path = "glow", optional = true }
+iced_core = { version = "0.6", path = "core" }
+iced_futures = { version = "0.5", path = "futures" }
+iced_native = { version = "0.6", path = "native" }
+iced_graphics = { version = "0.4", path = "graphics" }
+iced_winit = { version = "0.5", path = "winit", features = ["application"] }
+iced_glutin = { version = "0.4", path = "glutin", optional = true }
+iced_glow = { version = "0.4", path = "glow", optional = true }
 thiserror = "1.0"
 
 [dependencies.image_rs]
@@ -106,10 +106,10 @@ package = "image"
 optional = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-iced_wgpu = { version = "0.5", path = "wgpu", optional = true }
+iced_wgpu = { version = "0.6", path = "wgpu", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-iced_wgpu = { version = "0.5", path = "wgpu", features = ["webgl"], optional = true }
+iced_wgpu = { version = "0.6", path = "wgpu", features = ["webgl"], optional = true }
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iced_core"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Héctor Ramón Jiménez <hector0193@gmail.com>"]
 edition = "2021"
 description = "The essential concepts of Iced"

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iced_futures"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Héctor Ramón Jiménez <hector0193@gmail.com>"]
 edition = "2021"
 description = "Commands, subscriptions, and runtimes for Iced"

--- a/glow/Cargo.toml
+++ b/glow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iced_glow"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Héctor Ramón Jiménez <hector0193@gmail.com>"]
 edition = "2021"
 description = "A glow renderer for iced"
@@ -34,11 +34,11 @@ bytemuck = "1.4"
 log = "0.4"
 
 [dependencies.iced_native]
-version = "0.5"
+version = "0.6"
 path = "../native"
 
 [dependencies.iced_graphics]
-version = "0.3"
+version = "0.4"
 path = "../graphics"
 features = ["font-fallback", "font-icons", "opengl"]
 

--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iced_glutin"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Héctor Ramón Jiménez <hector0193@gmail.com>"]
 edition = "2021"
 description = "A glutin runtime for Iced"
@@ -23,15 +23,15 @@ git = "https://github.com/iced-rs/glutin"
 rev = "da8d291486b4c9bec12487a46c119c4b1d386abf"
 
 [dependencies.iced_native]
-version = "0.5"
+version = "0.6"
 path = "../native"
 
 [dependencies.iced_winit]
-version = "0.4"
+version = "0.5"
 path = "../winit"
 features = ["application"]
 
 [dependencies.iced_graphics]
-version = "0.3"
+version = "0.4"
 path = "../graphics"
 features = ["opengl"]

--- a/graphics/Cargo.toml
+++ b/graphics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iced_graphics"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Héctor Ramón Jiménez <hector0193@gmail.com>"]
 edition = "2021"
 description = "A bunch of backend-agnostic types that can be leveraged to build a renderer for Iced"
@@ -44,11 +44,11 @@ version = "1.4"
 features = ["derive"]
 
 [dependencies.iced_native]
-version = "0.5"
+version = "0.6"
 path = "../native"
 
 [dependencies.iced_style]
-version = "0.4"
+version = "0.5"
 path = "../style"
 
 [dependencies.lyon]

--- a/lazy/Cargo.toml
+++ b/lazy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iced_lazy"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Héctor Ramón Jiménez <hector0193@gmail.com>"]
 edition = "2021"
 description = "Lazy widgets for Iced"
@@ -14,5 +14,5 @@ categories = ["gui"]
 ouroboros = "0.13"
 
 [dependencies.iced_native]
-version = "0.5"
+version = "0.6"
 path = "../native"

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iced_native"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Héctor Ramón Jiménez <hector0193@gmail.com>"]
 edition = "2021"
 description = "A renderer-agnostic library for native GUIs"
@@ -16,14 +16,14 @@ unicode-segmentation = "1.6"
 num-traits = "0.2"
 
 [dependencies.iced_core]
-version = "0.5"
+version = "0.6"
 path = "../core"
 
 [dependencies.iced_futures]
-version = "0.4"
+version = "0.5"
 path = "../futures"
 features = ["thread-pool"]
 
 [dependencies.iced_style]
-version = "0.4"
+version = "0.5"
 path = "../style"

--- a/style/Cargo.toml
+++ b/style/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iced_style"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Héctor Ramón Jiménez <hector0193@gmail.com>"]
 edition = "2021"
 description = "The default set of styles of Iced"
@@ -11,7 +11,7 @@ keywords = ["gui", "ui", "graphics", "interface", "widgets"]
 categories = ["gui"]
 
 [dependencies.iced_core]
-version = "0.5"
+version = "0.6"
 path = "../core"
 features = ["palette"]
 

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iced_wgpu"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Héctor Ramón Jiménez <hector0193@gmail.com>"]
 edition = "2021"
 description = "A wgpu renderer for Iced"
@@ -42,11 +42,11 @@ version = "1.9"
 features = ["derive"]
 
 [dependencies.iced_native]
-version = "0.5"
+version = "0.6"
 path = "../native"
 
 [dependencies.iced_graphics]
-version = "0.3"
+version = "0.4"
 path = "../graphics"
 features = ["font-fallback", "font-icons"]
 

--- a/winit/Cargo.toml
+++ b/winit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iced_winit"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Héctor Ramón Jiménez <hector0193@gmail.com>"]
 edition = "2021"
 description = "A winit runtime for Iced"
@@ -26,15 +26,15 @@ git = "https://github.com/iced-rs/winit.git"
 rev = "940457522e9fb9f5dac228b0ecfafe0138b4048c"
 
 [dependencies.iced_native]
-version = "0.5"
+version = "0.6"
 path = "../native"
 
 [dependencies.iced_graphics]
-version = "0.3"
+version = "0.4"
 path = "../graphics"
 
 [dependencies.iced_futures]
-version = "0.4"
+version = "0.5"
 path = "../futures"
 
 [target.'cfg(target_os = "windows")'.dependencies.winapi]


### PR DESCRIPTION
<p align="center">
  <a href="https://www.phoronix.com/news/COSMIC-Desktop-Iced-Toolkit">
    <img alt="COSMIC Desktop" src="https://user-images.githubusercontent.com/518289/200920739-380f9fac-3edc-427b-8fc8-4abf8896d786.png" width="49%">
  </a>
  <a href="https://github.com/mkrueger/icy_term">
    <img alt="icy_term" src="https://user-images.githubusercontent.com/518289/200918485-8526869e-f449-4a79-a1ab-e5a0fa7516d4.png" width="50%">
  </a>
  <a href="https://github.com/carl-anders/slimevr-wrangler">
    <img alt="SlimeVR Wrangler" src="https://user-images.githubusercontent.com/518289/200920908-4181e4ac-51b9-4c0e-b5d4-e03897e94c87.png" width="50%">
  </a>
</p>

> Iced is an _experimental_ cross-platform GUI library for Rust focused on simplicity and type-safety. Inspired by [Elm].

This PR marks the end of the [`0.5.0` milestone] and the launch of a new release :rocket:

[Elm]: https://elm-lang.org/
[`0.5.0` milestone]: https://github.com/iced-rs/iced/milestone/8

# New features

- __[Stabilization of stateless widgets][stateless]__ (#1393)  
  The old widget API has been completely replaced by stateless widgets (introduced in #1284). Alongside the new API, there are a bunch of new helper functions and macros for easily describing view logic (like `row!` and `column!`).

- __[First-class theming][theming]__ (#1362)  
  A complete overhaul of our styling primitives, introducing a `Theme` as a first-class concept of the library.

- __[Widget operations][operations]__ (#1399)  
  An abstraction that can be used to traverse (and operate on) the widget tree of an application in order to query or update some widget state.

- __[`Lazy` widget][lazy]__ (#1400)  
  A widget that can call some view logic lazily only when some data has changed. Thanks to @nicksenger!

- __[Linear gradient support for `Canvas`][gradient]__ (#1448)  
  The `Canvas` widget can draw linear gradients now. Thanks to @bungoboingo!

- __[Touch support for `Canvas`][touch]__ (#1305)  
  The `Canvas` widget now supports touch events. Thanks to @artursapek!

- __[`Image` and `Svg` support for `iced_glow`][image]__ (#1485)  
  Our OpenGL renderer now is capable of rendering both the `Image` and `Svg` widgets. Thanks to @ids1024!

[stateless]: https://github.com/iced-rs/iced/pull/1393
[operations]: https://github.com/iced-rs/iced/pull/1399
[theming]: https://github.com/iced-rs/iced/pull/1362
[lazy]: https://github.com/iced-rs/iced/pull/1400
[gradient]: https://github.com/iced-rs/iced/pull/1448
[touch]: https://github.com/iced-rs/iced/pull/1305
[image]: https://github.com/iced-rs/iced/pull/1485
[The Elm Architecture]: https://guide.elm-lang.org/architecture/
[`wgpu`]: https://github.com/gfx-rs/wgpu


# Showcase

During this year, many users have chosen iced to build their applications! Here are some of the _coolest_ ones:

- __[Enclone Visual]__, a graphical user interface (GUI) for [enclone](https://10xgenomics.github.io/enclone/pages/auto/help.main.html).
- __[icy_term]__, a BBS terminal program which allows you to connect to BBSes.
- __[Microlaunch]__, a FINAL FANTASY XIV Online native launcher for Linux.
- __[mr3-advanced-viewer]__, a GUI application to view Monster Rancher 3 data running in PCSX2.
- __[SlimeVR Wrangler]__, use Joy-Con's as SlimeVR trackers, enabling you to make a full body system with your existing devices. 
- __[ytdlp-gui]__, a GUI for [`yt-dlp`](https://github.com/yt-dlp/yt-dlp) written in Rust.

Finally, and deserving a special mention, [System76 has decided to use iced instead of GTK for Pop!_OS' desktop environment](https://www.phoronix.com/news/COSMIC-Desktop-Iced-Toolkit) :tada: This is one of the most important adoption events since the inception of the library. The engineers at System76 are already contributing a bunch of great improvements to iced, as well as breaking ground in long-standing issues that could benefit the whole GUI ecosystem in Rust ([like proper text rendering!](https://github.com/pop-os/cosmic-text)).

[Enclone Visual]: https://10xgenomics.github.io/enclone/pages/auto/visual.html
[icy_term]: https://github.com/mkrueger/icy_term
[Microlaunch]: https://github.com/eorzeatools/microlaunch
[mr3-advanced-viewer]: https://github.com/ofeeg/mr3-advanced-viewer
[SlimeVR Wrangler]: https://github.com/carl-anders/slimevr-wrangler
[ytdlp-gui]: https://github.com/bksalman/ytdlp-gui

# Thank you! :tada:
As always, I want to say thank you to everyone that has contributed to this release:

- @0x192 exported `overlay::menu` publicly (#1425).
- @13r0ck updated the documentation for the `integration` examples after a rename (#1433).
- @aentity added an `application` feature to `iced_winit` (#1196).
- @AlistairKeiller fixed the supported backends listed in the `README` of `iced_wgpu` (#1458).
- @artursapek added touch support for the `Canvas` widget (#1305).
- @bungoboingo
    - added supported for linear gradients to the `Canvas` widget (#1448), and
    - fixed issues with old OpenGL versions in `iced_glow` (#1518).
- @casperstorm changed the images in the `README` to have similar height (#1356).
- @clarkmoody tweaked the system information queries (#1445).
- @Cupnfish updated `wgpu` to `0.13` (#1378).
- @daladim added convenience functions for `window::Icon` (#1174).
- @derezzedex implemented commands to query system information (#1314).
- @fralonra
    - fixed the import path in the documentation example of the pure `Canvas` widget (#1373), and
    - fixed the documentation for running `integration_wgpu` (#1434).
- @icedrocket enabled the `application` feature in `iced_glutin` (#1502).
- @ids1024
    - documented that `window::Action::Move` is unsupported on Wayland (#1440)
    - replaced `lazy_static!` with `once_cell` (#1497)
    - added support for `Cow<'static, [u8]>` in the `Image` and `Svg` widgets (#1453)
    - implemented `Image` and `Svg` support for `iced_glow` (#1485)
    - fixed wrong conversion to `BGRA` before passing to `image` shaders (#1507), and
    - combined the `glow_default_system_font` and `default_system_font` features (#1505).
- @jhannyjimenez clarified the position and alignment of text in the documentation of `Canvas` (#1370).
- @kaimast improved the integration of event processing for custom shells (#1230).
- @LordRatte implemented a `color!` macro helper (#1227).
- @Luni-4
    - added a `release-opt` profile to our `Cargo.toml` (#1346), and
    - improved our GitHub CI workflows (#1387).
- @maxwell8888 added a pure version of the `color_palette` example (#1326).
- @mmstick introduced additional actions for window controls (#1471).
- @mtkennerly
    - added a note about the `resolver` requirement (#1339)
    - added missing version to the issue template (#1340)
    - changed the title bar of the `PaneGrid` widget to prevent content and controls from overlapping (#1361), and
    - changed the title bar of the `PaneGrid` widget to still show content until hover when cramped (#1424).
- @nicksenger
    - fixed `Component` building overlay with stale layout (#1341)
    - implemented custom `border_radius` support for `pick_list::Menu` (#1396), and
    - implemented the `Lazy` widget (#1400).
- @pheki removed the old `pure` feature from docs.rs build metadata (#1429).
- @PolyMeilex addressed a bunch of `clippy` lints (#1379).
- @RamType0 introduced `Cow` support for the `Text` widget (#1107).
- @tarkah
    - fixed processing logic of captured events for overlays (#1353)
    - fixed alpha blending for MSAA in `iced_wgpu` (#1367)
    - allowed overriding the value of a pure `TextInput` during `draw` (#1371)
    - implemented `Widget::operate` for the `Component` widget (#1402)
    - fixed a double translation bug in the text clipping rectangle for the `Canvas` widget (#1411)
    - fixed the `Tooltip` widget when inside a `Scrollable` (#1405)
    - changed the `Tooltip` text layout to not be constricted by the viewport size (#1414)
    - changed the rendering order of the `PaneGrid` title bar and its body (#1463)
    - fixed some issues with the `PaneGrid` widget (#1480)
    - fixed `PickList` menu not closing when inside a `Scrollable` (#1496)
    - constrained `Padding` to fit available space during layout (#1494), and
    - added pane maximize and restore functionality for the `PaneGrid` widget (#1504).
- @ThatsNoMoon fixed the implementation of `arc_to` for the `Canvas` widget (#1358).
- @thenlevy fixed some issues with the `integration_wgpu` example (#1139).
- @ThisIsRex added an `is_selected` argument to the `StyleSheet` of a `Radio` widget (#1331).
- @traxys implemented support to replace an existing DOM element when targeting Wasm (#1443).
- @xkenmon implemented a `sierpinski-triangle` example (#1136).
- @xTeKc updated the test badge in the `README` (#1450).
- @wash2
    - fixed synchronization of window and viewport (#1437), and
    - added a `Custom` variant to the built-in `Theme` (#1432).
- @wuxianucw relaxed the `Fn` trait bounds for `Command` and `Action` (#1409).
- @wyatt-herkamp
    - added an `on_paste` handler to the `TextInput` widget (#1350)
    - updated `winit` to `0.27` and `glutin` to `0.29` (#1410), and
    - updated `wgpu` to `0.14` and `wgpu_glyph` to `0.18` (#1462).

Thank you, everyone! :tada: