### PR TITLE
Accept FnOnce instead of Fn in canvas cache draw

### DIFF
--- a/graphics/src/widget/canvas/cache.rs
+++ b/graphics/src/widget/canvas/cache.rs
@@ -49,7 +49,11 @@ impl Cache {
     /// Otherwise, the previously stored [`Geometry`] will be returned. The
     /// [`Cache`] is not cleared in this case. In other words, it will keep
     /// returning the stored [`Geometry`] if needed.
-    pub fn draw(&self, bounds: Size, draw_fn: impl Fn(&mut Frame)) -> Geometry {
+    pub fn draw(
+        &self,
+        bounds: Size,
+        draw_fn: impl FnOnce(&mut Frame),
+    ) -> Geometry {
         use std::ops::Deref;
 
         if let State::Filled {


### PR DESCRIPTION
Use FnOnce in `draw` function signature instead of `Fn`, permitting the use of iterators and other one-time functions. Resolves #1119 