### PR TITLE
Svg style support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ members = [
     "examples/stopwatch",
     "examples/styling",
     "examples/svg",
+    "examples/svg_style",
     "examples/system_information",
     "examples/todos",
     "examples/tooltip",

--- a/core/src/color.rs
+++ b/core/src/color.rs
@@ -89,6 +89,19 @@ impl Color {
         }
     }
 
+    /// Converts the [`Color`] into its RGBA8 equivalent.
+    #[must_use]
+    #[allow(clippy::cast_sign_loss)]
+    #[allow(clippy::cast_possible_truncation)]
+    pub fn into_rgba8(self) -> [u8; 4] {
+        [
+            (self.r * 255.0).round() as u8,
+            (self.g * 255.0).round() as u8,
+            (self.b * 255.0).round() as u8,
+            (self.a * 255.0).round() as u8,
+        ]
+    }
+
     /// Converts the [`Color`] into its linear values.
     pub fn into_linear(self) -> [f32; 4] {
         // As described in:

--- a/examples/svg_style/Cargo.toml
+++ b/examples/svg_style/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "svg_style"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+iced = { path = "../..", features = ["svg"] }
+iced_style = { path = "../../style" }

--- a/examples/svg_style/resources/go-next-symbolic.svg
+++ b/examples/svg_style/resources/go-next-symbolic.svg
@@ -1,0 +1,1 @@
+<svg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'><path color='#bebebe' d='M0 0h16v16H0z' fill='gray' fill-opacity='.01'/><path d='m7.94 1.94 6.062 6.063-6.062 6.063c-1.438 1.437-2.688-.063-1.625-1.125l4.937-4.938-4.937-4.937C5.502 2.253 6.752.753 7.94 1.94z' fill='#232323'/></svg>

--- a/examples/svg_style/src/main.rs
+++ b/examples/svg_style/src/main.rs
@@ -1,0 +1,78 @@
+use iced::widget::{container, svg};
+use iced::{Color, Element, Length, Sandbox, Settings};
+use iced_style::svg::Appearance;
+use iced_style::theme::{self, Theme};
+
+pub fn main() -> iced::Result {
+    SvgStyleExample::run(Settings::default())
+}
+
+struct SvgStyleExample;
+
+impl Sandbox for SvgStyleExample {
+    type Message = ();
+
+    fn new() -> Self {
+        SvgStyleExample
+    }
+
+    fn theme(&self) -> Theme {
+        Theme::Light
+    }
+
+    fn title(&self) -> String {
+        String::from("SVG - Iced")
+    }
+
+    fn update(&mut self, _message: ()) {}
+
+    fn view(&self) -> Element<()> {
+        let svg1: Element<_> = svg(svg::Handle::from_path(format!(
+            "{}/resources/go-next-symbolic.svg",
+            env!("CARGO_MANIFEST_DIR")
+        )))
+        .width(Length::Fill)
+        .height(Length::Fill)
+        .into();
+
+        let svg2: Element<_> = svg(svg::Handle::from_path(format!(
+            "{}/resources/go-next-symbolic.svg",
+            env!("CARGO_MANIFEST_DIR")
+        )))
+        .style(theme::Svg::Custom(|_theme| Appearance {
+            fill: Some(Color {
+                r: 0.0,
+                g: 0.28627452,
+                b: 0.42745098,
+                a: 1.0,
+            }),
+        }))
+        .width(Length::Fill)
+        .height(Length::Fill)
+        .into();
+
+        let svg3: Element<_> = svg(svg::Handle::from_path(format!(
+            "{}/resources/go-next-symbolic.svg",
+            env!("CARGO_MANIFEST_DIR")
+        )))
+        .style(theme::Svg::Custom(|_theme| Appearance {
+            fill: Some(Color {
+                r: 0.5803922,
+                g: 0.92156863,
+                b: 0.92156863,
+                a: 1.0,
+            }),
+        }))
+        .width(Length::Fill)
+        .height(Length::Fill)
+        .into();
+
+        container(iced::widget::row!(svg1, svg2, svg3))
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .padding(20)
+            .center_x()
+            .center_y()
+            .into()
+    }
+}

--- a/native/src/svg.rs
+++ b/native/src/svg.rs
@@ -6,11 +6,14 @@ use std::hash::{Hash, Hasher as _};
 use std::path::PathBuf;
 use std::sync::Arc;
 
+pub use iced_style::svg::{Appearance, StyleSheet};
+
 /// A handle of Svg data.
 #[derive(Debug, Clone)]
 pub struct Handle {
     id: u64,
     data: Arc<Data>,
+    appearance: Appearance,
 }
 
 impl Handle {
@@ -36,6 +39,7 @@ impl Handle {
         Handle {
             id: hasher.finish(),
             data: Arc::new(data),
+            appearance: Appearance::default(),
         }
     }
 
@@ -47,6 +51,16 @@ impl Handle {
     /// Returns a reference to the SVG [`Data`].
     pub fn data(&self) -> &Data {
         &self.data
+    }
+
+    /// Returns the styling [`Appearance`] for the SVG.
+    pub fn appearance(&self) -> Appearance {
+        self.appearance
+    }
+
+    /// Set the [`Appearance`] for the SVG.
+    pub fn set_appearance(&mut self, appearance: Appearance) {
+        self.appearance = appearance;
     }
 }
 

--- a/native/src/widget/helpers.rs
+++ b/native/src/widget/helpers.rs
@@ -285,6 +285,12 @@ where
 ///
 /// [`Svg`]: widget::Svg
 /// [`Handle`]: widget::svg::Handle
-pub fn svg(handle: impl Into<widget::svg::Handle>) -> widget::Svg {
+pub fn svg<Renderer>(
+    handle: impl Into<widget::svg::Handle>,
+) -> widget::Svg<Renderer>
+where
+    Renderer: crate::svg::Renderer,
+    Renderer::Theme: crate::svg::StyleSheet,
+{
     widget::Svg::new(handle)
 }

--- a/native/src/widget/svg.rs
+++ b/native/src/widget/svg.rs
@@ -9,7 +9,7 @@ use crate::{
 
 use std::path::PathBuf;
 
-pub use svg::Handle;
+pub use svg::{Handle, StyleSheet};
 
 /// A vector graphics image.
 ///
@@ -17,15 +17,25 @@ pub use svg::Handle;
 ///
 /// [`Svg`] images can have a considerable rendering cost when resized,
 /// specially when they are complex.
-#[derive(Debug, Clone)]
-pub struct Svg {
+#[derive(Clone)]
+#[allow(missing_debug_implementations)]
+pub struct Svg<Renderer>
+where
+    Renderer: svg::Renderer,
+    Renderer::Theme: StyleSheet,
+{
     handle: Handle,
     width: Length,
     height: Length,
     content_fit: ContentFit,
+    style: <Renderer::Theme as StyleSheet>::Style,
 }
 
-impl Svg {
+impl<Renderer> Svg<Renderer>
+where
+    Renderer: svg::Renderer,
+    Renderer::Theme: StyleSheet,
+{
     /// Creates a new [`Svg`] from the given [`Handle`].
     pub fn new(handle: impl Into<Handle>) -> Self {
         Svg {
@@ -33,22 +43,26 @@ impl Svg {
             width: Length::Fill,
             height: Length::Shrink,
             content_fit: ContentFit::Contain,
+            style: Default::default(),
         }
     }
 
     /// Creates a new [`Svg`] that will display the contents of the file at the
     /// provided path.
+    #[must_use]
     pub fn from_path(path: impl Into<PathBuf>) -> Self {
         Self::new(Handle::from_path(path))
     }
 
     /// Sets the width of the [`Svg`].
+    #[must_use]
     pub fn width(mut self, width: Length) -> Self {
         self.width = width;
         self
     }
 
     /// Sets the height of the [`Svg`].
+    #[must_use]
     pub fn height(mut self, height: Length) -> Self {
         self.height = height;
         self
@@ -57,17 +71,29 @@ impl Svg {
     /// Sets the [`ContentFit`] of the [`Svg`].
     ///
     /// Defaults to [`ContentFit::Contain`]
+    #[must_use]
     pub fn content_fit(self, content_fit: ContentFit) -> Self {
         Self {
             content_fit,
             ..self
         }
     }
+
+    /// Sets the style variant of this [`Svg`].
+    #[must_use]
+    pub fn style(
+        mut self,
+        style: <Renderer::Theme as StyleSheet>::Style,
+    ) -> Self {
+        self.style = style;
+        self
+    }
 }
 
-impl<Message, Renderer> Widget<Message, Renderer> for Svg
+impl<Message, Renderer> Widget<Message, Renderer> for Svg<Renderer>
 where
     Renderer: svg::Renderer,
+    Renderer::Theme: iced_style::svg::StyleSheet,
 {
     fn width(&self) -> Length {
         self.width
@@ -114,12 +140,15 @@ where
         &self,
         _state: &Tree,
         renderer: &mut Renderer,
-        _theme: &Renderer::Theme,
+        theme: &Renderer::Theme,
         _style: &renderer::Style,
         layout: Layout<'_>,
         _cursor_position: Point,
         _viewport: &Rectangle,
     ) {
+        let mut handle = self.handle.clone();
+        handle.set_appearance(theme.appearance(self.style));
+
         let Size { width, height } = renderer.dimensions(&self.handle);
         let image_size = Size::new(width as f32, height as f32);
 
@@ -138,7 +167,7 @@ where
                 ..bounds
             };
 
-            renderer.draw(self.handle.clone(), drawing_bounds + offset)
+            renderer.draw(handle, drawing_bounds + offset);
         };
 
         if adjusted_fit.width > bounds.width
@@ -146,16 +175,18 @@ where
         {
             renderer.with_layer(bounds, render);
         } else {
-            render(renderer)
+            render(renderer);
         }
     }
 }
 
-impl<'a, Message, Renderer> From<Svg> for Element<'a, Message, Renderer>
+impl<'a, Message, Renderer> From<Svg<Renderer>>
+    for Element<'a, Message, Renderer>
 where
-    Renderer: svg::Renderer,
+    Renderer: svg::Renderer + 'a,
+    Renderer::Theme: iced_style::svg::StyleSheet,
 {
-    fn from(icon: Svg) -> Element<'a, Message, Renderer> {
+    fn from(icon: Svg<Renderer>) -> Element<'a, Message, Renderer> {
         Element::new(icon)
     }
 }

--- a/style/src/lib.rs
+++ b/style/src/lib.rs
@@ -32,6 +32,7 @@ pub mod radio;
 pub mod rule;
 pub mod scrollable;
 pub mod slider;
+pub mod svg;
 pub mod text;
 pub mod text_input;
 pub mod theme;

--- a/style/src/svg.rs
+++ b/style/src/svg.rs
@@ -1,0 +1,21 @@
+//! Change the appearance of a svg.
+
+use iced_core::Color;
+
+/// The appearance of a svg.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Appearance {
+    /// Changes the fill color
+    ///
+    /// Useful for coloring a symbolic icon.
+    pub fill: Option<Color>,
+}
+
+/// The stylesheet of a svg.
+pub trait StyleSheet {
+    /// The supported style of the [`StyleSheet`].
+    type Style: Default + Copy;
+
+    /// Produces the [`Appearance`] of the svg.
+    fn appearance(&self, style: Self::Style) -> Appearance;
+}

--- a/style/src/theme.rs
+++ b/style/src/theme.rs
@@ -16,6 +16,7 @@ use crate::radio;
 use crate::rule;
 use crate::scrollable;
 use crate::slider;
+use crate::svg;
 use crate::text;
 use crate::text_input;
 use crate::toggler;
@@ -794,6 +795,29 @@ pub enum Rule {
 impl From<fn(&Theme) -> rule::Appearance> for Rule {
     fn from(f: fn(&Theme) -> rule::Appearance) -> Self {
         Self::Custom(Box::new(f))
+    }
+}
+
+/**
+ * SVG
+ */
+#[derive(Default, Clone, Copy)]
+pub enum Svg {
+    /// No filtering to the rendered SVG.
+    #[default]
+    Default,
+    /// Apply custom filtering to the SVG.
+    Custom(fn(&Theme) -> svg::Appearance),
+}
+
+impl svg::StyleSheet for Theme {
+    type Style = Svg;
+
+    fn appearance(&self, style: Self::Style) -> svg::Appearance {
+        match style {
+            Svg::Default => Default::default(),
+            Svg::Custom(appearance) => appearance(self),
+        }
     }
 }
 


### PR DESCRIPTION
Implements https://github.com/iced-rs/rfcs/pull/15

Makes it possible to change the fill color of a SVG symbolic icon. Appearance can be altered based on dark or light theme variants, or as a custom-defined Appearance.

## Example

A window displaying different styling variants of the included symbolic icon.

```
cargo run -p svg_style
```