### PR TITLE
Vectorial text for `Canvas`

### DIFF
--- a/examples/arc/src/main.rs
+++ b/examples/arc/src/main.rs
@@ -76,6 +76,7 @@ impl<Message> canvas::Program<Message> for Arc {
         &self,
         _state: &Self::State,
         theme: &Theme,
+        _text_cache: &canvas::text::Cache,
         bounds: Rectangle,
         _cursor: Cursor,
     ) -> Vec<Geometry> {

--- a/examples/bezier_tool/src/main.rs
+++ b/examples/bezier_tool/src/main.rs
@@ -153,6 +153,7 @@ mod bezier {
             &self,
             state: &Self::State,
             _theme: &Theme,
+            _text_cache: &canvas::text::Cache,
             bounds: Rectangle,
             cursor: Cursor,
         ) -> Vec<Geometry> {

--- a/examples/clock/src/main.rs
+++ b/examples/clock/src/main.rs
@@ -90,6 +90,7 @@ impl<Message> canvas::Program<Message> for Clock {
         &self,
         _state: &Self::State,
         _theme: &Theme,
+        _text_cache: &canvas::text::Cache,
         bounds: Rectangle,
         _cursor: Cursor,
     ) -> Vec<Geometry> {

--- a/examples/color_palette/src/main.rs
+++ b/examples/color_palette/src/main.rs
@@ -148,7 +148,7 @@ impl Theme {
             .into()
     }
 
-    fn draw(&self, frame: &mut Frame) {
+    fn draw(&self, text_cache: &canvas::text::Cache, frame: &mut Frame) {
         let pad = 20.0;
 
         let box_size = Size {
@@ -197,14 +197,17 @@ impl Theme {
                 });
             }
 
-            frame.fill_text(canvas::Text {
-                content: color_hex_string(&color),
-                position: Point {
-                    x: anchor.x + box_size.width / 2.0,
-                    y: box_size.height,
+            frame.fill_text(
+                text_cache,
+                canvas::Text {
+                    content: color_hex_string(&color),
+                    position: Point {
+                        x: anchor.x + box_size.width / 2.0,
+                        y: box_size.height,
+                    },
+                    ..text
                 },
-                ..text
-            });
+            );
         }
 
         text.vertical_alignment = alignment::Vertical::Bottom;
@@ -225,14 +228,17 @@ impl Theme {
 
             frame.fill_rectangle(anchor, box_size, color);
 
-            frame.fill_text(canvas::Text {
-                content: color_hex_string(&color),
-                position: Point {
-                    x: anchor.x + box_size.width / 2.0,
-                    y: box_size.height + 2.0 * pad,
+            frame.fill_text(
+                text_cache,
+                canvas::Text {
+                    content: color_hex_string(&color),
+                    position: Point {
+                        x: anchor.x + box_size.width / 2.0,
+                        y: box_size.height + 2.0 * pad,
+                    },
+                    ..text
                 },
-                ..text
-            });
+            );
         }
     }
 }
@@ -244,11 +250,12 @@ impl<Message> canvas::Program<Message> for Theme {
         &self,
         _state: &Self::State,
         _theme: &iced::Theme,
+        text_cache: &canvas::text::Cache,
         bounds: Rectangle,
         _cursor: Cursor,
     ) -> Vec<Geometry> {
         let theme = self.canvas_cache.draw(bounds.size(), |frame| {
-            self.draw(frame);
+            self.draw(text_cache, frame);
         });
 
         vec![theme]

--- a/examples/game_of_life/src/main.rs
+++ b/examples/game_of_life/src/main.rs
@@ -207,9 +207,8 @@ mod grid {
     use iced::touch;
     use iced::widget::canvas;
     use iced::widget::canvas::event::{self, Event};
-    use iced::widget::canvas::{
-        Cache, Canvas, Cursor, Frame, Geometry, Path, Text,
-    };
+    use iced::widget::canvas::text::{self, Text};
+    use iced::widget::canvas::{Cache, Canvas, Cursor, Frame, Geometry, Path};
     use iced::{
         alignment, mouse, Color, Element, Length, Point, Rectangle, Size,
         Theme, Vector,
@@ -537,6 +536,7 @@ mod grid {
             &self,
             _interaction: &Interaction,
             _theme: &Theme,
+            text_cache: &text::Cache,
             bounds: Rectangle,
             cursor: Cursor,
         ) -> Vec<Geometry> {
@@ -593,32 +593,38 @@ mod grid {
                 let text = Text {
                     color: Color::WHITE,
                     size: 14.0,
-                    position: Point::new(frame.width(), frame.height()),
+                    position: Point::new(frame.width(), frame.height() - 4.0),
                     horizontal_alignment: alignment::Horizontal::Right,
                     vertical_alignment: alignment::Vertical::Bottom,
                     ..Text::default()
                 };
 
                 if let Some(cell) = hovered_cell {
-                    frame.fill_text(Text {
-                        content: format!("({}, {})", cell.j, cell.i),
-                        position: text.position - Vector::new(0.0, 16.0),
-                        ..text
-                    });
+                    frame.fill_text(
+                        text_cache,
+                        Text {
+                            content: format!("({}, {})", cell.j, cell.i),
+                            position: text.position - Vector::new(0.0, 20.0),
+                            ..text
+                        },
+                    );
                 }
 
                 let cell_count = self.state.cell_count();
 
-                frame.fill_text(Text {
-                    content: format!(
-                        "{} cell{} @ {:?} ({})",
-                        cell_count,
-                        if cell_count == 1 { "" } else { "s" },
-                        self.last_tick_duration,
-                        self.last_queued_ticks
-                    ),
-                    ..text
-                });
+                frame.fill_text(
+                    text_cache,
+                    Text {
+                        content: format!(
+                            "{} cell{} @ {:?} ({})",
+                            cell_count,
+                            if cell_count == 1 { "" } else { "s" },
+                            self.last_tick_duration,
+                            self.last_queued_ticks
+                        ),
+                        ..text
+                    },
+                );
 
                 frame.into_geometry()
             };

--- a/examples/modern_art/src/main.rs
+++ b/examples/modern_art/src/main.rs
@@ -62,6 +62,7 @@ impl<Message> canvas::Program<Message> for ModernArt {
         &self,
         _state: &Self::State,
         _theme: &Theme,
+        _text_cache: &canvas::text::Cache,
         bounds: Rectangle,
         _cursor: Cursor,
     ) -> Vec<Geometry> {

--- a/examples/multitouch/src/main.rs
+++ b/examples/multitouch/src/main.rs
@@ -126,6 +126,7 @@ impl canvas::Program<Message> for State {
         &self,
         _state: &Self::State,
         _theme: &Theme,
+        _text_cache: &canvas::text::Cache,
         bounds: Rectangle,
         _cursor: Cursor,
     ) -> Vec<Geometry> {

--- a/examples/sierpinski_triangle/src/main.rs
+++ b/examples/sierpinski_triangle/src/main.rs
@@ -135,6 +135,7 @@ impl canvas::Program<Message> for SierpinskiGraph {
         &self,
         _state: &Self::State,
         _theme: &Theme,
+        _text_cache: &canvas::text::Cache,
         bounds: Rectangle,
         _cursor: canvas::Cursor,
     ) -> Vec<canvas::Geometry> {

--- a/examples/solar_system/src/main.rs
+++ b/examples/solar_system/src/main.rs
@@ -13,6 +13,7 @@ use iced::time;
 use iced::widget::canvas;
 use iced::widget::canvas::gradient::{self, Gradient};
 use iced::widget::canvas::stroke::{self, Stroke};
+use iced::widget::canvas::text;
 use iced::widget::canvas::{Cursor, Path};
 use iced::window;
 use iced::{
@@ -158,6 +159,7 @@ impl<Message> canvas::Program<Message> for State {
         &self,
         _state: &Self::State,
         _theme: &Theme,
+        _text_cache: &text::Cache,
         bounds: Rectangle,
         _cursor: Cursor,
     ) -> Vec<canvas::Geometry> {

--- a/examples/vectorial_text/Cargo.toml
+++ b/examples/vectorial_text/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "vectorial_text"
+version = "0.1.0"
+authors = ["Héctor Ramón Jiménez <hector0193@gmail.com>"]
+edition = "2021"
+publish = false
+
+[dependencies]
+iced = { path = "../..", features = ["canvas", "debug"] }

--- a/examples/vectorial_text/src/main.rs
+++ b/examples/vectorial_text/src/main.rs
@@ -1,0 +1,172 @@
+use iced::alignment::{self, Alignment};
+use iced::widget::canvas::{Cursor, Frame, Text};
+use iced::widget::{
+    canvas, checkbox, column, horizontal_space, row, slider, text,
+};
+use iced::{
+    Color, Element, Font, Length, Point, Rectangle, Sandbox, Settings, Theme,
+    Vector,
+};
+
+pub fn main() -> iced::Result {
+    VectorialText::run(Settings {
+        antialiasing: true,
+        ..Settings::default()
+    })
+}
+
+struct VectorialText {
+    state: State,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Message {
+    SizeChanged(f32),
+    AngleChanged(f32),
+    ScaleChanged(f32),
+    ToggleJapanese(bool),
+}
+
+impl Sandbox for VectorialText {
+    type Message = Message;
+
+    fn new() -> Self {
+        Self {
+            state: State::new(),
+        }
+    }
+
+    fn title(&self) -> String {
+        String::from("Vectorial Text - Iced")
+    }
+
+    fn update(&mut self, message: Message) {
+        match message {
+            Message::SizeChanged(size) => {
+                self.state.size = size;
+            }
+            Message::AngleChanged(angle) => {
+                self.state.angle = angle;
+            }
+            Message::ScaleChanged(scale) => {
+                self.state.scale = scale;
+            }
+            Message::ToggleJapanese(use_japanese) => {
+                self.state.use_japanese = use_japanese;
+            }
+        }
+    }
+
+    fn view(&self) -> Element<Message> {
+        let slider_with_label = |label, range, value, message: fn(f32) -> _| {
+            column![
+                row![
+                    text(label),
+                    horizontal_space(Length::Fill),
+                    text(format!("{:.2}", value))
+                ],
+                slider(range, value, message).step(0.01)
+            ]
+            .width(Length::Fill)
+            .spacing(2)
+        };
+
+        column![
+            canvas(&self.state).width(Length::Fill).height(Length::Fill),
+            column![
+                checkbox(
+                    "Use Japanese",
+                    self.state.use_japanese,
+                    Message::ToggleJapanese
+                ),
+                row![
+                    slider_with_label(
+                        "Size",
+                        2.0..=80.0,
+                        self.state.size,
+                        Message::SizeChanged,
+                    ),
+                    slider_with_label(
+                        "Angle",
+                        0.0..=360.0,
+                        self.state.angle,
+                        Message::AngleChanged,
+                    ),
+                    slider_with_label(
+                        "Scale",
+                        1.0..=20.0,
+                        self.state.scale,
+                        Message::ScaleChanged,
+                    ),
+                ]
+                .spacing(20),
+            ]
+            .align_items(Alignment::Center)
+            .spacing(10)
+        ]
+        .spacing(10)
+        .padding(20)
+        .into()
+    }
+
+    fn theme(&self) -> Theme {
+        Theme::Dark
+    }
+}
+
+struct State {
+    size: f32,
+    angle: f32,
+    scale: f32,
+    use_japanese: bool,
+}
+
+impl State {
+    pub fn new() -> Self {
+        Self {
+            size: 40.0,
+            angle: 0.0,
+            scale: 1.0,
+            use_japanese: false,
+        }
+    }
+}
+
+impl<Message> canvas::Program<Message> for State {
+    type State = ();
+
+    fn draw(
+        &self,
+        _state: &Self::State,
+        _theme: &Theme,
+        text_cache: &canvas::text::Cache,
+        bounds: Rectangle,
+        _cursor: Cursor,
+    ) -> Vec<canvas::Geometry> {
+        let mut frame = Frame::new(bounds.size());
+        let center = bounds.center();
+
+        frame.translate(Vector::new(center.x, center.y));
+        frame.scale(self.scale);
+        frame.rotate(self.angle * std::f32::consts::PI / 180.0);
+
+        frame.fill_text(
+            text_cache,
+            Text {
+                position: Point::new(0.0, self.size),
+                color: Color::WHITE,
+                font: Font::Default,
+                size: self.size,
+                content: String::from(if self.use_japanese {
+                    "ベクトルテキスト"
+                } else {
+                    "Vectorial Text!"
+                }),
+                horizontal_alignment: alignment::Horizontal::Center,
+                vertical_alignment: alignment::Vertical::Center,
+            },
+        );
+
+        vec![frame.into_geometry()]
+    }
+}

--- a/examples/vectorial_text/src/main.rs
+++ b/examples/vectorial_text/src/main.rs
@@ -158,9 +158,9 @@ impl<Message> canvas::Program<Message> for State {
                 font: Font::Default,
                 size: self.size,
                 content: String::from(if self.use_japanese {
-                    "ベクトルテキスト"
+                    "ベクトルテキスト🎉"
                 } else {
-                    "Vectorial Text!"
+                    "Vectorial Text! 🎉"
                 }),
                 horizontal_alignment: alignment::Horizontal::Center,
                 vertical_alignment: alignment::Vertical::Center,

--- a/glow/src/backend.rs
+++ b/glow/src/backend.rs
@@ -6,7 +6,7 @@ use crate::{program, triangle};
 use crate::{Settings, Transformation, Viewport};
 
 use iced_graphics::backend;
-use iced_graphics::font;
+use iced_graphics::text::font;
 use iced_graphics::{Layer, Primitive};
 use iced_native::alignment;
 use iced_native::{Font, Size};

--- a/glow/src/text.rs
+++ b/glow/src/text.rs
@@ -1,6 +1,6 @@
 use crate::Transformation;
 
-use iced_graphics::font;
+use iced_graphics::text::font;
 
 use glow_glyph::ab_glyph;
 use std::{cell::RefCell, collections::HashMap};

--- a/graphics/Cargo.toml
+++ b/graphics/Cargo.toml
@@ -24,7 +24,7 @@ bmp = ["image_rs/bmp"]
 hdr = ["image_rs/hdr"]
 dds = ["image_rs/dds"]
 farbfeld = ["image_rs/farbfeld"]
-canvas = ["lyon"]
+canvas = ["lyon", "cosmic-text"]
 qr_code = ["qrcode", "canvas"]
 font-source = ["font-kit"]
 font-fallback = []
@@ -38,6 +38,7 @@ log = "0.4"
 raw-window-handle = "0.5"
 thiserror = "1.0"
 bitflags = "1.2"
+once_cell = "1.0"
 
 [dependencies.bytemuck]
 version = "1.4"
@@ -53,6 +54,10 @@ path = "../style"
 
 [dependencies.lyon]
 version = "1.0"
+optional = true
+
+[dependencies.cosmic-text]
+version = "0.5.5"
 optional = true
 
 [dependencies.qrcode]

--- a/graphics/src/lib.rs
+++ b/graphics/src/lib.rs
@@ -28,12 +28,12 @@ mod transformation;
 mod viewport;
 
 pub mod backend;
-pub mod font;
 pub mod gradient;
 pub mod image;
 pub mod layer;
 pub mod overlay;
 pub mod renderer;
+pub mod text;
 pub mod triangle;
 pub mod widget;
 pub mod window;

--- a/graphics/src/renderer.rs
+++ b/graphics/src/renderer.rs
@@ -1,11 +1,11 @@
 //! Create a renderer from a [`Backend`].
 use crate::backend::{self, Backend};
+use crate::text::{self, Text};
 use crate::{Primitive, Vector};
 use iced_native::image;
 use iced_native::layout;
 use iced_native::renderer;
 use iced_native::svg;
-use iced_native::text::{self, Text};
 use iced_native::{Background, Color, Element, Font, Point, Rectangle, Size};
 
 pub use iced_native::renderer::Style;
@@ -13,10 +13,11 @@ pub use iced_native::renderer::Style;
 use std::marker::PhantomData;
 
 /// A backend-agnostic renderer that supports all the built-in widgets.
-#[derive(Debug)]
+#[allow(missing_debug_implementations)]
 pub struct Renderer<B: Backend, Theme> {
     backend: B,
     primitives: Vec<Primitive>,
+    text_cache: text::Cache,
     theme: PhantomData<Theme>,
 }
 
@@ -26,6 +27,7 @@ impl<B: Backend, T> Renderer<B, T> {
         Self {
             backend,
             primitives: Vec::new(),
+            text_cache: text::Cache::new(),
             theme: PhantomData,
         }
     }
@@ -44,6 +46,11 @@ impl<B: Backend, T> Renderer<B, T> {
     /// of the [`Renderer`].
     pub fn with_primitives(&mut self, f: impl FnOnce(&mut B, &[Primitive])) {
         f(&mut self.backend, &self.primitives);
+    }
+
+    /// Returns a reference to the current [`text::Cache`].
+    pub fn text_cache(&self) -> &text::Cache {
+        &self.text_cache
     }
 }
 

--- a/graphics/src/text.rs
+++ b/graphics/src/text.rs
@@ -1,0 +1,28 @@
+//! Draw text for your users.
+pub mod font;
+
+pub use iced_native::text::{self, *};
+
+use std::cell::RefCell;
+
+#[cfg(feature = "canvas")]
+/// An access to system fonts.
+pub static FONT_SYSTEM: once_cell::sync::Lazy<cosmic_text::FontSystem> =
+    once_cell::sync::Lazy::new(|| cosmic_text::FontSystem::new());
+
+/// A text cache.
+#[allow(missing_debug_implementations)]
+pub struct Cache {
+    #[cfg(feature = "canvas")]
+    pub(crate) swash: RefCell<cosmic_text::SwashCache<'static>>,
+}
+
+impl Cache {
+    /// Creates a new text [`Cache`].
+    pub fn new() -> Self {
+        Self {
+            #[cfg(feature = "canvas")]
+            swash: RefCell::new(cosmic_text::SwashCache::new(&FONT_SYSTEM)),
+        }
+    }
+}

--- a/graphics/src/text.rs
+++ b/graphics/src/text.rs
@@ -8,7 +8,7 @@ use std::cell::RefCell;
 #[cfg(feature = "canvas")]
 /// An access to system fonts.
 pub static FONT_SYSTEM: once_cell::sync::Lazy<cosmic_text::FontSystem> =
-    once_cell::sync::Lazy::new(|| cosmic_text::FontSystem::new());
+    once_cell::sync::Lazy::new(cosmic_text::FontSystem::new);
 
 /// A text cache.
 #[allow(missing_debug_implementations)]
@@ -24,5 +24,11 @@ impl Cache {
             #[cfg(feature = "canvas")]
             swash: RefCell::new(cosmic_text::SwashCache::new(&FONT_SYSTEM)),
         }
+    }
+}
+
+impl Default for Cache {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/graphics/src/text/font.rs
+++ b/graphics/src/text/font.rs
@@ -15,14 +15,14 @@ pub use font_kit::{
 /// A built-in fallback font, for convenience.
 #[cfg(feature = "font-fallback")]
 #[cfg_attr(docsrs, doc(cfg(feature = "font-fallback")))]
-pub const FALLBACK: &[u8] = include_bytes!("../fonts/Lato-Regular.ttf");
+pub const FALLBACK: &[u8] = include_bytes!("../../fonts/Lato-Regular.ttf");
 
 /// A built-in icon font, for convenience.
 #[cfg(feature = "font-icons")]
 #[cfg_attr(docsrs, doc(cfg(feature = "font-icons")))]
 pub const ICONS: iced_native::Font = iced_native::Font::External {
     name: "iced_wgpu icons",
-    bytes: include_bytes!("../fonts/Icons.ttf"),
+    bytes: include_bytes!("../../fonts/Icons.ttf"),
 };
 
 /// The `char` representing a ✔ icon in the built-in [`ICONS`] font.

--- a/graphics/src/text/font/source.rs
+++ b/graphics/src/text/font/source.rs
@@ -1,4 +1,4 @@
-use crate::font::{Family, LoadError};
+use crate::text::font::{Family, LoadError};
 
 /// A font source that can find and load system fonts.
 #[allow(missing_debug_implementations)]

--- a/graphics/src/widget/canvas.rs
+++ b/graphics/src/widget/canvas.rs
@@ -7,6 +7,7 @@ pub mod event;
 pub mod fill;
 pub mod path;
 pub mod stroke;
+pub mod text;
 
 mod cache;
 mod cursor;
@@ -14,7 +15,6 @@ mod frame;
 mod geometry;
 mod program;
 mod style;
-mod text;
 
 pub use crate::gradient::{self, Gradient};
 pub use cache::Cache;
@@ -53,6 +53,7 @@ use std::marker::PhantomData;
 /// #     }
 /// #     pub use iced_native::{Color, Rectangle, Theme};
 /// # }
+/// use iced::widget::canvas::text;
 /// use iced::widget::canvas::{self, Canvas, Cursor, Fill, Frame, Geometry, Path, Program};
 /// use iced::{Color, Rectangle, Theme};
 ///
@@ -66,7 +67,7 @@ use std::marker::PhantomData;
 /// impl Program<()> for Circle {
 ///     type State = ();
 ///
-///     fn draw(&self, _state: &(), _theme: &Theme, bounds: Rectangle, _cursor: Cursor) -> Vec<Geometry>{
+///     fn draw(&self, _state: &(), _theme: &Theme, _text_cache: &text::Cache, bounds: Rectangle, _cursor: Cursor) -> Vec<Geometry>{
 ///         // We prepare a new `Frame`
 ///         let mut frame = Frame::new(bounds.size());
 ///
@@ -243,7 +244,7 @@ where
             renderer.draw_primitive(Primitive::Group {
                 primitives: self
                     .program
-                    .draw(state, theme, bounds, cursor)
+                    .draw(state, theme, renderer.text_cache(), bounds, cursor)
                     .into_iter()
                     .map(Geometry::into_primitive)
                     .collect(),

--- a/graphics/src/widget/canvas/frame.rs
+++ b/graphics/src/widget/canvas/frame.rs
@@ -351,7 +351,7 @@ impl Frame {
         for run in layout.iter() {
             for glyph in run.glyphs.iter() {
                 let start_x = translation_x + glyph.x + glyph.x_offset;
-                let start_y = translation_y as f32 + glyph.y_offset - text.size;
+                let start_y = translation_y + glyph.y_offset - text.size;
 
                 let offset = Vector::new(start_x, start_y);
 

--- a/graphics/src/widget/canvas/frame.rs
+++ b/graphics/src/widget/canvas/frame.rs
@@ -407,9 +407,11 @@ impl Frame {
                         glyph.cache_key,
                         cosmic_text::Color::rgba(r, g, b, a),
                         |x, y, color| {
-                            self.fill_rectangle(
-                                Point::new(x as f32, y as f32) + offset,
-                                Size::new(1.0, 1.0),
+                            self.fill(
+                                &Path::rectangle(
+                                    Point::new(x as f32, y as f32) + offset,
+                                    Size::new(1.0, 1.0),
+                                ),
                                 Color::from_rgba8(
                                     color.r(),
                                     color.g(),

--- a/graphics/src/widget/canvas/program.rs
+++ b/graphics/src/widget/canvas/program.rs
@@ -1,3 +1,4 @@
+use crate::text;
 use crate::widget::canvas::event::{self, Event};
 use crate::widget::canvas::mouse;
 use crate::widget::canvas::{Cursor, Geometry};
@@ -45,6 +46,7 @@ pub trait Program<Message, Theme = iced_native::Theme> {
         &self,
         state: &Self::State,
         theme: &Theme,
+        text_cache: &text::Cache,
         bounds: Rectangle,
         cursor: Cursor,
     ) -> Vec<Geometry>;
@@ -85,10 +87,11 @@ where
         &self,
         state: &Self::State,
         theme: &Theme,
+        text_cache: &text::Cache,
         bounds: Rectangle,
         cursor: Cursor,
     ) -> Vec<Geometry> {
-        T::draw(self, state, theme, bounds, cursor)
+        T::draw(self, state, theme, text_cache, bounds, cursor)
     }
 
     fn mouse_interaction(

--- a/graphics/src/widget/canvas/text.rs
+++ b/graphics/src/widget/canvas/text.rs
@@ -1,5 +1,8 @@
+//! Draw text in a canvas.
 use crate::alignment;
 use crate::{Color, Font, Point};
+
+pub use crate::text::Cache;
 
 /// A bunch of text that can be drawn to a canvas
 #[derive(Debug, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,6 +176,7 @@ pub mod keyboard;
 pub mod mouse;
 pub mod overlay;
 pub mod settings;
+pub mod text;
 pub mod time;
 pub mod touch;
 pub mod widget;

--- a/src/text.rs
+++ b/src/text.rs
@@ -1,0 +1,2 @@
+//! Draw text for your users.
+pub use iced_graphics::text::Cache;

--- a/wgpu/src/backend.rs
+++ b/wgpu/src/backend.rs
@@ -4,8 +4,8 @@ use crate::triangle;
 use crate::{Settings, Transformation};
 
 use iced_graphics::backend;
-use iced_graphics::font;
 use iced_graphics::layer::Layer;
+use iced_graphics::text::font;
 use iced_graphics::{Primitive, Viewport};
 use iced_native::alignment;
 use iced_native::{Font, Size};

--- a/wgpu/src/text.rs
+++ b/wgpu/src/text.rs
@@ -1,6 +1,6 @@
 use crate::Transformation;
 
-use iced_graphics::font;
+use iced_graphics::text::font;
 
 use std::{cell::RefCell, collections::HashMap};
 use wgpu_glyph::ab_glyph;


### PR DESCRIPTION
This PR implements vectorial text support for the `Canvas` widget by leveraging [`cosmic-text`](https://github.com/pop-os/cosmic-text) :tada:

This means that text now is no different than any other kind of geometry in a `Canvas` and, as a result, it can be transformed (translated, rotated, and scaled) and composed (layering!) freely.

Also, `cosmic-text` implements both text shaping and font fallback, so a `Canvas` should now be able to support different scripts as well.

https://user-images.githubusercontent.com/518289/208642436-759ad908-e4ac-4333-b55a-933bf3ad5036.mp4

The bitmap font support is wonky (and very inefficient), as you can see in the example above. This is just the start of a series of PRs that will improve our text handling and rendering. Further improvements are coming!