### PR TITLE
fix: quad rendering including border only inside of the bounds

### DIFF
--- a/tiny_skia/src/backend.rs
+++ b/tiny_skia/src/backend.rs
@@ -1,3 +1,5 @@
+use tiny_skia::{Mask, Pixmap, PixmapPaint};
+
 use crate::core::text;
 use crate::core::{Background, Color, Font, Point, Rectangle, Size, Vector};
 use crate::graphics::backend;
@@ -212,17 +214,29 @@ impl Backend {
                     height: bounds.height - border_width,
                 };
 
+                // Make sure the border radius is correct
                 let mut border_radius = *border_radius;
-                for radius in &mut border_radius {
-                    *radius = radius
-                        .min(path_bounds.width / 2.0)
-                        .min(path_bounds.height / 2.0);
+                let mut border_radius_gt_half_border_width =
+                    [true, true, true, true];
+                for (i, radius) in &mut border_radius.iter_mut().enumerate() {
+                    *radius = if *radius == 0.0 {
+                        // Path should handle this fine
+                        0.0
+                    } else if *radius > border_width / 2.0 {
+                        *radius - border_width / 2.0
+                    } else {
+                        border_radius_gt_half_border_width[i] = false;
+                        0.0
+                    }
+                    .min(path_bounds.width / 2.0)
+                    .min(path_bounds.height / 2.0);
                 }
 
-                let border_radius_path =
-                    rounded_rectangle(path_bounds, border_radius);
+                // Stroking a path works well in this case.
+                if border_radius_gt_half_border_width.iter().all(|b| *b) {
+                    let border_radius_path =
+                        rounded_rectangle(path_bounds, border_radius);
 
-                if border_width > 0.0 {
                     pixels.stroke_path(
                         &border_radius_path,
                         &tiny_skia::Paint {
@@ -236,6 +250,68 @@ impl Backend {
                             width: border_width,
                             ..tiny_skia::Stroke::default()
                         },
+                        transform,
+                        clip_mask,
+                    );
+                } else {
+                    // Draw corners that have to small border radii as having no border radius,
+                    // but mask them with the rounded rectangle with the correct border radius.
+
+                    let mut temp_pixmap =
+                        Pixmap::new(bounds.width as u32, bounds.height as u32)
+                            .unwrap();
+
+                    let mut quad_mask =
+                        Mask::new(bounds.width as u32, bounds.height as u32)
+                            .unwrap();
+
+                    let zero_bounds = Rectangle {
+                        x: 0.0,
+                        y: 0.0,
+                        width: bounds.width,
+                        height: bounds.height,
+                    };
+                    let path =
+                        rounded_rectangle(zero_bounds, fill_border_radius);
+
+                    quad_mask.fill_path(
+                        &path,
+                        tiny_skia::FillRule::EvenOdd,
+                        true,
+                        transform,
+                    );
+                    let path_bounds = Rectangle {
+                        x: border_width / 2.0,
+                        y: border_width / 2.0,
+                        width: bounds.width - border_width,
+                        height: bounds.height - border_width,
+                    };
+
+                    let border_radius_path =
+                        rounded_rectangle(path_bounds, border_radius);
+
+                    temp_pixmap.stroke_path(
+                        &border_radius_path,
+                        &tiny_skia::Paint {
+                            shader: tiny_skia::Shader::SolidColor(into_color(
+                                *border_color,
+                            )),
+                            anti_alias: true,
+                            ..tiny_skia::Paint::default()
+                        },
+                        &tiny_skia::Stroke {
+                            width: border_width,
+                            ..tiny_skia::Stroke::default()
+                        },
+                        transform,
+                        Some(&quad_mask),
+                    );
+
+                    pixels.draw_pixmap(
+                        bounds.x as i32,
+                        bounds.y as i32,
+                        temp_pixmap.as_ref(),
+                        &PixmapPaint::default(),
                         transform,
                         clip_mask,
                     );

--- a/tiny_skia/src/backend.rs
+++ b/tiny_skia/src/backend.rs
@@ -1,5 +1,3 @@
-use tiny_skia::{Mask, Pixmap, PixmapPaint};
-
 use crate::core::text;
 use crate::core::{Background, Color, Font, Point, Rectangle, Size, Vector};
 use crate::graphics::backend;
@@ -256,13 +254,13 @@ impl Backend {
                     } else {
                         // Draw corners that have too small border radii as having no border radius,
                         // but mask them with the rounded rectangle with the correct border radius.
-                        let mut temp_pixmap = Pixmap::new(
+                        let mut temp_pixmap = tiny_skia::Pixmap::new(
                             bounds.width as u32,
                             bounds.height as u32,
                         )
                         .unwrap();
 
-                        let mut quad_mask = Mask::new(
+                        let mut quad_mask = tiny_skia::Mask::new(
                             bounds.width as u32,
                             bounds.height as u32,
                         )
@@ -314,7 +312,7 @@ impl Backend {
                             bounds.x as i32,
                             bounds.y as i32,
                             temp_pixmap.as_ref(),
-                            &PixmapPaint::default(),
+                            &tiny_skia::PixmapPaint::default(),
                             transform,
                             clip_mask,
                         );

--- a/tiny_skia/src/backend.rs
+++ b/tiny_skia/src/backend.rs
@@ -178,21 +178,13 @@ impl Backend {
                     .min(bounds.width / 2.0)
                     .min(bounds.height / 2.0);
 
-                // Offset the fill by the border width
-                let path_bounds = Rectangle {
-                    x: bounds.x + border_width,
-                    y: bounds.y + border_width,
-                    width: bounds.width - 2.0 * border_width,
-                    height: bounds.height - 2.0 * border_width,
-                };
-                // fill border radius is the border radius minus the border width
                 let mut fill_border_radius = *border_radius;
                 for radius in &mut fill_border_radius {
-                    *radius = (*radius - border_width / 2.0)
-                        .min(path_bounds.width / 2.0)
-                        .min(path_bounds.height / 2.0);
+                    *radius = (*radius)
+                        .min(bounds.width / 2.0)
+                        .min(bounds.height / 2.0);
                 }
-                let path = rounded_rectangle(path_bounds, fill_border_radius);
+                let path = rounded_rectangle(*bounds, fill_border_radius);
 
                 pixels.fill_path(
                     &path,


### PR DESCRIPTION
It seems that border should not be drawn outside the quad bounds. For example, a slider handle with a large border radius will leave a trail of the border color when it is dragged, because it goes un-tracked in the damage. 

This change also makes tiny-skia rendering of quads more consistent with the wgpu backend, which didn't seem to draw outside the bounds as far as i could tell with the same slider test.