### PR TITLE
Provide `&Dependency` to `Lazy` widget view fn

### DIFF
--- a/examples/lazy/src/main.rs
+++ b/examples/lazy/src/main.rs
@@ -167,7 +167,7 @@ impl Sandbox for App {
     }
 
     fn view(&self) -> Element<Message> {
-        let options = lazy(self.version, || {
+        let options = lazy(self.version, |_| {
             let mut items: Vec<_> = self.items.iter().cloned().collect();
 
             items.sort_by(|a, b| match self.order {

--- a/lazy/src/lib.rs
+++ b/lazy/src/lib.rs
@@ -33,7 +33,7 @@ use std::hash::Hash;
 
 pub fn lazy<'a, Message, Renderer, Dependency, View>(
     dependency: Dependency,
-    view: impl Fn() -> View + 'a,
+    view: impl Fn(&Dependency) -> View + 'a,
 ) -> Lazy<'a, Message, Renderer, Dependency, View>
 where
     Dependency: Hash + 'a,


### PR DESCRIPTION
This is a small ergonomics improvement that I noticed would be beneficial when working with the `Lazy` widget. The change is just to call the provided view function with a reference to the specified `Dependency`.

This is useful when the data provided for `Dependency` originates from the widget tree state, and so we don't have a reference to it which lives for the required `'a` lifetime bound on `Dependency`. In this case we need to take ownership of the data to use it for `Dependency`. Unfortunately, the provided view function must also satisfy the `'a` bound, so the data needs to be cloned again if we want to move it into the view function for use there.

By providing view with a reference to the dependency stored in the lazy widget, we can defer this second clone until the cache is actually invalidated rather than doing it on every view. I think it also makes using `Lazy` a bit more intuitive.

I'd be happy to write an RFC if more explanation/examples are required to make this change 