### PR TITLE
fix: Don't require text::Stylesheet::Style to be Copy

### DIFF
--- a/native/src/widget/text.rs
+++ b/native/src/widget/text.rs
@@ -163,7 +163,7 @@ where
             &self.content,
             self.size,
             self.font.clone(),
-            theme.appearance(self.style),
+            theme.appearance(&self.style),
             self.horizontal_alignment,
             self.vertical_alignment,
         );
@@ -243,7 +243,7 @@ where
             horizontal_alignment: self.horizontal_alignment,
             vertical_alignment: self.vertical_alignment,
             font: self.font.clone(),
-            style: self.style,
+            style: self.style.clone(),
         }
     }
 }

--- a/style/src/text.rs
+++ b/style/src/text.rs
@@ -4,10 +4,10 @@ use iced_core::Color;
 /// The style sheet of some text.
 pub trait StyleSheet {
     /// The supported style of the [`StyleSheet`].
-    type Style: Default + Copy;
+    type Style: Default + Clone;
 
     /// Produces the [`Appearance`] of some text.
-    fn appearance(&self, style: Self::Style) -> Appearance;
+    fn appearance(&self, style: &Self::Style) -> Appearance;
 }
 
 /// The apperance of some text.

--- a/style/src/theme.rs
+++ b/style/src/theme.rs
@@ -907,10 +907,10 @@ impl From<Color> for Text {
 impl text::StyleSheet for Theme {
     type Style = Text;
 
-    fn appearance(&self, style: Self::Style) -> text::Appearance {
+    fn appearance(&self, style: &Self::Style) -> text::Appearance {
         match style {
             Text::Default => Default::default(),
-            Text::Color(c) => text::Appearance { color: Some(c) },
+            Text::Color(c) => text::Appearance { color: Some(*c) },
         }
     }
 }


### PR DESCRIPTION
Hello,

In 18fb74f20092b2703a90afdb01f39754445998da the trait bounds for most widgets' `Stylesheet::Style` were relaxed from `Default + Copy` to `Default` or `Default + Clone`. However, `Text` was not changed, by mistake I assume. As a result, trying to implement a custom style for `Text` yields an error as `iced::Theme` is not `Copy`.

```rust
pub struct MenuTextStyle;

impl text::StyleSheet for MenuTextStyle {
    type Style = Theme;
    // the trait bound `iced::Theme: std::marker::Copy` is not satisfied
    // the trait `std::marker::Copy` is not implemented for `iced::Theme`

    fn appearance(&self, style: Self::Style) -> text::Appearance {
        let palette = style.palette();

        text::Appearance {
            color: Some(palette.background),
        }
    }
}
```

This PR fixes this issue and changes the signature of the `appearance` function to `fn appearance(&self, style: &Self::Style) -> text::Appearance`, to be consistent with the other widgets.