### PR TITLE
Nested overlays

### DIFF
--- a/core/src/overlay.rs
+++ b/core/src/overlay.rs
@@ -91,8 +91,22 @@ where
     ///
     /// By default, it returns true if the bounds of the `layout` contain
     /// the `cursor_position`.
-    fn is_over(&self, layout: Layout<'_>, cursor_position: Point) -> bool {
+    fn is_over(
+        &self,
+        layout: Layout<'_>,
+        _renderer: &Renderer,
+        cursor_position: Point,
+    ) -> bool {
         layout.bounds().contains(cursor_position)
+    }
+
+    /// Returns the nested overlay of the [`Overlay`], if there is any.
+    fn overlay<'a>(
+        &'a mut self,
+        _layout: Layout<'_>,
+        _renderer: &Renderer,
+    ) -> Option<Element<'a, Message, Renderer>> {
+        None
     }
 }
 

--- a/core/src/overlay/element.rs
+++ b/core/src/overlay/element.rs
@@ -112,8 +112,22 @@ where
     }
 
     /// Returns true if the cursor is over the [`Element`].
-    pub fn is_over(&self, layout: Layout<'_>, cursor_position: Point) -> bool {
-        self.overlay.is_over(layout, cursor_position)
+    pub fn is_over(
+        &self,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+        cursor_position: Point,
+    ) -> bool {
+        self.overlay.is_over(layout, renderer, cursor_position)
+    }
+
+    /// Returns the nested overlay of the [`Element`], if there is any.
+    pub fn overlay<'b>(
+        &'b mut self,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+    ) -> Option<Element<'b, Message, Renderer>> {
+        self.overlay.overlay(layout, renderer)
     }
 }
 
@@ -248,7 +262,12 @@ where
         self.content.draw(renderer, theme, style, layout, cursor)
     }
 
-    fn is_over(&self, layout: Layout<'_>, cursor_position: Point) -> bool {
-        self.content.is_over(layout, cursor_position)
+    fn is_over(
+        &self,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+        cursor_position: Point,
+    ) -> bool {
+        self.content.is_over(layout, renderer, cursor_position)
     }
 }

--- a/core/src/overlay/element.rs
+++ b/core/src/overlay/element.rs
@@ -270,4 +270,14 @@ where
     ) -> bool {
         self.content.is_over(layout, renderer, cursor_position)
     }
+
+    fn overlay<'b>(
+        &'b mut self,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+    ) -> Option<Element<'b, B, Renderer>> {
+        self.content
+            .overlay(layout, renderer)
+            .map(|overlay| overlay.map(self.mapper))
+    }
 }

--- a/core/src/overlay/group.rs
+++ b/core/src/overlay/group.rs
@@ -160,6 +160,21 @@ where
                 child.is_over(layout, renderer, cursor_position)
             })
     }
+
+    fn overlay<'b>(
+        &'b mut self,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+    ) -> Option<overlay::Element<'b, Message, Renderer>> {
+        let children = self
+            .children
+            .iter_mut()
+            .zip(layout.children())
+            .filter_map(|(child, layout)| child.overlay(layout, renderer))
+            .collect::<Vec<_>>();
+
+        (!children.is_empty()).then(|| Group::with_children(children).overlay())
+    }
 }
 
 impl<'a, Message, Renderer> From<Group<'a, Message, Renderer>>

--- a/core/src/overlay/group.rs
+++ b/core/src/overlay/group.rs
@@ -147,11 +147,18 @@ where
         });
     }
 
-    fn is_over(&self, layout: Layout<'_>, cursor_position: Point) -> bool {
+    fn is_over(
+        &self,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+        cursor_position: Point,
+    ) -> bool {
         self.children
             .iter()
             .zip(layout.children())
-            .any(|(child, layout)| child.is_over(layout, cursor_position))
+            .any(|(child, layout)| {
+                child.is_over(layout, renderer, cursor_position)
+            })
     }
 }
 

--- a/examples/modal/src/main.rs
+++ b/examples/modal/src/main.rs
@@ -3,11 +3,13 @@ use iced::keyboard;
 use iced::subscription::{self, Subscription};
 use iced::theme;
 use iced::widget::{
-    self, button, column, container, horizontal_space, row, text, text_input,
+    self, button, column, container, horizontal_space, pick_list, row, text,
+    text_input,
 };
 use iced::{Alignment, Application, Command, Element, Event, Length, Settings};
 
-use self::modal::Modal;
+use modal::Modal;
+use std::fmt;
 
 pub fn main() -> iced::Result {
     App::run(Settings::default())
@@ -18,6 +20,7 @@ struct App {
     show_modal: bool,
     email: String,
     password: String,
+    plan: Plan,
 }
 
 #[derive(Debug, Clone)]
@@ -26,6 +29,7 @@ enum Message {
     HideModal,
     Email(String),
     Password(String),
+    Plan(Plan),
     Submit,
     Event(Event),
 }
@@ -64,6 +68,10 @@ impl Application for App {
             }
             Message::Password(password) => {
                 self.password = password;
+                Command::none()
+            }
+            Message::Plan(plan) => {
+                self.plan = plan;
                 Command::none()
             }
             Message::Submit => {
@@ -149,6 +157,16 @@ impl Application for App {
                                 .padding(5),
                         ]
                         .spacing(5),
+                        column![
+                            text("Plan").size(12),
+                            pick_list(
+                                Plan::ALL,
+                                Some(self.plan),
+                                Message::Plan
+                            )
+                            .padding(5),
+                        ]
+                        .spacing(5),
                         button(text("Submit")).on_press(Message::HideModal),
                     ]
                     .spacing(10)
@@ -173,6 +191,29 @@ impl App {
         self.show_modal = false;
         self.email.clear();
         self.password.clear();
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+enum Plan {
+    #[default]
+    Basic,
+    Pro,
+    Enterprise,
+}
+
+impl Plan {
+    pub const ALL: &[Self] = &[Self::Basic, Self::Pro, Self::Enterprise];
+}
+
+impl fmt::Display for Plan {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Plan::Basic => "Basic",
+            Plan::Pro => "Pro",
+            Plan::Enterprise => "Enterprise",
+        }
+        .fmt(f)
     }
 }
 
@@ -466,6 +507,18 @@ mod modal {
                 layout.children().next().unwrap(),
                 cursor,
                 viewport,
+                renderer,
+            )
+        }
+
+        fn overlay<'c>(
+            &'c mut self,
+            layout: Layout<'_>,
+            renderer: &Renderer,
+        ) -> Option<overlay::Element<'c, Message, Renderer>> {
+            self.content.as_widget_mut().overlay(
+                self.tree,
+                layout.children().next().unwrap(),
                 renderer,
             )
         }

--- a/examples/toast/src/main.rs
+++ b/examples/toast/src/main.rs
@@ -650,7 +650,12 @@ mod toast {
                 .unwrap_or_default()
         }
 
