### PR TITLE
Pad after setting width in text input

### DIFF
--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -389,8 +389,8 @@ where
     let padding = padding.fit(Size::ZERO, limits.max());
 
     let limits = limits
-        .pad(padding)
         .width(width)
+        .pad(padding)
         .height(Length::Units(text_size));
 
     let mut text = layout::Node::new(limits.resolve(Size::ZERO));


### PR DESCRIPTION
This fixes an issue where using `Length::Units` and `Padding` with a text input causes it to be bigger than `Length::Units` by `Padding`.

We need to apply `pad` to `Limits` AFTER `width`, otherwise `width` will set `Limits` back to a fixed width if `Length::Units` is used, overwriting padding.