### PR TITLE
Make mouse::Button::Other take u16 instead of u8

### DIFF
--- a/core/src/mouse/button.rs
+++ b/core/src/mouse/button.rs
@@ -11,5 +11,5 @@ pub enum Button {
     Middle,
 
     /// Some other button.
-    Other(u8),
+    Other(u16),
 }

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -249,9 +249,7 @@ pub fn mouse_button(mouse_button: winit::event::MouseButton) -> mouse::Button {
         winit::event::MouseButton::Left => mouse::Button::Left,
         winit::event::MouseButton::Right => mouse::Button::Right,
         winit::event::MouseButton::Middle => mouse::Button::Middle,
-        winit::event::MouseButton::Other(other) => {
-            mouse::Button::Other(other as u8)
-        }
+        winit::event::MouseButton::Other(other) => mouse::Button::Other(other),
     }
 }
 


### PR DESCRIPTION
On wayland keys correspond to <input-event-codes.h>, and they are past the limit of u8, causing the
back and forward buttons to be 20 and 19 which definitely isn't right (they should all be around 0x110..=0x117).

This is a breaking change but will probably only affect apps on wayland relying on these wrong codes,
I also have [a winit pr that will also necessitate a breaking change to this enum](https://github.com/rust-windowing/winit/pull/2770),
maybe this should wait so both of these should be done at the same time.