### PR TITLE
Fix `clippy` lints for Rust 1.66

### DIFF
--- a/core/src/rectangle.rs
+++ b/core/src/rectangle.rs
@@ -116,8 +116,8 @@ impl std::ops::Mul<f32> for Rectangle<f32> {
 
     fn mul(self, scale: f32) -> Self {
         Self {
-            x: self.x as f32 * scale,
-            y: self.y as f32 * scale,
+            x: self.x * scale,
+            y: self.y * scale,
             width: self.width * scale,
             height: self.height * scale,
         }

--- a/examples/game_of_life/src/main.rs
+++ b/examples/game_of_life/src/main.rs
@@ -492,8 +492,10 @@ mod grid {
                                 let old_scaling = self.scaling;
 
                                 let scaling = (self.scaling * (1.0 + y / 30.0))
-                                    .max(Self::MIN_SCALING)
-                                    .min(Self::MAX_SCALING);
+                                    .clamp(
+                                        Self::MIN_SCALING,
+                                        Self::MAX_SCALING,
+                                    );
 
                                 let translation =
                                     if let Some(cursor_to_center) =

--- a/native/src/layout/limits.rs
+++ b/native/src/layout/limits.rs
@@ -51,7 +51,7 @@ impl Limits {
             }
             Length::Units(units) => {
                 let new_width =
-                    (units as f32).min(self.max.width).max(self.min.width);
+                    (units as f32).clamp(self.min.width, self.max.width);
 
                 self.min.width = new_width;
                 self.max.width = new_width;
@@ -73,7 +73,7 @@ impl Limits {
             }
             Length::Units(units) => {
                 let new_height =
-                    (units as f32).min(self.max.height).max(self.min.height);
+                    (units as f32).clamp(self.min.height, self.max.height);
 
                 self.min.height = new_height;
                 self.max.height = new_height;
@@ -86,16 +86,14 @@ impl Limits {
 
     /// Applies a minimum width constraint to the current [`Limits`].
     pub fn min_width(mut self, min_width: u32) -> Limits {
-        self.min.width =
-            self.min.width.max(min_width as f32).min(self.max.width);
+        self.min.width = self.min.width.clamp(min_width as f32, self.max.width);
 
         self
     }
 
     /// Applies a maximum width constraint to the current [`Limits`].
     pub fn max_width(mut self, max_width: u32) -> Limits {
-        self.max.width =
-            self.max.width.min(max_width as f32).max(self.min.width);
+        self.max.width = self.max.width.clamp(self.min.width, max_width as f32);
 
         self
     }
@@ -103,7 +101,7 @@ impl Limits {
     /// Applies a minimum height constraint to the current [`Limits`].
     pub fn min_height(mut self, min_height: u32) -> Limits {
         self.min.height =
-            self.min.height.max(min_height as f32).min(self.max.height);
+            self.min.height.clamp(min_height as f32, self.max.height);
 
         self
     }
@@ -111,7 +109,7 @@ impl Limits {
     /// Applies a maximum height constraint to the current [`Limits`].
     pub fn max_height(mut self, max_height: u32) -> Limits {
         self.max.height =
-            self.max.height.min(max_height as f32).max(self.min.height);
+            self.max.height.clamp(self.min.height, max_height as f32);
 
         self
     }
@@ -157,14 +155,10 @@ impl Limits {
     /// intrinsic size of some content.
     pub fn resolve(&self, intrinsic_size: Size) -> Size {
         Size::new(
-            intrinsic_size
-                .width
-                .min(self.max.width)
-                .max(self.fill.width),
+            intrinsic_size.width.clamp(self.fill.width, self.max.width),
             intrinsic_size
                 .height
-                .min(self.max.height)
-                .max(self.fill.height),
+                .clamp(self.fill.height, self.max.height),
         )
     }
 }

--- a/native/src/widget/image/viewer.rs
+++ b/native/src/widget/image/viewer.rs
@@ -170,8 +170,7 @@ where
                             } else {
                                 state.scale / (1.0 + self.scale_step)
                             })
-                            .max(self.min_scale)
-                            .min(self.max_scale);
+                            .clamp(self.min_scale, self.max_scale);
 
                             let image_size = image_size(
                                 renderer,
@@ -251,16 +250,14 @@ where
 
                     let x = if bounds.width < image_size.width {
                         (state.starting_offset.x - delta.x)
-                            .min(hidden_width)
-                            .max(-hidden_width)
+                            .clamp(-hidden_width, hidden_width)
                     } else {
                         0.0
                     };
 
                     let y = if bounds.height < image_size.height {
                         (state.starting_offset.y - delta.y)
-                            .min(hidden_height)
-                            .max(-hidden_height)
+                            .clamp(-hidden_height, hidden_height)
                     } else {
                         0.0
                     };
@@ -374,8 +371,8 @@ impl State {
             (image_size.height - bounds.height / 2.0).max(0.0).round();
 
         Vector::new(
-            self.current_offset.x.min(hidden_width).max(-hidden_width),
-            self.current_offset.y.min(hidden_height).max(-hidden_height),
+            self.current_offset.x.clamp(-hidden_width, hidden_width),
+            self.current_offset.y.clamp(-hidden_height, hidden_height),
         )
     }
 

--- a/native/src/widget/pane_grid.rs
+++ b/native/src/widget/pane_grid.rs
@@ -630,13 +630,13 @@ pub fn update<'a, Message, T: Draggable>(
                                 let position =
                                     cursor_position.y - bounds.y - rectangle.y;
 
-                                (position / rectangle.height).max(0.1).min(0.9)
+                                (position / rectangle.height).clamp(0.1, 0.9)
                             }
                             Axis::Vertical => {
                                 let position =
                                     cursor_position.x - bounds.x - rectangle.x;
 
-                                (position / rectangle.width).max(0.1).min(0.9)
+                                (position / rectangle.width).clamp(0.1, 0.9)
                             }
                         };
 

--- a/native/src/widget/progress_bar.rs
+++ b/native/src/widget/progress_bar.rs
@@ -47,7 +47,7 @@ where
     ///   * the current value of the [`ProgressBar`]
     pub fn new(range: RangeInclusive<f32>, value: f32) -> Self {
         ProgressBar {
-            value: value.max(*range.start()).min(*range.end()),
+            value: value.clamp(*range.start(), *range.end()),
             range,
             width: Length::Fill,
             height: None,

--- a/native/src/widget/scrollable.rs
+++ b/native/src/widget/scrollable.rs
@@ -881,8 +881,7 @@ impl State {
 
         self.offset = Offset::Absolute(
             (self.offset.absolute(bounds, content_bounds) - delta_y)
-                .max(0.0)
-                .min((content_bounds.height - bounds.height) as f32),
+                .clamp(0.0, content_bounds.height - bounds.height),
         );
     }
 
@@ -905,7 +904,7 @@ impl State {
     /// `0` represents scrollbar at the top, while `1` represents scrollbar at
     /// the bottom.
     pub fn snap_to(&mut self, percentage: f32) {
-        self.offset = Offset::Relative(percentage.max(0.0).min(1.0));
+        self.offset = Offset::Relative(percentage.clamp(0.0, 1.0));
     }
 
     /// Unsnaps the current scroll position, if snapped, given the bounds of the

--- a/native/src/widget/toggler.rs
+++ b/native/src/widget/toggler.rs
@@ -265,8 +265,8 @@ where
             theme.active(&self.style, self.is_active)
         };
 
-        let border_radius = bounds.height as f32 / BORDER_RADIUS_RATIO;
-        let space = SPACE_RATIO * bounds.height as f32;
+        let border_radius = bounds.height / BORDER_RADIUS_RATIO;
+        let space = SPACE_RATIO * bounds.height;
 
         let toggler_background_bounds = Rectangle {
             x: bounds.x + space,

--- a/wgpu/src/buffer/dynamic.rs
+++ b/wgpu/src/buffer/dynamic.rs
@@ -80,7 +80,7 @@ impl<T: ShaderType + WriteInto> Buffer<T> {
     pub fn push(&mut self, value: &T) {
         //this write operation on the cpu buffer will adjust for uniform alignment requirements
         let offset = self.cpu.write(value);
-        self.offsets.push(offset as u32);
+        self.offsets.push(offset);
     }
 
     /// Resize buffer contents if necessary. This will re-create the GPU buffer if current size is

--- a/wgpu/src/triangle.rs
+++ b/wgpu/src/triangle.rs
@@ -331,11 +331,7 @@ impl Pipeline {
                     wgpu::IndexFormat::Uint32,
                 );
 
-                render_pass.draw_indexed(
-                    0..(self.index_strides[index] as u32),
-                    0,
-                    0..1,
-                );
+                render_pass.draw_indexed(0..self.index_strides[index], 0, 0..1);
             }
         }
 


### PR DESCRIPTION
`f32::clamp` everywhere.