-        fn is_over(&self, layout: Layout<'_>, cursor_position: Point) -> bool {
+        fn is_over(
+            &self,
+            layout: Layout<'_>,
+            _renderer: &Renderer,
+            cursor_position: Point,
+        ) -> bool {
             layout
                 .children()
                 .any(|layout| layout.bounds().contains(cursor_position))

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -47,6 +47,7 @@ pub mod clipboard;
 pub mod command;
 pub mod font;
 pub mod keyboard;
+pub mod overlay;
 pub mod program;
 pub mod system;
 pub mod user_interface;

--- a/runtime/src/overlay.rs
+++ b/runtime/src/overlay.rs
@@ -1,0 +1,4 @@
+//! Overlays for user interfaces.
+mod nested;
+
+pub use nested::Nested;

--- a/runtime/src/overlay/nested.rs
+++ b/runtime/src/overlay/nested.rs
@@ -94,7 +94,7 @@ where
                     .and_then(|(cursor_position, nested_layout)| {
                         element.overlay(layout, renderer).map(|nested| {
                             nested.is_over(
-                                nested_layout,
+                                nested_layout.children().next().unwrap(),
                                 renderer,
                                 cursor_position,
                             )

--- a/runtime/src/overlay/nested.rs
+++ b/runtime/src/overlay/nested.rs
@@ -21,6 +21,12 @@ where
         Self { overlay: element }
     }
 
+    /// Returns the position of the [`Nested`] overlay.
+    pub fn position(&self) -> Point {
+        self.overlay.position()
+    }
+
+    /// Returns the layout [`Node`] of the [`Nested`] overlay.
     pub fn layout(
         &mut self,
         renderer: &Renderer,
@@ -36,7 +42,7 @@ where
         where
             Renderer: renderer::Renderer,
         {
-            let translation = position - Point::ORIGIN;
+            let translation = position - element.position();
 
             let node = element.layout(renderer, bounds, translation);
 
@@ -58,6 +64,7 @@ where
         recurse(&mut self.overlay, renderer, bounds, position)
     }
 
+    /// Draws the [`Nested`] overlay using the associated `Renderer`.
     pub fn draw(
         &mut self,
         renderer: &mut Renderer,
@@ -127,6 +134,7 @@ where
         recurse(&mut self.overlay, layout, renderer, theme, style, cursor);
     }
 
+    /// Applies a [`widget::Operation`] to the [`Nested`] overlay.
     pub fn operate(
         &mut self,
         layout: Layout<'_>,
@@ -157,6 +165,7 @@ where
         recurse(&mut self.overlay, layout, renderer, operation)
     }
 
+    /// Processes a runtime [`Event`].
     pub fn on_event(
         &mut self,
         event: Event,
@@ -247,6 +256,7 @@ where
         status
     }
 
+    /// Returns the current [`mouse::Interaction`] of the [`Nested`] overlay.
     pub fn mouse_interaction(
         &mut self,
         layout: Layout<'_>,
@@ -298,6 +308,7 @@ where
             .unwrap_or_default()
     }
 
+    /// Returns true if the cursor is over the [`Nested`] overlay.
     pub fn is_over(
         &mut self,
         layout: Layout<'_>,

--- a/runtime/src/user_interface.rs
+++ b/runtime/src/user_interface.rs
@@ -1,14 +1,12 @@
 //! Implement your own event loop to drive a user interface.
-mod overlay;
-
 use crate::core::event::{self, Event};
 use crate::core::layout;
 use crate::core::mouse;
 use crate::core::renderer;
 use crate::core::widget;
 use crate::core::window;
-use crate::core::{Clipboard, Point, Rectangle, Size};
-use crate::core::{Element, Layout, Shell};
+use crate::core::{Clipboard, Element, Layout, Point, Rectangle, Shell, Size};
+use crate::overlay;
 
 /// A set of interactive graphical elements with a specific [`Layout`].
 ///

--- a/runtime/src/user_interface.rs
+++ b/runtime/src/user_interface.rs
@@ -1,12 +1,14 @@
 //! Implement your own event loop to drive a user interface.
+mod overlay;
+
 use crate::core::event::{self, Event};
 use crate::core::layout;
 use crate::core::mouse;
 use crate::core::renderer;
 use crate::core::widget;
 use crate::core::window;
-use crate::core::{Clipboard, Rectangle, Size, Vector};
-use crate::core::{Element, Layout, Shell};
+use crate::core::{Clipboard, Point, Rectangle, Size};
+use crate::core::{Element, Layout, Overlay, Shell};
 
 /// A set of interactive graphical elements with a specific [`Layout`].
 ///
@@ -185,18 +187,18 @@ where
         let mut outdated = false;
         let mut redraw_request = None;
 
-        let mut manual_overlay =
-            ManuallyDrop::new(self.root.as_widget_mut().overlay(
-                &mut self.state,
-                Layout::new(&self.base),
-                renderer,
-            ));
+        let mut manual_overlay = ManuallyDrop::new(
+            self.root
+                .as_widget_mut()
+                .overlay(&mut self.state, Layout::new(&self.base), renderer)
+                .map(overlay::Nested::new),
+        );
 
         let (base_cursor, overlay_statuses) = if manual_overlay.is_some() {
             let bounds = self.bounds;
 
             let mut overlay = manual_overlay.as_mut().unwrap();
-            let mut layout = overlay.layout(renderer, bounds, Vector::ZERO);
+            let mut layout = overlay.layout(renderer, bounds, Point::ORIGIN);
             let mut event_statuses = Vec::new();
 
             for event in events.iter().cloned() {
@@ -231,12 +233,16 @@ where
                         &layout::Limits::new(Size::ZERO, self.bounds),
                     );
 
-                    manual_overlay =
-                        ManuallyDrop::new(self.root.as_widget_mut().overlay(
-                            &mut self.state,
-                            Layout::new(&self.base),
-                            renderer,
-                        ));
+                    manual_overlay = ManuallyDrop::new(
+                        self.root
+                            .as_widget_mut()
+                            .overlay(
+                                &mut self.state,
+                                Layout::new(&self.base),
+                                renderer,
+                            )
+                            .map(overlay::Nested::new),
+                    );
 
                     if manual_overlay.is_none() {
                         break;
@@ -245,7 +251,8 @@ where
                     overlay = manual_overlay.as_mut().unwrap();
 
                     shell.revalidate_layout(|| {
-                        layout = overlay.layout(renderer, bounds, Vector::ZERO);
+                        layout =
+                            overlay.layout(renderer, bounds, Point::ORIGIN);
                     });
                 }
 
@@ -260,8 +267,11 @@ where
                     cursor
                         .position()
                         .map(|cursor_position| {
-                            overlay
-                                .is_over(Layout::new(&layout), cursor_position)
+                            overlay.is_over(
+                                Layout::new(&layout),
+                                renderer,
+                                cursor_position,
+                            )
                         })
                         .unwrap_or_default()
                 })
@@ -428,16 +438,20 @@ where
             .root
             .as_widget_mut()
             .overlay(&mut self.state, Layout::new(&self.base), renderer)
+            .map(overlay::Nested::new)
         {
             let overlay_layout = self.overlay.take().unwrap_or_else(|| {
-                overlay.layout(renderer, self.bounds, Vector::ZERO)
+                overlay.layout(renderer, self.bounds, Point::ORIGIN)
             });
 
             let cursor = if cursor
                 .position()
                 .map(|cursor_position| {
-                    overlay
-                        .is_over(Layout::new(&overlay_layout), cursor_position)
+                    overlay.is_over(
+                        Layout::new(&overlay_layout),
+                        renderer,
+                        cursor_position,
+                    )
                 })
                 .unwrap_or_default()
             {
@@ -488,6 +502,7 @@ where
             .and_then(|layout| {
                 root.as_widget_mut()
                     .overlay(&mut self.state, Layout::new(base), renderer)
+                    .map(overlay::Nested::new)
                     .map(|overlay| {
                         let overlay_interaction = overlay.mouse_interaction(
                             Layout::new(layout),
@@ -513,6 +528,7 @@ where
                             .map(|cursor_position| {
                                 overlay.is_over(
                                     Layout::new(layout),
+                                    renderer,
                                     cursor_position,
                                 )
                             })
@@ -540,14 +556,15 @@ where
             operation,
         );
 
-        if let Some(mut overlay) = self.root.as_widget_mut().overlay(
-            &mut self.state,
-            Layout::new(&self.base),
-            renderer,
-        ) {
+        if let Some(mut overlay) = self
+            .root
+            .as_widget_mut()
+            .overlay(&mut self.state, Layout::new(&self.base), renderer)
+            .map(overlay::Nested::new)
+        {
             if self.overlay.is_none() {
                 self.overlay =
-                    Some(overlay.layout(renderer, self.bounds, Vector::ZERO));
+                    Some(overlay.layout(renderer, self.bounds, Point::ORIGIN));
             }
 
             overlay.operate(

--- a/runtime/src/user_interface/overlay.rs
+++ b/runtime/src/user_interface/overlay.rs
@@ -102,7 +102,9 @@ where
         {
             let layout = layouts.next().unwrap();
 
-            element.draw(renderer, theme, style, layout, cursor);
+            renderer.with_layer(layout.bounds(), |renderer| {
+                element.draw(renderer, theme, style, layout, cursor);
+            });
 
             if let Some(mut overlay) = element.overlay(layout, renderer) {
                 recurse(&mut overlay, layouts, renderer, theme, style, cursor);

--- a/runtime/src/user_interface/overlay.rs
+++ b/runtime/src/user_interface/overlay.rs
@@ -4,47 +4,25 @@ use crate::core::mouse;
 use crate::core::overlay;
 use crate::core::renderer;
 use crate::core::widget;
-use crate::core::{
-    Clipboard, Event, Layout, Overlay, Point, Rectangle, Shell, Size,
-};
-
-use std::cell::RefCell;
+use crate::core::{Clipboard, Event, Layout, Point, Rectangle, Shell, Size};
 
 /// An [`Overlay`] container that displays nested overlays
 #[allow(missing_debug_implementations)]
 pub struct Nested<'a, Message, Renderer> {
-    overlay: Inner<'a, Message, Renderer>,
+    overlay: overlay::Element<'a, Message, Renderer>,
 }
 
-impl<'a, Message, Renderer> Nested<'a, Message, Renderer> {
-    /// Creates a nested overlay from the provided [`overlay::Element`]
-    pub fn new(element: overlay::Element<'a, Message, Renderer>) -> Self {
-        Self {
-            overlay: Inner(RefCell::new(element)),
-        }
-    }
-}
-
-struct Inner<'a, Message, Renderer>(
-    RefCell<overlay::Element<'a, Message, Renderer>>,
-);
-
-impl<'a, Message, Renderer> Inner<'a, Message, Renderer> {
-    fn with_element_mut<T>(
-        &self,
-        mut f: impl FnMut(&mut overlay::Element<'_, Message, Renderer>) -> T,
-    ) -> T {
-        (f)(&mut self.0.borrow_mut())
-    }
-}
-
-impl<'a, Message, Renderer> Overlay<Message, Renderer>
-    for Nested<'a, Message, Renderer>
+impl<'a, Message, Renderer> Nested<'a, Message, Renderer>
 where
     Renderer: renderer::Renderer,
 {
-    fn layout(
-        &self,
+    /// Creates a nested overlay from the provided [`overlay::Element`]
+    pub fn new(element: overlay::Element<'a, Message, Renderer>) -> Self {
+        Self { overlay: element }
+    }
+
+    pub fn layout(
+        &mut self,
         renderer: &Renderer,
         bounds: Size,
         position: Point,
@@ -77,13 +55,11 @@ where
             }
         }
 
-        self.overlay.with_element_mut(|element| {
-            recurse(element, renderer, bounds, position)
-        })
+        recurse(&mut self.overlay, renderer, bounds, position)
     }
 
-    fn draw(
-        &self,
+    pub fn draw(
+        &mut self,
         renderer: &mut Renderer,
         theme: &<Renderer as renderer::Renderer>::Theme,
         style: &renderer::Style,
@@ -148,12 +124,10 @@ where
             }
         }
 
-        self.overlay.with_element_mut(|element| {
-            recurse(element, layout, renderer, theme, style, cursor);
-        })
+        recurse(&mut self.overlay, layout, renderer, theme, style, cursor);
     }
 
-    fn operate(
+    pub fn operate(
         &mut self,
         layout: Layout<'_>,
         renderer: &Renderer,
@@ -180,10 +154,10 @@ where
             }
         }
 
-        recurse(self.overlay.0.get_mut(), layout, renderer, operation)
+        recurse(&mut self.overlay, layout, renderer, operation)
     }
 
-    fn on_event(
+    pub fn on_event(
         &mut self,
         event: Event,
         layout: Layout<'_>,
@@ -236,7 +210,7 @@ where
         }
 
         recurse(
-            self.overlay.0.get_mut(),
+            &mut self.overlay,
             layout,
             event,
             cursor,
@@ -246,8 +220,8 @@ where
         )
     }
 
-    fn mouse_interaction(
-        &self,
+    pub fn mouse_interaction(
+        &mut self,
         layout: Layout<'_>,
         cursor: mouse::Cursor,
         viewport: &Rectangle,
@@ -293,15 +267,12 @@ where
             )
         }
 
-        self.overlay
-            .with_element_mut(|element| {
-                recurse(element, layout, cursor, viewport, renderer)
-            })
+        recurse(&mut self.overlay, layout, cursor, viewport, renderer)
             .unwrap_or_default()
     }
 
-    fn is_over(
-        &self,
+    pub fn is_over(
+        &mut self,
         layout: Layout<'_>,
         renderer: &Renderer,
         cursor_position: Point,
@@ -339,16 +310,6 @@ where
             }
         }
 
-        self.overlay.with_element_mut(|element| {
-            recurse(element, layout, renderer, cursor_position)
-        })
-    }
-
-    fn overlay<'b>(
-        &'b mut self,
-        _layout: Layout<'_>,
-        _renderer: &Renderer,
-    ) -> Option<overlay::Element<'b, Message, Renderer>> {
-        None
+        recurse(&mut self.overlay, layout, renderer, cursor_position)
     }
 }

--- a/runtime/src/user_interface/overlay.rs
+++ b/runtime/src/user_interface/overlay.rs
@@ -174,42 +174,67 @@ where
             renderer: &Renderer,
             clipboard: &mut dyn Clipboard,
             shell: &mut Shell<'_, Message>,
-        ) -> event::Status
+        ) -> (event::Status, bool)
         where
             Renderer: renderer::Renderer,
         {
             let mut layouts = layout.children();
 
             if let Some(layout) = layouts.next() {
-                let status = if let Some((mut nested, nested_layout)) =
-                    element.overlay(layout, renderer).zip(layouts.next())
-                {
-                    recurse(
-                        &mut nested,
-                        nested_layout,
-                        event.clone(),
-                        cursor,
-                        renderer,
-                        clipboard,
-                        shell,
-                    )
-                } else {
-                    event::Status::Ignored
-                };
+                let (nested_status, nested_is_over) =
+                    if let Some((mut nested, nested_layout)) =
+                        element.overlay(layout, renderer).zip(layouts.next())
+                    {
+                        recurse(
+                            &mut nested,
+                            nested_layout,
+                            event.clone(),
+                            cursor,
+                            renderer,
+                            clipboard,
+                            shell,
+                        )
+                    } else {
+                        (event::Status::Ignored, false)
+                    };
 
-                if matches!(status, event::Status::Ignored) {
-                    element.on_event(
-                        event, layout, cursor, renderer, clipboard, shell,
+                if matches!(nested_status, event::Status::Ignored) {
+                    let is_over = nested_is_over
+                        || cursor
+                            .position()
+                            .map(|cursor_position| {
+                                element.is_over(
+                                    layout,
+                                    renderer,
+                                    cursor_position,
+                                )
+                            })
+                            .unwrap_or_default();
+
+                    (
+                        element.on_event(
+                            event,
+                            layout,
+                            if nested_is_over {
+                                mouse::Cursor::Unavailable
+                            } else {
+                                cursor
+                            },
+                            renderer,
+                            clipboard,
+                            shell,
+                        ),
+                        is_over,
                     )
                 } else {
-                    status
+                    (nested_status, nested_is_over)
                 }
             } else {
-                event::Status::Ignored
+                (event::Status::Ignored, false)
             }
         }
 
-        recurse(
+        let (status, _) = recurse(
             &mut self.overlay,
             layout,
             event,
@@ -217,7 +242,9 @@ where
             renderer,
             clipboard,
             shell,
-        )
+        );
+
+        status
     }
 
     pub fn mouse_interaction(

--- a/runtime/src/user_interface/overlay.rs
+++ b/runtime/src/user_interface/overlay.rs
@@ -1,0 +1,288 @@
+use crate::core::event;
+use crate::core::layout;
+use crate::core::mouse;
+use crate::core::overlay;
+use crate::core::renderer;
+use crate::core::widget;
+use crate::core::{
+    Clipboard, Event, Layout, Overlay, Point, Rectangle, Shell, Size,
+};
+
+use std::cell::RefCell;
+
+/// An [`Overlay`] container that displays nested overlays
+#[allow(missing_debug_implementations)]
+pub struct Nested<'a, Message, Renderer> {
+    overlay: Inner<'a, Message, Renderer>,
+}
+
+impl<'a, Message, Renderer> Nested<'a, Message, Renderer> {
+    /// Creates a nested overlay from the provided [`overlay::Element`]
+    pub fn new(element: overlay::Element<'a, Message, Renderer>) -> Self {
+        Self {
+            overlay: Inner(RefCell::new(element)),
+        }
+    }
+}
+
+struct Inner<'a, Message, Renderer>(
+    RefCell<overlay::Element<'a, Message, Renderer>>,
+);
+
+impl<'a, Message, Renderer> Inner<'a, Message, Renderer> {
+    fn with_element_mut<T>(
+        &self,
+        mut f: impl FnMut(&mut overlay::Element<'_, Message, Renderer>) -> T,
+    ) -> T {
+        (f)(&mut self.0.borrow_mut())
+    }
+}
+
+impl<'a, Message, Renderer> Overlay<Message, Renderer>
+    for Nested<'a, Message, Renderer>
+where
+    Renderer: renderer::Renderer,
+{
+    fn layout(
+        &self,
+        renderer: &Renderer,
+        bounds: Size,
+        position: Point,
+    ) -> layout::Node {
+        fn recurse<Message, Renderer>(
+            element: &mut overlay::Element<'_, Message, Renderer>,
+            renderer: &Renderer,
+            bounds: Size,
+            position: Point,
+        ) -> Vec<layout::Node>
+        where
+            Renderer: renderer::Renderer,
+        {
+            let translation = position - Point::ORIGIN;
+
+            let node = element.layout(renderer, bounds, translation);
+
+            if let Some(mut overlay) =
+                element.overlay(Layout::new(&node), renderer)
+            {
+                vec![node]
+                    .into_iter()
+                    .chain(recurse(&mut overlay, renderer, bounds, position))
+                    .collect()
+            } else {
+                vec![node]
+            }
+        }
+
+        self.overlay.with_element_mut(|element| {
+            layout::Node::with_children(
+                bounds,
+                recurse(element, renderer, bounds, position),
+            )
+        })
+    }
+
+    fn draw(
+        &self,
+        renderer: &mut Renderer,
+        theme: &<Renderer as renderer::Renderer>::Theme,
+        style: &renderer::Style,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+    ) {
+        fn recurse<'a, Message, Renderer>(
+            element: &mut overlay::Element<'_, Message, Renderer>,
+            mut layouts: impl Iterator<Item = Layout<'a>>,
+            renderer: &mut Renderer,
+            theme: &<Renderer as renderer::Renderer>::Theme,
+            style: &renderer::Style,
+            cursor: mouse::Cursor,
+        ) where
+            Renderer: renderer::Renderer,
+        {
+            let layout = layouts.next().unwrap();
+
+            element.draw(renderer, theme, style, layout, cursor);
+
+            if let Some(mut overlay) = element.overlay(layout, renderer) {
+                recurse(&mut overlay, layouts, renderer, theme, style, cursor);
+            }
+        }
+
+        self.overlay.with_element_mut(|element| {
+            let layouts = layout.children();
+
+            recurse(element, layouts, renderer, theme, style, cursor);
+        })
+    }
+
+    fn operate(
+        &mut self,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+        operation: &mut dyn widget::Operation<Message>,
+    ) {
+        fn recurse<'a, Message, Renderer>(
+            element: &mut overlay::Element<'_, Message, Renderer>,
+            mut layouts: impl Iterator<Item = Layout<'a>>,
+            renderer: &Renderer,
+            operation: &mut dyn widget::Operation<Message>,
+        ) where
+            Renderer: renderer::Renderer,
+        {
+            let layout = layouts.next().unwrap();
+
+            element.operate(layout, renderer, operation);
+
+            if let Some(mut overlay) = element.overlay(layout, renderer) {
+                recurse(&mut overlay, layouts, renderer, operation);
+            }
+        }
+
+        let layouts = layout.children();
+
+        recurse(self.overlay.0.get_mut(), layouts, renderer, operation)
+    }
+
+    fn on_event(
+        &mut self,
+        event: Event,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        renderer: &Renderer,
+        clipboard: &mut dyn Clipboard,
+        shell: &mut Shell<'_, Message>,
+    ) -> event::Status {
+        fn recurse<'a, Message, Renderer>(
+            element: &mut overlay::Element<'_, Message, Renderer>,
+            mut layouts: impl Iterator<Item = Layout<'a>>,
+            event: Event,
+            cursor: mouse::Cursor,
+            renderer: &Renderer,
+            clipboard: &mut dyn Clipboard,
+            shell: &mut Shell<'_, Message>,
+        ) -> event::Status
+        where
+            Renderer: renderer::Renderer,
+        {
+            let layout = layouts.next().unwrap();
+
+            let status =
+                if let Some(mut overlay) = element.overlay(layout, renderer) {
+                    recurse(
+                        &mut overlay,
+                        layouts,
+                        event.clone(),
+                        cursor,
+                        renderer,
+                        clipboard,
+                        shell,
+                    )
+                } else {
+                    event::Status::Ignored
+                };
+
+            if matches!(status, event::Status::Ignored) {
+                element
+                    .on_event(event, layout, cursor, renderer, clipboard, shell)
+            } else {
+                status
+            }
+        }
+
+        let layouts = layout.children();
+
+        recurse(
+            self.overlay.0.get_mut(),
+            layouts,
+            event,
+            cursor,
+            renderer,
+            clipboard,
+            shell,
+        )
+    }
+
+    fn mouse_interaction(
+        &self,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+        renderer: &Renderer,
+    ) -> mouse::Interaction {
+        fn recurse<'a, Message, Renderer>(
+            element: &mut overlay::Element<'_, Message, Renderer>,
+            mut layouts: impl Iterator<Item = Layout<'a>>,
+            cursor: mouse::Cursor,
+            viewport: &Rectangle,
+            renderer: &Renderer,
+        ) -> mouse::Interaction
+        where
+            Renderer: renderer::Renderer,
+        {
+            let layout = layouts.next().unwrap();
+
+            let interaction =
+                if let Some(mut overlay) = element.overlay(layout, renderer) {
+                    recurse(&mut overlay, layouts, cursor, viewport, renderer)
+                } else {
+                    mouse::Interaction::default()
+                };
+
+            element
+                .mouse_interaction(layout, cursor, viewport, renderer)
+                .max(interaction)
+        }
+
+        self.overlay.with_element_mut(|element| {
+            let layouts = layout.children();
+
+            recurse(element, layouts, cursor, viewport, renderer)
+        })
+    }
+
+    fn is_over(
+        &self,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+        cursor_position: Point,
+    ) -> bool {
+        fn recurse<'a, Message, Renderer>(
+            element: &mut overlay::Element<'_, Message, Renderer>,
+            mut layouts: impl Iterator<Item = Layout<'a>>,
+            renderer: &Renderer,
+            cursor_position: Point,
+        ) -> bool
+        where
+            Renderer: renderer::Renderer,
+        {
+            let layout = layouts.next().unwrap();
+
+            let is_over = element.is_over(layout, renderer, cursor_position);
+
+            if is_over {
+                return true;
+            }
+
+            if let Some(mut overlay) = element.overlay(layout, renderer) {
+                recurse(&mut overlay, layouts, renderer, cursor_position)
+            } else {
+                false
+            }
+        }
+
+        self.overlay.with_element_mut(|element| {
+            let layouts = layout.children();
+
+            recurse(element, layouts, renderer, cursor_position)
+        })
+    }
+
+    fn overlay<'b>(
+        &'b mut self,
+        _layout: Layout<'_>,
+        _renderer: &Renderer,
+    ) -> Option<overlay::Element<'b, Message, Renderer>> {
+        None
+    }
+}

--- a/runtime/src/user_interface/overlay.rs
+++ b/runtime/src/user_interface/overlay.rs
@@ -224,16 +224,28 @@ where
         {
             let layout = layouts.next().unwrap();
 
-            let interaction =
-                if let Some(mut overlay) = element.overlay(layout, renderer) {
-                    recurse(&mut overlay, layouts, cursor, viewport, renderer)
-                } else {
-                    mouse::Interaction::default()
-                };
+            if let Some(cursor_position) = cursor.position() {
+                match element.overlay(layout, renderer) {
+                    Some(mut overlay)
+                        if overlay.is_over(
+                            layout,
+                            renderer,
+                            cursor_position,
+                        ) =>
+                    {
+                        return recurse(
+                            &mut overlay,
+                            layouts,
+                            cursor,
+                            viewport,
+                            renderer,
+                        );
+                    }
+                    _ => {}
+                }
+            }
 
-            element
-                .mouse_interaction(layout, cursor, viewport, renderer)
-                .max(interaction)
+            element.mouse_interaction(layout, cursor, viewport, renderer)
         }
 
         self.overlay.with_element_mut(|element| {

--- a/runtime/src/user_interface/overlay.rs
+++ b/runtime/src/user_interface/overlay.rs
@@ -9,7 +9,6 @@ use crate::core::{
 };
 
 use std::cell::RefCell;
-use std::iter::Peekable;
 
 /// An [`Overlay`] container that displays nested overlays
 #[allow(missing_debug_implementations)]
@@ -55,7 +54,7 @@ where
             renderer: &Renderer,
             bounds: Size,
             position: Point,
-        ) -> Vec<layout::Node>
+        ) -> layout::Node
         where
             Renderer: renderer::Renderer,
         {
@@ -63,23 +62,23 @@ where
 
             let node = element.layout(renderer, bounds, translation);
 
-            if let Some(mut overlay) =
+            if let Some(mut nested) =
                 element.overlay(Layout::new(&node), renderer)
             {
-                vec![node]
-                    .into_iter()
-                    .chain(recurse(&mut overlay, renderer, bounds, position))
-                    .collect()
+                layout::Node::with_children(
+                    node.size(),
+                    vec![
+                        node,
+                        recurse(&mut nested, renderer, bounds, position),
+                    ],
+                )
             } else {
-                vec![node]
+                layout::Node::with_children(node.size(), vec![node])
             }
         }
 
         self.overlay.with_element_mut(|element| {
-            layout::Node::with_children(
-                bounds,
-                recurse(element, renderer, bounds, position),
-            )
+            recurse(element, renderer, bounds, position)
         })
     }
 
