### PR TITLE
Feat: Offscreen Rendering & Screenshots

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,11 +41,6 @@ palette = ["iced_core/palette"]
 system = ["iced_winit/system"]
 # Enables the advanced module
 advanced = []
-# Enables chrome tracing support for Iced
-chrome-trace = [
-    "iced_winit/chrome-trace",
-    "iced_renderer/tracing",
-]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,11 @@ palette = ["iced_core/palette"]
 system = ["iced_winit/system"]
 # Enables the advanced module
 advanced = []
+# Enables chrome tracing support for Iced
+chrome-trace = [
+    "iced_winit/chrome-trace",
+    "iced_renderer/tracing",
+]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/examples/screenshot/Cargo.toml
+++ b/examples/screenshot/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "screenshot"
+version = "0.1.0"
+authors = ["Bingus <shankern@protonmail.com>"]
+edition = "2021"
+publish = false
+
+[dependencies]
+iced = { path = "../..", features = ["debug", "image", "advanced"] }
+image = { version = "0.24.6", features = ["png"]}
+env_logger = "0.10.0"
+wasm-bindgen = "0.2"

--- a/examples/screenshot/Cargo.toml
+++ b/examples/screenshot/Cargo.toml
@@ -9,4 +9,3 @@ publish = false
 iced = { path = "../..", features = ["debug", "image", "advanced"] }
 image = { version = "0.24.6", features = ["png"]}
 env_logger = "0.10.0"
-wasm-bindgen = "0.2"

