### PR TITLE
Fix panic when using operations with components in certain cases

### DIFF
--- a/lazy/src/component.rs
+++ b/lazy/src/component.rs
@@ -311,6 +311,8 @@ where
         }
 
         self.with_element(|element| {
+            tree.diff_children(std::slice::from_ref(&element));
+
             element.as_widget().operate(
                 &mut tree.children[0],
                 layout,


### PR DESCRIPTION
Using operations with components nested inside widgets which don't implement operate can cause the application to panic currently. The reason for this is that `Component`'s `overlay` assumes the element will exist, but we do not perform a diff after processing an operation for a component and rebuilding its element. As a result, components lower in the tree contained within widgets which don't forward `operate` to their contents will have their element left as `None`, and thus panic when determining their overlay.

This PR resolves the issue by diffing a component's widget sub-tree after processing an operation and rebuilding its element.