### PR TITLE
Impl std::ops for Size, Vector #1724

### DIFF
--- a/core/src/size.rs
+++ b/core/src/size.rs
@@ -84,13 +84,332 @@ impl From<Size> for Vector<f32> {
     }
 }
 
-impl std::ops::Sub for Size {
-    type Output = Size;
+// Addition with own type
+impl<T> std::ops::Add for Size<T>
+where
+    T: std::ops::Add<Output = T> + Copy,
+{
+    type Output = Self;
 
-    fn sub(self, rhs: Self) -> Self::Output {
-        Size {
-            width: self.width - rhs.width,
-            height: self.height - rhs.height,
+    fn add(self, other: Self) -> Self::Output {
+        Self {
+            width: self.width + other.width,
+            height: self.height + other.height,
         }
+    }
+}
+
+impl<T> std::ops::AddAssign for Size<T>
+where
+    T: std::ops::AddAssign + Copy,
+{
+    fn add_assign(&mut self, other: Self) {
+        self.width += other.width;
+        self.height += other.height;
+    }
+}
+
+// Addition with scalar
+impl<T> std::ops::Add<T> for Size<T>
+where
+    T: std::ops::Add<Output = T> + Copy,
+{
+    type Output = Self;
+
+    fn add(self, other: T) -> Self::Output {
+        Self {
+            width: self.width + other,
+            height: self.height + other,
+        }
+    }
+}
+
+impl<T> std::ops::AddAssign<T> for Size<T>
+where
+    T: std::ops::AddAssign + Copy,
+{
+    fn add_assign(&mut self, other: T) {
+        self.width += other;
+        self.height += other;
+    }
+}
+
+impl<T> std::ops::Div for Size<T>
+where
+    T: std::ops::Div<Output = T> + Copy,
+{
+    type Output = Self;
+
+    fn div(self, other: Self) -> Self {
+        Self {
+            width: self.width / other.width,
+            height: self.height / other.height,
+        }
+    }
+}
+
+impl<T> std::ops::DivAssign for Size<T>
+where
+    T: std::ops::DivAssign + Copy,
+{
+    fn div_assign(&mut self, other: Self) {
+        self.width /= other.width;
+        self.height /= other.height;
+    }
+}
+
+impl<T> std::ops::Div<T> for Size<T>
+where
+    T: std::ops::Div<Output = T> + Copy,
+{
+    type Output = Self;
+
+    fn div(self, other: T) -> Self {
+        Self {
+            width: self.width / other,
+            height: self.height / other,
+        }
+    }
+}
+
+impl<T> std::ops::DivAssign<T> for Size<T>
+where
+    T: std::ops::DivAssign + Copy,
+{
+    fn div_assign(&mut self, other: T) {
+        self.width /= other;
+        self.height /= other;
+    }
+}
+
+impl<T> std::ops::Mul for Size<T>
+where
+    T: std::ops::Mul<Output = T> + Copy,
+{
+    type Output = Self;
+
+    fn mul(self, other: Self) -> Self {
+        Self {
+            width: self.width * other.width,
+            height: self.height * other.height,
+        }
+    }
+}
+
+impl<T> std::ops::MulAssign for Size<T>
+where
+    T: std::ops::MulAssign + Copy,
+{
+    fn mul_assign(&mut self, other: Self) {
+        self.width *= other.width;
+        self.height *= other.height;
+    }
+}
+
+impl<T> std::ops::Mul<T> for Size<T>
+where
+    T: std::ops::Mul<Output = T> + Copy,
+{
+    type Output = Self;
+
+    fn mul(self, other: T) -> Self {
+        Self {
+            width: self.width * other,
+            height: self.height * other,
+        }
+    }
+}
+
+impl<T> std::ops::MulAssign<T> for Size<T>
+where
+    T: std::ops::MulAssign + Copy,
+{
+    fn mul_assign(&mut self, other: T) {
+        self.width *= other;
+        self.height *= other;
+    }
+}
+
+impl<T> std::ops::Rem for Size<T>
+where
+    T: std::ops::Rem<Output = T> + Copy,
+{
+    type Output = Self;
+
+    fn rem(self, other: Self) -> Self {
+        Self {
+            width: self.width % other.width,
+            height: self.height % other.height,
+        }
+    }
+}
+
+impl<T> std::ops::RemAssign for Size<T>
+where
+    T: std::ops::RemAssign + Copy,
+{
+    fn rem_assign(&mut self, other: Self) {
+        self.width %= other.width;
+        self.height %= other.height;
+    }
+}
+
+impl<T> std::ops::Rem<T> for Size<T>
+where
+    T: std::ops::Rem<Output = T> + Copy,
+{
+    type Output = Self;
+
+    fn rem(self, other: T) -> Self {
+        Self {
+            width: self.width % other,
+            height: self.height % other,
+        }
+    }
+}
+
+impl<T> std::ops::RemAssign<T> for Size<T>
+where
+    T: std::ops::RemAssign + Copy,
+{
+    fn rem_assign(&mut self, other: T) {
+        self.width %= other;
+        self.height %= other;
+    }
+}
+
+impl<T> std::ops::Sub for Size<T>
+where
+    T: std::ops::Sub<Output = T> + Copy,
+{
+    type Output = Self;
+
+    fn sub(self, other: Self) -> Self::Output {
+        Self {
+            width: self.width - other.width,
+            height: self.height - other.height,
+        }
+    }
+}
+
+impl<T> std::ops::SubAssign for Size<T>
+where
+    T: std::ops::SubAssign + Copy,
+{
+    fn sub_assign(&mut self, other: Self) {
+        self.width -= other.width;
+        self.height -= other.height;
+    }
+}
+
+impl<T> std::ops::Sub<T> for Size<T>
+where
+    T: std::ops::Sub<Output = T> + Copy,
+{
+    type Output = Self;
+
+    fn sub(self, other: T) -> Self::Output {
+        Self {
+            width: self.width - other,
+            height: self.height - other,
+        }
+    }
+}
+
+impl<T> std::ops::SubAssign<T> for Size<T>
+where
+    T: std::ops::SubAssign + Copy,
+{
+    fn sub_assign(&mut self, other: T) {
+        self.width -= other;
+        self.height -= other;
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_add() {
+        let mut a = Size::UNIT;
+        let other = Size::new(10.0, 20.0);
+        let r = Size::new(11.0, 21.0);
+        assert_eq!(r, a + other, "a + other self");
+        a += other;
+        assert_eq!(r, a, "a += other self");
+        
+        a = Size::new(8.0, 18.0);
+        let other = 3.0_f32;
+        assert_eq!(r, a + other, "a + other scalar");
+        a += other;
+        assert_eq!(r, a, "a += other scalar");
+    }
+
+    #[test]
+    fn test_div() {
+        let mut a = Size::UNIT;
+        let other = Size::new(10.0, 20.0);
+        let r = Size::new(0.1, 0.05);
+        assert_eq!(r, a / other, "a / other self");
+        a /= other;
+        assert_eq!(r, a, "a /= other self");
+        
+        a = Size::new(0.3, 0.15);
+        let other = 3.0_f32;
+        assert_eq!(r, a / other, "a / other scalar");
+        a /= other;
+        assert_eq!(r, a, "a /= other scalar");
+    }
+
+    #[test]
+    fn test_mul() {
+        let mut a = Size::UNIT;
+        let other = Size::new(10.0, 20.0);
+        let r = Size::new(10.0, 20.0);
+        assert_eq!(r, a * other, "a * other self");
+        a *= other;
+        assert_eq!(r, a, "a *= other self");
+        
+        a = Size::new(5.0, 10.0);
+        let other = 2.0_f32;
+        assert_eq!(r, a * other, "a * other scalar");
+        a *= other;
+        assert_eq!(r, a, "a *= other scalar");
+    }
+
+    #[test]
+    fn test_rem() {
+        let mut a = Size::UNIT;
+        let other = Size::new(10.0, 20.0);
+        let r = Size::new(1.0, 1.0);
+        assert_eq!(r, a % other, "a % other self");
+        a %= other;
+        assert_eq!(r, a, "a %= other self");
+        
+        a = Size::new(5.0, 0.8);
+        let other = 0.5_f32;
+        let r = Size::new(0.0, 0.3);
+        assert_eq!(r, a % other, "a % other scalar");
+        a %= other;
+        assert_eq!(r, a, "a %= other scalar");
+    }
+
+    #[test]
+    fn test_sub() {
+        let mut a = Size::UNIT;
+        let other = Size::new(10.0, 20.0);
+        let r = Size::new(-9.0, -19.0);
+        assert_eq!(r, a - other, "a - other self");
+        a -= other;
+        assert_eq!(r, a, "a -= other self");
+        
+        a = Size::new(-6.0, -16.0);
+        let other = 3.0_f32;
+        assert_eq!(r, a - other, "a - other scalar");
+        a -= other;
+        assert_eq!(r, a, "a -= other scalar");
     }
 }

--- a/core/src/vector.rs
+++ b/core/src/vector.rs
@@ -20,39 +20,6 @@ impl Vector {
     pub const ZERO: Self = Self::new(0.0, 0.0);
 }
 
-impl<T> std::ops::Add for Vector<T>
-where
-    T: std::ops::Add<Output = T>,
-{
-    type Output = Self;
-
-    fn add(self, b: Self) -> Self {
-        Self::new(self.x + b.x, self.y + b.y)
-    }
-}
-
-impl<T> std::ops::Sub for Vector<T>
-where
-    T: std::ops::Sub<Output = T>,
-{
-    type Output = Self;
-
-    fn sub(self, b: Self) -> Self {
-        Self::new(self.x - b.x, self.y - b.y)
-    }
-}
-
-impl<T> std::ops::Mul<T> for Vector<T>
-where
-    T: std::ops::Mul<Output = T> + Copy,
-{
-    type Output = Self;
-
-    fn mul(self, scale: T) -> Self {
-        Self::new(self.x * scale, self.y * scale)
-    }
-}
-
 impl<T> Default for Vector<T>
 where
     T: Default,
@@ -77,5 +44,335 @@ where
 {
     fn from(other: Vector<T>) -> Self {
         [other.x, other.y]
+    }
+}
+
+// Addition with own type
+impl<T> std::ops::Add for Vector<T>
+where
+    T: std::ops::Add<Output = T> + Copy,
+{
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self::Output {
+        Self {
+            x: self.x + other.x,
+            y: self.y + other.y,
+        }
+    }
+}
+
+impl<T> std::ops::AddAssign for Vector<T>
+where
+    T: std::ops::AddAssign + Copy,
+{
+    fn add_assign(&mut self, other: Self) {
+        self.x += other.x;
+        self.y += other.y;
+    }
+}
+
+// Addition with scalar
+impl<T> std::ops::Add<T> for Vector<T>
+where
+    T: std::ops::Add<Output = T> + Copy,
+{
+    type Output = Self;
+
+    fn add(self, other: T) -> Self::Output {
+        Self {
+            x: self.x + other,
+            y: self.y + other,
+        }
+    }
+}
+
+impl<T> std::ops::AddAssign<T> for Vector<T>
+where
+    T: std::ops::AddAssign + Copy,
+{
+    fn add_assign(&mut self, other: T) {
+        self.x += other;
+        self.y += other;
+    }
+}
+
+impl<T> std::ops::Div for Vector<T>
+where
+    T: std::ops::Div<Output = T> + Copy,
+{
+    type Output = Self;
+
+    fn div(self, other: Self) -> Self {
+        Self {
+            x: self.x / other.x,
+            y: self.y / other.y,
+        }
+    }
+}
+
+impl<T> std::ops::DivAssign for Vector<T>
+where
+    T: std::ops::DivAssign + Copy,
+{
+    fn div_assign(&mut self, other: Self) {
+        self.x /= other.x;
+        self.y /= other.y;
+    }
+}
+
+impl<T> std::ops::Div<T> for Vector<T>
+where
+    T: std::ops::Div<Output = T> + Copy,
+{
+    type Output = Self;
+
+    fn div(self, other: T) -> Self {
+        Self {
+            x: self.x / other,
+            y: self.y / other,
+        }
+    }
+}
+
+impl<T> std::ops::DivAssign<T> for Vector<T>
+where
+    T: std::ops::DivAssign + Copy,
+{
+    fn div_assign(&mut self, other: T) {
+        self.x /= other;
+        self.y /= other;
+    }
+}
+
+impl<T> std::ops::Mul for Vector<T>
+where
+    T: std::ops::Mul<Output = T> + Copy,
+{
+    type Output = Self;
+
+    fn mul(self, other: Self) -> Self {
+        Self {
+            x: self.x * other.x,
+            y: self.y * other.y,
+        }
+    }
+}
+
+impl<T> std::ops::MulAssign for Vector<T>
+where
+    T: std::ops::MulAssign + Copy,
+{
+    fn mul_assign(&mut self, other: Self) {
+        self.x *= other.x;
+        self.y *= other.y;
+    }
+}
+
+impl<T> std::ops::Mul<T> for Vector<T>
+where
+    T: std::ops::Mul<Output = T> + Copy,
+{
+    type Output = Self;
+
+    fn mul(self, other: T) -> Self {
+        Self {
+            x: self.x * other,
+            y: self.y * other,
+        }
+    }
+}
+
+impl<T> std::ops::MulAssign<T> for Vector<T>
+where
+    T: std::ops::MulAssign + Copy,
+{
+    fn mul_assign(&mut self, other: T) {
+        self.x *= other;
+        self.y *= other;
+    }
+}
+
+impl<T> std::ops::Rem for Vector<T>
+where
+    T: std::ops::Rem<Output = T> + Copy,
+{
+    type Output = Self;
+
+    fn rem(self, other: Self) -> Self {
+        Self {
+            x: self.x % other.x,
+            y: self.y % other.y,
+        }
+    }
+}
+
+impl<T> std::ops::RemAssign for Vector<T>
+where
+    T: std::ops::RemAssign + Copy,
+{
+    fn rem_assign(&mut self, other: Self) {
+        self.x %= other.x;
+        self.y %= other.y;
+    }
+}
+
+impl<T> std::ops::Rem<T> for Vector<T>
+where
+    T: std::ops::Rem<Output = T> + Copy,
+{
+    type Output = Self;
+
+    fn rem(self, other: T) -> Self {
+        Self {
+            x: self.x % other,
+            y: self.y % other,
+        }
+    }
+}
+
+impl<T> std::ops::RemAssign<T> for Vector<T>
+where
+    T: std::ops::RemAssign + Copy,
+{
+    fn rem_assign(&mut self, other: T) {
+        self.x %= other;
+        self.y %= other;
+    }
+}
+
+impl<T> std::ops::Sub for Vector<T>
+where
+    T: std::ops::Sub<Output = T> + Copy,
+{
+    type Output = Self;
+
+    fn sub(self, other: Self) -> Self::Output {
+        Self {
+            x: self.x - other.x,
+            y: self.y - other.y,
+        }
+    }
+}
+
+impl<T> std::ops::SubAssign for Vector<T>
+where
+    T: std::ops::SubAssign + Copy,
+{
+    fn sub_assign(&mut self, other: Self) {
+        self.x -= other.x;
+        self.y -= other.y;
+    }
+}
+
+impl<T> std::ops::Sub<T> for Vector<T>
+where
+    T: std::ops::Sub<Output = T> + Copy,
+{
+    type Output = Self;
+
+    fn sub(self, other: T) -> Self::Output {
+        Self {
+            x: self.x - other,
+            y: self.y - other,
+        }
+    }
+}
+
+impl<T> std::ops::SubAssign<T> for Vector<T>
+where
+    T: std::ops::SubAssign + Copy,
+{
+    fn sub_assign(&mut self, other: T) {
+        self.x -= other;
+        self.y -= other;
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_add() {
+        let mut a = Vector::new(1.0, 1.0);
+        let other = Vector::new(10.0, 20.0);
+        let r = Vector::new(11.0, 21.0);
+        assert_eq!(r, a + other, "a + other self");
+        a += other;
+        assert_eq!(r, a, "a += other self");
+        
+        a = Vector::new(8.0, 18.0);
+        let other = 3.0_f32;
+        assert_eq!(r, a + other, "a + other scalar");
+        a += other;
+        assert_eq!(r, a, "a += other scalar");
+    }
+
+    #[test]
+    fn test_div() {
+        let mut a = Vector::new(1.0, 1.0);
+        let other = Vector::new(10.0, 20.0);
+        let r = Vector::new(0.1, 0.05);
+        assert_eq!(r, a / other, "a / other self");
+        a /= other;
+        assert_eq!(r, a, "a /= other self");
+        
+        a = Vector::new(0.3, 0.15);
+        let other = 3.0_f32;
+        assert_eq!(r, a / other, "a / other scalar");
+        a /= other;
+        assert_eq!(r, a, "a /= other scalar");
+    }
+
+    #[test]
+    fn test_mul() {
+        let mut a = Vector::new(1.0, 1.0);
+        let other = Vector::new(10.0, 20.0);
+        let r = Vector::new(10.0, 20.0);
+        assert_eq!(r, a * other, "a * other self");
+        a *= other;
+        assert_eq!(r, a, "a *= other self");
+        
+        a = Vector::new(5.0, 10.0);
+        let other = 2.0_f32;
+        assert_eq!(r, a * other, "a * other scalar");
+        a *= other;
+        assert_eq!(r, a, "a *= other scalar");
+    }
+
+    #[test]
+    fn test_rem() {
+        let mut a = Vector::new(1.0, 1.0);
+        let other = Vector::new(10.0, 20.0);
+        let r = Vector::new(1.0, 1.0);
+        assert_eq!(r, a % other, "a % other self");
+        a %= other;
+        assert_eq!(r, a, "a %= other self");
+        
+        a = Vector::new(5.0, 0.8);
+        let other = 0.5_f32;
+        let r = Vector::new(0.0, 0.3);
+        assert_eq!(r, a % other, "a % other scalar");
+        a %= other;
+        assert_eq!(r, a, "a %= other scalar");
+    }
+
+    #[test]
+    fn test_sub() {
+        let mut a = Vector::new(1.0, 1.0);
+        let other = Vector::new(10.0, 20.0);
+        let r = Vector::new(-9.0, -19.0);
+        assert_eq!(r, a - other, "a - other self");
+        a -= other;
+        assert_eq!(r, a, "a -= other self");
+        
+        a = Vector::new(-6.0, -16.0);
+        let other = 3.0_f32;
+        assert_eq!(r, a - other, "a - other scalar");
+        a -= other;
+        assert_eq!(r, a, "a -= other scalar");
     }
 }


### PR DESCRIPTION
I found that the mathematical operations on Size, Vector are only partially implemented and prepared changes to support +, -, *, /, %, as well as +=, -=, *=, /=, %=. The second operand can be either a scalar or Self.