### PR TITLE
Invalidate responsive layout when shell layout is invalidated

### DIFF
--- a/lazy/src/responsive.rs
+++ b/lazy/src/responsive.rs
@@ -206,7 +206,7 @@ where
         );
 
         if local_shell.is_layout_invalid() {
-            let _ = content.layout.take();
+            content.layout = None;
         }
 
         shell.merge(local_shell, std::convert::identity);


### PR DESCRIPTION
`Responsive` layout was only being recomputed if `size` changed. This caused a panic if a downstream widget changed between `layout` calls of the same `view` / User Interface root element. This is technically possible with `Component` and panic's can be reliably recreated by nesting a `Component` inside a `Responsive` and returning totally different elements from it's `view` after processing updates.