### PR TITLE
Fix comment description on crate example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,7 @@
 //!             text(self.value).size(50),
 //!
 //!             // The decrement button. We tell it to produce a
+//!             // `DecrementPressed` message when pressed
 //!             button("-").on_press(Message::DecrementPressed),
 //!         ]
 //!     }


### PR DESCRIPTION
This tiny PR aligns the comment on the crate example to align to the comment that is in README.md.