### PR TITLE
Fix panic when overlay event processing removes overlay

### DIFF
--- a/native/src/user_interface.rs
+++ b/native/src/user_interface.rs
@@ -263,16 +263,16 @@ where
                 }
             }
 
-            let base_cursor = if manual_overlay
+            let base_cursor = manual_overlay
                 .as_ref()
-                .unwrap()
-                .is_over(Layout::new(&layout), cursor_position)
-            {
-                // TODO: Type-safe cursor availability
-                Point::new(-1.0, -1.0)
-            } else {
-                cursor_position
-            };
+                .filter(|overlay| {
+                    overlay.is_over(Layout::new(&layout), cursor_position)
+                })
+                .map(|_| {
+                    // TODO: Type-safe cursor availability
+                    Point::new(-1.0, -1.0)
+                })
+                .unwrap_or(cursor_position);
 
             self.overlay = Some(layout);
 


### PR DESCRIPTION
Currently if processing an event in the overlay both invalidates the layout and results in the overlay no longer being present (we hit line 251), the application will panic. This PR fixes the issue by using `cursor_position` for the base cursor position if the overlay no longer exists.

Example application that panics: https://gist.github.com/nicksenger/13f051ebdf34fbede31abe91981d70a6
