### PR TITLE
Extended `pick_list::Handle` to be more flexible

### DIFF
--- a/native/src/widget/pick_list.rs
+++ b/native/src/widget/pick_list.rs
@@ -224,7 +224,7 @@ where
             self.selected.as_ref(),
             &self.handle,
             &self.style,
-            || tree.state.downcast_ref::<State<T>>(),
+            tree.state.downcast_ref::<State<T>>(),
         )
     }
 
@@ -593,13 +593,12 @@ pub fn draw<'a, T, Renderer>(
     selected: Option<&T>,
     handle: &Handle<Renderer::Font>,
     style: &<Renderer::Theme as StyleSheet>::Style,
-    state: impl FnOnce() -> &'a State<T>,
+    state: &State<T>,
 ) where
     Renderer: text::Renderer,
     Renderer::Theme: StyleSheet,
     T: ToString + 'a,
 {
-    let state = state();
     let bounds = layout.bounds();
     let is_mouse_over = bounds.contains(cursor_position);
     let is_selected = selected.is_some();

--- a/native/src/widget/pick_list.rs
+++ b/native/src/widget/pick_list.rs
@@ -20,76 +20,6 @@ use std::borrow::Cow;
 
 pub use iced_style::pick_list::{Appearance, StyleSheet};
 
-/// The icon of a [`Handle`].
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Icon<Font> {
-    /// Font that will be used to display the `text`,
-    pub font: Font,
-    /// Text that will be shown.
-    pub text: String,
-    /// Font size of the content.
-    pub size: Option<u16>,
-}
-
-/// The handle to the right side of the [`PickList`].
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Handle<Font> {
-    /// Displays an arrow icon (▼).
-    ///
-    /// This is the default.
-    Arrow {
-        /// Font size of the content.
-        size: Option<u16>,
-    },
-    /// A custom static handle.
-    Static(Icon<Font>),
-    /// A custom dynamic handle.
-    Dynamic {
-        /// The [`Icon`] used when [`PickList`] is closed.
-        closed: Icon<Font>,
-        /// The [`Icon`] used when [`PickList`] is open.
-        open: Icon<Font>,
-    },
-    /// No handle will be shown.
-    None,
-}
-
-impl<Font> Default for Handle<Font> {
-    fn default() -> Self {
-        Self::Arrow { size: None }
-    }
-}
-
-impl<Font: Clone> Handle<Font> {
-    fn content<Renderer: text::Renderer<Font = Font>>(
-        &self,
-        is_open: bool,
-    ) -> Option<(Font, String, Option<u16>)> {
-        match self {
-            Self::Arrow { size } => Some((
-                Renderer::ICON_FONT,
-                Renderer::ARROW_DOWN_ICON.to_string(),
-                *size,
-            )),
-            Self::Static(Icon { font, text, size }) => {
-                Some((font.clone(), text.clone(), *size))
-            }
-            Self::Dynamic { open, closed } => {
-                if is_open {
-                    Some((open.font.clone(), open.text.clone(), open.size))
-                } else {
-                    Some((
-                        closed.font.clone(),
-                        closed.text.clone(),
-                        closed.size,
-                    ))
-                }
-            }
-            Self::None => None,
-        }
-    }
-}
-
 /// A widget for selecting a single value from a list of options.
 #[allow(missing_debug_implementations)]
 pub struct PickList<'a, T, Message, Renderer>
@@ -364,6 +294,76 @@ impl<T> Default for State<T> {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// The handle to the right side of the [`PickList`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Handle<Font> {
+    /// Displays an arrow icon (▼).
+    ///
+    /// This is the default.
+    Arrow {
+        /// Font size of the content.
+        size: Option<u16>,
+    },
+    /// A custom static handle.
+    Static(Icon<Font>),
+    /// A custom dynamic handle.
+    Dynamic {
+        /// The [`Icon`] used when [`PickList`] is closed.
+        closed: Icon<Font>,
+        /// The [`Icon`] used when [`PickList`] is open.
+        open: Icon<Font>,
+    },
+    /// No handle will be shown.
+    None,
+}
+
+impl<Font> Default for Handle<Font> {
+    fn default() -> Self {
+        Self::Arrow { size: None }
+    }
+}
+
+impl<Font: Clone> Handle<Font> {
+    fn content<Renderer: text::Renderer<Font = Font>>(
+        &self,
+        is_open: bool,
+    ) -> Option<(Font, String, Option<u16>)> {
+        match self {
+            Self::Arrow { size } => Some((
+                Renderer::ICON_FONT,
+                Renderer::ARROW_DOWN_ICON.to_string(),
+                *size,
+            )),
+            Self::Static(Icon { font, text, size }) => {
+                Some((font.clone(), text.clone(), *size))
+            }
+            Self::Dynamic { open, closed } => {
+                if is_open {
+                    Some((open.font.clone(), open.text.clone(), open.size))
+                } else {
+                    Some((
+                        closed.font.clone(),
+                        closed.text.clone(),
+                        closed.size,
+                    ))
+                }
+            }
+            Self::None => None,
+        }
+    }
+}
+
+/// The icon of a [`Handle`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Icon<Font> {
+    /// Font that will be used to display the `text`,
+    pub font: Font,
+    /// Text that will be shown.
+    pub text: String,
+    /// Font size of the content.
+    pub size: Option<u16>,
 }
 
 /// Computes the layout of a [`PickList`].

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -81,7 +81,7 @@ pub mod pane_grid {
 pub mod pick_list {
     //! Display a dropdown list of selectable values.
     pub use iced_native::widget::pick_list::{
-        Appearance, Handle, HandleContent, StyleSheet,
+        Appearance, Handle, Icon, StyleSheet,
     };
 
     /// A widget allowing the selection of a single value from a list of options.

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -80,7 +80,9 @@ pub mod pane_grid {
 
 pub mod pick_list {
     //! Display a dropdown list of selectable values.
-    pub use iced_native::widget::pick_list::{Appearance, Handle, StyleSheet};
+    pub use iced_native::widget::pick_list::{
+        Appearance, Handle, HandleContent, StyleSheet,
+    };
 
     /// A widget allowing the selection of a single value from a list of options.
     pub type PickList<'a, T, Message, Renderer = crate::Renderer> =


### PR DESCRIPTION
I have extended the  `pick_list::Handle` slightly:

```
{
    Arrow,
    Static({ .. }),
    Dynamic {
        closed: { .. },
        open: { .. },
    },
    None,
}
``` 

This was done because I felt the previous solution was too limited by not allowing the user to choose different content depending on the state of the `pick_list`. The main use case is to display a different icon, like ▲ and ▼, depending on the open/close state.

Below is a small gif show casing the different states.

![pick_list_handle](https://user-images.githubusercontent.com/2248455/214824570-12b04c24-890b-4c88-82d9-4962d7d0e76b.gif)