### PR TITLE
Add widget operation to find currently focused widget

### DIFF
--- a/native/src/widget/scrollable.rs
+++ b/native/src/widget/scrollable.rs
@@ -334,6 +334,12 @@ impl Id {
     }
 }
 
+impl From<Id> for widget::Id {
+    fn from(id: Id) -> Self {
+        id.0
+    }
+}
+
 /// Produces a [`Command`] that snaps the [`Scrollable`] with the given [`Id`]
 /// to the provided `percentage`.
 pub fn snap_to<Message: 'static>(id: Id, percentage: f32) -> Command<Message> {

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -332,6 +332,12 @@ impl Id {
     }
 }
 
+impl From<Id> for widget::Id {
+    fn from(id: Id) -> Self {
+        id.0
+    }
+}
+
 /// Produces a [`Command`] that focuses the [`TextInput`] with the given [`Id`].
 pub fn focus<Message: 'static>(id: Id) -> Command<Message> {
     Command::widget(operation::focusable::focus(id.0))


### PR DESCRIPTION
This also adds conversions from widget-specific IDs to the generic ID type, so that you can use the ID returned by this operation to match against specific `TextInput`s, for example.

More context: https://discord.com/channels/628993209984614400/1040413102606393434