### PR TITLE
#1484, #1527: Fix overlay transition

### DIFF
--- a/native/src/user_interface.rs
+++ b/native/src/user_interface.rs
@@ -255,7 +255,7 @@ where
                 cursor_position
             };
 
-            self.overlay = None;
+            self.overlay = Some(layout);
 
             (base_cursor, event_statuses)
         } else {
@@ -284,6 +284,10 @@ where
                     clipboard,
                     &mut shell,
                 );
+
+                if matches!(event_status, event::Status::Captured) {
+                    self.overlay = None;
+                }
 
                 shell.revalidate_layout(|| {
                     self.base = renderer.layout(

--- a/native/src/user_interface.rs
+++ b/native/src/user_interface.rs
@@ -255,7 +255,7 @@ where
                 cursor_position
             };
 
-            self.overlay = Some(layout);
+            self.overlay = None;
 
             (base_cursor, event_statuses)
         } else {


### PR DESCRIPTION
This fixes #1484 and #1527, at least on my system (Windows 11).

⚠️ I don't really understand what I did here! ⚠️

I just figured it seemed like the old overlay was being held onto, and so I tried to find where it might need to be flushed. This works, but I haven't studied the other `user_interface` code to see how this aligns with the rest of the design, so I don't know if it's a good/correct solution.

I tested the `pick_list` and `tour` examples with this change. Here's a modified `pick_list` to show the new behavior:

> https://user-images.githubusercontent.com/4934192/201336666-23823cb0-add6-49c7-8eb6-9a682d30e0fb.mp4