### PR TITLE
Sliders no longer bleed over rail

### DIFF
--- a/native/src/widget/slider.rs
+++ b/native/src/widget/slider.rs
@@ -423,8 +423,8 @@ pub fn draw<T, R>(
     let handle_offset = if range_start >= range_end {
         0.0
     } else {
-        bounds.width * (value - range_start) / (range_end - range_start)
-            - handle_width / 2.0
+        (bounds.width - handle_width) * (value - range_start)
+            / (range_end - range_start)
     };
 
     renderer.fill_quad(

--- a/native/src/widget/vertical_slider.rs
+++ b/native/src/widget/vertical_slider.rs
@@ -418,8 +418,8 @@ pub fn draw<T, R>(
     let handle_offset = if range_start >= range_end {
         0.0
     } else {
-        bounds.height * (value - range_end) / (range_start - range_end)
-            - handle_width / 2.0
+        (bounds.height - handle_width) * (value - range_end)
+            / (range_start - range_end)
     };
 
     renderer.fill_quad(


### PR DESCRIPTION
This PR is a suggestion for `Slider` to not bleed over the rails.   

The default behaviour is that `Slider` comes to a stop when the handle is `handle_width / 2` over the rail. I would like to propose we only move the handle within the rail. The gif below illustrate the current behaviour as well as my suggestion:

Bleed (current)           |  No bleed (this PR)
:-------------------------:|:-------------------------:
![slider_with_bleed](https://user-images.githubusercontent.com/2248455/220093609-43030287-232e-4e88-942e-e6056d56969c.gif)  |  ![slider_no_bleed](https://user-images.githubusercontent.com/2248455/220093718-cd38b1a4-6c8f-4315-83c7-9c760625255f.gif)

I believe this is the most common approach. macOS and Windows references below:

![macos](https://user-images.githubusercontent.com/2248455/220097431-2dbdba1d-6e9d-42fb-8544-33f0efe4ab71.gif)

![windows](https://user-images.githubusercontent.com/2248455/220097759-b1d163cb-ce90-4688-a814-9011aab90ab2.gif)


