### PR TITLE
Require and implement debug on Stylesheet types

### DIFF
--- a/examples/scrollable/src/main.rs
+++ b/examples/scrollable/src/main.rs
@@ -329,6 +329,7 @@ impl Application for ScrollableDemo {
     }
 }
 
+#[derive(Debug)]
 struct ScrollbarCustomStyle;
 
 impl scrollable::StyleSheet for ScrollbarCustomStyle {
@@ -358,6 +359,7 @@ impl scrollable::StyleSheet for ScrollbarCustomStyle {
     }
 }
 
+#[derive(Debug)]
 struct ProgressBarCustomStyle;
 
 impl progress_bar::StyleSheet for ProgressBarCustomStyle {

--- a/style/src/button.rs
+++ b/style/src/button.rs
@@ -1,5 +1,6 @@
 //! Change the apperance of a button.
 use iced_core::{Background, Color, Vector};
+use std::fmt::Debug;
 
 /// The appearance of a button.
 #[derive(Debug, Clone, Copy)]
@@ -32,7 +33,7 @@ impl std::default::Default for Appearance {
 }
 
 /// A set of rules that dictate the style of a button.
-pub trait StyleSheet {
+pub trait StyleSheet: Debug {
     /// The supported style of the [`StyleSheet`].
     type Style: Default;
 

--- a/style/src/checkbox.rs
+++ b/style/src/checkbox.rs
@@ -1,5 +1,6 @@
 //! Change the appearance of a checkbox.
 use iced_core::{Background, Color};
+use std::fmt::Debug;
 
 /// The appearance of a checkbox.
 #[derive(Debug, Clone, Copy)]
@@ -19,7 +20,7 @@ pub struct Appearance {
 }
 
 /// A set of rules that dictate the style of a checkbox.
-pub trait StyleSheet {
+pub trait StyleSheet: Debug {
     /// The supported style of the [`StyleSheet`].
     type Style: Default;
 

--- a/style/src/container.rs
+++ b/style/src/container.rs
@@ -1,5 +1,6 @@
 //! Change the appearance of a container.
 use iced_core::{Background, Color};
+use std::fmt::Debug;
 
 /// The appearance of a container.
 #[derive(Debug, Clone, Copy)]
@@ -29,7 +30,7 @@ impl std::default::Default for Appearance {
 }
 
 /// A set of rules that dictate the [`Appearance`] of a container.
-pub trait StyleSheet {
+pub trait StyleSheet: Debug {
     /// The supported style of the [`StyleSheet`].
     type Style: Default;
 

--- a/style/src/menu.rs
+++ b/style/src/menu.rs
@@ -1,5 +1,6 @@
 //! Change the appearance of menus.
 use iced_core::{Background, Color};
+use std::fmt::Debug;
 
 /// The appearance of a menu.
 #[derive(Debug, Clone, Copy)]
@@ -21,7 +22,7 @@ pub struct Appearance {
 }
 
 /// The style sheet of a menu.
-pub trait StyleSheet {
+pub trait StyleSheet: Debug {
     /// The supported style of the [`StyleSheet`].
     type Style: Default + Clone;
 

--- a/style/src/pane_grid.rs
+++ b/style/src/pane_grid.rs
@@ -1,8 +1,9 @@
 //! Change the appearance of a pane grid.
 use iced_core::Color;
+use std::fmt::Debug;
 
 /// A set of rules that dictate the style of a container.
-pub trait StyleSheet {
+pub trait StyleSheet: Debug {
     /// The supported style of the [`StyleSheet`].
     type Style: Default;
 

--- a/style/src/pick_list.rs
+++ b/style/src/pick_list.rs
@@ -1,5 +1,6 @@
 //! Change the appearance of a pick list.
 use iced_core::{Background, Color};
+use std::fmt::Debug;
 
 /// The appearance of a pick list.
 #[derive(Debug, Clone, Copy)]
@@ -21,7 +22,7 @@ pub struct Appearance {
 }
 
 /// A set of rules that dictate the style of a container.
-pub trait StyleSheet {
+pub trait StyleSheet: Debug {
     /// The supported style of the [`StyleSheet`].
     type Style: Default + Clone;
 

--- a/style/src/progress_bar.rs
+++ b/style/src/progress_bar.rs
@@ -1,5 +1,6 @@
 //! Change the appearance of a progress bar.
 use iced_core::Background;
+use std::fmt::Debug;
 
 /// The appearance of a progress bar.
 #[derive(Debug, Clone, Copy)]
@@ -13,7 +14,7 @@ pub struct Appearance {
 }
 
 /// A set of rules that dictate the style of a progress bar.
-pub trait StyleSheet {
+pub trait StyleSheet: Debug {
     /// The supported style of the [`StyleSheet`].
     type Style: Default;
 

--- a/style/src/radio.rs
+++ b/style/src/radio.rs
@@ -1,5 +1,6 @@
 //! Change the appearance of radio buttons.
 use iced_core::{Background, Color};
+use std::fmt::Debug;
 
 /// The appearance of a radio button.
 #[derive(Debug, Clone, Copy)]
@@ -17,7 +18,7 @@ pub struct Appearance {
 }
 
 /// A set of rules that dictate the style of a radio button.
-pub trait StyleSheet {
+pub trait StyleSheet: Debug {
     /// The supported style of the [`StyleSheet`].
     type Style: Default;
 

--- a/style/src/rule.rs
+++ b/style/src/rule.rs
@@ -1,5 +1,6 @@
 //! Change the appearance of a rule.
 use iced_core::Color;
+use std::fmt::Debug;
 
 /// The appearance of a rule.
 #[derive(Debug, Clone, Copy)]
@@ -15,7 +16,7 @@ pub struct Appearance {
 }
 
 /// A set of rules that dictate the style of a rule.
-pub trait StyleSheet {
+pub trait StyleSheet: Debug {
     /// The supported style of the [`StyleSheet`].
     type Style: Default;
 

--- a/style/src/scrollable.rs
+++ b/style/src/scrollable.rs
@@ -1,5 +1,6 @@
 //! Change the appearance of a scrollable.
 use iced_core::{Background, Color};
+use std::fmt::Debug;
 
 /// The appearance of a scrollable.
 #[derive(Debug, Clone, Copy)]
@@ -30,7 +31,7 @@ pub struct Scroller {
 }
 
 /// A set of rules that dictate the style of a scrollable.
-pub trait StyleSheet {
+pub trait StyleSheet: Debug {
     /// The supported style of the [`StyleSheet`].
     type Style: Default;
 

--- a/style/src/slider.rs
+++ b/style/src/slider.rs
@@ -1,5 +1,6 @@
 //! Change the apperance of a slider.
 use iced_core::Color;
+use std::fmt::Debug;
 
 /// The appearance of a slider.
 #[derive(Debug, Clone, Copy)]
@@ -41,7 +42,7 @@ pub enum HandleShape {
 }
 
 /// A set of rules that dictate the style of a slider.
-pub trait StyleSheet {
+pub trait StyleSheet: Debug {
     /// The supported style of the [`StyleSheet`].
     type Style: Default;
 

--- a/style/src/svg.rs
+++ b/style/src/svg.rs
@@ -1,6 +1,7 @@
 //! Change the appearance of a svg.
 
 use iced_core::Color;
+use std::fmt::Debug;
 
 /// The appearance of an SVG.
 #[derive(Debug, Default, Clone, Copy)]
@@ -14,7 +15,7 @@ pub struct Appearance {
 }
 
 /// The stylesheet of a svg.
-pub trait StyleSheet {
+pub trait StyleSheet: Debug {
     /// The supported style of the [`StyleSheet`].
     type Style: Default;
 

--- a/style/src/text.rs
+++ b/style/src/text.rs
@@ -1,5 +1,6 @@
 //! Change the appearance of text.
 use iced_core::Color;
+use std::fmt::Debug;
 
 /// The style sheet of some text.
 pub trait StyleSheet {

--- a/style/src/text_input.rs
+++ b/style/src/text_input.rs
@@ -1,5 +1,6 @@
 //! Change the appearance of a text input.
 use iced_core::{Background, Color};
+use std::fmt::Debug;
 
 /// The appearance of a text input.
 #[derive(Debug, Clone, Copy)]
@@ -15,7 +16,7 @@ pub struct Appearance {
 }
 
 /// A set of rules that dictate the style of a text input.
-pub trait StyleSheet {
+pub trait StyleSheet: Debug {
     /// The supported style of the [`StyleSheet`].
     type Style: Default;
 

--- a/style/src/theme.rs
+++ b/style/src/theme.rs
@@ -120,7 +120,7 @@ impl From<fn(&Theme) -> application::Appearance> for Application {
 }
 
 /// The style of a button.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub enum Button {
     /// The primary style.
     #[default]
@@ -228,7 +228,7 @@ impl button::StyleSheet for Theme {
 }
 
 /// The style of a checkbox.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub enum Checkbox {
     /// The primary style.
     #[default]
@@ -340,7 +340,7 @@ fn checkbox_appearance(
 }
 
 /// The style of a container.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub enum Container {
     /// No style.
     #[default]
@@ -388,7 +388,7 @@ impl container::StyleSheet for fn(&Theme) -> container::Appearance {
 }
 
 /// The style of a slider.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub enum Slider {
     /// The default style.
     #[default]
@@ -469,7 +469,7 @@ impl slider::StyleSheet for Theme {
 }
 
 /// The style of a menu.
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug)]
 pub enum Menu {
     /// The default style.
     #[default]
@@ -511,7 +511,7 @@ impl From<PickList> for Menu {
 }
 
 /// The style of a pick list.
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug)]
 pub enum PickList {
     /// The default style.
     #[default]
@@ -566,7 +566,7 @@ impl pick_list::StyleSheet for Theme {
 }
 
 /// The style of a radio button.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub enum Radio {
     /// The default style.
     #[default]
@@ -621,7 +621,7 @@ impl radio::StyleSheet for Theme {
 }
 
 /// The style of a toggler.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub enum Toggler {
     /// The default style.
     #[default]
@@ -688,7 +688,7 @@ impl toggler::StyleSheet for Theme {
 }
 
 /// The style of a pane grid.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub enum PaneGrid {
     /// The default style.
     #[default]
@@ -730,7 +730,7 @@ impl pane_grid::StyleSheet for Theme {
 }
 
 /// The style of a progress bar.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub enum ProgressBar {
     /// The primary style.
     #[default]
@@ -783,7 +783,7 @@ impl progress_bar::StyleSheet for fn(&Theme) -> progress_bar::Appearance {
 }
 
 /// The style of a rule.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub enum Rule {
     /// The default style.
     #[default]
@@ -827,7 +827,7 @@ impl rule::StyleSheet for fn(&Theme) -> rule::Appearance {
 /**
  * Svg
  */
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub enum Svg {
     /// No filtering to the rendered SVG.
     #[default]
@@ -863,7 +863,7 @@ impl svg::StyleSheet for fn(&Theme) -> svg::Appearance {
 }
 
 /// The style of a scrollable.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub enum Scrollable {
     /// The default style.
     #[default]
@@ -961,7 +961,7 @@ impl scrollable::StyleSheet for Theme {
 }
 
 /// The style of text.
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy, Default, Debug)]
 pub enum Text {
     /// The default style.
     #[default]
@@ -988,7 +988,7 @@ impl text::StyleSheet for Theme {
 }
 
 /// The style of a text input.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub enum TextInput {
     /// The default style.
     #[default]

--- a/style/src/toggler.rs
+++ b/style/src/toggler.rs
@@ -1,5 +1,6 @@
 //! Change the appearance of a toggler.
 use iced_core::Color;
+use std::fmt::Debug;
 
 /// The appearance of a toggler.
 #[derive(Debug, Clone, Copy)]
@@ -15,7 +16,7 @@ pub struct Appearance {
 }
 
 /// A set of rules that dictate the style of a toggler.
-pub trait StyleSheet {
+pub trait StyleSheet: Debug {
     /// The supported style of the [`StyleSheet`].
     type Style: Default;
 


### PR DESCRIPTION
Simplifies my use case where I have a type that holds one of the upstream iced theme types. ( currently `iced_style::theme::Button` )