### PR TITLE
Remove logging large bytes arrays

### DIFF
--- a/glow/src/settings.rs
+++ b/glow/src/settings.rs
@@ -43,7 +43,7 @@ impl std::fmt::Debug for Settings {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Settings")
             // Instead of printing the font bytes, we simply show a `bool` indicating if using a default font or not.
-            .field("default_font", &self.default_font.is_none())
+            .field("default_font", &self.default_font.is_some())
             .field("default_text_size", &self.default_text_size)
             .field("text_multithreading", &self.text_multithreading)
             .field("antialiasing", &self.antialiasing)

--- a/glutin/src/application.rs
+++ b/glutin/src/application.rs
@@ -71,7 +71,7 @@ where
             settings.id,
         );
 
-        log::info!("Window builder: {:#?}", builder);
+        log::debug!("Window builder: {:#?}", builder);
 
         let opengl_builder = ContextBuilder::new()
             .with_vsync(true)

--- a/src/window/icon.rs
+++ b/src/window/icon.rs
@@ -6,8 +6,14 @@ use std::io;
 use std::path::Path;
 
 /// The icon of a window.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Icon(iced_winit::winit::window::Icon);
+
+impl fmt::Debug for Icon {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Icon").field(&format_args!("_")).finish()
+    }
+}
 
 impl Icon {
     /// Creates an icon from 32bpp RGBA data.

--- a/wgpu/src/settings.rs
+++ b/wgpu/src/settings.rs
@@ -1,10 +1,12 @@
 //! Configure a renderer.
+use std::fmt;
+
 pub use crate::Antialiasing;
 
 /// The settings of a [`Backend`].
 ///
 /// [`Backend`]: crate::Backend
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq)]
 pub struct Settings {
     /// The present mode of the [`Backend`].
     ///
@@ -34,6 +36,20 @@ pub struct Settings {
     ///
     /// By default, it is `None`.
     pub antialiasing: Option<Antialiasing>,
+}
+
+impl fmt::Debug for Settings {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Settings")
+            .field("present_mode", &self.present_mode)
+            .field("internal_backend", &self.internal_backend)
+            // Instead of printing the font bytes, we simply show a `bool` indicating if using a default font or not.
+            .field("default_font", &self.default_font.is_some())
+            .field("default_text_size", &self.default_text_size)
+            .field("text_multithreading", &self.text_multithreading)
+            .field("antialiasing", &self.antialiasing)
+            .finish()
+    }
 }
 
 impl Settings {

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -157,7 +157,7 @@ where
         )
         .with_visible(false);
 
-    log::info!("Window builder: {:#?}", builder);
+    log::debug!("Window builder: {:#?}", builder);
 
     let window = builder
         .build(&event_loop)

--- a/winit/src/settings.rs
+++ b/winit/src/settings.rs
@@ -23,8 +23,11 @@ pub use platform::PlatformSpecific;
 
 use crate::conversion;
 use crate::Position;
+
 use winit::monitor::MonitorHandle;
 use winit::window::WindowBuilder;
+
+use std::fmt;
 
 /// The settings of an application.
 #[derive(Debug, Clone, Default)]
@@ -59,7 +62,7 @@ pub struct Settings<Flags> {
 }
 
 /// The window settings of an application.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Window {
     /// The size of the window.
     pub size: (u32, u32),
@@ -93,6 +96,24 @@ pub struct Window {
 
     /// Platform specific settings.
     pub platform_specific: platform::PlatformSpecific,
+}
+
+impl fmt::Debug for Window {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Window")
+            .field("size", &self.size)
+            .field("position", &self.position)
+            .field("min_size", &self.min_size)
+            .field("max_size", &self.max_size)
+            .field("visible", &self.visible)
+            .field("resizable", &self.resizable)
+            .field("decorations", &self.decorations)
+            .field("transparent", &self.transparent)
+            .field("always_on_top", &self.always_on_top)
+            .field("icon", &self.icon.is_some())
+            .field("platform_specific", &self.platform_specific)
+            .finish()
+    }
 }
 
 impl Window {


### PR DESCRIPTION
I've noticed a huge impact on startup time when logging is enabled w/ `iced` due to large byte arrays getting printed to the terminal. This is due to the font bytes that are debugged, as well as the winit icon bytes that is debugged.

We log the `winit::WindowBuilder` directly, so I don't have access to customize how that is logged. This will require an upstream fix, if accepted. In the meantime, I think it's fair to log that struct as `debug` instead of `info`. We already log the iced window settings on `info` anyways.

I noticed there was already a fix for this on the glow side for default_font bytes. I've flipped this to `is_some` since it makes more sense the `default_font: true` means `default_font: is_some / Some`, meaning a default font was provided.