--- a/examples/screenshot/src/main.rs
+++ b/examples/screenshot/src/main.rs
@@ -1,0 +1,317 @@
+use iced::alignment::{Horizontal, Vertical};
+use iced::keyboard::KeyCode;
+use iced::theme::{Button, Container};
+use iced::widget::runtime::{CropError, Screenshot};
+use iced::widget::{
+    button, column as col, container, image as iced_image, row, text,
+    text_input,
+};
+use iced::{
+    event, executor, keyboard, subscription, Alignment, Application, Command,
+    ContentFit, Element, Event, Length, Rectangle, Renderer, Subscription,
+    Theme,
+};
+use image as img;
+use image::ColorType;
+
+fn main() -> iced::Result {
+    env_logger::builder().format_timestamp(None).init();
+
+    Example::run(iced::Settings::default())
+}
+
+struct Example {
+    screenshot: Option<Screenshot>,
+    saved_png_path: Option<Result<String, PngError>>,
+    png_saving: bool,
+    crop_error: Option<CropError>,
+    x_input_value: u32,
+    y_input_value: u32,
+    width_input_value: u32,
+    height_input_value: u32,
+}
+
+#[derive(Clone, Debug)]
+enum Message {
+    Crop,
+    Screenshot,
+    ScreenshotData(Screenshot),
+    Png,
+    PngSaved(Result<String, PngError>),
+    XInputChanged(String),
+    YInputChanged(String),
+    WidthInputChanged(String),
+    HeightInputChanged(String),
+}
+
+impl Application for Example {
+    type Executor = executor::Default;
+    type Message = Message;
+    type Theme = Theme;
+    type Flags = ();
+
+    fn new(_flags: Self::Flags) -> (Self, Command<Self::Message>) {
+        (
+            Example {
+                screenshot: None,
+                saved_png_path: None,
+                png_saving: false,
+                crop_error: None,
+                x_input_value: 0,
+                y_input_value: 0,
+                width_input_value: 0,
+                height_input_value: 0,
+            },
+            Command::none(),
+        )
+    }
+
+    fn title(&self) -> String {
+        "Screenshot".to_string()
+    }
+
+    fn update(&mut self, message: Self::Message) -> Command<Self::Message> {
+        match message {
+            Message::Screenshot => {
+                return iced::window::screenshot(Message::ScreenshotData);
+            }
+            Message::ScreenshotData(screenshot) => {
+                self.screenshot = Some(screenshot);
+            }
+            Message::Png => {
+                if let Some(screenshot) = &self.screenshot {
+                    return Command::perform(
+                        save_to_png(screenshot.clone()),
+                        Message::PngSaved,
+                    );
+                }
+                self.png_saving = true;
+            }
+            Message::PngSaved(res) => {
+                self.png_saving = false;
+                self.saved_png_path = Some(res);
+            }
+            Message::XInputChanged(new) => {
+                if let Ok(value) = new.parse::<u32>() {
+                    self.x_input_value = value;
+                }
+            }
+            Message::YInputChanged(new) => {
+                if let Ok(value) = new.parse::<u32>() {
+                    self.y_input_value = value;
+                }
+            }
+            Message::WidthInputChanged(new) => {
+                if let Ok(value) = new.parse::<u32>() {
+                    self.width_input_value = value;
+                }
+            }
+            Message::HeightInputChanged(new) => {
+                if let Ok(value) = new.parse::<u32>() {
+                    self.height_input_value = value;
+                }
+            }
+            Message::Crop => {
+                if let Some(screenshot) = &self.screenshot {
+                    let cropped = screenshot.crop(Rectangle::<u32> {
+                        x: self.x_input_value,
+                        y: self.y_input_value,
+                        width: self.width_input_value,
+                        height: self.height_input_value,
+                    });
+
+                    match cropped {
+                        Ok(screenshot) => {
+                            self.screenshot = Some(screenshot);
+                            self.crop_error = None;
+                        }
+                        Err(crop_error) => {
+                            self.crop_error = Some(crop_error);
+                        }
+                    }
+                }
+            }
+        }
+
+        Command::none()
+    }
+
+    fn view(&self) -> Element<'_, Self::Message, Renderer<Self::Theme>> {
+        let image: Element<Message> = if let Some(screenshot) = &self.screenshot
+        {
+            iced_image(iced_image::Handle::from_pixels(
+                screenshot.size.width,
+                screenshot.size.height,
+                screenshot.bytes.clone(),
+            ))
+            .content_fit(ContentFit::ScaleDown)
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .into()
+        } else {
+            text("Press the button to take a screenshot!").into()
+        };
+
+        let image = container(image)
+            .padding(10)
+            .style(Container::Custom(Box::new(ScreenshotDisplayContainer)))
+            .width(Length::FillPortion(2))
+            .height(Length::Fill)
+            .center_x()
+            .center_y();
+
+        let crop_origin_controls = row![
+            text("X:").vertical_alignment(Vertical::Center).width(14),
+            text_input(
+                "0",
+                &format!("{}", self.x_input_value),
+                Message::XInputChanged
+            )
+            .width(40),
+            text("Y:").vertical_alignment(Vertical::Center).width(14),
+            text_input(
+                "0",
+                &format!("{}", self.y_input_value),
+                Message::YInputChanged
+            )
+            .width(40),
+        ]
+        .spacing(10)
+        .align_items(Alignment::Center);
+
+        let crop_dimension_controls = row![
+            text("W:").vertical_alignment(Vertical::Center).width(14),
+            text_input(
+                "0",
+                &format!("{}", self.width_input_value),
+                Message::WidthInputChanged
+            )
+            .width(40),
+            text("H:").vertical_alignment(Vertical::Center).width(14),
+            text_input(
+                "0",
+                &format!("{}", self.height_input_value),
+                Message::HeightInputChanged
+            )
+            .width(40),
+        ]
+        .spacing(10)
+        .align_items(Alignment::Center);
+
+        let mut crop_controls =
+            col![crop_origin_controls, crop_dimension_controls]
+                .spacing(10)
+                .align_items(Alignment::Center);
+
+        if let Some(crop_error) = &self.crop_error {
+            crop_controls = crop_controls
+                .push(text(format!("Crop error! \n{}", crop_error)));
+        }
+
+        let png_button = if !self.png_saving {
+            button("Save to png.")
+                .style(Button::Secondary)
+                .padding([10, 20, 10, 20])
+                .on_press(Message::Png)
+        } else {
+            button("Saving..")
+                .style(Button::Secondary)
+                .padding([10, 20, 10, 20])
+        };
+
+        let mut controls = col![
+            button("Screenshot!")
+                .padding([10, 20, 10, 20])
+                .on_press(Message::Screenshot),
+            button("Crop")
+                .style(Button::Destructive)
+                .padding([10, 20, 10, 20])
+                .on_press(Message::Crop),
+            crop_controls,
+            png_button,
+        ]
+        .spacing(40)
+        .align_items(Alignment::Center);
+
+        if let Some(png_result) = &self.saved_png_path {
+            let msg = match png_result {
+                Ok(path) => format!("Png saved as: {:?}!", path),
+                Err(msg) => {
+                    format!("Png could not be saved due to:\n{:?}", msg)
+                }
+            };
+
+            controls = controls.push(text(msg));
+        }
+
+        let side_content = container(controls)
+            .align_x(Horizontal::Center)
+            .width(Length::FillPortion(1))
+            .height(Length::Fill)
+            .center_y()
+            .center_x();
+
+        let content = row![side_content, image]
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .align_items(Alignment::Center);
+
+        container(content)
+            .padding(10)
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .center_x()
+            .center_y()
+            .into()
+    }
+
+    fn subscription(&self) -> Subscription<Self::Message> {
+        subscription::events_with(|event, status| {
+            if let event::Status::Captured = status {
+                return None;
+            }
+
+            if let Event::Keyboard(keyboard::Event::KeyPressed {
+                key_code: KeyCode::F5,
+                ..
+            }) = event
+            {
+                Some(Message::Screenshot)
+            } else {
+                None
+            }
+        })
+    }
+}
+
+struct ScreenshotDisplayContainer;
+
+impl container::StyleSheet for ScreenshotDisplayContainer {
+    type Style = Theme;
+
+    fn appearance(&self, style: &Self::Style) -> container::Appearance {
+        container::Appearance {
+            text_color: None,
+            background: None,
+            border_radius: 5.0,
+            border_width: 4.0,
+            border_color: style.palette().primary,
+        }
+    }
+}
+
+async fn save_to_png(screenshot: Screenshot) -> Result<String, PngError> {
+    let path = "screenshot.png".to_string();
+    img::save_buffer(
+        &path,
+        &screenshot.bytes,
+        screenshot.size.width,
+        screenshot.size.height,
+        ColorType::Rgba8,
+    )
+    .map(|_| path)
+    .map_err(|err| PngError(format!("{:?}", err)))
+}
+
+#[derive(Clone, Debug)]
+struct PngError(String);

