### PR TITLE
Hide window until `Renderer` has been initialized

### DIFF
--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -147,11 +147,15 @@ where
     #[cfg(target_arch = "wasm32")]
     let target = settings.window.platform_specific.target.clone();
 
-    let builder = settings.window.into_builder(
-        &application.title(),
-        event_loop.primary_monitor(),
-        settings.id,
-    );
+    let should_be_visible = settings.window.visible;
+    let builder = settings
+        .window
+        .into_builder(
+            &application.title(),
+            event_loop.primary_monitor(),
+            settings.id,
+        )
+        .with_visible(false);
 
     log::info!("Window builder: {:#?}", builder);
 
@@ -202,6 +206,7 @@ where
             control_sender,
             init_command,
             window,
+            should_be_visible,
             settings.exit_on_close_request,
         );
 
@@ -268,6 +273,7 @@ async fn run_instance<A, E, C>(
     mut control_sender: mpsc::UnboundedSender<winit::event_loop::ControlFlow>,
     init_command: Command<A::Message>,
     window: winit::window::Window,
+    should_be_visible: bool,
     exit_on_close_request: bool,
 ) where
     A: Application + 'static,
@@ -294,6 +300,10 @@ async fn run_instance<A, E, C>(
         physical_size.width,
         physical_size.height,
     );
+
+    if should_be_visible {
+        window.set_visible(true);
+    }
 
     run_command(
         &application,

--- a/winit/src/settings.rs
+++ b/winit/src/settings.rs
@@ -114,8 +114,7 @@ impl Window {
             .with_decorations(self.decorations)
             .with_transparent(self.transparent)
             .with_window_icon(self.icon)
-            .with_always_on_top(self.always_on_top)
-            .with_visible(self.visible);
+            .with_always_on_top(self.always_on_top);
 
         if let Some(position) = conversion::position(
             primary_monitor.as_ref(),


### PR DESCRIPTION
I gave this a shot in #1389 but, apparently, we cannot draw in an invisible window. The changes here make the window visible right before starting the event loop.