### PR TITLE
Fix height of `overlay::Menu`

### DIFF
--- a/native/src/overlay/menu.rs
+++ b/native/src/overlay/menu.rs
@@ -344,7 +344,8 @@ where
         let size = {
             let intrinsic = Size::new(
                 0.0,
-                text_size + self.padding.vertical() * self.options.len() as f32,
+                (text_size + self.padding.vertical())
+                    * self.options.len() as f32,
             );
 
             limits.resolve(intrinsic)


### PR DESCRIPTION
Fixes #1712 and closes #1713.