### PR TITLE
Add Widget related base iterator functions 

### DIFF
--- a/native/src/element.rs
+++ b/native/src/element.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 use std::any::Any;
-use std::borrow::Borrow;
+use std::borrow::{Borrow, BorrowMut};
 
 /// A generic [`Widget`].
 ///
@@ -221,11 +221,35 @@ impl<'a, Message, Renderer> Borrow<dyn Widget<Message, Renderer> + 'a>
     }
 }
 
+impl<'a, Message, Renderer> BorrowMut<dyn Widget<Message, Renderer> + 'a>
+    for Element<'a, Message, Renderer>
+{
+    fn borrow_mut(&mut self) -> &mut (dyn Widget<Message, Renderer> + 'a) {
+        self.widget.borrow_mut()
+    }
+}
+
 impl<'a, Message, Renderer> Borrow<dyn Widget<Message, Renderer> + 'a>
     for &Element<'a, Message, Renderer>
 {
     fn borrow(&self) -> &(dyn Widget<Message, Renderer> + 'a) {
         self.widget.borrow()
+    }
+}
+
+impl<'a, Message, Renderer> Borrow<dyn Widget<Message, Renderer> + 'a>
+    for &mut Element<'a, Message, Renderer>
+{
+    fn borrow(&self) -> &(dyn Widget<Message, Renderer> + 'a) {
+        self.widget.borrow()
+    }
+}
+
+impl<'a, Message, Renderer> BorrowMut<dyn Widget<Message, Renderer> + 'a>
+    for &mut Element<'a, Message, Renderer>
+{
+    fn borrow_mut(&mut self) -> &mut (dyn Widget<Message, Renderer> + 'a) {
+        self.widget.borrow_mut()
     }
 }
 

--- a/native/src/layout/flex.rs
+++ b/native/src/layout/flex.rs
@@ -82,7 +82,14 @@ where
     )
 }
 
-pub(crate) fn resolve_iter<'a, Message, Renderer>(
+/// Computes the flex layout with the given axis and limits, applying spacing,
+/// padding and alignment to the items as needed.
+///
+/// It returns a new layout [`Node`].
+///
+/// It takes an [`IntoIterator`] along with the length of the `items`
+/// rather than a [`slice`] as in [`resolve`].
+pub fn resolve_iter<'a, Message, Renderer>(
     axis: Axis,
     renderer: &Renderer,
     limits: &Limits,

--- a/native/src/overlay.rs
+++ b/native/src/overlay.rs
@@ -115,7 +115,14 @@ where
     from_children_iter(children.iter_mut(), tree, layout, renderer)
 }
 
-pub(crate) fn from_children_iter<'a: 'b, 'b, Message: 'b, Renderer: 'b>(
+
+/// Returns a [`Group`] of overlay [`Element`] children.
+///
+/// This method will generally only be used by advanced users that are
+/// implementing the [`Widget`](crate::Widget) trait.
+///
+/// It takes an [`IntoIterator`] rather than a [`slice`] of `children` as in [`from_children`].
+pub fn from_children_iter<'a: 'b, 'b, Message: 'b, Renderer: 'b>(
     children: impl IntoIterator<
         Item = &'b mut (impl std::borrow::BorrowMut<
             dyn crate::Widget<Message, Renderer> + 'a,

--- a/native/src/overlay.rs
+++ b/native/src/overlay.rs
@@ -112,12 +112,28 @@ pub fn from_children<'a, Message, Renderer>(
 where
     Renderer: crate::Renderer,
 {
+    from_children_iter(children.iter_mut(), tree, layout, renderer)
+}
+
+pub(crate) fn from_children_iter<'a: 'b, 'b, Message: 'b, Renderer: 'b>(
+    children: impl IntoIterator<
+        Item = &'b mut (impl std::borrow::BorrowMut<
+            dyn crate::Widget<Message, Renderer> + 'a,
+        > + 'b),
+    >,
+    tree: &'b mut Tree,
+    layout: Layout<'_>,
+    renderer: &Renderer,
+) -> Option<Element<'b, Message, Renderer>>
+where
+    Renderer: crate::Renderer,
+{
     let children = children
-        .iter_mut()
+        .into_iter()
         .zip(&mut tree.children)
         .zip(layout.children())
         .filter_map(|((child, state), layout)| {
-            child.as_widget_mut().overlay(state, layout, renderer)
+            child.borrow_mut().overlay(state, layout, renderer)
         })
         .collect::<Vec<_>>();
 

--- a/native/src/widget/tree.rs
+++ b/native/src/widget/tree.rs
@@ -95,7 +95,12 @@ impl Tree {
         )
     }
 
