### PR TITLE
Annotate `Command` and `Subscription` with `#[must_use]`

### DIFF
--- a/futures/src/command.rs
+++ b/futures/src/command.rs
@@ -1,4 +1,5 @@
 /// A set of asynchronous actions to be performed by some runtime.
+#[must_use = "`Command` must be returned to runtime to take effect"]
 #[derive(Debug)]
 pub struct Command<T>(Internal<T>);
 

--- a/futures/src/subscription.rs
+++ b/futures/src/subscription.rs
@@ -20,6 +20,7 @@ use crate::BoxStream;
 /// `Hasher`.
 ///
 /// [`Command`]: crate::Command
+#[must_use = "`Subscription` must be returned to runtime to take effect"]
 pub struct Subscription<Hasher, Event, Output> {
     recipes: Vec<Box<dyn Recipe<Hasher, Event, Output = Output>>>,
 }

--- a/native/src/command.rs
+++ b/native/src/command.rs
@@ -11,6 +11,7 @@ use std::fmt;
 use std::future::Future;
 
 /// A set of asynchronous actions to be performed by some runtime.
+#[must_use = "`Command` must be returned to runtime to take effect"]
 pub struct Command<T>(iced_futures::Command<Action<T>>);
 
 impl<T> Command<T> {


### PR DESCRIPTION
Calling a function returning one of these types without using it is almost certainly a mistake. Luckily Rust's `#[must_use]` can help warn about this.