@@ -91,9 +90,9 @@ where
         layout: Layout<'_>,
         cursor: mouse::Cursor,
     ) {
-        fn recurse<'a, Message, Renderer>(
+        fn recurse<Message, Renderer>(
             element: &mut overlay::Element<'_, Message, Renderer>,
-            mut layouts: Peekable<impl Iterator<Item = Layout<'a>>>,
+            layout: Layout<'_>,
             renderer: &mut Renderer,
             theme: &<Renderer as renderer::Renderer>::Theme,
             style: &renderer::Style,
@@ -101,18 +100,21 @@ where
         ) where
             Renderer: renderer::Renderer,
         {
+            let mut layouts = layout.children();
+
             if let Some(layout) = layouts.next() {
+                let nested_layout = layouts.next();
+
                 let is_over = cursor
                     .position()
-                    .and_then(|cursor_position| {
-                        layouts.peek().and_then(|nested_layout| {
-                            element.overlay(layout, renderer).map(|overlay| {
-                                overlay.is_over(
-                                    *nested_layout,
-                                    renderer,
-                                    cursor_position,
-                                )
-                            })
+                    .zip(nested_layout)
+                    .and_then(|(cursor_position, nested_layout)| {
+                        element.overlay(layout, renderer).map(|nested| {
+                            nested.is_over(
+                                nested_layout,
+                                renderer,
+                                cursor_position,
+                            )
                         })
                     })
                     .unwrap_or_default();
@@ -131,10 +133,12 @@ where
                     );
                 });
 
-                if let Some(mut overlay) = element.overlay(layout, renderer) {
+                if let Some((mut nested, nested_layout)) =
+                    element.overlay(layout, renderer).zip(nested_layout)
+                {
                     recurse(
-                        &mut overlay,
-                        layouts,
+                        &mut nested,
+                        nested_layout,
                         renderer,
                         theme,
                         style,
@@ -145,9 +149,7 @@ where
         }
 
         self.overlay.with_element_mut(|element| {
-            let layouts = layout.children().peekable();
-
-            recurse(element, layouts, renderer, theme, style, cursor);
+            recurse(element, layout, renderer, theme, style, cursor);
         })
     }
 
@@ -157,26 +159,28 @@ where
         renderer: &Renderer,
         operation: &mut dyn widget::Operation<Message>,
     ) {
-        fn recurse<'a, Message, Renderer>(
+        fn recurse<Message, Renderer>(
             element: &mut overlay::Element<'_, Message, Renderer>,
-            mut layouts: impl Iterator<Item = Layout<'a>>,
+            layout: Layout<'_>,
             renderer: &Renderer,
             operation: &mut dyn widget::Operation<Message>,
         ) where
             Renderer: renderer::Renderer,
         {
+            let mut layouts = layout.children();
+
             if let Some(layout) = layouts.next() {
                 element.operate(layout, renderer, operation);
 
-                if let Some(mut overlay) = element.overlay(layout, renderer) {
-                    recurse(&mut overlay, layouts, renderer, operation);
+                if let Some((mut nested, nested_layout)) =
+                    element.overlay(layout, renderer).zip(layouts.next())
+                {
+                    recurse(&mut nested, nested_layout, renderer, operation);
                 }
             }
         }
 
-        let layouts = layout.children();
-
-        recurse(self.overlay.0.get_mut(), layouts, renderer, operation)
+        recurse(self.overlay.0.get_mut(), layout, renderer, operation)
     }
 
     fn on_event(
@@ -188,9 +192,9 @@ where
         clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, Message>,
     ) -> event::Status {
-        fn recurse<'a, Message, Renderer>(
+        fn recurse<Message, Renderer>(
             element: &mut overlay::Element<'_, Message, Renderer>,
-            mut layouts: impl Iterator<Item = Layout<'a>>,
+            layout: Layout<'_>,
             event: Event,
             cursor: mouse::Cursor,
             renderer: &Renderer,
@@ -200,13 +204,15 @@ where
         where
             Renderer: renderer::Renderer,
         {
+            let mut layouts = layout.children();
+
             if let Some(layout) = layouts.next() {
-                let status = if let Some(mut overlay) =
-                    element.overlay(layout, renderer)
+                let status = if let Some((mut nested, nested_layout)) =
+                    element.overlay(layout, renderer).zip(layouts.next())
                 {
                     recurse(
-                        &mut overlay,
-                        layouts,
+                        &mut nested,
+                        nested_layout,
                         event.clone(),
                         cursor,
                         renderer,
@@ -229,11 +235,9 @@ where
             }
         }
 
-        let layouts = layout.children();
-
         recurse(
             self.overlay.0.get_mut(),
-            layouts,
+            layout,
             event,
             cursor,
             renderer,
@@ -249,9 +253,9 @@ where
         viewport: &Rectangle,
         renderer: &Renderer,
     ) -> mouse::Interaction {
-        fn recurse<'a, Message, Renderer>(
+        fn recurse<Message, Renderer>(
             element: &mut overlay::Element<'_, Message, Renderer>,
-            mut layouts: impl Iterator<Item = Layout<'a>>,
+            layout: Layout<'_>,
             cursor: mouse::Cursor,
             viewport: &Rectangle,
             renderer: &Renderer,
@@ -259,6 +263,8 @@ where
         where
             Renderer: renderer::Renderer,
         {
+            let mut layouts = layout.children();
+
             let layout = layouts.next()?;
             let cursor_position = cursor.position()?;
 
@@ -269,10 +275,11 @@ where
             Some(
                 element
                     .overlay(layout, renderer)
-                    .and_then(|mut overlay| {
+                    .zip(layouts.next())
+                    .and_then(|(mut overlay, layout)| {
                         recurse(
                             &mut overlay,
-                            layouts,
+                            layout,
                             cursor,
                             viewport,
                             renderer,
@@ -288,9 +295,7 @@ where
 
         self.overlay
             .with_element_mut(|element| {
-                let layouts = layout.children();
-
-                recurse(element, layouts, cursor, viewport, renderer)
+                recurse(element, layout, cursor, viewport, renderer)
             })
             .unwrap_or_default()
     }
@@ -301,22 +306,31 @@ where
         renderer: &Renderer,
         cursor_position: Point,
     ) -> bool {
-        fn recurse<'a, Message, Renderer>(
+        fn recurse<Message, Renderer>(
             element: &mut overlay::Element<'_, Message, Renderer>,
-            mut layouts: impl Iterator<Item = Layout<'a>>,
+            layout: Layout<'_>,
             renderer: &Renderer,
             cursor_position: Point,
         ) -> bool
         where
             Renderer: renderer::Renderer,
         {
+            let mut layouts = layout.children();
+
             if let Some(layout) = layouts.next() {
                 if element.is_over(layout, renderer, cursor_position) {
                     return true;
                 }
 
-                if let Some(mut overlay) = element.overlay(layout, renderer) {
-                    recurse(&mut overlay, layouts, renderer, cursor_position)
+                if let Some((mut nested, nested_layout)) =
+                    element.overlay(layout, renderer).zip(layouts.next())
+                {
+                    recurse(
+                        &mut nested,
+                        nested_layout,
+                        renderer,
+                        cursor_position,
+                    )
                 } else {
                     false
                 }
@@ -326,9 +340,7 @@ where
         }
 
         self.overlay.with_element_mut(|element| {
-            let layouts = layout.children();
-
-            recurse(element, layouts, renderer, cursor_position)
+            recurse(element, layout, renderer, cursor_position)
         })
     }
 

--- a/widget/src/lazy.rs
+++ b/widget/src/lazy.rs
@@ -20,6 +20,7 @@ use crate::core::Element;
 use crate::core::{
     self, Clipboard, Hasher, Length, Point, Rectangle, Shell, Size,
 };
+use crate::runtime::overlay::Nested;
 
 use ouroboros::self_referencing;
 use std::cell::RefCell;
@@ -260,14 +261,17 @@ where
                     .unwrap(),
                 tree: &mut tree.children[0],
                 overlay_builder: |element, tree| {
-                    element.as_widget_mut().overlay(tree, layout, renderer)
+                    element
+                        .as_widget_mut()
+                        .overlay(tree, layout, renderer)
+                        .map(|overlay| RefCell::new(Nested::new(overlay)))
                 },
             }
             .build(),
         ));
 
-        let has_overlay = overlay
-            .with_overlay_maybe(|overlay| overlay::Element::position(overlay));
+        let has_overlay =
+            overlay.with_overlay_maybe(|overlay| overlay.position());
 
         has_overlay
             .map(|position| overlay::Element::new(position, Box::new(overlay)))
@@ -285,8 +289,8 @@ where
     tree: &'a mut Tree,
 
     #[borrows(mut element, mut tree)]
-    #[covariant]
-    overlay: Option<overlay::Element<'this, Message, Renderer>>,
+    #[not_covariant]
+    overlay: Option<RefCell<Nested<'this, Message, Renderer>>>,
 }
 
 struct Overlay<'a, Message, Renderer>(Option<Inner<'a, Message, Renderer>>);
@@ -301,19 +305,20 @@ impl<'a, Message, Renderer> Drop for Overlay<'a, Message, Renderer> {
 impl<'a, Message, Renderer> Overlay<'a, Message, Renderer> {
     fn with_overlay_maybe<T>(
         &self,
-        f: impl FnOnce(&overlay::Element<'_, Message, Renderer>) -> T,
+        f: impl FnOnce(&mut Nested<'_, Message, Renderer>) -> T,
     ) -> Option<T> {
-        self.0.as_ref().unwrap().borrow_overlay().as_ref().map(f)
+        self.0.as_ref().unwrap().with_overlay(|overlay| {
+            overlay.as_ref().map(|nested| (f)(&mut nested.borrow_mut()))
+        })
     }
 
     fn with_overlay_mut_maybe<T>(
         &mut self,
-        f: impl FnOnce(&mut overlay::Element<'_, Message, Renderer>) -> T,
+        f: impl FnOnce(&mut Nested<'_, Message, Renderer>) -> T,
     ) -> Option<T> {
-        self.0
-            .as_mut()
-            .unwrap()
-            .with_overlay_mut(|overlay| overlay.as_mut().map(f))
+        self.0.as_mut().unwrap().with_overlay_mut(|overlay| {
+            overlay.as_mut().map(|nested| (f)(nested.get_mut()))
+        })
     }
 }
 
@@ -329,9 +334,7 @@ where
         position: Point,
     ) -> layout::Node {
         self.with_overlay_maybe(|overlay| {
-            let translation = position - overlay.position();
-
-            overlay.layout(renderer, bounds, translation)
+            overlay.layout(renderer, bounds, position)
         })
         .unwrap_or_default()
     }

--- a/widget/src/lazy.rs
+++ b/widget/src/lazy.rs
@@ -377,9 +377,14 @@ where
         .unwrap_or(event::Status::Ignored)
     }
 
-    fn is_over(&self, layout: Layout<'_>, cursor_position: Point) -> bool {
+    fn is_over(
+        &self,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+        cursor_position: Point,
+    ) -> bool {
         self.with_overlay_maybe(|overlay| {
-            overlay.is_over(layout, cursor_position)
+            overlay.is_over(layout, renderer, cursor_position)
         })
         .unwrap_or_default()
     }

--- a/widget/src/lazy/component.rs
+++ b/widget/src/lazy/component.rs
@@ -9,6 +9,7 @@ use crate::core::widget::tree::{self, Tree};
 use crate::core::{
     self, Clipboard, Element, Length, Point, Rectangle, Shell, Size, Widget,
 };
+use crate::runtime::overlay::Nested;
 
 use ouroboros::self_referencing;
 use std::cell::RefCell;
@@ -455,11 +456,18 @@ where
                 overlay_builder: |instance, tree| {
                     instance.state.get_mut().as_mut().unwrap().with_element_mut(
                         move |element| {
-                            element.as_mut().unwrap().as_widget_mut().overlay(
-                                &mut tree.children[0],
-                                layout,
-                                renderer,
-                            )
+                            element
+                                .as_mut()
+                                .unwrap()
+                                .as_widget_mut()
+                                .overlay(
+                                    &mut tree.children[0],
+                                    layout,
+                                    renderer,
+                                )
+                                .map(|overlay| {
+                                    RefCell::new(Nested::new(overlay))
+                                })
                         },
                     )
                 },
@@ -468,7 +476,7 @@ where
         ));
 
         let has_overlay = overlay.0.as_ref().unwrap().with_overlay(|overlay| {
-            overlay.as_ref().map(overlay::Element::position)
+            overlay.as_ref().map(|nested| nested.borrow().position())
         });
 
         has_overlay.map(|position| {
@@ -503,8 +511,8 @@ struct Inner<'a, 'b, Message, Renderer, Event, S> {
     types: PhantomData<(Message, Event, S)>,
 
     #[borrows(mut instance, mut tree)]
-    #[covariant]
-    overlay: Option<overlay::Element<'this, Event, Renderer>>,
+    #[not_covariant]
+    overlay: Option<RefCell<Nested<'this, Event, Renderer>>>,
 }
 
 struct OverlayInstance<'a, 'b, Message, Renderer, Event, S> {
@@ -516,7 +524,7 @@ impl<'a, 'b, Message, Renderer, Event, S>
 {
     fn with_overlay_maybe<T>(
         &self,
-        f: impl FnOnce(&overlay::Element<'_, Event, Renderer>) -> T,
+        f: impl FnOnce(&mut Nested<'_, Event, Renderer>) -> T,
     ) -> Option<T> {
         self.overlay
             .as_ref()
@@ -524,14 +532,14 @@ impl<'a, 'b, Message, Renderer, Event, S>
             .0
             .as_ref()
             .unwrap()
-            .borrow_overlay()
-            .as_ref()
-            .map(f)
+            .with_overlay(|overlay| {
+                overlay.as_ref().map(|nested| (f)(&mut nested.borrow_mut()))
+            })
     }
 
     fn with_overlay_mut_maybe<T>(
         &mut self,
-        f: impl FnOnce(&mut overlay::Element<'_, Event, Renderer>) -> T,
+        f: impl FnOnce(&mut Nested<'_, Event, Renderer>) -> T,
     ) -> Option<T> {
         self.overlay
             .as_mut()
@@ -539,7 +547,9 @@ impl<'a, 'b, Message, Renderer, Event, S>
             .0
             .as_mut()
             .unwrap()
-            .with_overlay_mut(|overlay| overlay.as_mut().map(f))
+            .with_overlay_mut(|overlay| {
+                overlay.as_mut().map(|nested| (f)(nested.get_mut()))
+            })
     }
 }
 
@@ -556,9 +566,7 @@ where
         position: Point,
     ) -> layout::Node {
         self.with_overlay_maybe(|overlay| {
-            let translation = position - overlay.position();
-
-            overlay.layout(renderer, bounds, translation)
+            overlay.layout(renderer, bounds, position)
         })
         .unwrap_or_default()
     }

--- a/widget/src/lazy/component.rs
+++ b/widget/src/lazy/component.rs
@@ -655,9 +655,14 @@ where
         event_status
     }
 
-    fn is_over(&self, layout: Layout<'_>, cursor_position: Point) -> bool {
+    fn is_over(
+        &self,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+        cursor_position: Point,
+    ) -> bool {
         self.with_overlay_maybe(|overlay| {
-            overlay.is_over(layout, cursor_position)
+            overlay.is_over(layout, renderer, cursor_position)
         })
         .unwrap_or_default()
     }

--- a/widget/src/lazy/responsive.rs
+++ b/widget/src/lazy/responsive.rs
@@ -409,9 +409,14 @@ where
         .unwrap_or(event::Status::Ignored)
     }
 
-    fn is_over(&self, layout: Layout<'_>, cursor_position: Point) -> bool {
+    fn is_over(
+        &self,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+        cursor_position: Point,
+    ) -> bool {
         self.with_overlay_maybe(|overlay| {
-            overlay.is_over(layout, cursor_position)
+            overlay.is_over(layout, renderer, cursor_position)
         })
         .unwrap_or_default()
     }

--- a/widget/src/lazy/responsive.rs
+++ b/widget/src/lazy/responsive.rs
@@ -9,6 +9,7 @@ use crate::core::{
     self, Clipboard, Element, Length, Point, Rectangle, Shell, Size, Widget,
 };
 use crate::horizontal_space;
+use crate::runtime::overlay::Nested;
 
 use ouroboros::self_referencing;
 use std::cell::{RefCell, RefMut};
@@ -298,13 +299,13 @@ where
                 element
                     .as_widget_mut()
                     .overlay(tree, content_layout, renderer)
+                    .map(|overlay| RefCell::new(Nested::new(overlay)))
             },
         }
         .build();
 
-        let has_overlay = overlay.with_overlay(|overlay| {
-            overlay.as_ref().map(overlay::Element::position)
-        });
+        let has_overlay =
+            overlay.with_overlay_maybe(|overlay| overlay.position());
 
         has_overlay
             .map(|position| overlay::Element::new(position, Box::new(overlay)))
@@ -329,23 +330,27 @@ struct Overlay<'a, 'b, Message, Renderer> {
     types: PhantomData<Message>,
 
     #[borrows(mut content, mut tree)]
-    #[covariant]
-    overlay: Option<overlay::Element<'this, Message, Renderer>>,
+    #[not_covariant]
+    overlay: Option<RefCell<Nested<'this, Message, Renderer>>>,
 }
 
 impl<'a, 'b, Message, Renderer> Overlay<'a, 'b, Message, Renderer> {
     fn with_overlay_maybe<T>(
         &self,
-        f: impl FnOnce(&overlay::Element<'_, Message, Renderer>) -> T,
+        f: impl FnOnce(&mut Nested<'_, Message, Renderer>) -> T,
     ) -> Option<T> {
-        self.borrow_overlay().as_ref().map(f)
+        self.with_overlay(|overlay| {
+            overlay.as_ref().map(|nested| (f)(&mut nested.borrow_mut()))
+        })
     }
 
     fn with_overlay_mut_maybe<T>(
         &mut self,
-        f: impl FnOnce(&mut overlay::Element<'_, Message, Renderer>) -> T,
+        f: impl FnOnce(&mut Nested<'_, Message, Renderer>) -> T,
     ) -> Option<T> {
-        self.with_overlay_mut(|overlay| overlay.as_mut().map(f))
+        self.with_overlay_mut(|overlay| {
+            overlay.as_mut().map(|nested| (f)(nested.get_mut()))
+        })
     }
 }
 
@@ -361,9 +366,7 @@ where
         position: Point,
     ) -> layout::Node {
         self.with_overlay_maybe(|overlay| {
-            let translation = position - overlay.position();
-
-            overlay.layout(renderer, bounds, translation)
+            overlay.layout(renderer, bounds, position)
         })
         .unwrap_or_default()
     }


### PR DESCRIPTION
This implements a new overlay which allows for nesting. It's fairly inefficient as it calls `Overlay::overlay` within every method, but this reduces complexity as dealing w/ lifetimes here will be really rough.

The nice part is this doesn't touch the `UserInterface` code at all except to wrap the root overlay into a `Nested`. `Nested` is only public to the crate and only meant to be used as the root overlay used by the user interface. This means that the layout caching done in user interface works for the `Nested` layout as well.

I haven't implemented the nested `Overlay::overlay` on any of the `lazy` overlay implementations yet, but I can implement if we feel this is a good approach.


If approved, we can rebase #1692 as that should now work w/ this.


https://user-images.githubusercontent.com/10239377/219901259-7a187e90-f4d6-43d3-ae86-c25716c08f66.mp4

