### PR TITLE
Additional cfg for wasm target for gradients

### DIFF
--- a/glow/src/triangle.rs
+++ b/glow/src/triangle.rs
@@ -141,6 +141,7 @@ impl Pipeline {
                     triangle::Style::Solid(color) => {
                         self.programs.solid.use_program(gl, color, &transform);
                     }
+                    #[cfg(not(target_arch = "wasm32"))]
                     triangle::Style::Gradient(gradient) => {
                         self.programs
                             .gradient

--- a/graphics/src/triangle.rs
+++ b/graphics/src/triangle.rs
@@ -1,5 +1,7 @@
 //! Draw geometry using meshes of triangles.
-use crate::{Color, Gradient};
+use crate::Color;
+#[cfg(not(target_arch = "wasm32"))]
+use crate::Gradient;
 
 use bytemuck::{Pod, Zeroable};
 
@@ -27,6 +29,7 @@ pub struct Vertex2D {
 pub enum Style {
     /// Fill a primitive with a solid color.
     Solid(Color),
+    #[cfg(not(target_arch = "wasm32"))]
     /// Fill a primitive with an interpolated color.
     Gradient(Gradient),
 }
@@ -37,6 +40,7 @@ impl From<Color> for Style {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl From<Gradient> for Style {
     fn from(gradient: Gradient) -> Self {
         Self::Gradient(gradient)

--- a/graphics/src/widget/canvas/frame.rs
+++ b/graphics/src/widget/canvas/frame.rs
@@ -76,6 +76,7 @@ impl Transform {
     fn transform_style(&self, style: triangle::Style) -> triangle::Style {
         match style {
             triangle::Style::Solid(color) => triangle::Style::Solid(color),
+            #[cfg(not(target_arch = "wasm32"))]
             triangle::Style::Gradient(gradient) => {
                 triangle::Style::Gradient(self.transform_gradient(gradient))
             }

--- a/wgpu/src/buffer/dynamic.rs
+++ b/wgpu/src/buffer/dynamic.rs
@@ -24,6 +24,7 @@ impl<T: ShaderType + WriteInto> Buffer<T> {
         )
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     /// Creates a new dynamic storage buffer.
     pub fn storage(device: &wgpu::Device, label: &'static str) -> Self {
         Buffer::new(
@@ -91,6 +92,7 @@ impl<T: ShaderType + WriteInto> Buffer<T> {
                 Internal::Uniform(_) => {
                     wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST
                 }
+                #[cfg(not(target_arch = "wasm32"))]
                 Internal::Storage(_) => {
                     wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST
                 }
@@ -154,6 +156,8 @@ impl<T: ShaderType + WriteInto> Buffer<T> {
 // Currently supported dynamic buffers.
 enum Internal {
     Uniform(encase::DynamicUniformBuffer<Vec<u8>>),
+    #[cfg(not(target_arch = "wasm32"))]
+    //storage buffers are not supported on wgpu wasm target (yet)
     Storage(encase::DynamicStorageBuffer<Vec<u8>>),
 }
 
@@ -168,6 +172,7 @@ impl Internal {
                 .write(value)
                 .expect("Error when writing to dynamic uniform buffer.")
                 as u32,
+            #[cfg(not(target_arch = "wasm32"))]
             Internal::Storage(buf) => buf
                 .write(value)
                 .expect("Error when writing to dynamic storage buffer.")
@@ -179,6 +184,7 @@ impl Internal {
     pub(super) fn get_ref(&self) -> &Vec<u8> {
         match self {
             Internal::Uniform(buf) => buf.as_ref(),
+            #[cfg(not(target_arch = "wasm32"))]
             Internal::Storage(buf) => buf.as_ref(),
         }
     }
@@ -190,6 +196,7 @@ impl Internal {
                 buf.as_mut().clear();
                 buf.set_offset(0);
             }
+            #[cfg(not(target_arch = "wasm32"))]
             Internal::Storage(buf) => {
                 buf.as_mut().clear();
                 buf.set_offset(0);


### PR DESCRIPTION
Storage buffers aren't supported by wgpu WASM + webgl which gradients currently use. For now I've just added a `#cfg` around relevant bits of code so WASM targets that don't use gradients will compile as expected.

Not quite sure if there is a preferred way to separate out this code, but I figured writing a separate implementation for WASM which uses a static uniform array like the GL target would be a relatively simple process so it didn't make sense to reorganize the code to reduce the number of target-specific compilation exclusions.