### PR TITLE
fix: scissor layer bounds for images when using glow

### DIFF
--- a/glow/src/backend.rs
+++ b/glow/src/backend.rs
@@ -129,7 +129,7 @@ impl Backend {
                 * Transformation::scale(scale_factor, scale_factor);
 
             self.image_pipeline
-                .draw(gl, scaled, scale_factor, &layer.images);
+                .draw(gl, scaled, scale_factor, &layer.images, bounds);
         }
 
         if !layer.text.is_empty() {

--- a/glow/src/backend.rs
+++ b/glow/src/backend.rs
@@ -130,6 +130,7 @@ impl Backend {
 
             self.image_pipeline.draw(
                 gl,
+                target_height,
                 scaled,
                 scale_factor,
                 &layer.images,

--- a/glow/src/backend.rs
+++ b/glow/src/backend.rs
@@ -128,8 +128,13 @@ impl Backend {
             let scaled = transformation
                 * Transformation::scale(scale_factor, scale_factor);
 
-            self.image_pipeline
-                .draw(gl, scaled, scale_factor, &layer.images, bounds);
+            self.image_pipeline.draw(
+                gl,
+                scaled,
+                scale_factor,
+                &layer.images,
+                bounds,
+            );
         }
 
         if !layer.text.is_empty() {

--- a/glow/src/image.rs
+++ b/glow/src/image.rs
@@ -14,6 +14,7 @@ use iced_graphics::image::raster;
 use iced_graphics::image::vector;
 
 use iced_graphics::layer;
+use iced_graphics::Rectangle;
 use iced_graphics::Size;
 
 use glow::HasContext;
@@ -144,11 +145,13 @@ impl Pipeline {
         transformation: Transformation,
         _scale_factor: f32,
         images: &[layer::Image],
+        layer_bounds: Rectangle<u32>,
     ) {
         unsafe {
             gl.use_program(Some(self.program));
             gl.bind_vertex_array(Some(self.vertex_array));
             gl.bind_buffer(glow::ARRAY_BUFFER, Some(self.vertex_buffer));
+            gl.enable(glow::SCISSOR_TEST);
         }
 
         #[cfg(feature = "image")]
@@ -187,6 +190,13 @@ impl Pipeline {
             };
 
             unsafe {
+                gl.scissor(
+                    layer_bounds.x as i32,
+                    layer_bounds.y as i32,
+                    layer_bounds.width as i32,
+                    layer_bounds.height as i32,
+                );
+
                 if let Some(storage::Entry { texture, .. }) = entry {
                     gl.bind_texture(glow::TEXTURE_2D, Some(*texture))
                 } else {
@@ -213,6 +223,7 @@ impl Pipeline {
             gl.bind_buffer(glow::ARRAY_BUFFER, None);
             gl.bind_vertex_array(None);
             gl.use_program(None);
+            gl.disable(glow::SCISSOR_TEST);
         }
     }
 

--- a/glow/src/image.rs
+++ b/glow/src/image.rs
@@ -142,6 +142,7 @@ impl Pipeline {
     pub fn draw(
         &mut self,
         mut gl: &glow::Context,
+        target_height: u32,
         transformation: Transformation,
         _scale_factor: f32,
         images: &[layer::Image],
@@ -192,7 +193,8 @@ impl Pipeline {
             unsafe {
                 gl.scissor(
                     layer_bounds.x as i32,
-                    layer_bounds.y as i32,
+                    (target_height - (layer_bounds.y + layer_bounds.height))
+                        as i32,
                     layer_bounds.width as i32,
                     layer_bounds.height as i32,
                 );


### PR DESCRIPTION
This fixes an issue where images show up outside of the bounds of their parent, for example when in a scrollable.