### PR TITLE
native/subscription/unfold: terminate stream when user returns `None`

### DIFF
--- a/examples/download_progress/src/main.rs
+++ b/examples/download_progress/src/main.rs
@@ -170,12 +170,13 @@ impl Download {
             State::Idle => button("Start the download!")
                 .on_press(Message::Download(self.id))
                 .into(),
-            State::Finished => {
-                column!["Download finished!", button("Start again")]
-                    .spacing(10)
-                    .align_items(Alignment::Center)
-                    .into()
-            }
+            State::Finished => column![
+                "Download finished!",
+                button("Start again").on_press(Message::Download(self.id)),
+            ]
+            .spacing(10)
+            .align_items(Alignment::Center)
+            .into(),
             State::Downloading { .. } => {
                 text(format!("Downloading... {current_progress:.2}%")).into()
             }

--- a/examples/websocket/src/echo.rs
+++ b/examples/websocket/src/echo.rs
@@ -27,10 +27,10 @@ pub fn connect() -> Subscription<Event> {
                         Ok((websocket, _)) => {
                             let (sender, receiver) = mpsc::channel(100);
 
-                            (
-                                Some(Event::Connected(Connection(sender))),
+                            Some((
+                                Event::Connected(Connection(sender)),
                                 State::Connected(websocket, receiver),
-                            )
+                            ))
                         }
                         Err(_) => {
                             tokio::time::sleep(
@@ -38,27 +38,25 @@ pub fn connect() -> Subscription<Event> {
                             )
                             .await;
 
-                            (Some(Event::Disconnected), State::Disconnected)
+                            Some((Event::Disconnected, State::Disconnected))
                         }
                     }
                 }
-                State::Connected(mut websocket, mut input) => {
+                State::Connected(mut websocket, mut input) => loop {
                     let mut fused_websocket = websocket.by_ref().fuse();
 
                     futures::select! {
                         received = fused_websocket.select_next_some() => {
                             match received {
                                 Ok(tungstenite::Message::Text(message)) => {
-                                    (
-                                        Some(Event::MessageReceived(Message::User(message))),
+                                    return Some((
+                                        Event::MessageReceived(Message::User(message)),
                                         State::Connected(websocket, input)
-                                    )
+                                    ));
                                 }
-                                Ok(_) => {
-                                    (None, State::Connected(websocket, input))
-                                }
+                                Ok(_) => (),
                                 Err(_) => {
-                                    (Some(Event::Disconnected), State::Disconnected)
+                                    return Some((Event::Disconnected, State::Disconnected));
                                 }
                             }
                         }
@@ -66,14 +64,12 @@ pub fn connect() -> Subscription<Event> {
                         message = input.select_next_some() => {
                             let result = websocket.send(tungstenite::Message::Text(message.to_string())).await;
 
-                            if result.is_ok() {
-                                (None, State::Connected(websocket, input))
-                            } else {
-                                (Some(Event::Disconnected), State::Disconnected)
+                            if result.is_err() {
+                                return Some((Event::Disconnected, State::Disconnected));
                             }
                         }
                     }
-                }
+                },
             }
         },
     )


### PR DESCRIPTION
## Context

While experimenting with `iced` for a WIP application, I ran into issues with the `subscription::unfold` behaviour. This MR proposes a change to the API which would solve my issues and which I believe would be preferable for `iced` in general.

Note: I read the contributing guidelines. Since this seemed like a small improvement to me, I didn't feel the need to introduce myself on the Discord server. In order to reflect on this I had to experiment to the extent of this MR anyway. Please tell me if I was wrong!

## Analysis

[`futures::stream::unfold`] builds a `Stream` from the provided seed of type `T` and a `Future` returned by the `f` function. The resulting `Stream` produces values as long the `Future` returns `Some` tuple `(Item, T)`. If the `Future` returns `None`, `unfold` is supposed to stop producing items.

In `iced`, the `subscription::unfold` function is based on the `stream::unfold`. However the `Output` of the `Future` is defined as `(Option<Message>, T)`. The `Future` can return a `None` `Message` and the `Stream` will keep running.

The above behaviour is exemplified in `examples/download_progress`. When the download is finished (either because it is complete or if an error occurred), the `Future` is still being called. Adding a `println` statement shows that the `Future` is called repeatedly. The original code added a `pending().await` as a workaround. This means that the executor `Tasks` is kept in queues even if it will no longer make progress.

The first commit removes the `pending().await` workaround in `download_progress` and adds `stdout` & `stderr` traces so as to assess the impact of the second commit.

## Proposal

One way to solve this would be to keep the existing signature for `subscription::unfold` and to `map` the `Future` output in such a way that it return `None` if the provided `Option<Message>` is `None`. However, this would be inconsistent with the `unfold` function from the `futures` crate and it wouldn't be suitable since the `state` is no longer usable after the `Stream`
completes.

This MR aligns the `subscription::unfold` function with its `futures` counterpart. In the `download_progress` example, after a download is finished, the `Task` in no longer kept in queues.

This changes a bit the implementation for the `websocket` example. Previous implementation returned from the `Future` with a `None` message and an unchanged state when the websocket or input were awaken but the result didn't need to be propagated. With this MR, in such cases the implementation loops on the wbesocket & input async select awaiting for the next message to be propagated.

The last commit is a small unrelated improvement to the `download_progress` example.

[`futures::stream::unfold`]: https://docs.rs/futures/0.3.25/futures/stream/fn.unfold.html