### PR TITLE
[Fix] Fullscreen only works on primary monitor

### DIFF
--- a/examples/todos/src/main.rs
+++ b/examples/todos/src/main.rs
@@ -1,6 +1,6 @@
 use iced::alignment::{self, Alignment};
 use iced::event::{self, Event};
-use iced::keyboard;
+use iced::keyboard::{self, KeyCode, Modifiers};
 use iced::subscription;
 use iced::theme::{self, Theme};
 use iced::widget::{
@@ -8,6 +8,8 @@ use iced::widget::{
     text_input, Text,
 };
 use iced::window;
+#[cfg(not(target_arch = "wasm32"))]
+use iced::window::Mode;
 use iced::{Application, Element};
 use iced::{Color, Command, Font, Length, Settings, Subscription};
 
@@ -49,7 +51,11 @@ enum Message {
     CreateTask,
     FilterChanged(Filter),
     TaskMessage(usize, TaskMessage),
-    TabPressed { shift: bool },
+    TabPressed {
+        shift: bool,
+    },
+    #[cfg(not(target_arch = "wasm32"))]
+    ToggleFullscreen(Mode),
 }
 
 impl Application for Todos {
@@ -155,6 +161,10 @@ impl Application for Todos {
                         } else {
                             widget::focus_next()
                         }
+                    }
+                    #[cfg(not(target_arch = "wasm32"))]
+                    Message::ToggleFullscreen(mode) => {
+                        window::change_mode(mode)
                     }
                     _ => Command::none(),
                 };
@@ -266,6 +276,22 @@ impl Application for Todos {
             ) => Some(Message::TabPressed {
                 shift: modifiers.shift(),
             }),
+            #[cfg(not(target_arch = "wasm32"))]
+            (
+                Event::Keyboard(keyboard::Event::KeyPressed {
+                    key_code,
+                    modifiers: Modifiers::SHIFT,
+                }),
+                event::Status::Ignored,
+            ) => match key_code {
+                KeyCode::Up => {
+                    Some(Message::ToggleFullscreen(Mode::Fullscreen))
+                }
+                KeyCode::Down => {
+                    Some(Message::ToggleFullscreen(Mode::Windowed))
+                }
+                _ => None,
+            },
             _ => None,
         })
     }

--- a/examples/todos/src/main.rs
+++ b/examples/todos/src/main.rs
@@ -8,8 +8,6 @@ use iced::widget::{
     text_input, Text,
 };
 use iced::window;
-#[cfg(not(target_arch = "wasm32"))]
-use iced::window::Mode;
 use iced::{Application, Element};
 use iced::{Color, Command, Font, Length, Settings, Subscription};
 
@@ -51,11 +49,8 @@ enum Message {
     CreateTask,
     FilterChanged(Filter),
     TaskMessage(usize, TaskMessage),
-    TabPressed {
-        shift: bool,
-    },
-    #[cfg(not(target_arch = "wasm32"))]
-    ToggleFullscreen(Mode),
+    TabPressed { shift: bool },
+    ToggleFullscreen(window::Mode),
 }
 
 impl Application for Todos {
@@ -162,7 +157,6 @@ impl Application for Todos {
                             widget::focus_next()
                         }
                     }
-                    #[cfg(not(target_arch = "wasm32"))]
                     Message::ToggleFullscreen(mode) => {
                         window::change_mode(mode)
                     }
@@ -276,7 +270,6 @@ impl Application for Todos {
             ) => Some(Message::TabPressed {
                 shift: modifiers.shift(),
             }),
-            #[cfg(not(target_arch = "wasm32"))]
             (
                 Event::Keyboard(keyboard::Event::KeyPressed {
                     key_code,
@@ -285,10 +278,10 @@ impl Application for Todos {
                 event::Status::Ignored,
             ) => match key_code {
                 KeyCode::Up => {
-                    Some(Message::ToggleFullscreen(Mode::Fullscreen))
+                    Some(Message::ToggleFullscreen(window::Mode::Fullscreen))
                 }
                 KeyCode::Down => {
-                    Some(Message::ToggleFullscreen(Mode::Windowed))
+                    Some(Message::ToggleFullscreen(window::Mode::Windowed))
                 }
                 _ => None,
             },

--- a/src/window.rs
+++ b/src/window.rs
@@ -8,5 +8,4 @@ pub use icon::Icon;
 pub use position::Position;
 pub use settings::Settings;
 
-#[cfg(not(target_arch = "wasm32"))]
 pub use crate::runtime::window::*;

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -762,7 +762,7 @@ pub fn run_command<A, E>(
                 window::Action::ChangeMode(mode) => {
                     window.set_visible(conversion::visible(mode));
                     window.set_fullscreen(conversion::fullscreen(
-                        window.primary_monitor(),
+                        window.current_monitor(),
                         mode,
                     ));
                 }


### PR DESCRIPTION
This fixes a bug where `window::change_mode` Command was using only the primary monitor, not the current monitor. Also added a fullscreen/windowed hotkey to the `Todos` example