### PR TITLE
Minor update: `example/qr_code`

### DIFF
--- a/examples/qr_code/src/main.rs
+++ b/examples/qr_code/src/main.rs
@@ -38,7 +38,7 @@ impl Sandbox for QRGenerator {
                 } else {
                     qr_code::State::new(&data).ok()
                 };
-                
+
                 self.data = data;
             }
         }

--- a/examples/qr_code/src/main.rs
+++ b/examples/qr_code/src/main.rs
@@ -37,7 +37,7 @@ impl Sandbox for QRGenerator {
                     None
                 } else {
                     qr_code::State::new(&data).ok()
-                }
+                };
                 
                 self.data = data;
             }

--- a/examples/qr_code/src/main.rs
+++ b/examples/qr_code/src/main.rs
@@ -21,10 +21,7 @@ impl Sandbox for QRGenerator {
     type Message = Message;
 
     fn new() -> Self {
-        QRGenerator {
-            qr_code: qr_code::State::new("").ok(),
-            ..Self::default()
-        }
+        QRGenerator::default()
     }
 
     fn title(&self) -> String {
@@ -36,7 +33,12 @@ impl Sandbox for QRGenerator {
             Message::DataChanged(mut data) => {
                 data.truncate(100);
 
-                self.qr_code = qr_code::State::new(&data).ok();
+                self.qr_code = if data.is_empty() {
+                    None
+                } else {
+                    qr_code::State::new(&data).ok()
+                }
+                
                 self.data = data;
             }
         }


### PR DESCRIPTION
The app should not render qr_code when data is empty at the beginning