### PR TITLE
Use `glutin-winit` in `integration_opengl` example

### DIFF
--- a/examples/integration_opengl/Cargo.toml
+++ b/examples/integration_opengl/Cargo.toml
@@ -6,7 +6,10 @@ edition = "2021"
 publish = false
 
 [dependencies]
-iced_glutin = { path = "../../glutin" }
 iced_glow = { path = "../../glow" }
-iced_winit = { path = "../../winit" }
+iced_native = { path = "../../native" }
 env_logger = "0.8"
+glutin = "0.30.3"
+glutin-winit = "0.2.2"
+raw-window-handle = "0.5.0"
+winit = "0.27.5"

--- a/examples/integration_opengl/src/controls.rs
+++ b/examples/integration_opengl/src/controls.rs
@@ -1,7 +1,7 @@
 use iced_glow::Renderer;
-use iced_glutin::widget::Slider;
-use iced_glutin::widget::{Column, Row, Text};
-use iced_glutin::{Alignment, Color, Command, Element, Length, Program};
+use iced_native::widget::Slider;
+use iced_native::widget::{Column, Row, Text};
+use iced_native::{Alignment, Color, Command, Element, Length, Program};
 
 pub struct Controls {
     background_color: Color,

--- a/examples/integration_opengl/src/main.rs
+++ b/examples/integration_opengl/src/main.rs
@@ -1,39 +1,82 @@
 mod controls;
 mod scene;
 
+use std::{ffi::CString, num::NonZeroU32};
+
 use controls::Controls;
 use scene::Scene;
 
 use glow::*;
-use glutin::dpi::PhysicalPosition;
-use glutin::event::{Event, ModifiersState, WindowEvent};
-use glutin::event_loop::ControlFlow;
+use glutin::{
+    context::NotCurrentGlContextSurfaceAccessor,
+    display::{GetGlDisplay, GlDisplay},
+    surface::GlSurface,
+};
 use iced_glow::glow;
 use iced_glow::{Backend, Renderer, Settings, Viewport};
-use iced_glutin::conversion;
-use iced_glutin::glutin;
-use iced_glutin::renderer;
-use iced_glutin::{program, Clipboard, Color, Debug, Size};
+use iced_native::renderer;
+use iced_native::{program, Color, Debug, Point, Size};
+use raw_window_handle::HasRawWindowHandle;
+use winit::dpi::PhysicalPosition;
+use winit::event::{Event, ModifiersState, WindowEvent};
+use winit::event_loop::ControlFlow;
 
 pub fn main() {
     env_logger::init();
-    let (gl, event_loop, windowed_context, shader_version) = {
-        let el = glutin::event_loop::EventLoop::new();
+    let (gl, event_loop, window, context, surface, shader_version) = {
+        let el = winit::event_loop::EventLoop::new();
 
-        let wb = glutin::window::WindowBuilder::new()
+        let wb = winit::window::WindowBuilder::new()
             .with_title("OpenGL integration example")
-            .with_inner_size(glutin::dpi::LogicalSize::new(1024.0, 768.0));
+            .with_inner_size(winit::dpi::LogicalSize::new(1024.0, 768.0));
 
-        let windowed_context = glutin::ContextBuilder::new()
-            .with_vsync(true)
-            .build_windowed(wb, &el)
+        // Just using first config
+        let tb = glutin::config::ConfigTemplateBuilder::new()
+            .with_transparency(true);
+        let (window, config) = glutin_winit::DisplayBuilder::new()
+            .with_window_builder(Some(wb))
+            .build(&el, tb, |mut iter| iter.next().unwrap())
             .unwrap();
+        let window = window.unwrap();
+
+        let attributes = glutin::context::ContextAttributesBuilder::new()
+            .build(Some(window.raw_window_handle()));
+        let context =
+            unsafe { config.display().create_context(&config, &attributes) }
+                .unwrap();
+
+        let physical_size = window.inner_size();
+
+        let surface_attributes = glutin::surface::SurfaceAttributesBuilder::<
+            glutin::surface::WindowSurface,
+        >::new()
+        .build(
+            window.raw_window_handle(),
+            NonZeroU32::new(physical_size.width).unwrap(),
+            NonZeroU32::new(physical_size.height).unwrap(),
+        );
+        let surface = unsafe {
+            config
+                .display()
+                .create_window_surface(&config, &surface_attributes)
+                .unwrap()
+        };
 
         unsafe {
-            let windowed_context = windowed_context.make_current().unwrap();
+            let context = context.make_current(&surface).unwrap();
+
+            // Enable vsync
+            surface
+                .set_swap_interval(
+                    &context,
+                    glutin::surface::SwapInterval::Wait(
+                        NonZeroU32::new(1).unwrap(),
+                    ),
+                )
+                .unwrap();
 
             let gl = glow::Context::from_loader_function(|s| {
-                windowed_context.get_proc_address(s) as *const _
+                config.display().get_proc_address(&CString::new(s).unwrap())
             });
 
             // Enable auto-conversion from/to sRGB
@@ -46,19 +89,19 @@ pub fn main() {
             // Disable multisampling by default
             gl.disable(glow::MULTISAMPLE);
 
-            (gl, el, windowed_context, "#version 410")
+            (gl, el, window, context, surface, "#version 410")
         }
     };
 
-    let physical_size = windowed_context.window().inner_size();
+    let physical_size = window.inner_size();
     let mut viewport = Viewport::with_physical_size(
         Size::new(physical_size.width, physical_size.height),
-        windowed_context.window().scale_factor(),
+        window.scale_factor(),
     );
 
     let mut cursor_position = PhysicalPosition::new(-1.0, -1.0);
     let mut modifiers = ModifiersState::default();
-    let mut clipboard = Clipboard::connect(windowed_context.window());
+    let mut clipboard = iced_native::clipboard::Null;
 
     let mut renderer = Renderer::new(Backend::new(&gl, Settings::default()));
 
@@ -93,7 +136,7 @@ pub fn main() {
                                 physical_size.width,
                                 physical_size.height,
                             ),
-                            windowed_context.window().scale_factor(),
+                            window.scale_factor(),
                         );
 
                         resized = true;
@@ -105,25 +148,21 @@ pub fn main() {
                     _ => (),
                 }
 
-                // Map window event to iced event
-                if let Some(event) = iced_winit::conversion::window_event(
-                    &event,
-                    windowed_context.window().scale_factor(),
-                    modifiers,
-                ) {
+                if let Some(event) =
+                    window_event(&event, window.scale_factor(), modifiers)
+                {
                     state.queue_event(event);
                 }
             }
             Event::MainEventsCleared => {
                 // If there are events pending
+                let logical_position =
+                    cursor_position.to_logical(viewport.scale_factor());
                 if !state.is_queue_empty() {
                     // We update iced
                     let _ = state.update(
                         viewport.logical_size(),
-                        conversion::cursor_position(
-                            cursor_position,
-                            viewport.scale_factor(),
-                        ),
+                        Point::new(logical_position.x, logical_position.y),
                         &mut renderer,
                         &iced_glow::Theme::Dark,
                         &renderer::Style {
@@ -134,12 +173,12 @@ pub fn main() {
                     );
 
                     // and request a redraw
-                    windowed_context.window().request_redraw();
+                    window.request_redraw();
                 }
             }
             Event::RedrawRequested(_) => {
                 if resized {
-                    let size = windowed_context.window().inner_size();
+                    let size = window.inner_size();
 
                     unsafe {
                         gl.viewport(
@@ -173,15 +212,120 @@ pub fn main() {
                 });
 
                 // Update the mouse cursor
-                windowed_context.window().set_cursor_icon(
-                    iced_winit::conversion::mouse_interaction(
-                        state.mouse_interaction(),
-                    ),
-                );
+                window.set_cursor_icon(mouse_interaction(
+                    state.mouse_interaction(),
+                ));
 
-                windowed_context.swap_buffers().unwrap();
+                surface.swap_buffers(&context).unwrap();
             }
             _ => (),
         }
     });
+}
+
+// Duplicates logic from `iced_winit`, but only relevant events
+fn window_event(
+    event: &winit::event::WindowEvent<'_>,
+    scale_factor: f64,
+    _modifiers: winit::event::ModifiersState,
+) -> Option<iced_native::Event> {
+    use iced_native::{mouse, window};
+
+    match event {
+        WindowEvent::Resized(new_size) => {
+            let logical_size = new_size.to_logical(scale_factor);
+
+            Some(iced_native::Event::Window(window::Event::Resized {
+                width: logical_size.width,
+                height: logical_size.height,
+            }))
+        }
+        WindowEvent::ScaleFactorChanged { new_inner_size, .. } => {
+            let logical_size = new_inner_size.to_logical(scale_factor);
+
+            Some(iced_native::Event::Window(window::Event::Resized {
+                width: logical_size.width,
+                height: logical_size.height,
+            }))
+        }
+        WindowEvent::CloseRequested => {
+            Some(iced_native::Event::Window(window::Event::CloseRequested))
+        }
+        WindowEvent::CursorMoved { position, .. } => {
+            let position = position.to_logical::<f64>(scale_factor);
+
+            Some(iced_native::Event::Mouse(mouse::Event::CursorMoved {
+                position: Point::new(position.x as f32, position.y as f32),
+            }))
+        }
+        WindowEvent::CursorEntered { .. } => {
+            Some(iced_native::Event::Mouse(mouse::Event::CursorEntered))
+        }
+        WindowEvent::CursorLeft { .. } => {
+            Some(iced_native::Event::Mouse(mouse::Event::CursorLeft))
+        }
+        WindowEvent::MouseInput { button, state, .. } => {
+            let button = mouse_button(*button);
+
+            Some(iced_native::Event::Mouse(match state {
+                winit::event::ElementState::Pressed => {
+                    mouse::Event::ButtonPressed(button)
+                }
+                winit::event::ElementState::Released => {
+                    mouse::Event::ButtonReleased(button)
+                }
+            }))
+        }
+        WindowEvent::Focused(focused) => {
+            Some(iced_native::Event::Window(if *focused {
+                window::Event::Focused
+            } else {
+                window::Event::Unfocused
+            }))
+        }
+        WindowEvent::Moved(position) => {
+            let winit::dpi::LogicalPosition { x, y } =
+                position.to_logical(scale_factor);
+
+            Some(iced_native::Event::Window(window::Event::Moved { x, y }))
+        }
+        _ => None,
+    }
+}
+
+// Duplicates logic from `iced_winit`
+fn mouse_button(
+    mouse_button: winit::event::MouseButton,
+) -> iced_native::mouse::Button {
+    use iced_native::mouse;
+
+    match mouse_button {
+        winit::event::MouseButton::Left => mouse::Button::Left,
+        winit::event::MouseButton::Right => mouse::Button::Right,
+        winit::event::MouseButton::Middle => mouse::Button::Middle,
+        winit::event::MouseButton::Other(other) => {
+            mouse::Button::Other(other as u8)
+        }
+    }
+}
+
+// Duplicates logic from `iced_winit`
+fn mouse_interaction(
+    interaction: iced_native::mouse::Interaction,
+) -> winit::window::CursorIcon {
+    use iced_native::mouse::Interaction;
+
+    match interaction {
+        Interaction::Idle => winit::window::CursorIcon::Default,
+        Interaction::Pointer => winit::window::CursorIcon::Hand,
+        Interaction::Working => winit::window::CursorIcon::Progress,
+        Interaction::Grab => winit::window::CursorIcon::Grab,
+        Interaction::Grabbing => winit::window::CursorIcon::Grabbing,
+        Interaction::Crosshair => winit::window::CursorIcon::Crosshair,
+        Interaction::Text => winit::window::CursorIcon::Text,
+        Interaction::ResizingHorizontally => {
+            winit::window::CursorIcon::EwResize
+        }
+        Interaction::ResizingVertically => winit::window::CursorIcon::NsResize,
+    }
 }


### PR DESCRIPTION
Glutin 0.30 changes the API to not depend on winit, and instead take a raw window handle. `glutin-winit` is a helper to make it a bit easier to create a GL context on top of winit.

Things like `iced_winit::conversion::window_event` are problematic here since we end up using a different winit version from `iced_winit`, and that function is quite complicated to duplicate...