### PR TITLE
Allow user defined renderer::Settings

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -203,7 +203,9 @@ pub trait Application: Sized {
             } else {
                 None
             },
-            ..crate::renderer::Settings::from_env()
+            ..settings
+                .renderer
+                .unwrap_or_else(|| crate::renderer::Settings::from_env())
         };
 
         Ok(crate::runtime::application::run::<

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,4 +1,5 @@
 //! Configure your application.
+use crate::renderer;
 use crate::window;
 
 /// The settings of an application.
@@ -64,6 +65,14 @@ pub struct Settings<Flags> {
     ///
     /// [`Application`]: crate::Application
     pub try_opengles_first: bool,
+
+    /// Override renderer settings
+    ///
+    /// Fields: `default_font`, `default_text_size`, `text_multithreading` and
+    /// `antialiasing` of these override settings are ignored
+    ///
+    /// If `None` is provided, default settings are used
+    pub renderer: Option<renderer::Settings>,
 }
 
 impl<Flags> Settings<Flags> {
@@ -77,6 +86,7 @@ impl<Flags> Settings<Flags> {
             flags,
             id: default_settings.id,
             window: default_settings.window,
+            renderer: default_settings.renderer,
             default_font: default_settings.default_font,
             default_text_size: default_settings.default_text_size,
             text_multithreading: default_settings.text_multithreading,
@@ -95,6 +105,7 @@ where
         Self {
             id: None,
             window: Default::default(),
+            renderer: Default::default(),
             flags: Default::default(),
             default_font: Default::default(),
             default_text_size: 20.0,


### PR DESCRIPTION
This PR adds a `renderer` field to the `Settings` struct for overriding `renderer::Settings`.

When this field is used, `renderer::Settings` other than what is already defined in the `Settings` struct (e.g. text size, anti-aliasing, ..) are used.

This helps with #1810 because wpgu `display_mode` can be overwritten.