### PR TITLE
Fix shadowed variable

### DIFF
--- a/lazy/src/responsive.rs
+++ b/lazy/src/responsive.rs
@@ -280,12 +280,14 @@ where
                 );
 
                 let Content {
-                    element, layout, ..
+                    element,
+                    layout: content_layout,
+                    ..
                 } = content.deref_mut();
 
                 let content_layout = Layout::with_offset(
                     layout.bounds().position() - Point::ORIGIN,
-                    layout,
+                    content_layout,
                 );
 
                 element


### PR DESCRIPTION
I created this bug with #1563 :see_no_evil: . In trying to please the compiler to satisfy borrow constraints, I accidentally shadowed the `layout` variable passed into the `overlay` method with  the content's layout. This causes the offset to be incorrect and therefore causes any overlay under a `Responsive` to be positioned incorrectly. 