### PR TITLE
Implement `is_over` for iced_lazy widget `Overlay`s 

### DIFF
--- a/lazy/src/component.rs
+++ b/lazy/src/component.rs
@@ -563,4 +563,11 @@ where
 
         event_status
     }
+
+    fn is_over(&self, layout: Layout<'_>, cursor_position: Point) -> bool {
+        self.with_overlay_maybe(|overlay| {
+            overlay.is_over(layout, cursor_position)
+        })
+        .unwrap_or_default()
+    }
 }

--- a/lazy/src/lazy.rs
+++ b/lazy/src/lazy.rs
@@ -372,6 +372,13 @@ where
         })
         .unwrap_or(iced_native::event::Status::Ignored)
     }
+
+    fn is_over(&self, layout: Layout<'_>, cursor_position: Point) -> bool {
+        self.with_overlay_maybe(|overlay| {
+            overlay.is_over(layout, cursor_position)
+        })
+        .unwrap_or_default()
+    }
 }
 
 impl<'a, Message, Renderer, Dependency, View>

--- a/lazy/src/responsive.rs
+++ b/lazy/src/responsive.rs
@@ -415,4 +415,11 @@ where
         })
         .unwrap_or(iced_native::event::Status::Ignored)
     }
+
+    fn is_over(&self, layout: Layout<'_>, cursor_position: Point) -> bool {
+        self.with_overlay_maybe(|overlay| {
+            overlay.is_over(layout, cursor_position)
+        })
+        .unwrap_or_default()
+    }
 }


### PR DESCRIPTION
The lazy widgets all share this pattern of storing some element which may or may not produce an overlay, but they are not delegating `is_over` to the stored element's overlay. This PR adds the `is_over` method to each of the lazy widgets' overlay implementations, forwarding the call to the contained overlay.