### PR TITLE
Widget-driven animations

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,4 +15,4 @@ version = "0.6"
 optional = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-timer = { version = "0.2" }
+instant = "0.1"

--- a/core/src/time.rs
+++ b/core/src/time.rs
@@ -1,9 +1,13 @@
 //! Keep track of time, both in native and web platforms!
 
 #[cfg(target_arch = "wasm32")]
-pub use wasm_timer::Instant;
+pub use instant::Instant;
+
+#[cfg(target_arch = "wasm32")]
+pub use instant::Duration;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use std::time::Instant;
 
+#[cfg(not(target_arch = "wasm32"))]
 pub use std::time::Duration;

--- a/examples/events/Cargo.toml
+++ b/examples/events/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 publish = false
 
 [dependencies]
-iced = { path = "../.." }
+iced = { path = "../..", features = ["debug"] }
 iced_native = { path = "../../native" }

--- a/examples/events/src/main.rs
+++ b/examples/events/src/main.rs
@@ -1,11 +1,12 @@
 use iced::alignment;
 use iced::executor;
 use iced::widget::{button, checkbox, container, text, Column};
+use iced::window;
 use iced::{
     Alignment, Application, Command, Element, Length, Settings, Subscription,
     Theme,
 };
-use iced_native::{window, Event};
+use iced_native::Event;
 
 pub fn main() -> iced::Result {
     Events::run(Settings {
@@ -18,7 +19,6 @@ pub fn main() -> iced::Result {
 struct Events {
     last: Vec<iced_native::Event>,
     enabled: bool,
-    should_exit: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -50,29 +50,27 @@ impl Application for Events {
                 if self.last.len() > 5 {
                     let _ = self.last.remove(0);
                 }
+
+                Command::none()
             }
             Message::EventOccurred(event) => {
                 if let Event::Window(window::Event::CloseRequested) = event {
-                    self.should_exit = true;
+                    window::close()
+                } else {
+                    Command::none()
                 }
             }
             Message::Toggled(enabled) => {
                 self.enabled = enabled;
-            }
-            Message::Exit => {
-                self.should_exit = true;
-            }
-        };
 
-        Command::none()
+                Command::none()
+            }
+            Message::Exit => window::close(),
+        }
     }
 
     fn subscription(&self) -> Subscription<Message> {
         iced_native::subscription::events().map(Message::EventOccurred)
-    }
-
-    fn should_exit(&self) -> bool {
-        self.should_exit
     }
 
     fn view(&self) -> Element<Message> {

--- a/examples/exit/src/main.rs
+++ b/examples/exit/src/main.rs
@@ -1,5 +1,7 @@
+use iced::executor;
 use iced::widget::{button, column, container};
-use iced::{Alignment, Element, Length, Sandbox, Settings};
+use iced::window;
+use iced::{Alignment, Application, Command, Element, Length, Settings, Theme};
 
 pub fn main() -> iced::Result {
     Exit::run(Settings::default())
@@ -8,7 +10,6 @@ pub fn main() -> iced::Result {
 #[derive(Default)]
 struct Exit {
     show_confirm: bool,
-    exit: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -17,28 +18,27 @@ enum Message {
     Exit,
 }
 
-impl Sandbox for Exit {
+impl Application for Exit {
+    type Executor = executor::Default;
     type Message = Message;
+    type Theme = Theme;
+    type Flags = ();
 
-    fn new() -> Self {
-        Self::default()
+    fn new(_flags: ()) -> (Self, Command<Message>) {
+        (Self::default(), Command::none())
     }
 
     fn title(&self) -> String {
         String::from("Exit - Iced")
     }
 
-    fn should_exit(&self) -> bool {
-        self.exit
-    }
-
-    fn update(&mut self, message: Message) {
+    fn update(&mut self, message: Message) -> Command<Message> {
         match message {
-            Message::Confirm => {
-                self.exit = true;
-            }
+            Message::Confirm => window::close(),
             Message::Exit => {
                 self.show_confirm = true;
+
+                Command::none()
             }
         }
     }

--- a/examples/solar_system/src/main.rs
+++ b/examples/solar_system/src/main.rs
@@ -9,7 +9,6 @@
 use iced::application;
 use iced::executor;
 use iced::theme::{self, Theme};
-use iced::time;
 use iced::widget::canvas;
 use iced::widget::canvas::gradient::{self, Gradient};
 use iced::widget::canvas::stroke::{self, Stroke};
@@ -90,7 +89,7 @@ impl Application for SolarSystem {
     }
 
     fn subscription(&self) -> Subscription<Message> {
-        time::every(time::Duration::from_millis(10)).map(Message::Tick)
+        window::frames().map(Message::Tick)
     }
 }
 

--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -15,8 +15,9 @@ trace = ["iced_winit/trace"]
 debug = ["iced_winit/debug"]
 system = ["iced_winit/system"]
 
-[dependencies.log]
-version = "0.4"
+[dependencies]
+log = "0.4"
+instant = "0.1"
 
 [dependencies.glutin]
 version = "0.29"

--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -17,7 +17,6 @@ system = ["iced_winit/system"]
 
 [dependencies]
 log = "0.4"
-instant = "0.1"
 
 [dependencies.glutin]
 version = "0.29"

--- a/glutin/src/application.rs
+++ b/glutin/src/application.rs
@@ -340,9 +340,8 @@ async fn run_instance<A, E, C>(
                 // TODO: Avoid redrawing all the time by forcing widgets to
                 // request redraws on state changes
                 //
-                // Then, we can use the `interface_state` here to decide whether
-                // if a redraw is needed right away, or simply wait until a
-                // specific time.
+                // Then, we can use the `interface_state` here to decide if a redraw
+                // is needed right away, or simply wait until a specific time.
                 let redraw_event = Event::Window(
                     crate::window::Event::RedrawRequested(Instant::now()),
                 );

--- a/glutin/src/application.rs
+++ b/glutin/src/application.rs
@@ -11,11 +11,11 @@ use iced_winit::conversion;
 use iced_winit::futures;
 use iced_winit::futures::channel::mpsc;
 use iced_winit::renderer;
+use iced_winit::time::Instant;
 use iced_winit::user_interface;
 use iced_winit::{Clipboard, Command, Debug, Event, Proxy, Settings};
 
 use glutin::window::Window;
-use instant::Instant;
 use std::mem::ManuallyDrop;
 
 #[cfg(feature = "tracing")]

--- a/glutin/src/application.rs
+++ b/glutin/src/application.rs
@@ -15,8 +15,8 @@ use iced_winit::user_interface;
 use iced_winit::{Clipboard, Command, Debug, Event, Proxy, Settings};
 
 use glutin::window::Window;
+use instant::Instant;
 use std::mem::ManuallyDrop;
-use std::time::Instant;
 
 #[cfg(feature = "tracing")]
 use tracing::{info_span, instrument::Instrument};

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -14,7 +14,6 @@ debug = []
 twox-hash = { version = "1.5", default-features = false }
 unicode-segmentation = "1.6"
 num-traits = "0.2"
-instant = "0.1"
 
 [dependencies.iced_core]
 version = "0.6"

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -14,6 +14,7 @@ debug = []
 twox-hash = { version = "1.5", default-features = false }
 unicode-segmentation = "1.6"
 num-traits = "0.2"
+instant = "0.1"
 
 [dependencies.iced_core]
 version = "0.6"

--- a/native/src/renderer.rs
+++ b/native/src/renderer.rs
@@ -36,11 +36,11 @@ pub trait Renderer: Sized {
         f: impl FnOnce(&mut Self),
     );
 
-    /// Clears all of the recorded primitives in the [`Renderer`].
-    fn clear(&mut self);
-
     /// Fills a [`Quad`] with the provided [`Background`].
     fn fill_quad(&mut self, quad: Quad, background: impl Into<Background>);
+
+    /// Clears all of the recorded primitives in the [`Renderer`].
+    fn clear(&mut self);
 }
 
 /// A polygon with four sides.

--- a/native/src/subscription.rs
+++ b/native/src/subscription.rs
@@ -1,5 +1,6 @@
 //! Listen to external events in your application.
 use crate::event::{self, Event};
+use crate::window;
 use crate::Hasher;
 
 use iced_futures::futures::{self, Future, Stream};
@@ -33,7 +34,7 @@ pub type Tracker =
 
 pub use iced_futures::subscription::Recipe;
 
-/// Returns a [`Subscription`] to all the runtime events.
+/// Returns a [`Subscription`] to all the ignored runtime events.
 ///
 /// This subscription will notify your application of any [`Event`] that was
 /// not captured by any widget.
@@ -65,7 +66,10 @@ where
             use futures::stream::StreamExt;
 
             events.filter_map(move |(event, status)| {
-                future::ready(f(event, status))
+                future::ready(match event {
+                    Event::Window(window::Event::RedrawRequested(_)) => None,
+                    _ => f(event, status),
+                })
             })
         },
     })

--- a/native/src/user_interface.rs
+++ b/native/src/user_interface.rs
@@ -5,9 +5,8 @@ use crate::layout;
 use crate::mouse;
 use crate::renderer;
 use crate::widget;
+use crate::window;
 use crate::{Clipboard, Element, Layout, Point, Rectangle, Shell, Size};
-
-use std::time::Instant;
 
 /// A set of interactive graphical elements with a specific [`Layout`].
 ///
@@ -191,7 +190,7 @@ where
         use std::mem::ManuallyDrop;
 
         let mut outdated = false;
-        let mut redraw_requested_at = None;
+        let mut redraw_request = None;
 
         let mut manual_overlay =
             ManuallyDrop::new(self.root.as_widget_mut().overlay(
@@ -221,12 +220,12 @@ where
 
                 event_statuses.push(event_status);
 
-                match (redraw_requested_at, shell.redraw_requested_at()) {
+                match (redraw_request, shell.redraw_request()) {
                     (None, Some(at)) => {
-                        redraw_requested_at = Some(at);
+                        redraw_request = Some(at);
                     }
                     (Some(current), Some(new)) if new < current => {
-                        redraw_requested_at = Some(new);
+                        redraw_request = Some(new);
                     }
                     _ => {}
                 }
@@ -303,12 +302,12 @@ where
                     self.overlay = None;
                 }
 
-                match (redraw_requested_at, shell.redraw_requested_at()) {
+                match (redraw_request, shell.redraw_request()) {
                     (None, Some(at)) => {
-                        redraw_requested_at = Some(at);
+                        redraw_request = Some(at);
                     }
                     (Some(current), Some(new)) if new < current => {
-                        redraw_requested_at = Some(new);
+                        redraw_request = Some(new);
                     }
                     _ => {}
                 }
@@ -334,9 +333,7 @@ where
             if outdated {
                 State::Outdated
             } else {
-                State::Updated {
-                    redraw_requested_at,
-                }
+                State::Updated { redraw_request }
             },
             event_statuses,
         )
@@ -594,6 +591,6 @@ pub enum State {
     /// rebuilding.
     Updated {
         /// The [`Instant`] when a redraw should be performed.
-        redraw_requested_at: Option<Instant>,
+        redraw_request: Option<window::RedrawRequest>,
     },
 }

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -18,6 +18,7 @@ use crate::layout;
 use crate::mouse::{self, click};
 use crate::renderer;
 use crate::text::{self, Text};
+use crate::time::{Duration, Instant};
 use crate::touch;
 use crate::widget;
 use crate::widget::operation::{self, Operation};
@@ -27,8 +28,6 @@ use crate::{
     Clipboard, Color, Command, Element, Layout, Length, Padding, Point,
     Rectangle, Shell, Size, Vector, Widget,
 };
-
-use instant::{Duration, Instant};
 
 pub use iced_style::text_input::{Appearance, StyleSheet};
 

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -28,7 +28,7 @@ use crate::{
     Rectangle, Shell, Size, Vector, Widget,
 };
 
-use std::time::{Duration, Instant};
+use instant::{Duration, Instant};
 
 pub use iced_style::text_input::{Appearance, StyleSheet};
 

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -432,7 +432,10 @@ where
                 state.is_focused.or_else(|| {
                     let now = Instant::now();
 
-                    Some(Focus { at: now, now })
+                    Some(Focus {
+                        updated_at: now,
+                        now,
+                    })
                 })
             } else {
                 None
@@ -564,7 +567,7 @@ where
                     let message = (on_change)(editor.contents());
                     shell.publish(message);
 
-                    focus.at = Instant::now();
+                    focus.updated_at = Instant::now();
 
                     return event::Status::Captured;
                 }
@@ -575,7 +578,7 @@ where
 
             if let Some(focus) = &mut state.is_focused {
                 let modifiers = state.keyboard_modifiers;
-                focus.at = Instant::now();
+                focus.updated_at = Instant::now();
 
                 match key_code {
                     keyboard::KeyCode::Enter
@@ -787,7 +790,7 @@ where
                 focus.now = now;
 
                 let millis_until_redraw = CURSOR_BLINK_INTERVAL_MILLIS
-                    - (now - focus.at).as_millis()
+                    - (now - focus.updated_at).as_millis()
                         % CURSOR_BLINK_INTERVAL_MILLIS;
 
                 shell.request_redraw(
@@ -863,7 +866,8 @@ pub fn draw<Renderer>(
                         font.clone(),
                     );
 
-                let is_cursor_visible = ((focus.now - focus.at).as_millis()
+                let is_cursor_visible = ((focus.now - focus.updated_at)
+                    .as_millis()
                     / CURSOR_BLINK_INTERVAL_MILLIS)
                     % 2
                     == 0;
@@ -1007,7 +1011,7 @@ pub struct State {
 
 #[derive(Debug, Clone, Copy)]
 struct Focus {
-    at: Instant,
+    updated_at: Instant,
     now: Instant,
 }
 
@@ -1043,7 +1047,10 @@ impl State {
     pub fn focus(&mut self) {
         let now = Instant::now();
 
-        self.is_focused = Some(Focus { at: now, now });
+        self.is_focused = Some(Focus {
+            updated_at: now,
+            now,
+        });
 
         self.move_cursor_to_end();
     }

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -1043,7 +1043,7 @@ impl State {
     pub fn focus(&mut self) {
         let now = Instant::now();
 
-        self.is_focused = Some(Focus { at: now, now: now });
+        self.is_focused = Some(Focus { at: now, now });
 
         self.move_cursor_to_end();
     }

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -793,9 +793,9 @@ where
                     - (now - focus.updated_at).as_millis()
                         % CURSOR_BLINK_INTERVAL_MILLIS;
 
-                shell.request_redraw(
+                shell.request_redraw(window::RedrawRequest::At(
                     now + Duration::from_millis(millis_until_redraw as u64),
-                );
+                ));
             }
         }
         _ => {}

--- a/native/src/window.rs
+++ b/native/src/window.rs
@@ -17,7 +17,11 @@ use crate::time::Instant;
 /// Subscribes to the frames of the window of the running application.
 ///
 /// The resulting [`Subscription`] will produce items at a rate equal to the
-/// framerate of the monitor of said window.
+/// refresh rate of the window. Note that this rate may be variable, as it is
+/// normally managed by the graphics driver and/or the OS.
+///
+/// In any case, this [`Subscription`] is useful to smoothly draw application-driven
+/// animations without missing any frames.
 pub fn frames() -> Subscription<Instant> {
     subscription::raw_events(|event, _status| match event {
         crate::Event::Window(Event::RedrawRequested(at)) => Some(at),

--- a/native/src/window.rs
+++ b/native/src/window.rs
@@ -2,11 +2,13 @@
 mod action;
 mod event;
 mod mode;
+mod redraw_request;
 mod user_attention;
 
 pub use action::Action;
 pub use event::Event;
 pub use mode::Mode;
+pub use redraw_request::RedrawRequest;
 pub use user_attention::UserAttention;
 
 use crate::subscription::{self, Subscription};

--- a/native/src/window.rs
+++ b/native/src/window.rs
@@ -8,3 +8,18 @@ pub use action::Action;
 pub use event::Event;
 pub use mode::Mode;
 pub use user_attention::UserAttention;
+
+use crate::subscription::{self, Subscription};
+
+use std::time::Instant;
+
+/// Subscribes to the frames of the window of the running application.
+///
+/// The resulting [`Subscription`] will produce items at a rate equal to the
+/// framerate of the monitor of said window.
+pub fn frames() -> Subscription<Instant> {
+    subscription::raw_events(|event, _status| match event {
+        crate::Event::Window(Event::RedrawRequested(at)) => Some(at),
+        _ => None,
+    })
+}

--- a/native/src/window.rs
+++ b/native/src/window.rs
@@ -13,7 +13,7 @@ pub use user_attention::UserAttention;
 
 use crate::subscription::{self, Subscription};
 
-use std::time::Instant;
+use instant::Instant;
 
 /// Subscribes to the frames of the window of the running application.
 ///

--- a/native/src/window.rs
+++ b/native/src/window.rs
@@ -12,8 +12,7 @@ pub use redraw_request::RedrawRequest;
 pub use user_attention::UserAttention;
 
 use crate::subscription::{self, Subscription};
-
-use instant::Instant;
+use crate::time::Instant;
 
 /// Subscribes to the frames of the window of the running application.
 ///

--- a/native/src/window/event.rs
+++ b/native/src/window/event.rs
@@ -1,4 +1,5 @@
-use instant::Instant;
+use crate::time::Instant;
+
 use std::path::PathBuf;
 
 /// A window-related event.

--- a/native/src/window/event.rs
+++ b/native/src/window/event.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::time::Instant;
 
 /// A window-related event.
 #[derive(PartialEq, Eq, Clone, Debug)]
@@ -18,6 +19,11 @@ pub enum Event {
         /// The new logical height of the window
         height: u32,
     },
+
+    /// A window redraw was requested.
+    ///
+    /// The [`Instant`] contains the current time.
+    RedrawRequested(Instant),
 
     /// The user has requested for the window to close.
     ///

--- a/native/src/window/event.rs
+++ b/native/src/window/event.rs
@@ -1,5 +1,5 @@
+use instant::Instant;
 use std::path::PathBuf;
-use std::time::Instant;
 
 /// A window-related event.
 #[derive(PartialEq, Eq, Clone, Debug)]

--- a/native/src/window/redraw_request.rs
+++ b/native/src/window/redraw_request.rs
@@ -1,0 +1,38 @@
+use std::time::Instant;
+
+/// A request to redraw a window.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum RedrawRequest {
+    /// Redraw the next frame.
+    NextFrame,
+
+    /// Redraw at the given time.
+    At(Instant),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn ordering() {
+        let now = Instant::now();
+        let later = now + Duration::from_millis(10);
+
+        assert_eq!(RedrawRequest::NextFrame, RedrawRequest::NextFrame);
+        assert_eq!(RedrawRequest::At(now), RedrawRequest::At(now));
+
+        assert!(RedrawRequest::NextFrame < RedrawRequest::At(now));
+        assert!(RedrawRequest::At(now) > RedrawRequest::NextFrame);
+        assert!(RedrawRequest::At(now) < RedrawRequest::At(later));
+        assert!(RedrawRequest::At(later) > RedrawRequest::At(now));
+
+        assert!(RedrawRequest::NextFrame <= RedrawRequest::NextFrame);
+        assert!(RedrawRequest::NextFrame <= RedrawRequest::At(now));
+        assert!(RedrawRequest::At(now) >= RedrawRequest::NextFrame);
+        assert!(RedrawRequest::At(now) <= RedrawRequest::At(now));
+        assert!(RedrawRequest::At(now) <= RedrawRequest::At(later));
+        assert!(RedrawRequest::At(later) >= RedrawRequest::At(now));
+    }
+}

--- a/native/src/window/redraw_request.rs
+++ b/native/src/window/redraw_request.rs
@@ -1,4 +1,4 @@
-use instant::Instant;
+use crate::time::Instant;
 
 /// A request to redraw a window.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]

--- a/native/src/window/redraw_request.rs
+++ b/native/src/window/redraw_request.rs
@@ -1,4 +1,4 @@
-use std::time::Instant;
+use instant::Instant;
 
 /// A request to redraw a window.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]

--- a/src/application.rs
+++ b/src/application.rs
@@ -180,13 +180,6 @@ pub trait Application: Sized {
         1.0
     }
 
-    /// Returns whether the [`Application`] should be terminated.
-    ///
-    /// By default, it returns `false`.
-    fn should_exit(&self) -> bool {
-        false
-    }
-
     /// Runs the [`Application`].
     ///
     /// On native platforms, this method will take control of the current thread

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -140,13 +140,6 @@ pub trait Sandbox {
         1.0
     }
 
-    /// Returns whether the [`Sandbox`] should be terminated.
-    ///
-    /// By default, it returns `false`.
-    fn should_exit(&self) -> bool {
-        false
-    }
-
     /// Runs the [`Sandbox`].
     ///
     /// On native platforms, this method will take control of the current thread
@@ -202,9 +195,5 @@ where
 
     fn scale_factor(&self) -> f64 {
         T::scale_factor(self)
-    }
-
-    fn should_exit(&self) -> bool {
-        T::should_exit(self)
     }
 }

--- a/winit/Cargo.toml
+++ b/winit/Cargo.toml
@@ -21,7 +21,6 @@ application = []
 window_clipboard = "0.2"
 log = "0.4"
 thiserror = "1.0"
-instant = "0.1"
 
 [dependencies.winit]
 version = "0.27"

--- a/winit/Cargo.toml
+++ b/winit/Cargo.toml
@@ -21,6 +21,7 @@ application = []
 window_clipboard = "0.2"
 log = "0.4"
 thiserror = "1.0"
+instant = "0.1"
 
 [dependencies.winit]
 version = "0.27"

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -24,8 +24,8 @@ use iced_native::user_interface::{self, UserInterface};
 
 pub use iced_native::application::{Appearance, StyleSheet};
 
+use instant::Instant;
 use std::mem::ManuallyDrop;
-use std::time::Instant;
 
 #[cfg(feature = "trace")]
 pub use profiler::Profiler;

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -20,11 +20,11 @@ use iced_futures::futures::channel::mpsc;
 use iced_graphics::compositor;
 use iced_graphics::window;
 use iced_native::program::Program;
+use iced_native::time::Instant;
 use iced_native::user_interface::{self, UserInterface};
 
 pub use iced_native::application::{Appearance, StyleSheet};
 
-use instant::Instant;
 use std::mem::ManuallyDrop;
 
 #[cfg(feature = "trace")]

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -401,9 +401,8 @@ async fn run_instance<A, E, C>(
                 // TODO: Avoid redrawing all the time by forcing widgets to
                 // request redraws on state changes
                 //
-                // Then, we can use the `interface_state` here to decide whether
-                // if a redraw is needed right away, or simply wait until a
-                // specific time.
+                // Then, we can use the `interface_state` here to decide if a redraw
+                // is needed right away, or simply wait until a specific time.
                 let redraw_event = Event::Window(
                     crate::window::Event::RedrawRequested(Instant::now()),
                 );

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -11,7 +11,7 @@ use crate::mouse;
 use crate::renderer;
 use crate::widget::operation;
 use crate::{
-    Command, Debug, Error, Executor, Proxy, Runtime, Settings, Size,
+    Command, Debug, Error, Event, Executor, Proxy, Runtime, Settings, Size,
     Subscription,
 };
 
@@ -25,6 +25,7 @@ use iced_native::user_interface::{self, UserInterface};
 pub use iced_native::application::{Appearance, StyleSheet};
 
 use std::mem::ManuallyDrop;
+use std::time::Instant;
 
 #[cfg(feature = "trace")]
 pub use profiler::Profiler;
@@ -186,7 +187,8 @@ where
 
     let (compositor, renderer) = C::new(compositor_settings, Some(&window))?;
 
-    let (mut sender, receiver) = mpsc::unbounded();
+    let (mut event_sender, event_receiver) = mpsc::unbounded();
+    let (control_sender, mut control_receiver) = mpsc::unbounded();
 
     let mut instance = Box::pin({
         let run_instance = run_instance::<A, E, C>(
@@ -196,7 +198,8 @@ where
             runtime,
             proxy,
             debug,
-            receiver,
+            event_receiver,
+            control_sender,
             init_command,
             window,
             settings.exit_on_close_request,
@@ -234,13 +237,19 @@ where
         };
 
         if let Some(event) = event {
-            sender.start_send(event).expect("Send event");
+            event_sender.start_send(event).expect("Send event");
 
             let poll = instance.as_mut().poll(&mut context);
 
-            *control_flow = match poll {
-                task::Poll::Pending => ControlFlow::Wait,
-                task::Poll::Ready(_) => ControlFlow::Exit,
+            match poll {
+                task::Poll::Pending => {
+                    if let Ok(Some(flow)) = control_receiver.try_next() {
+                        *control_flow = flow;
+                    }
+                }
+                task::Poll::Ready(_) => {
+                    *control_flow = ControlFlow::Exit;
+                }
             };
         }
     })
@@ -253,7 +262,10 @@ async fn run_instance<A, E, C>(
     mut runtime: Runtime<E, Proxy<A::Message>, A::Message>,
     mut proxy: winit::event_loop::EventLoopProxy<A::Message>,
     mut debug: Debug,
-    mut receiver: mpsc::UnboundedReceiver<winit::event::Event<'_, A::Message>>,
+    mut event_receiver: mpsc::UnboundedReceiver<
+        winit::event::Event<'_, A::Message>,
+    >,
+    mut control_sender: mpsc::UnboundedSender<winit::event_loop::ControlFlow>,
     init_command: Command<A::Message>,
     window: winit::window::Window,
     exit_on_close_request: bool,
@@ -265,6 +277,7 @@ async fn run_instance<A, E, C>(
 {
     use iced_futures::futures::stream::StreamExt;
     use winit::event;
+    use winit::event_loop::ControlFlow;
 
     let mut clipboard = Clipboard::connect(&window);
     let mut cache = user_interface::Cache::default();
@@ -309,13 +322,21 @@ async fn run_instance<A, E, C>(
     let mut mouse_interaction = mouse::Interaction::default();
     let mut events = Vec::new();
     let mut messages = Vec::new();
+    let mut redraw_pending = false;
 
     debug.startup_finished();
 
-    while let Some(event) = receiver.next().await {
+    while let Some(event) = event_receiver.next().await {
         match event {
+            event::Event::NewEvents(start_cause) => {
+                redraw_pending = matches!(
+                    start_cause,
+                    event::StartCause::Init
+                        | event::StartCause::ResumeTimeReached { .. }
+                );
+            }
             event::Event::MainEventsCleared => {
-                if events.is_empty() && messages.is_empty() {
+                if !redraw_pending && events.is_empty() && messages.is_empty() {
                     continue;
                 }
 
@@ -338,7 +359,7 @@ async fn run_instance<A, E, C>(
                 if !messages.is_empty()
                     || matches!(
                         interface_state,
-                        user_interface::State::Outdated,
+                        user_interface::State::Outdated
                     )
                 {
                     let mut cache =
@@ -376,6 +397,24 @@ async fn run_instance<A, E, C>(
                     }
                 }
 
+                // TODO: Avoid redrawing all the time by forcing widgets to
+                // request redraws on state changes
+                //
+                // Then, we can use the `interface_state` here to decide whether
+                // if a redraw is needed right away, or simply wait until a
+                // specific time.
+                let redraw_event = Event::Window(
+                    crate::window::Event::RedrawRequested(Instant::now()),
+                );
+
+                let (interface_state, _) = user_interface.update(
+                    &[redraw_event.clone()],
+                    state.cursor_position(),
+                    &mut renderer,
+                    &mut clipboard,
+                    &mut messages,
+                );
+
                 debug.draw_started();
                 let new_mouse_interaction = user_interface.draw(
                     &mut renderer,
@@ -396,6 +435,17 @@ async fn run_instance<A, E, C>(
                 }
 
                 window.request_redraw();
+                runtime
+                    .broadcast((redraw_event, crate::event::Status::Ignored));
+
+                let _ = control_sender.start_send(match interface_state {
+                    user_interface::State::Updated {
+                        redraw_requested_at: Some(at),
+                    } => ControlFlow::WaitUntil(at),
+                    _ => ControlFlow::Wait,
+                });
+
+                redraw_pending = false;
             }
             event::Event::PlatformSpecific(event::PlatformSpecific::MacOS(
                 event::MacOS::ReceivedUrl(url),

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -332,6 +332,7 @@ async fn run_instance<A, E, C>(
                 redraw_pending = matches!(
                     start_cause,
                     event::StartCause::Init
+                        | event::StartCause::Poll
                         | event::StartCause::ResumeTimeReached { .. }
                 );
             }
@@ -440,8 +441,15 @@ async fn run_instance<A, E, C>(
 
                 let _ = control_sender.start_send(match interface_state {
                     user_interface::State::Updated {
-                        redraw_requested_at: Some(at),
-                    } => ControlFlow::WaitUntil(at),
+                        redraw_request: Some(redraw_request),
+                    } => match redraw_request {
+                        crate::window::RedrawRequest::NextFrame => {
+                            ControlFlow::Poll
+                        }
+                        crate::window::RedrawRequest::At(at) => {
+                            ControlFlow::WaitUntil(at)
+                        }
+                    },
                     _ => ControlFlow::Wait,
                 });
 

--- a/winit/src/window.rs
+++ b/winit/src/window.rs
@@ -2,7 +2,7 @@
 use crate::command::{self, Command};
 use iced_native::window;
 
-pub use window::{Event, Mode, UserAttention};
+pub use window::{frames, Event, Mode, UserAttention};
 
 /// Closes the current window and exits the application.
 pub fn close<Message>() -> Command<Message> {

--- a/winit/src/window.rs
+++ b/winit/src/window.rs
@@ -2,7 +2,7 @@
 use crate::command::{self, Command};
 use iced_native::window;
 
-pub use window::{frames, Event, Mode, UserAttention};
+pub use window::{frames, Event, Mode, RedrawRequest, UserAttention};
 
 /// Closes the current window and exits the application.
 pub fn close<Message>() -> Command<Message> {


### PR DESCRIPTION
Fixes #31 and closes #560.

This PR introduces a new method `request_redraw` to the `Shell` type which enables a `Widget` to request a redraw during `on_event`.

`Shell::request_redraw` takes a `window::RedrawRequest`, which is defined as follows:

```rust
/// A request to redraw a window.
#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
pub enum RedrawRequest {
    /// Redraw the next frame.
    NextFrame,

    /// Redraw at the given time.
    At(Instant),
}
```

Additionally, a new variant `RedrawRequested(Instant)` has been added to `window::Event`. This event is triggered before the user interface is redrawn.

As a result, widgets can now choose to draw whenever necessary; making animations possible! For instance, the `TextInput` widget has now a blinking cursor:

https://user-images.githubusercontent.com/518289/211976226-47b10743-0648-498b-98d3-8167191f41d3.mp4

Furthermore, these changes allow us to finally implement a subscription to subscribe to the frame rate of a window. The brand new `window::frames` subscription produces an `Instant` at the same frequency as the frame rate of the screen of the user. This can be very useful to smoothly animate layout or different parts of an application (as opposed to using `time::every` with a fixed frame rate). The `solar_system` example now uses the `window::frames` subscription!