### PR TITLE
Implement `window::close` action and remove `should_exit`

### DIFF
--- a/glutin/src/application.rs
+++ b/glutin/src/application.rs
@@ -200,6 +200,7 @@ async fn run_instance<A, E, C>(
     let mut cache = user_interface::Cache::default();
     let mut state = application::State::new(&application, context.window());
     let mut viewport_version = state.viewport_version();
+    let mut should_exit = false;
 
     application::run_command(
         &application,
@@ -209,6 +210,7 @@ async fn run_instance<A, E, C>(
         init_command,
         &mut runtime,
         &mut clipboard,
+        &mut should_exit,
         &mut proxy,
         &mut debug,
         context.window(),
@@ -271,6 +273,7 @@ async fn run_instance<A, E, C>(
                         &mut renderer,
                         &mut runtime,
                         &mut clipboard,
+                        &mut should_exit,
                         &mut proxy,
                         &mut debug,
                         &mut messages,
@@ -280,8 +283,6 @@ async fn run_instance<A, E, C>(
 
                     // Update window
                     state.synchronize(&application, context.window());
-
-                    let should_exit = application.should_exit();
 
                     user_interface =
                         ManuallyDrop::new(application::build_user_interface(

--- a/native/src/window/action.rs
+++ b/native/src/window/action.rs
@@ -5,6 +5,8 @@ use std::fmt;
 
 /// An operation to be performed on some window.
 pub enum Action<T> {
+    /// Closes the current window and exits the application.
+    Close,
     /// Moves the window with the left mouse button until the button is
     /// released.
     ///
@@ -54,6 +56,7 @@ impl<T> Action<T> {
         T: 'static,
     {
         match self {
+            Self::Close => Action::Close,
             Self::Drag => Action::Drag,
             Self::Resize { width, height } => Action::Resize { width, height },
             Self::Maximize(bool) => Action::Maximize(bool),
@@ -70,6 +73,7 @@ impl<T> Action<T> {
 impl<T> fmt::Debug for Action<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::Close => write!(f, "Action::Close"),
             Self::Drag => write!(f, "Action::Drag"),
             Self::Resize { width, height } => write!(
                 f,

--- a/src/application.rs
+++ b/src/application.rs
@@ -270,8 +270,4 @@ where
     fn scale_factor(&self) -> f64 {
         self.0.scale_factor()
     }
-
-    fn should_exit(&self) -> bool {
-        self.0.should_exit()
-    }
 }

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -93,13 +93,6 @@ where
     fn scale_factor(&self) -> f64 {
         1.0
     }
-
-    /// Returns whether the [`Application`] should be terminated.
-    ///
-    /// By default, it returns `false`.
-    fn should_exit(&self) -> bool {
-        false
-    }
 }
 
 /// Runs an [`Application`] with an executor, compositor, and the provided
@@ -255,6 +248,7 @@ async fn run_instance<A, E, C>(
     let mut clipboard = Clipboard::connect(&window);
     let mut cache = user_interface::Cache::default();
     let mut surface = compositor.create_surface(&window);
+    let mut should_exit = false;
 
     let mut state = State::new(&application, &window);
     let mut viewport_version = state.viewport_version();
@@ -275,6 +269,7 @@ async fn run_instance<A, E, C>(
         init_command,
         &mut runtime,
         &mut clipboard,
+        &mut should_exit,
         &mut proxy,
         &mut debug,
         &window,
@@ -336,6 +331,7 @@ async fn run_instance<A, E, C>(
                         &mut renderer,
                         &mut runtime,
                         &mut clipboard,
+                        &mut should_exit,
                         &mut proxy,
                         &mut debug,
                         &mut messages,
@@ -345,8 +341,6 @@ async fn run_instance<A, E, C>(
 
                     // Update window
                     state.synchronize(&application, &window);
-
-                    let should_exit = application.should_exit();
 
                     user_interface = ManuallyDrop::new(build_user_interface(
                         &application,
@@ -555,6 +549,7 @@ pub fn update<A: Application, E: Executor>(
     renderer: &mut A::Renderer,
     runtime: &mut Runtime<E, Proxy<A::Message>, A::Message>,
     clipboard: &mut Clipboard,
+    should_exit: &mut bool,
     proxy: &mut winit::event_loop::EventLoopProxy<A::Message>,
     debug: &mut Debug,
     messages: &mut Vec<A::Message>,
@@ -578,6 +573,7 @@ pub fn update<A: Application, E: Executor>(
             command,
             runtime,
             clipboard,
+            should_exit,
             proxy,
             debug,
             window,
@@ -598,6 +594,7 @@ pub fn run_command<A, E>(
     command: Command<A::Message>,
     runtime: &mut Runtime<E, Proxy<A::Message>, A::Message>,
     clipboard: &mut Clipboard,
+    should_exit: &mut bool,
     proxy: &mut winit::event_loop::EventLoopProxy<A::Message>,
     debug: &mut Debug,
     window: &winit::window::Window,
@@ -629,6 +626,9 @@ pub fn run_command<A, E>(
                 }
             },
             command::Action::Window(action) => match action {
+                window::Action::Close => {
+                    *should_exit = true;
+                }
                 window::Action::Drag => {
                     let _res = window.drag_window();
                 }

--- a/winit/src/window.rs
+++ b/winit/src/window.rs
@@ -4,6 +4,11 @@ use iced_native::window;
 
 pub use window::{Event, Mode};
 
+/// Closes the current window and exits the application.
+pub fn close<Message>() -> Command<Message> {
+    Command::single(command::Action::Window(window::Action::Close))
+}
+
 /// Begins dragging the window while the left mouse button is held.
 pub fn drag<Message>() -> Command<Message> {
     Command::single(command::Action::Window(window::Action::Drag))


### PR DESCRIPTION
Instead of returning `true` once in `should_exit`, simply return `window::close()` in your `update` whenever the application is ready to exit.