### PR TITLE
Fix layout translation in `overlay::Group`

### DIFF
--- a/core/src/vector.rs
+++ b/core/src/vector.rs
@@ -15,6 +15,11 @@ impl<T> Vector<T> {
     }
 }
 
+impl Vector {
+    /// The zero [`Vector`].
+    pub const ZERO: Self = Self::new(0.0, 0.0);
+}
+
 impl<T> std::ops::Add for Vector<T>
 where
     T: std::ops::Add<Output = T>,

--- a/lazy/src/component.rs
+++ b/lazy/src/component.rs
@@ -455,9 +455,9 @@ where
         position: Point,
     ) -> layout::Node {
         self.with_overlay_maybe(|overlay| {
-            let vector = position - overlay.position();
+            let translation = position - overlay.position();
 
-            overlay.layout(renderer, bounds).translate(vector)
+            overlay.layout(renderer, bounds, translation)
         })
         .unwrap_or_default()
     }

--- a/lazy/src/lazy.rs
+++ b/lazy/src/lazy.rs
@@ -313,9 +313,9 @@ where
         position: Point,
     ) -> layout::Node {
         self.with_overlay_maybe(|overlay| {
-            let vector = position - overlay.position();
+            let translation = position - overlay.position();
 
-            overlay.layout(renderer, bounds).translate(vector)
+            overlay.layout(renderer, bounds, translation)
         })
         .unwrap_or_default()
     }

--- a/lazy/src/responsive.rs
+++ b/lazy/src/responsive.rs
@@ -356,9 +356,9 @@ where
         position: Point,
     ) -> layout::Node {
         self.with_overlay_maybe(|overlay| {
-            let vector = position - overlay.position();
+            let translation = position - overlay.position();
 
-            overlay.layout(renderer, bounds).translate(vector)
+            overlay.layout(renderer, bounds, translation)
         })
         .unwrap_or_default()
     }

--- a/native/src/overlay/element.rs
+++ b/native/src/overlay/element.rs
@@ -53,8 +53,14 @@ where
     }
 
     /// Computes the layout of the [`Element`] in the given bounds.
-    pub fn layout(&self, renderer: &Renderer, bounds: Size) -> layout::Node {
-        self.overlay.layout(renderer, bounds, self.position)
+    pub fn layout(
+        &self,
+        renderer: &Renderer,
+        bounds: Size,
+        translation: Vector,
+    ) -> layout::Node {
+        self.overlay
+            .layout(renderer, bounds, self.position + translation)
     }
 
     /// Processes a runtime [`Event`].

--- a/native/src/overlay/group.rs
+++ b/native/src/overlay/group.rs
@@ -66,13 +66,15 @@ where
         &self,
         renderer: &Renderer,
         bounds: Size,
-        _position: Point,
+        position: Point,
     ) -> layout::Node {
+        let translation = position - Point::ORIGIN;
+
         layout::Node::with_children(
             bounds,
             self.children
                 .iter()
-                .map(|child| child.layout(renderer, bounds))
+                .map(|child| child.layout(renderer, bounds, translation))
                 .collect(),
         )
     }

--- a/native/src/user_interface.rs
+++ b/native/src/user_interface.rs
@@ -6,7 +6,9 @@ use crate::mouse;
 use crate::renderer;
 use crate::widget;
 use crate::window;
-use crate::{Clipboard, Element, Layout, Point, Rectangle, Shell, Size};
+use crate::{
+    Clipboard, Element, Layout, Point, Rectangle, Shell, Size, Vector,
+};
 
 /// A set of interactive graphical elements with a specific [`Layout`].
 ///
@@ -203,7 +205,7 @@ where
             let bounds = self.bounds;
 
             let mut overlay = manual_overlay.as_mut().unwrap();
-            let mut layout = overlay.layout(renderer, bounds);
+            let mut layout = overlay.layout(renderer, bounds, Vector::ZERO);
             let mut event_statuses = Vec::new();
 
             for event in events.iter().cloned() {
@@ -252,7 +254,7 @@ where
                     overlay = manual_overlay.as_mut().unwrap();
 
                     shell.revalidate_layout(|| {
-                        layout = overlay.layout(renderer, bounds);
+                        layout = overlay.layout(renderer, bounds, Vector::ZERO);
                     });
                 }
 
@@ -434,10 +436,9 @@ where
             .as_widget_mut()
             .overlay(&mut self.state, Layout::new(&self.base), renderer)
         {
-            let overlay_layout = self
-                .overlay
-                .take()
-                .unwrap_or_else(|| overlay.layout(renderer, self.bounds));
+            let overlay_layout = self.overlay.take().unwrap_or_else(|| {
+                overlay.layout(renderer, self.bounds, Vector::ZERO)
+            });
 
             let new_cursor_position =
                 if overlay_layout.bounds().contains(cursor_position) {
@@ -538,7 +539,8 @@ where
             renderer,
         ) {
             if self.overlay.is_none() {
-                self.overlay = Some(overlay.layout(renderer, self.bounds));
+                self.overlay =
+                    Some(overlay.layout(renderer, self.bounds, Vector::ZERO));
             }
 
             overlay.operate(


### PR DESCRIPTION
This bug produced improper positioning of overlays of elements inside a `Scrollable`.