### PR TITLE
Optimise layout performance

### DIFF
--- a/examples/modal/src/main.rs
+++ b/examples/modal/src/main.rs
@@ -276,7 +276,7 @@ mod modal {
             cursor_position: Point,
             viewport: &Rectangle,
         ) {
-            self.base.as_widget().draw(
+            self.base.as_widget_mut().draw(
                 &state.children[0],
                 renderer,
                 theme,
@@ -424,7 +424,7 @@ mod modal {
                 },
             );
 
-            self.content.as_widget().draw(
+            self.content.as_widget_mut().draw(
                 self.tree,
                 renderer,
                 theme,

--- a/examples/toast/src/main.rs
+++ b/examples/toast/src/main.rs
@@ -414,7 +414,7 @@ mod toast {
             cursor_position: Point,
             viewport: &Rectangle,
         ) {
-            self.content.as_widget().draw(
+            self.content.as_widget_mut().draw(
                 &state.children[0],
                 renderer,
                 theme,
@@ -597,7 +597,7 @@ mod toast {
                 .zip(self.state.iter())
                 .zip(layout.children())
             {
-                child.as_widget().draw(
+                child.as_widget_mut().draw(
                     state,
                     renderer,
                     theme,

--- a/graphics/src/renderer.rs
+++ b/graphics/src/renderer.rs
@@ -55,10 +55,10 @@ where
 
     fn layout<Message>(
         &mut self,
-        element: &Element<'_, Message, Self>,
+        element: &mut Element<'_, Message, Self>,
         limits: &layout::Limits,
     ) -> layout::Node {
-        let layout = element.as_widget().layout(self, limits);
+        let layout = element.as_widget_mut().layout(self, limits);
 
         self.backend.trim_measurements();
 

--- a/lazy/src/component.rs
+++ b/lazy/src/component.rs
@@ -333,7 +333,7 @@ where
         viewport: &Rectangle,
     ) {
         self.with_element(|element| {
-            element.as_widget().draw(
+            element.as_widget_mut().draw(
                 &tree.children[0],
                 renderer,
                 theme,

--- a/lazy/src/lazy.rs
+++ b/lazy/src/lazy.rs
@@ -213,7 +213,7 @@ where
         viewport: &Rectangle,
     ) {
         self.with_element(|element| {
-            element.as_widget().draw(
+            element.as_widget_mut().draw(
                 &tree.children[0],
                 renderer,
                 theme,

--- a/lazy/src/responsive.rs
+++ b/lazy/src/responsive.rs
@@ -216,7 +216,7 @@ where
             layout,
             &self.view,
             |tree, renderer, layout, element| {
-                element.as_widget().draw(
+                element.as_widget_mut().draw(
                     tree,
                     renderer,
                     theme,

--- a/native/src/element.rs
+++ b/native/src/element.rs
@@ -377,7 +377,7 @@ where
     }
 
     fn draw(
-        &self,
+        &mut self,
         tree: &Tree,
         renderer: &mut Renderer,
         theme: &Renderer::Theme,
@@ -513,7 +513,7 @@ where
     }
 
     fn draw(
-        &self,
+        &mut self,
         state: &Tree,
         renderer: &mut Renderer,
         theme: &Renderer::Theme,

--- a/native/src/element.rs
+++ b/native/src/element.rs
@@ -280,7 +280,7 @@ where
     }
 
     fn layout(
-        &self,
+        &mut self,
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
@@ -472,7 +472,7 @@ where
     }
 
     fn layout(
-        &self,
+        &mut self,
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {

--- a/native/src/element.rs
+++ b/native/src/element.rs
@@ -6,7 +6,7 @@ use crate::renderer;
 use crate::widget;
 use crate::widget::tree::{self, Tree};
 use crate::{
-    Clipboard, Color, Layout, Length, Point, Rectangle, Shell, Widget,
+    Clipboard, Color, Layout, Length, Point, Rectangle, Shell, Size, Widget,
 };
 
 use std::any::Any;
@@ -285,6 +285,14 @@ where
         limits: &layout::Limits,
     ) -> layout::Node {
         self.widget.layout(renderer, limits)
+    }
+
+    fn measure(
+        &mut self,
+        renderer: &Renderer,
+        limits: &layout::Limits,
+    ) -> Size {
+        self.widget.measure(renderer, limits)
     }
 
     fn operate(

--- a/native/src/layout/flex.rs
+++ b/native/src/layout/flex.rs
@@ -65,7 +65,7 @@ pub fn resolve<Message, Renderer>(
     padding: Padding,
     spacing: f32,
     align_items: Alignment,
-    items: &[Element<'_, Message, Renderer>],
+    items: &mut [Element<'_, Message, Renderer>],
 ) -> Node
 where
     Renderer: crate::Renderer,
@@ -84,7 +84,7 @@ where
     if align_items == Alignment::Fill {
         let mut fill_cross = axis.cross(limits.min());
 
-        items.iter().for_each(|child| {
+        items.iter_mut().for_each(|child| {
             let cross_fill_factor = match axis {
                 Axis::Horizontal => child.as_widget().height(),
                 Axis::Vertical => child.as_widget().width(),
@@ -97,7 +97,8 @@ where
                 let child_limits =
                     Limits::new(Size::ZERO, Size::new(max_width, max_height));
 
-                let layout = child.as_widget().layout(renderer, &child_limits);
+                let layout =
+                    child.as_widget_mut().layout(renderer, &child_limits);
                 let size = layout.size();
 
                 fill_cross = fill_cross.max(axis.cross(size));
@@ -107,7 +108,7 @@ where
         cross = fill_cross;
     }
 
-    for (i, child) in items.iter().enumerate() {
+    for (i, child) in items.iter_mut().enumerate() {
         let fill_factor = match axis {
             Axis::Horizontal => child.as_widget().width(),
             Axis::Vertical => child.as_widget().height(),
@@ -132,7 +133,7 @@ where
                 Size::new(max_width, max_height),
             );
 
-            let layout = child.as_widget().layout(renderer, &child_limits);
+            let layout = child.as_widget_mut().layout(renderer, &child_limits);
             let size = layout.size();
 
             available -= axis.main(size);
@@ -149,7 +150,7 @@ where
 
     let remaining = available.max(0.0);
 
-    for (i, child) in items.iter().enumerate() {
+    for (i, child) in items.iter_mut().enumerate() {
         let fill_factor = match axis {
             Axis::Horizontal => child.as_widget().width(),
             Axis::Vertical => child.as_widget().height(),
@@ -181,7 +182,7 @@ where
                 Size::new(max_width, max_height),
             );
 
-            let layout = child.as_widget().layout(renderer, &child_limits);
+            let layout = child.as_widget_mut().layout(renderer, &child_limits);
 
             if align_items != Alignment::Fill {
                 cross = cross.max(axis.cross(layout.size()));

--- a/native/src/layout/node.rs
+++ b/native/src/layout/node.rs
@@ -81,6 +81,12 @@ impl Node {
         self.bounds.y = position.y;
     }
 
+    /// Set the [`Node`] to the given size.
+    pub fn set_size(&mut self, size: Size) {
+        self.bounds.width = size.width;
+        self.bounds.height = size.height;
+    }
+
     /// Translates the [`Node`] by the given translation.
     pub fn translate(self, translation: Vector) -> Self {
         Self {

--- a/native/src/layout/node.rs
+++ b/native/src/layout/node.rs
@@ -36,9 +36,14 @@ impl Node {
         self.bounds
     }
 
-    /// Returns the children of the [`Node`].
+    /// Returns a view into the children of the [`Node`].
     pub fn children(&self) -> &[Node] {
         &self.children
+    }
+
+    /// Consumes the [`Node`] and returns the children of the [`Node`].
+    pub fn into_children(self) -> Vec<Node> {
+        self.children
     }
 
     /// Aligns the [`Node`] in the given space.

--- a/native/src/overlay.rs
+++ b/native/src/overlay.rs
@@ -28,7 +28,7 @@ where
     ///
     /// [`Node`]: layout::Node
     fn layout(
-        &self,
+        &mut self,
         renderer: &Renderer,
         bounds: Size,
         position: Point,

--- a/native/src/overlay.rs
+++ b/native/src/overlay.rs
@@ -36,7 +36,7 @@ where
 
     /// Draws the [`Overlay`] using the associated `Renderer`.
     fn draw(
-        &self,
+        &mut self,
         renderer: &mut Renderer,
         theme: &Renderer::Theme,
         style: &renderer::Style,

--- a/native/src/overlay/element.rs
+++ b/native/src/overlay/element.rs
@@ -101,7 +101,7 @@ where
 
     /// Draws the [`Element`] and its children using the given [`Layout`].
     pub fn draw(
-        &self,
+        &mut self,
         renderer: &mut Renderer,
         theme: &Renderer::Theme,
         style: &renderer::Style,
@@ -253,7 +253,7 @@ where
     }
 
     fn draw(
-        &self,
+        &mut self,
         renderer: &mut Renderer,
         theme: &Renderer::Theme,
         style: &renderer::Style,

--- a/native/src/overlay/element.rs
+++ b/native/src/overlay/element.rs
@@ -54,7 +54,7 @@ where
 
     /// Computes the layout of the [`Element`] in the given bounds.
     pub fn layout(
-        &self,
+        &mut self,
         renderer: &Renderer,
         bounds: Size,
         translation: Vector,
@@ -147,7 +147,7 @@ where
     Renderer: crate::Renderer,
 {
     fn layout(
-        &self,
+        &mut self,
         renderer: &Renderer,
         bounds: Size,
         position: Point,

--- a/native/src/overlay/group.rs
+++ b/native/src/overlay/group.rs
@@ -105,14 +105,14 @@ where
     }
 
     fn draw(
-        &self,
+        &mut self,
         renderer: &mut Renderer,
         theme: &<Renderer as crate::Renderer>::Theme,
         style: &renderer::Style,
         layout: Layout<'_>,
         cursor_position: Point,
     ) {
-        for (child, layout) in self.children.iter().zip(layout.children()) {
+        for (child, layout) in self.children.iter_mut().zip(layout.children()) {
             child.draw(renderer, theme, style, layout, cursor_position);
         }
     }

--- a/native/src/overlay/group.rs
+++ b/native/src/overlay/group.rs
@@ -63,7 +63,7 @@ where
     Renderer: crate::Renderer,
 {
     fn layout(
-        &self,
+        &mut self,
         renderer: &Renderer,
         bounds: Size,
         position: Point,
@@ -73,7 +73,7 @@ where
         layout::Node::with_children(
             bounds,
             self.children
-                .iter()
+                .iter_mut()
                 .map(|child| child.layout(renderer, bounds, translation))
                 .collect(),
         )

--- a/native/src/overlay/menu.rs
+++ b/native/src/overlay/menu.rs
@@ -269,7 +269,7 @@ where
     }
 
     fn draw(
-        &self,
+        &mut self,
         renderer: &mut Renderer,
         theme: &Renderer::Theme,
         style: &renderer::Style,
@@ -436,7 +436,7 @@ where
     }
 
     fn draw(
-        &self,
+        &mut self,
         _state: &Tree,
         renderer: &mut Renderer,
         theme: &Renderer::Theme,

--- a/native/src/overlay/menu.rs
+++ b/native/src/overlay/menu.rs
@@ -200,7 +200,7 @@ where
     Renderer::Theme: StyleSheet + container::StyleSheet,
 {
     fn layout(
-        &self,
+        &mut self,
         renderer: &Renderer,
         bounds: Size,
         position: Point,
@@ -331,7 +331,7 @@ where
     }
 
     fn layout(
-        &self,
+        &mut self,
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {

--- a/native/src/renderer.rs
+++ b/native/src/renderer.rs
@@ -18,10 +18,10 @@ pub trait Renderer: Sized {
     /// after layouting. For instance, trimming the measurements cache.
     fn layout<Message>(
         &mut self,
-        element: &Element<'_, Message, Self>,
+        element: &mut Element<'_, Message, Self>,
         limits: &layout::Limits,
     ) -> layout::Node {
-        element.as_widget().layout(self, limits)
+        element.as_widget_mut().layout(self, limits)
     }
 
     /// Draws the primitives recorded in the given closure in a new layer.

--- a/native/src/user_interface.rs
+++ b/native/src/user_interface.rs
@@ -455,7 +455,7 @@ where
             cursor_position
         };
 
-        self.root.as_widget().draw(
+        self.root.as_widget_mut().draw(
             &self.state,
             renderer,
             theme,
@@ -490,7 +490,7 @@ where
             .and_then(|layout| {
                 root.as_widget_mut()
                     .overlay(&mut self.state, Layout::new(base), renderer)
-                    .map(|overlay| {
+                    .map(|mut overlay| {
                         let overlay_interaction = overlay.mouse_interaction(
                             Layout::new(layout),
                             cursor_position,

--- a/native/src/user_interface.rs
+++ b/native/src/user_interface.rs
@@ -97,13 +97,13 @@ where
         cache: Cache,
         renderer: &mut Renderer,
     ) -> Self {
-        let root = root.into();
+        let mut root = root.into();
 
         let Cache { mut state } = cache;
         state.diff(root.as_widget());
 
-        let base =
-            renderer.layout(&root, &layout::Limits::new(Size::ZERO, bounds));
+        let base = renderer
+            .layout(&mut root, &layout::Limits::new(Size::ZERO, bounds));
 
         UserInterface {
             root,
@@ -236,7 +236,7 @@ where
                     let _ = ManuallyDrop::into_inner(manual_overlay);
 
                     self.base = renderer.layout(
-                        &self.root,
+                        &mut self.root,
                         &layout::Limits::new(Size::ZERO, self.bounds),
                     );
 
@@ -320,7 +320,7 @@ where
 
                 shell.revalidate_layout(|| {
                     self.base = renderer.layout(
-                        &self.root,
+                        &mut self.root,
                         &layout::Limits::new(Size::ZERO, self.bounds),
                     );
 
@@ -431,7 +431,7 @@ where
 
         let viewport = Rectangle::with_size(self.bounds);
 
-        let base_cursor = if let Some(overlay) = self
+        let base_cursor = if let Some(mut overlay) = self
             .root
             .as_widget_mut()
             .overlay(&mut self.state, Layout::new(&self.base), renderer)

--- a/native/src/widget.rs
+++ b/native/src/widget.rs
@@ -92,7 +92,7 @@ use crate::layout;
 use crate::mouse;
 use crate::overlay;
 use crate::renderer;
-use crate::{Clipboard, Layout, Length, Point, Rectangle, Shell};
+use crate::{Clipboard, Layout, Length, Point, Rectangle, Shell, Size};
 
 /// A component that displays information and allows interaction.
 ///
@@ -135,6 +135,17 @@ where
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node;
+
+    /// Returns the intrinsic (content based) [`Size`] of the [`Widget`].
+    ///
+    /// This [`Size`] is used by the parent widget to compute a final size for the widget
+    fn measure(
+        &mut self,
+        renderer: &Renderer,
+        limits: &layout::Limits,
+    ) -> Size {
+        self.layout(renderer, limits).size()
+    }
 
     /// Draws the [`Widget`] using the associated `Renderer`.
     fn draw(

--- a/native/src/widget.rs
+++ b/native/src/widget.rs
@@ -138,7 +138,7 @@ where
 
     /// Draws the [`Widget`] using the associated `Renderer`.
     fn draw(
-        &self,
+        &mut self,
         state: &Tree,
         renderer: &mut Renderer,
         theme: &Renderer::Theme,

--- a/native/src/widget.rs
+++ b/native/src/widget.rs
@@ -131,7 +131,7 @@ where
     /// This [`layout::Node`] is used by the runtime to compute the [`Layout`] of the
     /// user interface.
     fn layout(
-        &self,
+        &mut self,
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node;

--- a/native/src/widget/button.rs
+++ b/native/src/widget/button.rs
@@ -149,7 +149,7 @@ where
     }
 
     fn layout(
-        &self,
+        &mut self,
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
@@ -160,7 +160,7 @@ where
             self.height,
             self.padding,
             |renderer, limits| {
-                self.content.as_widget().layout(renderer, limits)
+                self.content.as_widget_mut().layout(renderer, limits)
             },
         )
     }

--- a/native/src/widget/button.rs
+++ b/native/src/widget/button.rs
@@ -215,7 +215,7 @@ where
     }
 
     fn draw(
-        &self,
+        &mut self,
         tree: &Tree,
         renderer: &mut Renderer,
         theme: &Renderer::Theme,
@@ -237,7 +237,7 @@ where
             || tree.state.downcast_ref::<State>(),
         );
 
-        self.content.as_widget().draw(
+        self.content.as_widget_mut().draw(
             &tree.children[0],
             renderer,
             theme,

--- a/native/src/widget/checkbox.rs
+++ b/native/src/widget/checkbox.rs
@@ -164,7 +164,7 @@ where
     }
 
     fn layout(
-        &self,
+        &mut self,
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {

--- a/native/src/widget/checkbox.rs
+++ b/native/src/widget/checkbox.rs
@@ -228,7 +228,7 @@ where
     }
 
     fn draw(
-        &self,
+        &mut self,
         _tree: &Tree,
         renderer: &mut Renderer,
         theme: &Renderer::Theme,

--- a/native/src/widget/column.rs
+++ b/native/src/widget/column.rs
@@ -121,7 +121,7 @@ where
     }
 
     fn layout(
-        &self,
+        &mut self,
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
@@ -137,7 +137,7 @@ where
             self.padding,
             self.spacing,
             self.align_items,
-            &self.children,
+            &mut self.children,
         )
     }
 

--- a/native/src/widget/column.rs
+++ b/native/src/widget/column.rs
@@ -215,7 +215,7 @@ where
     }
 
     fn draw(
-        &self,
+        &mut self,
         tree: &Tree,
         renderer: &mut Renderer,
         theme: &Renderer::Theme,
@@ -226,11 +226,11 @@ where
     ) {
         for ((child, state), layout) in self
             .children
-            .iter()
+            .iter_mut()
             .zip(&tree.children)
             .zip(layout.children())
         {
-            child.as_widget().draw(
+            child.as_widget_mut().draw(
                 state,
                 renderer,
                 theme,

--- a/native/src/widget/column.rs
+++ b/native/src/widget/column.rs
@@ -7,7 +7,7 @@ use crate::renderer;
 use crate::widget::{Operation, Tree};
 use crate::{
     Alignment, Clipboard, Element, Layout, Length, Padding, Pixels, Point,
-    Rectangle, Shell, Widget,
+    Rectangle, Shell, Size, Widget,
 };
 
 /// A container that distributes its contents vertically.
@@ -138,7 +138,31 @@ where
             self.spacing,
             self.align_items,
             &mut self.children,
+            layout::flex::LayoutMode::PerformLayout,
         )
+    }
+
+    fn measure(
+        &mut self,
+        renderer: &Renderer,
+        limits: &layout::Limits,
+    ) -> Size {
+        let limits = limits
+            .max_width(self.max_width)
+            .width(self.width)
+            .height(self.height);
+
+        layout::flex::resolve(
+            layout::flex::Axis::Vertical,
+            renderer,
+            &limits,
+            self.padding,
+            self.spacing as f32,
+            self.align_items,
+            &mut self.children,
+            layout::flex::LayoutMode::MeasureSize,
+        )
+        .size()
     }
 
     fn operate(

--- a/native/src/widget/container.rs
+++ b/native/src/widget/container.rs
@@ -151,7 +151,7 @@ where
     }
 
     fn layout(
-        &self,
+        &mut self,
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
@@ -166,7 +166,7 @@ where
             self.horizontal_alignment,
             self.vertical_alignment,
             |renderer, limits| {
-                self.content.as_widget().layout(renderer, limits)
+                self.content.as_widget_mut().layout(renderer, limits)
             },
         )
     }

--- a/native/src/widget/container.rs
+++ b/native/src/widget/container.rs
@@ -230,7 +230,7 @@ where
     }
 
     fn draw(
-        &self,
+        &mut self,
         tree: &Tree,
         renderer: &mut Renderer,
         theme: &Renderer::Theme,
@@ -243,7 +243,7 @@ where
 
         draw_background(renderer, &style, layout.bounds());
 
-        self.content.as_widget().draw(
+        self.content.as_widget_mut().draw(
             &tree.children[0],
             renderer,
             theme,

--- a/native/src/widget/image.rs
+++ b/native/src/widget/image.rs
@@ -164,7 +164,7 @@ where
     }
 
     fn layout(
-        &self,
+        &mut self,
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {

--- a/native/src/widget/image.rs
+++ b/native/src/widget/image.rs
@@ -179,7 +179,7 @@ where
     }
 
     fn draw(
-        &self,
+        &mut self,
         _state: &Tree,
         renderer: &mut Renderer,
         _theme: &Renderer::Theme,

--- a/native/src/widget/image/viewer.rs
+++ b/native/src/widget/image/viewer.rs
@@ -104,7 +104,7 @@ where
     }
 
     fn layout(
-        &self,
+        &mut self,
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {

--- a/native/src/widget/image/viewer.rs
+++ b/native/src/widget/image/viewer.rs
@@ -295,7 +295,7 @@ where
     }
 
     fn draw(
-        &self,
+        &mut self,
         tree: &Tree,
         renderer: &mut Renderer,
         _theme: &Renderer::Theme,

--- a/native/src/widget/pane_grid.rs
+++ b/native/src/widget/pane_grid.rs
@@ -402,7 +402,7 @@ where
     }
 
     fn draw(
-        &self,
+        &mut self,
         tree: &Tree,
         renderer: &mut Renderer,
         theme: &Renderer::Theme,
@@ -411,9 +411,11 @@ where
         cursor_position: Point,
         viewport: &Rectangle,
     ) {
+        let (content_layout, content_iter) =
+            self.contents.layout_and_mut_iterator();
         draw(
             tree.state.downcast_ref(),
-            self.contents.layout(),
+            content_layout,
             layout,
             cursor_position,
             renderer,
@@ -423,8 +425,7 @@ where
             self.spacing,
             self.on_resize.as_ref().map(|(leeway, _)| *leeway),
             &self.style,
-            self.contents
-                .iter()
+            content_iter
                 .zip(&tree.children)
                 .map(|((pane, content), tree)| (pane, (content, tree))),
             |(content, tree),

--- a/native/src/widget/pane_grid/content.rs
+++ b/native/src/widget/pane_grid/content.rs
@@ -149,11 +149,11 @@ where
     }
 
     pub(crate) fn layout(
-        &self,
+        &mut self,
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
-        if let Some(title_bar) = &self.title_bar {
+        if let Some(title_bar) = &mut self.title_bar {
             let max_size = limits.max();
 
             let title_bar_layout = title_bar
@@ -161,7 +161,7 @@ where
 
             let title_bar_size = title_bar_layout.size();
 
-            let mut body_layout = self.body.as_widget().layout(
+            let mut body_layout = self.body.as_widget_mut().layout(
                 renderer,
                 &layout::Limits::new(
                     Size::ZERO,
@@ -179,7 +179,7 @@ where
                 vec![title_bar_layout, body_layout],
             )
         } else {
-            self.body.as_widget().layout(renderer, limits)
+            self.body.as_widget_mut().layout(renderer, limits)
         }
     }
 

--- a/native/src/widget/pane_grid/content.rs
+++ b/native/src/widget/pane_grid/content.rs
@@ -89,7 +89,7 @@ where
     ///
     /// [`Renderer`]: crate::Renderer
     pub fn draw(
-        &self,
+        &mut self,
         tree: &Tree,
         renderer: &mut Renderer,
         theme: &Renderer::Theme,
@@ -108,14 +108,14 @@ where
             container::draw_background(renderer, &style, bounds);
         }
 
-        if let Some(title_bar) = &self.title_bar {
+        if let Some(title_bar) = &mut self.title_bar {
             let mut children = layout.children();
             let title_bar_layout = children.next().unwrap();
             let body_layout = children.next().unwrap();
 
             let show_controls = bounds.contains(cursor_position);
 
-            self.body.as_widget().draw(
+            self.body.as_widget_mut().draw(
                 &tree.children[0],
                 renderer,
                 theme,
@@ -136,7 +136,7 @@ where
                 show_controls,
             );
         } else {
-            self.body.as_widget().draw(
+            self.body.as_widget_mut().draw(
                 &tree.children[0],
                 renderer,
                 theme,

--- a/native/src/widget/pane_grid/title_bar.rs
+++ b/native/src/widget/pane_grid/title_bar.rs
@@ -212,7 +212,7 @@ where
     }
 
     pub(crate) fn layout(
-        &self,
+        &mut self,
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
@@ -221,14 +221,14 @@ where
 
         let title_layout = self
             .content
-            .as_widget()
+            .as_widget_mut()
             .layout(renderer, &layout::Limits::new(Size::ZERO, max_size));
 
         let title_size = title_layout.size();
 
-        let mut node = if let Some(controls) = &self.controls {
+        let mut node = if let Some(controls) = &mut self.controls {
             let mut controls_layout = controls
-                .as_widget()
+                .as_widget_mut()
                 .layout(renderer, &layout::Limits::new(Size::ZERO, max_size));
 
             let controls_size = controls_layout.size();

--- a/native/src/widget/pane_grid/title_bar.rs
+++ b/native/src/widget/pane_grid/title_bar.rs
@@ -116,7 +116,7 @@ where
     ///
     /// [`Renderer`]: crate::Renderer
     pub fn draw(
-        &self,
+        &mut self,
         tree: &Tree,
         renderer: &mut Renderer,
         theme: &Renderer::Theme,
@@ -143,7 +143,7 @@ where
         let title_layout = children.next().unwrap();
         let mut show_title = true;
 
-        if let Some(controls) = &self.controls {
+        if let Some(controls) = &mut self.controls {
             if show_controls || self.always_show_controls {
                 let controls_layout = children.next().unwrap();
                 if title_layout.bounds().width + controls_layout.bounds().width
@@ -152,7 +152,7 @@ where
                     show_title = false;
                 }
 
-                controls.as_widget().draw(
+                controls.as_widget_mut().draw(
                     &tree.children[1],
                     renderer,
                     theme,
@@ -165,7 +165,7 @@ where
         }
 
         if show_title {
-            self.content.as_widget().draw(
+            self.content.as_widget_mut().draw(
                 &tree.children[0],
                 renderer,
                 theme,

--- a/native/src/widget/pick_list.rs
+++ b/native/src/widget/pick_list.rs
@@ -203,7 +203,7 @@ where
     }
 
     fn draw(
-        &self,
+        &mut self,
         tree: &Tree,
         renderer: &mut Renderer,
         theme: &Renderer::Theme,

--- a/native/src/widget/pick_list.rs
+++ b/native/src/widget/pick_list.rs
@@ -153,7 +153,7 @@ where
     }
 
     fn layout(
-        &self,
+        &mut self,
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {

--- a/native/src/widget/progress_bar.rs
+++ b/native/src/widget/progress_bar.rs
@@ -105,7 +105,7 @@ where
     }
 
     fn draw(
-        &self,
+        &mut self,
         _state: &Tree,
         renderer: &mut Renderer,
         theme: &Renderer::Theme,

--- a/native/src/widget/progress_bar.rs
+++ b/native/src/widget/progress_bar.rs
@@ -91,7 +91,7 @@ where
     }
 
     fn layout(
-        &self,
+        &mut self,
         _renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {

--- a/native/src/widget/radio.rs
+++ b/native/src/widget/radio.rs
@@ -155,7 +155,7 @@ where
     }
 
     fn layout(
-        &self,
+        &mut self,
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {

--- a/native/src/widget/radio.rs
+++ b/native/src/widget/radio.rs
@@ -211,7 +211,7 @@ where
     }
 
     fn draw(
-        &self,
+        &mut self,
         _state: &Tree,
         renderer: &mut Renderer,
         theme: &Renderer::Theme,

--- a/native/src/widget/row.rs
+++ b/native/src/widget/row.rs
@@ -204,7 +204,7 @@ where
     }
 
     fn draw(
-        &self,
+        &mut self,
         tree: &Tree,
         renderer: &mut Renderer,
         theme: &Renderer::Theme,
@@ -215,11 +215,11 @@ where
     ) {
         for ((child, state), layout) in self
             .children
-            .iter()
+            .iter_mut()
             .zip(&tree.children)
             .zip(layout.children())
         {
-            child.as_widget().draw(
+            child.as_widget_mut().draw(
                 state,
                 renderer,
                 theme,

--- a/native/src/widget/row.rs
+++ b/native/src/widget/row.rs
@@ -7,7 +7,7 @@ use crate::renderer;
 use crate::widget::{Operation, Tree};
 use crate::{
     Alignment, Clipboard, Element, Length, Padding, Pixels, Point, Rectangle,
-    Shell, Widget,
+    Shell, Size, Widget,
 };
 
 /// A container that distributes its contents horizontally.
@@ -127,7 +127,28 @@ where
             self.spacing,
             self.align_items,
             &mut self.children,
+            layout::flex::LayoutMode::PerformLayout,
         )
+    }
+
+    fn measure(
+        &mut self,
+        renderer: &Renderer,
+        limits: &layout::Limits,
+    ) -> Size {
+        let limits = limits.width(self.width).height(self.height);
+
+        layout::flex::resolve(
+            layout::flex::Axis::Horizontal,
+            renderer,
+            &limits,
+            self.padding,
+            self.spacing as f32,
+            self.align_items,
+            &mut self.children,
+            layout::flex::LayoutMode::MeasureSize,
+        )
+        .size()
     }
 
     fn operate(

--- a/native/src/widget/row.rs
+++ b/native/src/widget/row.rs
@@ -113,7 +113,7 @@ where
     }
 
     fn layout(
-        &self,
+        &mut self,
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
@@ -126,7 +126,7 @@ where
             self.padding,
             self.spacing,
             self.align_items,
-            &self.children,
+            &mut self.children,
         )
     }
 

--- a/native/src/widget/rule.rs
+++ b/native/src/widget/rule.rs
@@ -80,7 +80,7 @@ where
     }
 
     fn draw(
-        &self,
+        &mut self,
         _state: &Tree,
         renderer: &mut Renderer,
         theme: &Renderer::Theme,

--- a/native/src/widget/rule.rs
+++ b/native/src/widget/rule.rs
@@ -70,7 +70,7 @@ where
     }
 
     fn layout(
-        &self,
+        &mut self,
         _renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {

--- a/native/src/widget/scrollable.rs
+++ b/native/src/widget/scrollable.rs
@@ -256,7 +256,7 @@ where
     }
 
     fn draw(
-        &self,
+        &mut self,
         tree: &Tree,
         renderer: &mut Renderer,
         theme: &Renderer::Theme,
@@ -275,7 +275,7 @@ where
             self.horizontal.as_ref(),
             &self.style,
             |renderer, layout, cursor_position, viewport| {
-                self.content.as_widget().draw(
+                self.content.as_widget_mut().draw(
                     &tree.children[0],
                     renderer,
                     theme,

--- a/native/src/widget/scrollable.rs
+++ b/native/src/widget/scrollable.rs
@@ -181,7 +181,7 @@ where
     }
 
     fn layout(
-        &self,
+        &mut self,
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
@@ -192,7 +192,7 @@ where
             self.height,
             self.horizontal.is_some(),
             |renderer, limits| {
-                self.content.as_widget().layout(renderer, limits)
+                self.content.as_widget_mut().layout(renderer, limits)
             },
         )
     }

--- a/native/src/widget/slider.rs
+++ b/native/src/widget/slider.rs
@@ -203,7 +203,7 @@ where
     }
 
     fn draw(
-        &self,
+        &mut self,
         tree: &Tree,
         renderer: &mut Renderer,
         theme: &Renderer::Theme,

--- a/native/src/widget/slider.rs
+++ b/native/src/widget/slider.rs
@@ -168,7 +168,7 @@ where
     }
 
     fn layout(
-        &self,
+        &mut self,
         _renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {

--- a/native/src/widget/space.rs
+++ b/native/src/widget/space.rs
@@ -52,7 +52,7 @@ where
     }
 
     fn layout(
-        &self,
+        &mut self,
         _renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {

--- a/native/src/widget/space.rs
+++ b/native/src/widget/space.rs
@@ -62,7 +62,7 @@ where
     }
 
     fn draw(
-        &self,
+        &mut self,
         _state: &Tree,
         _renderer: &mut Renderer,
         _theme: &Renderer::Theme,

--- a/native/src/widget/svg.rs
+++ b/native/src/widget/svg.rs
@@ -137,7 +137,7 @@ where
     }
 
     fn draw(
-        &self,
+        &mut self,
         _state: &Tree,
         renderer: &mut Renderer,
         theme: &Renderer::Theme,

--- a/native/src/widget/svg.rs
+++ b/native/src/widget/svg.rs
@@ -104,7 +104,7 @@ where
     }
 
     fn layout(
-        &self,
+        &mut self,
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {

--- a/native/src/widget/text.rs
+++ b/native/src/widget/text.rs
@@ -128,7 +128,7 @@ where
     }
 
     fn layout(
-        &self,
+        &mut self,
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {

--- a/native/src/widget/text.rs
+++ b/native/src/widget/text.rs
@@ -147,7 +147,7 @@ where
     }
 
     fn draw(
-        &self,
+        &mut self,
         _state: &Tree,
         renderer: &mut Renderer,
         theme: &Renderer::Theme,

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -268,7 +268,7 @@ where
     }
 
     fn draw(
-        &self,
+        &mut self,
         tree: &Tree,
         renderer: &mut Renderer,
         theme: &Renderer::Theme,

--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -219,7 +219,7 @@ where
     }
 
     fn layout(
-        &self,
+        &mut self,
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {

--- a/native/src/widget/toggler.rs
+++ b/native/src/widget/toggler.rs
@@ -147,7 +147,7 @@ where
     }
 
     fn layout(
-        &self,
+        &mut self,
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {

--- a/native/src/widget/toggler.rs
+++ b/native/src/widget/toggler.rs
@@ -216,7 +216,7 @@ where
     }
 
     fn draw(
-        &self,
+        &mut self,
         _state: &Tree,
         renderer: &mut Renderer,
         theme: &Renderer::Theme,

--- a/native/src/widget/tooltip.rs
+++ b/native/src/widget/tooltip.rs
@@ -123,11 +123,11 @@ where
     }
 
     fn layout(
-        &self,
+        &mut self,
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
-        self.content.as_widget().layout(renderer, limits)
+        self.content.as_widget_mut().layout(renderer, limits)
     }
 
     fn on_event(
@@ -188,7 +188,9 @@ where
             viewport,
         );
 
-        let tooltip = &self.tooltip;
+        todo!();
+
+        let tooltip = &mut self.tooltip;
 
         draw(
             renderer,

--- a/native/src/widget/vertical_slider.rs
+++ b/native/src/widget/vertical_slider.rs
@@ -197,7 +197,7 @@ where
     }
 
     fn draw(
-        &self,
+        &mut self,
         tree: &Tree,
         renderer: &mut Renderer,
         theme: &Renderer::Theme,

--- a/native/src/widget/vertical_slider.rs
+++ b/native/src/widget/vertical_slider.rs
@@ -162,7 +162,7 @@ where
     }
 
     fn layout(
-        &self,
+        &mut self,
         _renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {


### PR DESCRIPTION
## Objective

- Make layout faster.
- Enable https://github.com/iced-rs/iced/issues/34 to be implemented with decent performance.

## Context

https://github.com/iced-rs/iced/issues/34#issuecomment-1430373717

## Changes made

- Makes the `layout` method on the `Widget` trait take `&mut self` instead of `&self` (this enables caching the resultant layout)
- Makes the `draw` method on the `Widget` trait take `&mut self` instead of `&self` (this was necessary because the tooltip component calls `layout` from `draw`)
- Adds a `measure` method to the `Widget` trait which has the semantics "compute the size of this widget without performing a full recursive layout unless necessary". This method has a default implementation with just calls `layout`.
- Implement optimised versions of `measure` for `row`, `column`, and `container.
- Adds `set_size (&mut self, size: Size)` and `into_children(self) -> Vec<Node>` methods to `layout::Node`

This PR (along with associated changes in [iced_taffy](https://github.com/nicoburns/iced_taffy)) improves the performance of an [iced_taffy stress test](https://github.com/nicoburns/iced_taffy/blob/main/examples/huge_nested.rs) of a 7000+ node nested grid by 20x (from 200ms for layout down to 12ms).

## Further work 

Further work will be needed to make things really fast for realistic layouts. Including:

- Add optimised `measure` methods to other widgets where appropriate (esp. other container widgets if there are any)
- Add layout caching to row/column/container and other widgets where appropriate
- Add layout caching for text (at least caching the results of shaping)

## Feedback wanted

- In general, are the Iced maintainers amenable to accepting changes along these lines?
- Is changing the `layout` method to take `&mut self` acceptable? Converting the widgets to work with this was fairly easy, and it seems like the cleanest solution to enabling caching to me. But caching could also be implemented using `RefCell` without this change.
- Is changing the `draw` method to take `&mut self` acceptable? I didn't look into why `tooltip` is calling `layout` in `draw`, but it seems to me that it probably shouldn't be? If `tooltip` was modified to not do this then this change could be reverted.