### PR TITLE
Add text input operations

### DIFF
--- a/examples/todos/src/main.rs
+++ b/examples/todos/src/main.rs
@@ -131,7 +131,11 @@ impl Application for Todos {
                             task.update(task_message);
 
                             if should_focus {
-                                text_input::focus(Task::text_input_id(i))
+                                let id = Task::text_input_id(i);
+                                Command::batch(vec![
+                                    text_input::focus(id.clone()),
+                                    text_input::select_all(id),
+                                ])
                             } else {
                                 Command::none()
                             }

--- a/lazy/src/component.rs
+++ b/lazy/src/component.rs
@@ -260,6 +260,14 @@ where
             ) {
                 self.operation.focusable(state, id);
             }
+
+            fn text_input(
+                &mut self,
+                state: &mut dyn widget::operation::TextInput,
+                id: Option<&widget::Id>,
+            ) {
+                self.operation.text_input(state, id);
+            }
         }
 
         self.with_element(|element| {

--- a/native/src/element.rs
+++ b/native/src/element.rs
@@ -324,6 +324,14 @@ where
             ) {
                 self.operation.scrollable(state, id);
             }
+
+            fn text_input(
+                &mut self,
+                state: &mut dyn widget::operation::TextInput,
+                id: Option<&widget::Id>,
+            ) {
+                self.operation.text_input(state, id);
+            }
         }
 
         self.widget

--- a/native/src/overlay/element.rs
+++ b/native/src/overlay/element.rs
@@ -178,6 +178,14 @@ where
             ) {
                 self.operation.scrollable(state, id);
             }
+
+            fn text_input(
+                &mut self,
+                state: &mut dyn widget::operation::TextInput,
+                id: Option<&widget::Id>,
+            ) {
+                self.operation.text_input(state, id)
+            }
         }
 
         self.content

--- a/native/src/widget/action.rs
+++ b/native/src/widget/action.rs
@@ -93,4 +93,12 @@ where
     ) {
         self.operation.scrollable(state, id);
     }
+
+    fn text_input(
+        &mut self,
+        state: &mut dyn operation::TextInput,
+        id: Option<&Id>,
+    ) {
+        self.operation.text_input(state, id);
+    }
 }

--- a/native/src/widget/operation.rs
+++ b/native/src/widget/operation.rs
@@ -1,9 +1,11 @@
 //! Query or update internal widget state.
 pub mod focusable;
 pub mod scrollable;
+pub mod text_input;
 
 pub use focusable::Focusable;
 pub use scrollable::Scrollable;
+pub use text_input::TextInput;
 
 use crate::widget::Id;
 
