### PR TITLE
Remove min width 1 from scrollbar & scroller

### DIFF
--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -809,9 +809,11 @@ pub fn draw<Renderer>(
              style: Scrollbar,
              scrollbar: &internals::Scrollbar| {
                 //track
-                if style.background.is_some()
-                    || (style.border_color != Color::TRANSPARENT
-                        && style.border_width > 0.0)
+                if scrollbar.bounds.width > 0.0
+                    && scrollbar.bounds.height > 0.0
+                    && (style.background.is_some()
+                        || (style.border_color != Color::TRANSPARENT
+                            && style.border_width > 0.0))
                 {
                     renderer.fill_quad(
                         renderer::Quad {
@@ -827,9 +829,11 @@ pub fn draw<Renderer>(
                 }
 
                 //thumb
-                if style.scroller.color != Color::TRANSPARENT
-                    || (style.scroller.border_color != Color::TRANSPARENT
-                        && style.scroller.border_width > 0.0)
+                if scrollbar.scroller.bounds.width > 0.0
+                    && scrollbar.scroller.bounds.height > 0.0
+                    && (style.scroller.color != Color::TRANSPARENT
+                        || (style.scroller.border_color != Color::TRANSPARENT
+                            && style.scroller.border_width > 0.0))
                 {
                     renderer.fill_quad(
                         renderer::Quad {

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -128,9 +128,8 @@ impl Properties {
     }
 
     /// Sets the scrollbar width of the [`Scrollable`] .
-    /// Silently enforces a minimum width of 1.
     pub fn width(mut self, width: impl Into<Pixels>) -> Self {
-        self.width = width.into().0.max(1.0);
+        self.width = width.into().0.max(0.0);
         self
     }
 
@@ -141,9 +140,8 @@ impl Properties {
     }
 
     /// Sets the scroller width of the [`Scrollable`] .
-    /// Silently enforces a minimum width of 1.
     pub fn scroller_width(mut self, scroller_width: impl Into<Pixels>) -> Self {
-        self.scroller_width = scroller_width.into().0.max(1.0);
+        self.scroller_width = scroller_width.into().0.max(0.0);
         self
     }
 }


### PR DESCRIPTION
I'm not sure if there's a reason to enforce this, but ideally the user can set it to `0.0` to "hide" the scrollbar / scroller.

The only way to "hide" the scrollbar / scroller currently is via the stylesheet, which is only aesthetic. This still allows them to be interacted with.

You can test this change by running `scrollable` example. If you set both to 0, the scrollable still works via scrollwheel / trackpad, but the scrollbar / scroller are hidden / don't work. You can even set scrollbar to 0 but keep scroller width to have a floating scroller w/ no scrollbar, which is a feature imo.