### PR TITLE
image: Allow any kind of data that implements `AsRef<[u8]>` for the i…

### DIFF
--- a/examples/pokedex/src/main.rs
+++ b/examples/pokedex/src/main.rs
@@ -193,7 +193,7 @@ impl Pokemon {
         {
             let bytes = reqwest::get(&url).await?.bytes().await?;
 
-            Ok(image::Handle::from_memory(bytes.as_ref().to_vec()))
+            Ok(image::Handle::from_memory(bytes))
         }
 
         #[cfg(target_arch = "wasm32")]


### PR DESCRIPTION
…mage data

It's not required anywhere for it to be a plain slice or a `Vec` and this makes it possible to use data allocated in a different way without copying.

Also store the data in an `Arc` to allow cheap cloning.