### PR TITLE
Add focus operation and style for button

### DIFF
--- a/src/widget.rs
+++ b/src/widget.rs
@@ -22,7 +22,7 @@ pub mod text {
 
 pub mod button {
     //! Allow your users to perform actions by pressing a button.
-    pub use iced_native::widget::button::{Appearance, StyleSheet};
+    pub use iced_native::widget::button::{focus, Appearance, Id, StyleSheet};
 
     /// A widget that produces a message when clicked.
     pub type Button<'a, Message, Renderer = crate::Renderer> =

--- a/style/src/button.rs
+++ b/style/src/button.rs
@@ -39,6 +39,16 @@ pub trait StyleSheet {
     /// Produces the active [`Appearance`] of a button.
     fn active(&self, style: &Self::Style) -> Appearance;
 
+    /// Produces the focused [`Appearance`] of a button.
+    fn focused(&self, style: &Self::Style) -> Appearance {
+        let active = self.active(style);
+
+        Appearance {
+            shadow_offset: active.shadow_offset + Vector::new(0.0, 1.0),
+            ..active
+        }
+    }
+
     /// Produces the hovered [`Appearance`] of a button.
     fn hovered(&self, style: &Self::Style) -> Appearance {
         let active = self.active(style);

--- a/style/src/theme.rs
+++ b/style/src/theme.rs
@@ -192,6 +192,25 @@ impl button::StyleSheet for Theme {
         }
     }
 
+    fn focused(&self, style: &Self::Style) -> button::Appearance {
+        let palette = self.extended_palette();
+
+        let background = match style {
+            Button::Primary => Some(palette.primary.base.color),
+            Button::Secondary => Some(palette.background.strong.color),
+            Button::Positive => Some(palette.success.strong.color),
+            Button::Destructive => Some(palette.danger.strong.color),
+            Button::Text | Button::Custom(_) => None,
+        };
+
+        let active = self.active(style);
+
+        button::Appearance {
+            background: background.map(Background::from),
+            ..active
+        }
+    }
+
     fn pressed(&self, style: &Self::Style) -> button::Appearance {
         if let Button::Custom(custom) = style {
             return custom.pressed(self);


### PR DESCRIPTION
This lets buttons also be tab navigated like the text_input.
It should be possible to tab cycle buttons with the `widget::focus_next` & `widget::focus_previous`, as well as focus by ID. Then when pressing `Enter` submits the same message as `on_press()`.

By default this just sets a button to the hovered styling when focused.