-    pub(crate) fn diff_children_iter<'a, T: 'a>(
+    /// Reconciliates the children of the tree with the provided list of widgets using custom
+    /// logic both for diffing and creating new widget state.
+    ///
+    /// It takes an [`IntoIterator`] along with the length of the `new_children`
+    /// rather than a [`slice`] as in [`diff_children`].
+    pub fn diff_children_iter<'a, T: 'a>(
         &mut self,
         new_children: impl IntoIterator<Item = &'a T>,
         new_children_len: usize,


### PR DESCRIPTION
This PR adds base functions that take iterators rather than slices as arguments to the following functions related to `Widget`:
- `layout::flex::resolve`
- `overlay::from_children`
- `widget::tree::diff_children`

Currently, these functions are unnecessarily restrictive in the sense that they only take slice references, as most non-vector/array data structures in a widget field would be expensive to convert to, e.g. `HashMap`, multiple vectors, optional fields, etc. (One such example can be found in my [table widget fork](https://github.com/my4ng/iced/tree/table-widget) where the widget contains an optional header and vector content rows fields.) Furthermore, these functions do **not** utilise any special property of a slice apart from the `len` method, since _most_ of the implementations are iterator-based anyway.

Therefore, the following base functions take a more general approach with iterator arguments while keeping the original versions as wrappers to avoid any breaking changes, for example:
```rust
pub fn from_children<'a, Message, Renderer>(
    children: &'a mut [crate::Element<'_, Message, Renderer>],
    tree: &'a mut Tree,
    layout: Layout<'_>,
    renderer: &Renderer,
) -> Option<Element<'a, Message, Renderer>>
where
    Renderer: crate::Renderer,
{...}
```
Becomes
```rust
pub fn from_children<'a, Message, Renderer>(
    children: &'a mut [crate::Element<'_, Message, Renderer>],
    tree: &'a mut Tree,
    layout: Layout<'_>,
    renderer: &Renderer,
) -> Option<Element<'a, Message, Renderer>>
where
    Renderer: crate::Renderer,
{
    from_children_iter(children.iter_mut(), tree, layout, renderer)
}

pub fn from_children_iter<'a: 'b, 'b, Message: 'b, Renderer: 'b>(
    children: impl IntoIterator<
        Item = &'b mut (impl std::borrow::BorrowMut<
            dyn crate::Widget<Message, Renderer> + 'a,
        > + 'b),
    >,
    tree: &'b mut Tree,
    layout: Layout<'_>,
    renderer: &Renderer,
) -> Option<Element<'b, Message, Renderer>>
where
    Renderer: crate::Renderer,
{...}
```
In order to facilitate this, further `Borrow` and `BorrowMut` trait implementations are added to `Element`, e.g. :
```rust
impl<'a, Message, Renderer> BorrowMut<dyn Widget<Message, Renderer> + 'a>
    for Element<'a, Message, Renderer>
{
    fn borrow_mut(&mut self) -> &mut (dyn Widget<Message, Renderer> + 'a) {
        self.widget.borrow_mut()
    }
}
```
In places where the length is required, a `*_len` argument is supplied instead. 

Currently, the base functions have a `pub(crate)` visibility modifier, so they are not exposed to outside the crate, but of course that can easily be the subject of any further changes. 

---

EDIT: I have changed the visibility modifiers to `pub` given 'official' custom widgets may be implemented outside the crate, e.g. in `iced_aw`. I have also added documentations to distinguish them from their original counterparts by emphasising the `IntoIterator` type of their argument.