### PR TITLE
Update to winit 0.28

### DIFF
--- a/core/src/window.rs
+++ b/core/src/window.rs
@@ -2,12 +2,14 @@
 pub mod icon;
 
 mod event;
+mod level;
 mod mode;
 mod redraw_request;
 mod user_attention;
 
 pub use event::Event;
 pub use icon::Icon;
+pub use level::Level;
 pub use mode::Mode;
 pub use redraw_request::RedrawRequest;
 pub use user_attention::UserAttention;

--- a/core/src/window/level.rs
+++ b/core/src/window/level.rs
@@ -1,0 +1,19 @@
+/// A window level groups windows with respect to their z-position.
+///
+/// The relative ordering between windows in different window levels is fixed.
+/// The z-order of a window within the same window level may change dynamically
+/// on user interaction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Level {
+    /// The default behavior.
+    #[default]
+    Normal,
+
+    /// The window will always be below normal windows.
+    ///
+    /// This is useful for a widget-based app.
+    AlwaysOnBottom,
+
+    /// The window will always be on top of normal windows.
+    AlwaysOnTop,
+}

--- a/runtime/src/window.rs
+++ b/runtime/src/window.rs
@@ -5,7 +5,7 @@ pub use action::Action;
 
 use crate::command::{self, Command};
 use crate::core::time::Instant;
-use crate::core::window::{Event, Icon, Mode, UserAttention};
+use crate::core::window::{Event, Icon, Level, Mode, UserAttention};
 use crate::futures::subscription::{self, Subscription};
 
 /// Subscribes to the frames of the window of the running application.
@@ -53,7 +53,7 @@ pub fn move_to<Message>(x: i32, y: i32) -> Command<Message> {
     Command::single(command::Action::Window(Action::Move { x, y }))
 }
 
-/// Sets the [`Mode`] of the window.
+/// Changes the [`Mode`] of the window.
 pub fn change_mode<Message>(mode: Mode) -> Command<Message> {
     Command::single(command::Action::Window(Action::ChangeMode(mode)))
 }
@@ -99,9 +99,9 @@ pub fn gain_focus<Message>() -> Command<Message> {
     Command::single(command::Action::Window(Action::GainFocus))
 }
 
