### PR TITLE
Center `TextInput::Icon` vertically

### DIFF
--- a/native/src/widget/text_input.rs
+++ b/native/src/widget/text_input.rs
@@ -970,9 +970,12 @@ pub fn draw<Renderer>(
             size: icon.size.unwrap_or_else(|| renderer.default_size()),
             font: icon.font.clone(),
             color: appearance.icon_color,
-            bounds: icon_layout.bounds(),
+            bounds: Rectangle {
+                y: text_bounds.center_y(),
+                ..icon_layout.bounds()
+            },
             horizontal_alignment: alignment::Horizontal::Left,
-            vertical_alignment: alignment::Vertical::Top,
+            vertical_alignment: alignment::Vertical::Center,
         });
     }
 


### PR DESCRIPTION
This fixes a small issue i noticed after https://github.com/iced-rs/iced/pull/1702.
The `Icon` was not properly centered. Notice the two images below.

Old             |  New
:-------------------------:|:-------------------------:
<img width="658" alt="Screenshot 2023-04-20 at 12 16 12" src="https://user-images.githubusercontent.com/2248455/233337360-fafe29a1-28ff-4db5-8622-cdab6722522e.png">  |  <img width="643" alt="Screenshot 2023-04-20 at 12 15 32" src="https://user-images.githubusercontent.com/2248455/233337424-02171b57-77a8-42aa-8648-8a7746fe678d.png">)

I think the reason we didn't notice when merging the other PR was because the icon had a size so it looked to be centered.


