### PR TITLE
Unsnap scrollable after `snap_to` operation

### DIFF
--- a/native/src/widget/scrollable.rs
+++ b/native/src/widget/scrollable.rs
@@ -214,7 +214,17 @@ where
     ) {
         let state = tree.state.downcast_mut::<State>();
 
+        let offset_x = state.offset_x;
+        let offset_y = state.offset_x;
+
         operation.scrollable(state, self.id.as_ref().map(|id| &id.0));
+
+        // If `snap_to` was used, unsnap to convert offset to "absolute"
+        if offset_x != state.offset_x || offset_y != state.offset_y {
+            let bounds = layout.bounds();
+            let content_bounds = layout.children().next().unwrap().bounds();
+            state.unsnap(bounds, content_bounds);
+        }
 
         operation.container(
             self.id.as_ref().map(|id| &id.0),
@@ -968,7 +978,7 @@ impl operation::Scrollable for State {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 enum Offset {
     Absolute(f32),
     Relative(f32),


### PR DESCRIPTION
When issuing a `snap_to` operation to a scrollable, it leaves it's offset "relative".

This is typically fine, except for when you use `on_scroll` /  `snap_to` to keep 2 separate scrollables in "sync". For example, consider a table widget that has a separate `header` scrollable from it's `body` scrollable. We can keep the `header` in sync w/ the `body` by firing `snap_to` on the `header` from the `body`'s `on_scroll` message. If you have "resizing" functionality setup on the columns of the table and you are horizontally scrolled and try to "resize" a column, the two scrollables now behave in opposite ways.

- The `header` which is at `relative` will stay `x%` scrolled as the width of the table changes, causing the viewport of the scrollable to change relative to the content.

- The `body` which is at `absolute` will stay scrolled at `x` regardless of the width changing, keeping the viewport static.

The behavior of always having an `absolute` offset stored is desired for when content width changes. 

This fixes the issue by always "unsnapping" after offset changes from an operation. 