### PR TITLE
Resize images on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,12 @@
 A cross-platform GUI library for Rust focused on simplicity and type-safety.
 Inspired by [Elm].
 
-<div align="center">
-  <a href="https://gfycat.com/littlesanehalicore">
-    <img src="https://thumbs.gfycat.com/LittleSaneHalicore-small.gif" width="33%">
-  </a>
-  <a href="https://gfycat.com/politeadorableiberianmole">
-    <img src="https://thumbs.gfycat.com/PoliteAdorableIberianmole-small.gif" width="33%">
-  </a>
-</div>
+<a href="https://gfycat.com/littlesanehalicore">
+  <img src="https://thumbs.gfycat.com/LittleSaneHalicore-small.gif" width="334px">
+</a>
+<a href="https://gfycat.com/politeadorableiberianmole">
+  <img src="https://thumbs.gfycat.com/PoliteAdorableIberianmole-small.gif" width="334px">
+</a>
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ A cross-platform GUI library for Rust focused on simplicity and type-safety.
 Inspired by [Elm].
 
 <a href="https://gfycat.com/littlesanehalicore">
-  <img src="https://thumbs.gfycat.com/LittleSaneHalicore-small.gif" width="334px">
+  <img src="https://thumbs.gfycat.com/LittleSaneHalicore-small.gif" width="275px">
 </a>
 <a href="https://gfycat.com/politeadorableiberianmole">
-  <img src="https://thumbs.gfycat.com/PoliteAdorableIberianmole-small.gif" width="334px">
+  <img src="https://thumbs.gfycat.com/PoliteAdorableIberianmole-small.gif" width="273px">
 </a>
 
 </div>

--- a/README.md
+++ b/README.md
@@ -14,12 +14,14 @@
 A cross-platform GUI library for Rust focused on simplicity and type-safety.
 Inspired by [Elm].
 
-<a href="https://gfycat.com/littlesanehalicore">
-  <img src="https://thumbs.gfycat.com/LittleSaneHalicore-small.gif" height="350px">
-</a>
-<a href="https://gfycat.com/politeadorableiberianmole">
-  <img src="https://thumbs.gfycat.com/PoliteAdorableIberianmole-small.gif" height="350px">
-</a>
+<div align="center">
+  <a href="https://gfycat.com/littlesanehalicore">
+    <img src="https://thumbs.gfycat.com/LittleSaneHalicore-small.gif" width="33%">
+  </a>
+  <a href="https://gfycat.com/politeadorableiberianmole">
+    <img src="https://thumbs.gfycat.com/PoliteAdorableIberianmole-small.gif" width="33%">
+  </a>
+</div>
 
 </div>
 


### PR DESCRIPTION
## Overview

I resized image on `README.md` to match the proportion.

## Changes

### PC Layouts

Before --> After

<img src="https://user-images.githubusercontent.com/26380261/213342697-b74427cb-0b44-47b8-b649-f4d3de6f7fa7.png" alt="image" width="50%"><img src="https://user-images.githubusercontent.com/26380261/213341921-83af53e7-a610-4b5a-8437-fd4efebf27fb.png" alt="image" width="50%">

### Mobile Layouts

<img width="494" alt="image" src="https://user-images.githubusercontent.com/26380261/213342390-15468d58-02e6-44ba-b647-5fd1c915ae11.png">

It shows well on mobile too! 😎