### PR TITLE
remove colons from shader labels

### DIFF
--- a/wgpu/src/image.rs
+++ b/wgpu/src/image.rs
@@ -141,7 +141,7 @@ impl Pipeline {
 
         let shader =
             device.create_shader_module(wgpu::ShaderModuleDescriptor {
-                label: Some("iced_wgpu::image::shader"),
+                label: Some("iced_wgpu image shader"),
                 source: wgpu::ShaderSource::Wgsl(std::borrow::Cow::Borrowed(
                     include_str!("shader/image.wgsl"),
                 )),

--- a/wgpu/src/quad.rs
+++ b/wgpu/src/quad.rs
@@ -63,7 +63,7 @@ impl Pipeline {
 
         let shader =
             device.create_shader_module(wgpu::ShaderModuleDescriptor {
-                label: Some("iced_wgpu::quad::shader"),
+                label: Some("iced_wgpu quad shader"),
                 source: wgpu::ShaderSource::Wgsl(std::borrow::Cow::Borrowed(
                     include_str!("shader/quad.wgsl"),
                 )),

--- a/wgpu/src/triangle.rs
+++ b/wgpu/src/triangle.rs
@@ -457,7 +457,7 @@ mod solid {
             let shader =
                 device.create_shader_module(wgpu::ShaderModuleDescriptor {
                     label: Some(
-                        "iced_wgpu::triangle::solid create shader module",
+                        "iced_wgpu triangle solid create shader module",
                     ),
                     source: wgpu::ShaderSource::Wgsl(
                         std::borrow::Cow::Borrowed(include_str!(
@@ -654,7 +654,7 @@ mod gradient {
             let shader =
                 device.create_shader_module(wgpu::ShaderModuleDescriptor {
                     label: Some(
-                        "iced_wgpu::triangle::gradient create shader module",
+                        "iced_wgpu triangle gradient create shader module",
                     ),
                     source: wgpu::ShaderSource::Wgsl(
                         std::borrow::Cow::Borrowed(include_str!(

--- a/wgpu/src/triangle/msaa.rs
+++ b/wgpu/src/triangle/msaa.rs
@@ -75,7 +75,7 @@ impl Blit {
 
         let shader =
             device.create_shader_module(wgpu::ShaderModuleDescriptor {
-                label: Some("iced_wgpu::triangle::blit_shader"),
+                label: Some("iced_wgpu triangle blit_shader"),
                 source: wgpu::ShaderSource::Wgsl(std::borrow::Cow::Borrowed(
                     include_str!("../shader/blit.wgsl"),
                 )),


### PR DESCRIPTION
when using the DXC compiler feature from wgpu, iced's shaders fail to compile due to a weird bug I discovered that causes something to go wrong if the shader's label contains any colons. So this PR removed the colons (they can alternatively be escaped if you prefer that, like `"iced\\:\\:image"`. I checked it and it works).