-/// Changes whether or not the window will always be on top of other windows.
-pub fn change_always_on_top<Message>(on_top: bool) -> Command<Message> {
-    Command::single(command::Action::Window(Action::ChangeAlwaysOnTop(on_top)))
+/// Changes the window [`Level`].
+pub fn change_level<Message>(level: Level) -> Command<Message> {
+    Command::single(command::Action::Window(Action::ChangeLevel(level)))
 }
 
 /// Fetches an identifier unique to the window.

--- a/runtime/src/window/action.rs
+++ b/runtime/src/window/action.rs
@@ -1,13 +1,13 @@
-use crate::core::window::{Icon, Mode, UserAttention};
+use crate::core::window::{Icon, Level, Mode, UserAttention};
 use crate::futures::MaybeSend;
 
 use std::fmt;
 
 /// An operation to be performed on some window.
 pub enum Action<T> {
-    /// Closes the current window and exits the application.
+    /// Close the current window and exits the application.
     Close,
-    /// Moves the window with the left mouse button until the button is
+    /// Move the window with the left mouse button until the button is
     /// released.
     ///
     /// There’s no guarantee that this will work unless the left mouse
@@ -20,7 +20,7 @@ pub enum Action<T> {
         /// The new logical height of the window
         height: u32,
     },
-    /// Sets the window to maximized or back
+    /// Set the window to maximized or back
     Maximize(bool),
     /// Set the window to minimized or back
     Minimize(bool),
@@ -70,15 +70,11 @@ pub enum Action<T> {
     ///
     /// - **Web / Wayland:** Unsupported.
     GainFocus,
-    /// Change whether or not the window will always be on top of other windows.
-    ///
-    /// ## Platform-specific
-    ///
-    /// - **Web / Wayland:** Unsupported.
-    ChangeAlwaysOnTop(bool),
+    /// Change the window [`Level`].
+    ChangeLevel(Level),
     /// Fetch an identifier unique to the window.
     FetchId(Box<dyn FnOnce(u64) -> T + 'static>),
-    /// Changes the window [`Icon`].
+    /// Change the window [`Icon`].
     ///
     /// On Windows and X11, this is typically the small icon in the top-left
     /// corner of the titlebar.
@@ -119,9 +115,7 @@ impl<T> Action<T> {
                 Action::RequestUserAttention(attention_type)
             }
             Self::GainFocus => Action::GainFocus,
-            Self::ChangeAlwaysOnTop(on_top) => {
-                Action::ChangeAlwaysOnTop(on_top)
-            }
+            Self::ChangeLevel(level) => Action::ChangeLevel(level),
             Self::FetchId(o) => Action::FetchId(Box::new(move |s| f(o(s)))),
             Self::ChangeIcon(icon) => Action::ChangeIcon(icon),
         }
@@ -154,8 +148,8 @@ impl<T> fmt::Debug for Action<T> {
                 write!(f, "Action::RequestUserAttention")
             }
             Self::GainFocus => write!(f, "Action::GainFocus"),
-            Self::ChangeAlwaysOnTop(on_top) => {
-                write!(f, "Action::AlwaysOnTop({on_top})")
+            Self::ChangeLevel(level) => {
+                write!(f, "Action::ChangeLevel({level:?})")
             }
             Self::FetchId(_) => write!(f, "Action::FetchId"),
             Self::ChangeIcon(_icon) => {

--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -1,4 +1,4 @@
-use crate::window::{Icon, Position};
+use crate::window::{Icon, Level, Position};
 
 pub use iced_winit::settings::PlatformSpecific;
 
@@ -29,8 +29,8 @@ pub struct Settings {
     /// Whether the window should be transparent.
     pub transparent: bool,
 
-    /// Whether the window will always be on top of other windows.
-    pub always_on_top: bool,
+    /// The window [`Level`].
+    pub level: Level,
 
     /// The icon of the window.
     pub icon: Option<Icon>,
@@ -50,7 +50,7 @@ impl Default for Settings {
             resizable: true,
             decorations: true,
             transparent: false,
-            always_on_top: false,
+            level: Level::default(),
             icon: None,
             platform_specific: Default::default(),
         }
@@ -68,7 +68,7 @@ impl From<Settings> for iced_winit::settings::Window {
             resizable: settings.resizable,
             decorations: settings.decorations,
             transparent: settings.transparent,
-            always_on_top: settings.always_on_top,
+            level: settings.level,
             icon: settings.icon.map(Icon::into),
             platform_specific: settings.platform_specific,
         }

--- a/winit/Cargo.toml
+++ b/winit/Cargo.toml
@@ -30,8 +30,8 @@ raw-window-handle = "0.5"
 
 [dependencies.winit]
 version = "0.28"
-git = "https://github.com/nicoburns/winit.git"
-rev = "dd5fcaf30114baf876677d997e362c23d7d134c8"
+git = "https://github.com/iced-rs/winit.git"
+rev = "ac1ddfe0bd870910b3aa64a18d386fdd55b30a1d"
 default-features = false
 
 [dependencies.iced_runtime]

--- a/winit/Cargo.toml
+++ b/winit/Cargo.toml
@@ -26,6 +26,7 @@ wayland-csd-adwaita = ["winit/wayland-csd-adwaita"]
 window_clipboard = { git = "https://github.com/TobTobXX/window_clipboard", rev = "1392da8339c8aebb9849d00eb7383a73ed076f1d" }
 log = "0.4"
 thiserror = "1.0"
+raw-window-handle = "0.5"
 
 [dependencies.winit]
 version = "0.28"

--- a/winit/Cargo.toml
+++ b/winit/Cargo.toml
@@ -23,7 +23,7 @@ wayland-dlopen = ["winit/wayland-dlopen"]
 wayland-csd-adwaita = ["winit/wayland-csd-adwaita"]
 
 [dependencies]
-window_clipboard = { git = "https://github.com/TobTobXX/window_clipboard", rev = "1392da8339c8aebb9849d00eb7383a73ed076f1d" }
+window_clipboard = "0.3"
 log = "0.4"
 thiserror = "1.0"
 raw-window-handle = "0.5"

--- a/winit/Cargo.toml
+++ b/winit/Cargo.toml
@@ -23,14 +23,14 @@ wayland-dlopen = ["winit/wayland-dlopen"]
 wayland-csd-adwaita = ["winit/wayland-csd-adwaita"]
 
 [dependencies]
-window_clipboard = "0.2"
+window_clipboard = { git = "https://github.com/TobTobXX/window_clipboard", rev = "1392da8339c8aebb9849d00eb7383a73ed076f1d" }
 log = "0.4"
 thiserror = "1.0"
 
 [dependencies.winit]
-version = "0.27"
-git = "https://github.com/iced-rs/winit.git"
-rev = "940457522e9fb9f5dac228b0ecfafe0138b4048c"
+version = "0.28"
+git = "https://github.com/nicoburns/winit.git"
+rev = "f160dc321eaa2e30f770f0b61f7ffc74541cafe0"
 default-features = false
 
 [dependencies.iced_runtime]

--- a/winit/Cargo.toml
+++ b/winit/Cargo.toml
@@ -31,7 +31,7 @@ raw-window-handle = "0.5"
 [dependencies.winit]
 version = "0.28"
 git = "https://github.com/nicoburns/winit.git"
-rev = "f160dc321eaa2e30f770f0b61f7ffc74541cafe0"
+rev = "dd5fcaf30114baf876677d997e362c23d7d134c8"
 default-features = false
 
 [dependencies.iced_runtime]

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -26,6 +26,7 @@ use crate::{Clipboard, Error, Proxy, Settings};
 use futures::channel::mpsc;
 
 use std::mem::ManuallyDrop;
+use winit::window::WindowLevel;
 
 #[cfg(feature = "trace")]
 pub use profiler::Profiler;
@@ -795,7 +796,11 @@ pub fn run_command<A, E>(
                     window.focus_window();
                 }
                 window::Action::ChangeAlwaysOnTop(on_top) => {
-                    window.set_always_on_top(on_top);
+                    let level = match on_top {
+                        true => WindowLevel::AlwaysOnTop,
+                        false => WindowLevel::Normal,
+                    };
+                    window.set_window_level(level);
                 }
                 window::Action::FetchId(tag) => {
                     proxy

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -26,7 +26,6 @@ use crate::{Clipboard, Error, Proxy, Settings};
 use futures::channel::mpsc;
 
 use std::mem::ManuallyDrop;
-use winit::window::WindowLevel;
 
 #[cfg(feature = "trace")]
 pub use profiler::Profiler;
@@ -795,12 +794,8 @@ pub fn run_command<A, E>(
                 window::Action::GainFocus => {
                     window.focus_window();
                 }
-                window::Action::ChangeAlwaysOnTop(on_top) => {
-                    let level = match on_top {
-                        true => WindowLevel::AlwaysOnTop,
-                        false => WindowLevel::Normal,
-                    };
-                    window.set_window_level(level);
+                window::Action::ChangeLevel(level) => {
+                    window.set_window_level(conversion::window_level(level));
                 }
                 window::Action::FetchId(tag) => {
                     proxy

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -140,6 +140,19 @@ pub fn window_event(
     }
 }
 
+/// Converts a [`window::Level`] to a [`winit`] window level.
+///
+/// [`winit`]: https://github.com/rust-windowing/winit
+pub fn window_level(level: window::Level) -> winit::window::WindowLevel {
+    match level {
+        window::Level::Normal => winit::window::WindowLevel::Normal,
+        window::Level::AlwaysOnBottom => {
+            winit::window::WindowLevel::AlwaysOnBottom
+        }
+        window::Level::AlwaysOnTop => winit::window::WindowLevel::AlwaysOnTop,
+    }
+}
+
 /// Converts a [`Position`] to a [`winit`] logical position for a given monitor.
 ///
 /// [`winit`]: https://github.com/rust-windowing/winit

--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -25,9 +25,10 @@
     clippy::from_over_into,
     clippy::needless_borrow,
     clippy::new_without_default,
-    clippy::useless_conversion
+    clippy::useless_conversion,
+    unsafe_code
 )]
-#![forbid(rust_2018_idioms, unsafe_code)]
+#![forbid(rust_2018_idioms)]
 #![allow(clippy::inherent_to_string, clippy::type_complexity)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 pub use iced_graphics as graphics;

--- a/winit/src/settings.rs
+++ b/winit/src/settings.rs
@@ -173,6 +173,7 @@ impl Window {
         #[cfg(target_os = "windows")]
         {
             use winit::platform::windows::WindowBuilderExtWindows;
+            #[allow(unsafe_code)]
             unsafe {
                 window_builder = window_builder
                     .with_parent_window(self.platform_specific.parent);

--- a/winit/src/settings.rs
+++ b/winit/src/settings.rs
@@ -173,12 +173,8 @@ impl Window {
         #[cfg(target_os = "windows")]
         {
             use winit::platform::windows::WindowBuilderExtWindows;
-
-            if let Some(parent) = self.platform_specific.parent {
-                window_builder = window_builder.with_parent_window(parent);
-            }
-
             window_builder = window_builder
+                .with_parent_window(self.platform_specific.parent)
                 .with_drag_and_drop(self.platform_specific.drag_and_drop);
         }
 

--- a/winit/src/settings.rs
+++ b/winit/src/settings.rs
@@ -26,7 +26,7 @@ use crate::core::window::Icon;
 use crate::Position;
 
 use winit::monitor::MonitorHandle;
-use winit::window::WindowBuilder;
+use winit::window::{WindowBuilder, WindowLevel};
 
 use std::fmt;
 
@@ -121,6 +121,10 @@ impl Window {
 
         let (width, height) = self.size;
 
+        let window_level = match self.always_on_top {
+            true => WindowLevel::AlwaysOnTop,
+            false => WindowLevel::Normal,
+        };
         window_builder = window_builder
             .with_title(title)
             .with_inner_size(winit::dpi::LogicalSize { width, height })
@@ -128,7 +132,7 @@ impl Window {
             .with_decorations(self.decorations)
             .with_transparent(self.transparent)
             .with_window_icon(self.icon.and_then(conversion::icon))
-            .with_always_on_top(self.always_on_top)
+            .with_window_level(window_level)
             .with_visible(self.visible);
 
         if let Some(position) = conversion::position(

--- a/winit/src/settings.rs
+++ b/winit/src/settings.rs
@@ -22,11 +22,11 @@ mod platform;
 pub use platform::PlatformSpecific;
 
 use crate::conversion;
-use crate::core::window::Icon;
+use crate::core::window::{Icon, Level};
 use crate::Position;
 
 use winit::monitor::MonitorHandle;
-use winit::window::{WindowBuilder, WindowLevel};
+use winit::window::WindowBuilder;
 
 use std::fmt;
 
@@ -81,8 +81,8 @@ pub struct Window {
     /// Whether the window should be transparent.
     pub transparent: bool,
 
-    /// Whether the window will always be on top of other windows.
-    pub always_on_top: bool,
+    /// The window [`Level`].
+    pub level: Level,
 
     /// The window icon, which is also usually used in the taskbar
     pub icon: Option<Icon>,
@@ -102,7 +102,7 @@ impl fmt::Debug for Window {
             .field("resizable", &self.resizable)
             .field("decorations", &self.decorations)
             .field("transparent", &self.transparent)
-            .field("always_on_top", &self.always_on_top)
+            .field("level", &self.level)
             .field("icon", &self.icon.is_some())
             .field("platform_specific", &self.platform_specific)
             .finish()
@@ -121,10 +121,6 @@ impl Window {
 
         let (width, height) = self.size;
 
-        let window_level = match self.always_on_top {
-            true => WindowLevel::AlwaysOnTop,
-            false => WindowLevel::Normal,
-        };
         window_builder = window_builder
             .with_title(title)
             .with_inner_size(winit::dpi::LogicalSize { width, height })
@@ -132,7 +128,7 @@ impl Window {
             .with_decorations(self.decorations)
             .with_transparent(self.transparent)
             .with_window_icon(self.icon.and_then(conversion::icon))
-            .with_window_level(window_level)
+            .with_window_level(conversion::window_level(self.level))
             .with_visible(self.visible);
 
         if let Some(position) = conversion::position(
@@ -211,7 +207,7 @@ impl Default for Window {
             resizable: true,
             decorations: true,
             transparent: false,
-            always_on_top: false,
+            level: Level::default(),
             icon: None,
             platform_specific: Default::default(),
         }

--- a/winit/src/settings.rs
+++ b/winit/src/settings.rs
@@ -163,7 +163,7 @@ impl Window {
         {
             // `with_name` is available on both `WindowBuilderExtWayland` and `WindowBuilderExtX11` and they do
             // exactly the same thing. We arbitrarily choose `WindowBuilderExtWayland` here.
-            use ::winit::platform::x11::WindowBuilderExtWayland;
+            use ::winit::platform::wayland::WindowBuilderExtWayland;
 
             if let Some(id) = _id {
                 window_builder = window_builder.with_name(id.clone(), id);

--- a/winit/src/settings.rs
+++ b/winit/src/settings.rs
@@ -173,8 +173,11 @@ impl Window {
         #[cfg(target_os = "windows")]
         {
             use winit::platform::windows::WindowBuilderExtWindows;
+            unsafe {
+                window_builder = window_builder
+                    .with_parent_window(self.platform_specific.parent);
+            }
             window_builder = window_builder
-                .with_parent_window(self.platform_specific.parent)
                 .with_drag_and_drop(self.platform_specific.drag_and_drop);
         }
 

--- a/winit/src/settings.rs
+++ b/winit/src/settings.rs
@@ -161,7 +161,9 @@ impl Window {
             target_os = "openbsd"
         ))]
         {
-            use ::winit::platform::unix::WindowBuilderExtUnix;
+            // `with_name` is available on both `WindowBuilderExtWayland` and `WindowBuilderExtX11` and they do
+            // exactly the same thing. We arbitrarily choose `WindowBuilderExtWayland` here.
+            use ::winit::platform::x11::WindowBuilderExtWayland;
 
             if let Some(id) = _id {
                 window_builder = window_builder.with_name(id.clone(), id);

--- a/winit/src/settings/windows.rs
+++ b/winit/src/settings/windows.rs
@@ -1,5 +1,4 @@
 //! Platform specific settings for Windows.
-
 use raw_window_handle::RawWindowHandle;
 
 /// The platform specific window settings of an application.

--- a/winit/src/settings/windows.rs
+++ b/winit/src/settings/windows.rs
@@ -1,10 +1,12 @@
 //! Platform specific settings for Windows.
 
+use raw_window_handle::RawWindowHandle;
+
 /// The platform specific window settings of an application.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PlatformSpecific {
     /// Parent window
-    pub parent: Option<winit::platform::windows::HWND>,
+    pub parent: Option<RawWindowHandle>,
 
     /// Drag and drop support
     pub drag_and_drop: bool,


### PR DESCRIPTION
This updates Iced to work with a rebased version of Iced's winit fork to latest winit master (nominally 0.28)

This depends on:

- https://github.com/iced-rs/winit/pull/9/
- https://github.com/hecrj/window_clipboard/pull/20

This PR will need to be updated with the new dependency versions once those have been merged.

The only code change in this PR is due winit now having a `Window::set_window_level(WindowLevel)` method rather then `Window::set_always_on_top(bool)`. WindowLevel as defined as:

```rust
pub enum WindowLevel {
    AlwaysOnBottom,
    Normal,
    AlwaysOnTop,
}
```

This PR just maps the boolean from Iced's existing API to the correct value in the new enum. It could alternatively expose this new enum to Iced users if that's considered desirable.