### PR TITLE
Fixed iced_glow crate compilation when image feature is enabled and the svg feature is disabled

### DIFF
--- a/glow/src/image.rs
+++ b/glow/src/image.rs
@@ -192,7 +192,7 @@ impl Pipeline {
                 }
 
                 #[cfg(not(feature = "svg"))]
-                layer::Image::Vector { handle: _, bounds } => (None, bounds),
+                layer::Image::Vector { bounds, .. } => (None, bounds),
             };
 
             unsafe {


### PR DESCRIPTION
Fixes #1592 