--- a/graphics/src/compositor.rs
+++ b/graphics/src/compositor.rs
@@ -59,6 +59,18 @@ pub trait Compositor: Sized {
         background_color: Color,
         overlay: &[T],
     ) -> Result<(), SurfaceError>;
+
+    /// Renders the current [`Renderer`] primitives to an offscreen texture, and returns the bytes of
+    /// the texture.
+    ///
+    /// [`Renderer`]: Self::Renderer;
+    fn render_offscreen<T: AsRef<str>>(
+        &mut self,
+        renderer: &mut Self::Renderer,
+        viewport: &Viewport,
+        background_color: Color,
+        overlay: &[T],
+    ) -> Vec<u8>;
 }
 
 /// Result of an unsuccessful call to [`Compositor::present`].
@@ -82,7 +94,7 @@ pub enum SurfaceError {
     OutOfMemory,
 }
 
-/// Contains informations about the graphics (e.g. graphics adapter, graphics backend).
+/// Contains information about the graphics (e.g. graphics adapter, graphics backend).
 #[derive(Debug)]
 pub struct Information {
     /// Contains the graphics adapter.

--- a/graphics/src/compositor.rs
+++ b/graphics/src/compositor.rs
@@ -60,11 +60,11 @@ pub trait Compositor: Sized {
         overlay: &[T],
     ) -> Result<(), SurfaceError>;
 
-    /// Renders the current [`Renderer`] primitives to an offscreen texture, and returns the bytes of
-    /// the texture.
+    /// Screenshots the current [`Renderer`] primitives to an offscreen texture, and returns the bytes of
+    /// the texture ordered as `RGBA` in the sRGB color space.
     ///
     /// [`Renderer`]: Self::Renderer;
-    fn render_offscreen<T: AsRef<str>>(
+    fn screenshot<T: AsRef<str>>(
         &mut self,
         renderer: &mut Self::Renderer,
         viewport: &Viewport,

--- a/renderer/Cargo.toml
+++ b/renderer/Cargo.toml
@@ -9,7 +9,7 @@ tiny-skia = ["iced_tiny_skia"]
 image = ["iced_wgpu/image", "iced_tiny_skia/image"]
 svg = ["iced_wgpu/svg", "iced_tiny_skia/svg"]
 geometry = ["iced_graphics/geometry", "iced_wgpu?/geometry", "iced_tiny_skia?/geometry"]
-tracing = ["iced_wgpu/tracing"]
+tracing = ["iced_wgpu?/tracing", "iced_tiny_skia?/tracing"]
 
 [dependencies]
 raw-window-handle = "0.5"

--- a/renderer/src/compositor.rs
+++ b/renderer/src/compositor.rs
@@ -183,7 +183,7 @@ impl<Theme> crate::graphics::Compositor for Compositor<Theme> {
         })
     }
 
-    fn render_offscreen<T: AsRef<str>>(
+    fn screenshot<T: AsRef<str>>(
         &mut self,
         renderer: &mut Self::Renderer,
         viewport: &Viewport,
@@ -193,7 +193,7 @@ impl<Theme> crate::graphics::Compositor for Compositor<Theme> {
         renderer.with_primitives(|backend, primitives| match (self, backend) {
             #[cfg(feature = "wgpu")]
             (Self::Wgpu(compositor), crate::Backend::Wgpu(backend)) => {
-                iced_wgpu::window::compositor::render_offscreen(
+                iced_wgpu::window::compositor::screenshot(
                     compositor,
                     backend,
                     primitives,
@@ -204,7 +204,7 @@ impl<Theme> crate::graphics::Compositor for Compositor<Theme> {
             },
             #[cfg(feature = "tiny-skia")]
             (Self::TinySkia(compositor), crate::Backend::TinySkia(backend)) => {
-                iced_tiny_skia::window::compositor::render_offscreen(
+                iced_tiny_skia::window::compositor::screenshot(
                     compositor,
                     backend,
                     primitives,

--- a/renderer/src/compositor.rs
+++ b/renderer/src/compositor.rs
@@ -182,4 +182,41 @@ impl<Theme> crate::graphics::Compositor for Compositor<Theme> {
             }
         })
     }
+
+    fn render_offscreen<T: AsRef<str>>(
+        &mut self,
+        renderer: &mut Self::Renderer,
+        viewport: &Viewport,
+        background_color: Color,
+        overlay: &[T],
+    ) -> Vec<u8> {
+        renderer.with_primitives(|backend, primitives| match (self, backend) {
+            #[cfg(feature = "wgpu")]
+            (Self::Wgpu(compositor), crate::Backend::Wgpu(backend)) => {
+                iced_wgpu::window::compositor::render_offscreen(
+                    compositor,
+                    backend,
+                    primitives,
+                    viewport,
+                    background_color,
+                    overlay,
+                )
+            },
+            #[cfg(feature = "tiny-skia")]
+            (Self::TinySkia(compositor), crate::Backend::TinySkia(backend)) => {
+                iced_tiny_skia::window::compositor::render_offscreen(
+                    compositor,
+                    backend,
+                    primitives,
+                    viewport,
+                    background_color,
+                    overlay,
+                )
+            }
+            #[allow(unreachable_patterns)]
+            _ => panic!(
+                "The provided renderer or backend are not compatible with the compositor."
+            ),
+        })
+    }
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -60,6 +60,7 @@ mod debug;
 #[cfg(not(feature = "debug"))]
 #[path = "debug/null.rs"]
 mod debug;
+mod screenshot;
 
 pub use iced_core as core;
 pub use iced_futures as futures;
@@ -68,4 +69,5 @@ pub use command::Command;
 pub use debug::Debug;
 pub use font::Font;
 pub use program::Program;
+pub use screenshot::{CropError, Screenshot};
 pub use user_interface::UserInterface;

--- a/runtime/src/screenshot.rs
+++ b/runtime/src/screenshot.rs
@@ -3,7 +3,7 @@ use std::fmt::{Debug, Formatter};
 
 /// Data of a screenshot, captured with `window::screenshot()`.
 ///
-/// This screenshot will always be in RGBA format.
+/// The `bytes` of this screenshot will always be ordered as `RGBA` in the sRGB color space.
 #[derive(Clone)]
 pub struct Screenshot {
     /// The bytes of the [`Screenshot`].

--- a/runtime/src/screenshot.rs
+++ b/runtime/src/screenshot.rs
@@ -1,0 +1,78 @@
+use iced_core::{Rectangle, Size};
+use std::fmt::{Debug, Formatter};
+
+/// Data of a screenshot, captured with `window::screenshot()`.
+///
+/// This screenshot will always be in RGBA format.
+#[derive(Clone)]
+pub struct Screenshot {
+    /// The bytes of the [`Screenshot`].
+    pub bytes: Vec<u8>,
+    /// The size of the [`Screenshot`].
+    pub size: Size<u32>,
+}
+
+impl Debug for Screenshot {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Screenshot: {{ \n bytes: {}\n size: {:?} }}",
+            self.bytes.len(),
+            self.size
+        )
+    }
+}
+
+impl Screenshot {
+    /// Creates a new [`Screenshot`].
+    pub fn new(bytes: Vec<u8>, size: Size<u32>) -> Self {
+        Self { bytes, size }
+    }
+
+    /// Crops a [`Screenshot`] to the provided `region`. This will always be relative to the
+    /// top-left corner of the [`Screenshot`].
+    pub fn crop(&self, region: Rectangle<u32>) -> Result<Self, CropError> {
+        if region.width == 0 || region.height == 0 {
+            return Err(CropError::Zero);
+        }
+
+        if region.x + region.width > self.size.width
+            || region.y + region.height > self.size.height
+        {
+            return Err(CropError::OutOfBounds);
+        }
+
+        // Image is always RGBA8 = 4 bytes per pixel
+        const PIXEL_SIZE: usize = 4;
+
+        let bytes_per_row = self.size.width as usize * PIXEL_SIZE;
+        let row_range = region.y as usize..(region.y + region.height) as usize;
+        let column_range = region.x as usize * PIXEL_SIZE
+            ..(region.x + region.width) as usize * PIXEL_SIZE;
+
+        let chopped = self.bytes.chunks(bytes_per_row).enumerate().fold(
+            vec![],
+            |mut acc, (row, bytes)| {
+                if row_range.contains(&row) {
+                    acc.extend(&bytes[column_range.clone()]);
+                }
+
+                acc
+            },
+        );
+
+        Ok(Self {
+            bytes: chopped,
+            size: Size::new(region.width, region.height),
+        })
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+/// Errors that can occur when cropping a [`Screenshot`].
+pub enum CropError {
+    #[error("The cropped region is out of bounds.")]
+    OutOfBounds,
+    #[error("The cropped region is not visible.")]
+    Zero,
+}

--- a/runtime/src/window.rs
+++ b/runtime/src/window.rs
@@ -7,6 +7,7 @@ use crate::command::{self, Command};
 use crate::core::time::Instant;
 use crate::core::window::{Event, Mode, UserAttention};
 use crate::futures::subscription::{self, Subscription};
+use crate::screenshot::Screenshot;
 
 /// Subscribes to the frames of the window of the running application.
 ///
@@ -109,4 +110,10 @@ pub fn fetch_id<Message>(
     f: impl FnOnce(u64) -> Message + 'static,
 ) -> Command<Message> {
     Command::single(command::Action::Window(Action::FetchId(Box::new(f))))
+}
+
+pub fn screenshot<Message>(
+    f: impl FnOnce(Screenshot) -> Message + Send + 'static,
+) -> Command<Message> {
+    Command::single(command::Action::Window(Action::Screenshot(Box::new(f))))
 }

--- a/runtime/src/window/action.rs
+++ b/runtime/src/window/action.rs
@@ -1,6 +1,7 @@
 use crate::core::window::{Mode, UserAttention};
 use crate::futures::MaybeSend;
 
+use crate::screenshot::Screenshot;
 use std::fmt;
 
 /// An operation to be performed on some window.
@@ -78,6 +79,8 @@ pub enum Action<T> {
     ChangeAlwaysOnTop(bool),
     /// Fetch an identifier unique to the window.
     FetchId(Box<dyn FnOnce(u64) -> T + 'static>),
+    /// Screenshot the viewport of the window.
+    Screenshot(Box<dyn FnOnce(Screenshot) -> T + 'static>),
 }
 
 impl<T> Action<T> {
@@ -108,6 +111,11 @@ impl<T> Action<T> {
                 Action::ChangeAlwaysOnTop(on_top)
             }
             Self::FetchId(o) => Action::FetchId(Box::new(move |s| f(o(s)))),
+            Self::Screenshot(tag) => {
+                Action::Screenshot(Box::new(move |screenshot| {
+                    f(tag(screenshot))
+                }))
+            }
         }
     }
 }
@@ -142,6 +150,7 @@ impl<T> fmt::Debug for Action<T> {
                 write!(f, "Action::AlwaysOnTop({on_top})")
             }
             Self::FetchId(_) => write!(f, "Action::FetchId"),
+            Self::Screenshot(_) => write!(f, "Action::Screenshot"),
         }
     }
 }

--- a/tiny_skia/Cargo.toml
+++ b/tiny_skia/Cargo.toml
@@ -34,3 +34,7 @@ features = ["std"]
 [dependencies.resvg]
 version = "0.29"
 optional = true
+
+[dependencies.tracing]
+version = "0.1.6"
+optional = true

--- a/tiny_skia/src/backend.rs
+++ b/tiny_skia/src/backend.rs
@@ -43,6 +43,9 @@ impl Backend {
         background_color: Color,
         overlay: &[T],
     ) {
+        #[cfg(feature = "tracing")]
+        let _ = tracing::info_span!("iced_tiny_skia::DRAW").entered();
+
         pixels.fill(into_color(background_color));
 
         let scale_factor = viewport.scale_factor() as f32;

--- a/tiny_skia/src/raster.rs
+++ b/tiny_skia/src/raster.rs
@@ -33,6 +33,9 @@ impl Pipeline {
         transform: tiny_skia::Transform,
         clip_mask: Option<&tiny_skia::ClipMask>,
     ) {
+        #[cfg(feature = "tracing")]
+        let _ = tracing::info_span!("iced_tiny_skia::RASTER_DRAW");
+
         if let Some(image) = self.cache.borrow_mut().allocate(handle) {
             let width_scale = bounds.width / image.width() as f32;
             let height_scale = bounds.height / image.height() as f32;

--- a/tiny_skia/src/window/compositor.rs
+++ b/tiny_skia/src/window/compositor.rs
@@ -83,7 +83,7 @@ impl<Theme> crate::graphics::Compositor for Compositor<Theme> {
         })
     }
 
-    fn render_offscreen<T: AsRef<str>>(
+    fn screenshot<T: AsRef<str>>(
         &mut self,
         renderer: &mut Self::Renderer,
         viewport: &Viewport,
@@ -91,7 +91,7 @@ impl<Theme> crate::graphics::Compositor for Compositor<Theme> {
         overlay: &[T],
     ) -> Vec<u8> {
         renderer.with_primitives(|backend, primitives| {
-            render_offscreen(
+            screenshot(
                 self,
                 backend,
                 primitives,
@@ -148,7 +148,7 @@ pub fn present<Theme, T: AsRef<str>>(
     Ok(())
 }
 
-pub fn render_offscreen<Theme, T: AsRef<str>>(
+pub fn screenshot<Theme, T: AsRef<str>>(
     compositor: &mut Compositor<Theme>,
     backend: &mut Backend,
     primitives: &[Primitive],
@@ -181,10 +181,10 @@ pub fn render_offscreen<Theme, T: AsRef<str>>(
     offscreen_buffer.iter().fold(
         Vec::with_capacity(offscreen_buffer.len() * 4),
         |mut acc, pixel| {
-            const A_MASK: u32 = 0xFF_000000;
-            const R_MASK: u32 = 0x00_FF_0000;
-            const G_MASK: u32 = 0x0000_FF_00;
-            const B_MASK: u32 = 0x000000_FF;
+            const A_MASK: u32 = 0xFF_00_00_00;
+            const R_MASK: u32 = 0x00_FF_00_00;
+            const G_MASK: u32 = 0x00_00_FF_00;
+            const B_MASK: u32 = 0x00_00_00_FF;
 
             let a = ((A_MASK & pixel) >> 24) as u8;
             let r = ((R_MASK & pixel) >> 16) as u8;

--- a/wgpu/src/backend.rs
+++ b/wgpu/src/backend.rs
@@ -145,46 +145,16 @@ impl Backend {
         #[cfg(feature = "tracing")]
         let _ = info_span!("iced_wgpu::offscreen", "DRAW").entered();
 
-        let target_size = viewport.physical_size();
-        let scale_factor = viewport.scale_factor() as f32;
-        let transformation = viewport.projection();
-
-        let mut layers = Layer::generate(primitives, viewport);
-        layers.push(Layer::overlay(overlay_text, viewport));
-
-        self.prepare(
+        self.present(
             device,
             queue,
             encoder,
-            scale_factor,
-            transformation,
-            &layers,
-        );
-
-        while !self.prepare_text(
-            device,
-            queue,
-            scale_factor,
-            target_size,
-            &layers,
-        ) {}
-
-        self.render(
-            device,
-            encoder,
-            frame,
             clear_color,
-            scale_factor,
-            target_size,
-            &layers,
+            frame,
+            primitives,
+            viewport,
+            overlay_text,
         );
-
-        self.quad_pipeline.end_frame();
-        self.text_pipeline.end_frame();
-        self.triangle_pipeline.end_frame();
-
-        #[cfg(any(feature = "image", feature = "svg"))]
-        self.image_pipeline.end_frame();
 
         if format != wgpu::TextureFormat::Rgba8UnormSrgb {
             log::info!("Texture format is {format:?}; performing conversion to rgba8..");

--- a/wgpu/src/backend.rs
+++ b/wgpu/src/backend.rs
@@ -166,6 +166,7 @@ impl Backend {
                 format: wgpu::TextureFormat::Rgba8Unorm,
                 usage: wgpu::TextureUsages::STORAGE_BINDING
                     | wgpu::TextureUsages::COPY_SRC,
+                view_formats: &[],
             });
 
             let view =

--- a/wgpu/src/backend.rs
+++ b/wgpu/src/backend.rs
@@ -24,7 +24,6 @@ pub struct Backend {
     quad_pipeline: quad::Pipeline,
     text_pipeline: text::Pipeline,
     triangle_pipeline: triangle::Pipeline,
-    offscreen_pipeline: offscreen::Pipeline,
 
     #[cfg(any(feature = "image", feature = "svg"))]
     image_pipeline: image::Pipeline,
@@ -44,7 +43,6 @@ impl Backend {
         let quad_pipeline = quad::Pipeline::new(device, format);
         let triangle_pipeline =
             triangle::Pipeline::new(device, format, settings.antialiasing);
-        let offscreen_pipeline = offscreen::Pipeline::new(device);
 
         #[cfg(any(feature = "image", feature = "svg"))]
         let image_pipeline = image::Pipeline::new(device, format);
@@ -53,7 +51,6 @@ impl Backend {
             quad_pipeline,
             text_pipeline,
             triangle_pipeline,
-            offscreen_pipeline,
 
             #[cfg(any(feature = "image", feature = "svg"))]
             image_pipeline,
@@ -158,6 +155,7 @@ impl Backend {
 
         if format != wgpu::TextureFormat::Rgba8UnormSrgb {
             log::info!("Texture format is {format:?}; performing conversion to rgba8..");
+            let pipeline = offscreen::Pipeline::new(device);
 
             let texture = device.create_texture(&wgpu::TextureDescriptor {
                 label: Some("iced_wgpu::offscreen rgba8 source texture"),
@@ -173,13 +171,7 @@ impl Backend {
             let view =
                 texture.create_view(&wgpu::TextureViewDescriptor::default());
 
-            self.offscreen_pipeline.convert(
-                device,
-                texture_extent,
-                frame,
-                &view,
-                encoder,
-            );
+            pipeline.convert(device, texture_extent, frame, &view, encoder);
 
             return Some(texture);
         }

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -46,6 +46,7 @@ pub mod geometry;
 
 mod backend;
 mod buffer;
+mod offscreen;
 mod quad;
 mod text;
 mod triangle;

--- a/wgpu/src/offscreen.rs
+++ b/wgpu/src/offscreen.rs
@@ -1,0 +1,102 @@
+use std::borrow::Cow;
+
+/// A simple compute pipeline to convert any texture to Rgba8UnormSrgb.
+#[derive(Debug)]
+pub struct Pipeline {
+    pipeline: wgpu::ComputePipeline,
+    layout: wgpu::BindGroupLayout,
+}
+
+impl Pipeline {
+    pub fn new(device: &wgpu::Device) -> Self {
+        let shader =
+            device.create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some("iced_wgpu::offscreen::blit shader"),
+                source: wgpu::ShaderSource::Wgsl(Cow::Borrowed(include_str!(
+                    "shader/offscreen_blit.wgsl"
+                ))),
+            });
+
+        let bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("iced_wgpu::offscreen::blit bind group layout"),
+                entries: &[
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 0,
+                        visibility: wgpu::ShaderStages::COMPUTE,
+                        ty: wgpu::BindingType::Texture {
+                            sample_type: wgpu::TextureSampleType::Float {
+                                filterable: false,
+                            },
+                            view_dimension: wgpu::TextureViewDimension::D2,
+                            multisampled: false,
+                        },
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 1,
+                        visibility: wgpu::ShaderStages::COMPUTE,
+                        ty: wgpu::BindingType::StorageTexture {
+                            access: wgpu::StorageTextureAccess::WriteOnly,
+                            format: wgpu::TextureFormat::Rgba8Unorm,
+                            view_dimension: wgpu::TextureViewDimension::D2,
+                        },
+                        count: None,
+                    },
+                ],
+            });
+
+        let pipeline_layout =
+            device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("iced_wgpu::offscreen::blit pipeline layout"),
+                bind_group_layouts: &[&bind_group_layout],
+                push_constant_ranges: &[],
+            });
+
+        let pipeline =
+            device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+                label: Some("iced_wgpu::offscreen::blit pipeline"),
+                layout: Some(&pipeline_layout),
+                module: &shader,
+                entry_point: "main",
+            });
+
+        Self {
+            pipeline,
+            layout: bind_group_layout,
+        }
+    }
+
+    pub fn convert(
+        &self,
+        device: &wgpu::Device,
+        extent: wgpu::Extent3d,
+        frame: &wgpu::TextureView,
+        view: &wgpu::TextureView,
+        encoder: &mut wgpu::CommandEncoder,
+    ) {
+        let bind = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("iced_wgpu::offscreen::blit bind group"),
+            layout: &self.layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(frame),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::TextureView(view),
+                },
+            ],
+        });
+
+        let mut compute_pass =
+            encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                label: Some("iced_wgpu::offscreen::blit compute pass"),
+            });
+
+        compute_pass.set_pipeline(&self.pipeline);
+        compute_pass.set_bind_group(0, &bind, &[]);
+        compute_pass.dispatch_workgroups(extent.width, extent.height, 1);
+    }
+}

--- a/wgpu/src/shader/offscreen_blit.wgsl
+++ b/wgpu/src/shader/offscreen_blit.wgsl
@@ -1,0 +1,22 @@
+@group(0) @binding(0) var u_texture: texture_2d<f32>;
+@group(0) @binding(1) var out_texture: texture_storage_2d<rgba8unorm, write>;
+
+fn srgb(color: f32) -> f32 {
+    if (color <= 0.0031308) {
+        return 12.92 * color;
+    } else {
+        return (1.055 * (pow(color, (1.0/2.4)))) - 0.055;
+    }
+}
+
+@compute @workgroup_size(1)
+fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+    // texture coord must be i32 due to a naga bug:
+    // https://github.com/gfx-rs/naga/issues/1997
+    let coords = vec2(i32(id.x), i32(id.y));
+
+    let src: vec4<f32> = textureLoad(u_texture, coords, 0);
+    let srgb_color: vec4<f32> = vec4(srgb(src.x), srgb(src.y), srgb(src.z), src.w);
+
+    textureStore(out_texture, coords, srgb_color);
+}

--- a/wgpu/src/triangle/msaa.rs
+++ b/wgpu/src/triangle/msaa.rs
@@ -16,15 +16,8 @@ impl Blit {
         format: wgpu::TextureFormat,
         antialiasing: graphics::Antialiasing,
     ) -> Blit {
-        let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
-            address_mode_u: wgpu::AddressMode::ClampToEdge,
-            address_mode_v: wgpu::AddressMode::ClampToEdge,
-            address_mode_w: wgpu::AddressMode::ClampToEdge,
-            mag_filter: wgpu::FilterMode::Nearest,
-            min_filter: wgpu::FilterMode::Nearest,
-            mipmap_filter: wgpu::FilterMode::Nearest,
-            ..Default::default()
-        });
+        let sampler =
+            device.create_sampler(&wgpu::SamplerDescriptor::default());
 
         let constant_layout =
             device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {

--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -327,6 +327,7 @@ pub fn screenshot<Theme, T: AsRef<str>>(
         usage: wgpu::TextureUsages::RENDER_ATTACHMENT
             | wgpu::TextureUsages::COPY_SRC
             | wgpu::TextureUsages::TEXTURE_BINDING,
+        view_formats: &[],
     });
 
     let view = texture.create_view(&wgpu::TextureViewDescriptor::default());

--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -272,7 +272,7 @@ impl<Theme> graphics::Compositor for Compositor<Theme> {
         })
     }
 
-    fn render_offscreen<T: AsRef<str>>(
+    fn screenshot<T: AsRef<str>>(
         &mut self,
         renderer: &mut Self::Renderer,
         viewport: &Viewport,
@@ -280,7 +280,7 @@ impl<Theme> graphics::Compositor for Compositor<Theme> {
         overlay: &[T],
     ) -> Vec<u8> {
         renderer.with_primitives(|backend, primitives| {
-            render_offscreen(
+            screenshot(
                 self,
                 backend,
                 primitives,
@@ -292,7 +292,7 @@ impl<Theme> graphics::Compositor for Compositor<Theme> {
     }
 }
 
-pub fn render_offscreen<Theme, T: AsRef<str>>(
+pub fn screenshot<Theme, T: AsRef<str>>(
     compositor: &Compositor<Theme>,
     backend: &mut Backend,
     primitives: &[Primitive],

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -798,7 +798,7 @@ pub fn run_command<A, C, E>(
                         .expect("Send message to event loop");
                 }
                 window::Action::Screenshot(tag) => {
-                    let bytes = compositor.render_offscreen(
+                    let bytes = compositor.screenshot(
                         renderer,
                         state.viewport(),
                         state.background_color(),


### PR DESCRIPTION
## This PR adds support for offscreen rendering in Iced! 🎉 

https://user-images.githubusercontent.com/4241774/230238292-03b8d796-c8cb-4870-adc1-3dbac36c3a8d.mov

### 📸 Users can now capture screenshots 🖼️ using the `window::screenshot()` command.

```rust
fn update(&mut self, message: Self::Message) -> Command<Self::Message> {
    match message {
        Message::Screenshot => {
            return iced::window::screenshot(Message::ScreenshotData); //new!
        }
        //...
```

The `window::screenshot` command requires a `Message` which takes a `Screenshot`. This is a new struct exposed in the `iced_runtime` crate which contains the RGBA bytes of the screenshot, in addition to its size.

For now this command is limited to the entire viewport, with an optional `crop()` method available which will crop the bytes to the specified `Rectangle`.

https://user-images.githubusercontent.com/4241774/230238237-a9b3ddfa-cb79-463f-85d9-18621585dd79.mov

```rust
let cropped = screenshot.crop(Rectangle::<u32> {
    x: 0,
    y: 0,
    width: 500,
    height: 500,
});
```

This method returns a `Result<Screenshot, CropError>` for situations where the cropped region is out of bounds, or is not visible.

### 🎉 Offscreen rendering capabilities are now added to both `wgpu` and `tiny_skia`!

Rendering offscreen is now exposed in the `Compositor` interface with a `render_offscreen` function. The outputted texture data is always guaranteed to be in RGBA format in the SRGB color space for compatibility with image libraries & iced images, and to simplify the `Screenshot` struct with a predetermined byte order & pixel size.

### 🔢 Implementation details

For `wgpu`, performing offscreen rendering was fairly straightforward. I create a texture based on the viewport size & the chosen texture format, and then pass that into the backend with a new `backend.offscreen` method. This method performs a normal render pass on the new texture, and optionally runs a tiny compute shader after drawing all primitives that converts it to `wgpu::TextureFormat::Rgba8Unorm` with a manual srgb conversion due to `wgpu::TextureFormat::Rgba8UnormSrgb` not being a supported format for a storage texture. The whole process on my (admittedly very powerful!) test suite of GPUs (AMD, NVIDIA, M1) took about ~2µs in the test example. The only added overhead over a normal render pass is the compute shader to convert to rgba.

For `tiny-skia` this was _very_ straightforward, the same as a normal `present` call but rendering to a new buffer vs the surface buffer. Our backend returns `ARGB` format, so just had to do some bit shiftin' and we're all good.

### 🤔 Outstanding API questions

1. It was discussed whether it's a cleaner API to do a `window::screenshot` command which optionally can be cropped, or a `window::screenshot(area)` command which can either be `Fullscreen` or `Region`, which would be a rectangle. Obviously there is a performance hit when rendering the whole window to an offscreen buffer vs a potentially very small region if only a small portion is desired, but the execution is so fast it's almost negligible. I'm curious as to people's thoughts on this!
 
 2. The offscreen render capabilities are only exposed at the moment through this `window::screenshot` command. The intent was to implement the capabilities for offscreen rendering in this PR and expand upon it further in later iterations if new applications of offscreen rendering are needed. Curious to see if anyone has any thoughts on how else this might be exposed!
 
 ### 🧪 Testing
Tested wgpu & tiny-skia implementations on MacOS + M1, Linux + PopOS + AMD, Windows 10 + Nvidia combos. Further testing would be greatly appreciated!

Feedback very much welcome! This was my first time working this deeply with textures on the GPU so might have made some rookie mistakes 😉 I also know that there is an open draft PR for offscreen rendering but it hasn't been updated in a few years so thought I'd take a crack at it.