### PR TITLE
Introduce `custom` method to `widget::Operation` trait

### DIFF
--- a/native/src/element.rs
+++ b/native/src/element.rs
@@ -9,6 +9,7 @@ use crate::{
     Clipboard, Color, Layout, Length, Point, Rectangle, Shell, Widget,
 };
 
+use std::any::Any;
 use std::borrow::Borrow;
 
 /// A generic [`Widget`].
@@ -332,6 +333,10 @@ where
                 id: Option<&widget::Id>,
             ) {
                 self.operation.text_input(state, id);
+            }
+
+            fn custom(&mut self, state: &mut dyn Any, id: Option<&widget::Id>) {
+                self.operation.custom(state, id);
             }
         }
 

--- a/native/src/overlay/element.rs
+++ b/native/src/overlay/element.rs
@@ -7,6 +7,8 @@ use crate::renderer;
 use crate::widget;
 use crate::{Clipboard, Layout, Point, Rectangle, Shell, Size, Vector};
 
+use std::any::Any;
+
 /// A generic [`Overlay`].
 #[allow(missing_debug_implementations)]
 pub struct Element<'a, Message, Renderer> {
@@ -187,6 +189,10 @@ where
                 id: Option<&widget::Id>,
             ) {
                 self.operation.text_input(state, id)
+            }
+
+            fn custom(&mut self, state: &mut dyn Any, id: Option<&widget::Id>) {
+                self.operation.custom(state, id);
             }
         }
 

--- a/native/src/widget/action.rs
+++ b/native/src/widget/action.rs
@@ -3,6 +3,7 @@ use crate::widget::Id;
 
 use iced_futures::MaybeSend;
 
+use std::any::Any;
 use std::rc::Rc;
 
 /// An operation to be performed on the widget tree.
@@ -84,6 +85,10 @@ where
             ) {
                 self.operation.focusable(state, id);
             }
+
+            fn custom(&mut self, state: &mut dyn Any, id: Option<&Id>) {
+                self.operation.custom(state, id);
+            }
         }
 
         let Self { operation, .. } = self;
@@ -116,6 +121,10 @@ where
         id: Option<&Id>,
     ) {
         self.operation.text_input(state, id);
+    }
+
+    fn custom(&mut self, state: &mut dyn Any, id: Option<&Id>) {
+        self.operation.custom(state, id);
     }
 
     fn finish(&self) -> operation::Outcome<B> {

--- a/native/src/widget/operation.rs
+++ b/native/src/widget/operation.rs
@@ -9,6 +9,7 @@ pub use text_input::TextInput;
 
 use crate::widget::Id;
 
+use std::any::Any;
 use std::fmt;
 
 /// A piece of logic that can traverse the widget tree of an application in
@@ -32,6 +33,9 @@ pub trait Operation<T> {
 
     /// Operates on a widget that has text input.
     fn text_input(&mut self, _state: &mut dyn TextInput, _id: Option<&Id>) {}
+
+    /// Operates on a custom widget with some state.
+    fn custom(&mut self, _state: &mut dyn Any, _id: Option<&Id>) {}
 
     /// Finishes the [`Operation`] and returns its [`Outcome`].
     fn finish(&self) -> Outcome<T> {


### PR DESCRIPTION
This allows users to write operations for their custom widgets.