### PR TITLE
Add `operate` method to `Component` trait

### DIFF
--- a/lazy/src/component.rs
+++ b/lazy/src/component.rs
@@ -46,6 +46,14 @@ pub trait Component<Message, Renderer> {
     /// Produces the widgets of the [`Component`], which may trigger an [`Event`](Component::Event)
     /// on user interaction.
     fn view(&self, state: &Self::State) -> Element<'_, Self::Event, Renderer>;
+
+    /// Update the [`Component`] state based on the provided [`Operation`](widget::Operation)
+    fn operate(
+        &self,
+        #[allow(unused)] state: &mut Self::State,
+        #[allow(unused)] operation: &mut dyn widget::Operation<Message>,
+    ) {
+    }
 }
 
 /// Turns an implementor of [`Component`] into an [`Element`] that can be
@@ -94,6 +102,26 @@ where
 {
     fn rebuild_element(&self, state: &S) {
         let heads = self.state.borrow_mut().take().unwrap().into_heads();
+
+        *self.state.borrow_mut() = Some(
+            StateBuilder {
+                component: heads.component,
+                message: PhantomData,
+                state: PhantomData,
+                element_builder: |component| Some(component.view(state)),
+            }
+            .build(),
+        );
+    }
+
+    fn rebuild_element_with_operation(
+        &self,
+        state: &mut S,
+        operation: &mut dyn widget::Operation<Message>,
+    ) {
+        let heads = self.state.borrow_mut().take().unwrap().into_heads();
+
+        heads.component.operate(state, operation);
 
         *self.state.borrow_mut() = Some(
             StateBuilder {
@@ -237,6 +265,11 @@ where
         renderer: &Renderer,
         operation: &mut dyn widget::Operation<Message>,
     ) {
+        self.rebuild_element_with_operation(
+            tree.state.downcast_mut(),
+            operation,
+        );
+
         struct MapOperation<'a, B> {
             operation: &'a mut dyn widget::Operation<B>,
         }

--- a/lazy/src/component.rs
+++ b/lazy/src/component.rs
@@ -48,10 +48,12 @@ pub trait Component<Message, Renderer> {
     fn view(&self, state: &Self::State) -> Element<'_, Self::Event, Renderer>;
 
     /// Update the [`Component`] state based on the provided [`Operation`](widget::Operation)
+    ///
+    /// By default, it does nothing.
     fn operate(
         &self,
-        #[allow(unused)] state: &mut Self::State,
-        #[allow(unused)] operation: &mut dyn widget::Operation<Message>,
+        _state: &mut Self::State,
+        _operation: &mut dyn widget::Operation<Message>,
     ) {
     }
 }


### PR DESCRIPTION
This PR adds the option for components to mutate their internal state in response to widget operations. As a consequence of this the stored element is rebuilt for any operation. The component will still delegate operations to the rebuilt element.