### PR TITLE
Fixed a 1-pixel width issue on `pick_list`

### DIFF
--- a/native/src/overlay/menu.rs
+++ b/native/src/overlay/menu.rs
@@ -281,10 +281,7 @@ where
 
         renderer.fill_quad(
             renderer::Quad {
-                bounds: Rectangle {
-                    width: bounds.width - 1.0,
-                    ..bounds
-                },
+                bounds,
                 border_color: appearance.border_color,
                 border_width: appearance.border_width,
                 border_radius: appearance.border_radius.into(),


### PR DESCRIPTION
I noticed the width of `menu` was 1-pixel too short. This is particularly noticeable in a `pick_list` if you pay a close attention when hovering on an item. See below and notice the container of the `menu` is shorter than the selection.

<img width="230" alt="Screenshot 2023-01-26 at 9 36 11 AM" src="https://user-images.githubusercontent.com/2248455/215052239-9bb283a9-afb0-44fd-94c3-0116669c8f6d.png">

The `width: bounds.width - 1.0` in the code looked intentional but I don't think it was, so I removed it.

<img width="204" alt="Screenshot 2023-01-27 at 10 20 18 AM" src="https://user-images.githubusercontent.com/2248455/215059746-b04f02f6-662d-405f-9295-96fb72da3c60.png">
