### PR TITLE
Fix scroller in `Scrollable` always being drawn

### DIFF
--- a/native/src/widget/scrollable.rs
+++ b/native/src/widget/scrollable.rs
@@ -714,9 +714,8 @@ pub fn draw<Renderer>(
                     );
                 }
 
-                if is_mouse_over
-                    || state.is_scroller_grabbed()
-                    || is_scrollbar_visible
+                if (is_mouse_over || state.is_scroller_grabbed())
+                    && is_scrollbar_visible
                 {
                     renderer.fill_quad(
                         renderer::Quad {


### PR DESCRIPTION
... instead of only drawing it when the mouse is over the `Scrollable`.

Fixes #1573.