@@ -27,6 +29,9 @@ pub trait Operation<T> {
 
     /// Operates on a widget that can be scrolled.
     fn scrollable(&mut self, _state: &mut dyn Scrollable, _id: Option<&Id>) {}
+
+    /// Operates on a widget that has text input.
+    fn text_input(&mut self, _state: &mut dyn TextInput, _id: Option<&Id>) {}
 
     /// Finishes the [`Operation`] and returns its [`Outcome`].
     fn finish(&self) -> Outcome<T> {

--- a/native/src/widget/operation/text_input.rs
+++ b/native/src/widget/operation/text_input.rs
@@ -1,0 +1,131 @@
+//! Operate on widgets that have text input.
+use crate::widget::operation::Operation;
+use crate::widget::Id;
+
+/// The internal state of a widget that has text input.
+pub trait TextInput {
+    /// Moves the cursor of the text input to the front of the input text.
+    fn move_cursor_to_front(&mut self);
+    /// Moves the cursor of the text input to the end of the input text.
+    fn move_cursor_to_end(&mut self);
+    /// Moves the cursor of the text input to an arbitrary location.
+    fn move_cursor_to(&mut self, position: usize);
+    /// Selects all the content of the text input.
+    fn select_all(&mut self);
+}
+
+/// Produces an [`Operation`] that moves the cursor of the widget with the given [`Id`] to the
+/// front.
+pub fn move_cursor_to_front<T>(target: Id) -> impl Operation<T> {
+    struct MoveCursor {
+        target: Id,
+    }
+
+    impl<T> Operation<T> for MoveCursor {
+        fn text_input(&mut self, state: &mut dyn TextInput, id: Option<&Id>) {
+            match id {
+                Some(id) if id == &self.target => {
+                    state.move_cursor_to_front();
+                }
+                _ => {}
+            }
+        }
+
+        fn container(
+            &mut self,
+            _id: Option<&Id>,
+            operate_on_children: &mut dyn FnMut(&mut dyn Operation<T>),
+        ) {
+            operate_on_children(self)
+        }
+    }
+
+    MoveCursor { target }
+}
+
+/// Produces an [`Operation`] that moves the cursor of the widget with the given [`Id`] to the
+/// end.
+pub fn move_cursor_to_end<T>(target: Id) -> impl Operation<T> {
+    struct MoveCursor {
+        target: Id,
+    }
+
+    impl<T> Operation<T> for MoveCursor {
+        fn text_input(&mut self, state: &mut dyn TextInput, id: Option<&Id>) {
+            match id {
+                Some(id) if id == &self.target => {
+                    state.move_cursor_to_end();
+                }
+                _ => {}
+            }
+        }
+
+        fn container(
+            &mut self,
+            _id: Option<&Id>,
+            operate_on_children: &mut dyn FnMut(&mut dyn Operation<T>),
+        ) {
+            operate_on_children(self)
+        }
+    }
+
+    MoveCursor { target }
+}
+
+/// Produces an [`Operation`] that moves the cursor of the widget with the given [`Id`] to the
+/// provided position.
+pub fn move_cursor_to<T>(target: Id, position: usize) -> impl Operation<T> {
+    struct MoveCursor {
+        target: Id,
+        position: usize,
+    }
+
+    impl<T> Operation<T> for MoveCursor {
+        fn text_input(&mut self, state: &mut dyn TextInput, id: Option<&Id>) {
+            match id {
+                Some(id) if id == &self.target => {
+                    state.move_cursor_to(self.position);
+                }
+                _ => {}
+            }
+        }
+
+        fn container(
+            &mut self,
+            _id: Option<&Id>,
+            operate_on_children: &mut dyn FnMut(&mut dyn Operation<T>),
+        ) {
+            operate_on_children(self)
+        }
+    }
+
+    MoveCursor { target, position }
+}
+
+/// Produces an [`Operation`] that selects all the content of the widget with the given [`Id`].
+pub fn select_all<T>(target: Id) -> impl Operation<T> {
+    struct MoveCursor {
+        target: Id,
+    }
+
+    impl<T> Operation<T> for MoveCursor {
+        fn text_input(&mut self, state: &mut dyn TextInput, id: Option<&Id>) {
+            match id {
+                Some(id) if id == &self.target => {
+                    state.select_all();
+                }
+                _ => {}
+            }
+        }
+
+        fn container(
+            &mut self,
+            _id: Option<&Id>,
+            operate_on_children: &mut dyn FnMut(&mut dyn Operation<T>),
+        ) {
+            operate_on_children(self)
+        }
+    }
+
+    MoveCursor { target }
+}

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -233,6 +233,7 @@ where
         let state = tree.state.downcast_mut::<State>();
 
         operation.focusable(state, self.id.as_ref().map(|id| &id.0));
+        operation.text_input(state, self.id.as_ref().map(|id| &id.0));
     }
 
     fn on_event(
@@ -335,6 +336,32 @@ impl Id {
 /// Produces a [`Command`] that focuses the [`TextInput`] with the given [`Id`].
 pub fn focus<Message: 'static>(id: Id) -> Command<Message> {
     Command::widget(operation::focusable::focus(id.0))
+}
+
+/// Produces a [`Command`] that moves the cursor of the [`TextInput`] with the given [`Id`] to the
+/// end.
+pub fn move_cursor_to_end<Message: 'static>(id: Id) -> Command<Message> {
+    Command::widget(operation::text_input::move_cursor_to_end(id.0))
+}
+
+/// Produces a [`Command`] that moves the cursor of the [`TextInput`] with the given [`Id`] to the
+/// front.
+pub fn move_cursor_to_front<Message: 'static>(id: Id) -> Command<Message> {
+    Command::widget(operation::text_input::move_cursor_to_front(id.0))
+}
+
+/// Produces a [`Command`] that moves the cursor of the [`TextInput`] with the given [`Id`] to the
+/// provided position.
+pub fn move_cursor_to<Message: 'static>(
+    id: Id,
+    position: usize,
+) -> Command<Message> {
+    Command::widget(operation::text_input::move_cursor_to(id.0, position))
+}
+
+/// Produces a [`Command`] that selects all the content of the [`TextInput`] with the given [`Id`].
+pub fn select_all<Message: 'static>(id: Id) -> Command<Message> {
+    Command::widget(operation::text_input::select_all(id.0))
 }
 
 /// Computes the layout of a [`TextInput`].
@@ -998,6 +1025,24 @@ impl operation::Focusable for State {
 
     fn unfocus(&mut self) {
         State::unfocus(self)
+    }
+}
+
+impl operation::TextInput for State {
+    fn move_cursor_to_front(&mut self) {
+        State::move_cursor_to_front(self)
+    }
+
+    fn move_cursor_to_end(&mut self) {
+        State::move_cursor_to_end(self)
+    }
+
+    fn move_cursor_to(&mut self, position: usize) {
+        State::move_cursor_to(self, position)
+    }
+
+    fn select_all(&mut self) {
+        State::select_all(self)
     }
 }
 

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -120,7 +120,8 @@ pub mod toggler {
 pub mod text_input {
     //! Display fields that can be filled with text.
     pub use iced_native::widget::text_input::{
-        focus, Appearance, Id, StyleSheet,
+        focus, move_cursor_to, move_cursor_to_end, move_cursor_to_front,
+        select_all, Appearance, Id, StyleSheet,
     };
 
     /// A field that can be filled with text.


### PR DESCRIPTION
We're missing operations for manipulating the text input cursor / selection of text.

TODOs example is updated to `select_all` text when an entry is edited, which is how the impure example used to work.