### PR TITLE
Fix race condition when growing an `image::Atlas`

### DIFF
--- a/wgpu/src/image.rs
+++ b/wgpu/src/image.rs
@@ -369,7 +369,6 @@ impl Pipeline {
                 layer::Image::Raster { handle, bounds } => {
                     if let Some(atlas_entry) = raster_cache.upload(
                         device,
-                        queue,
                         encoder,
                         handle,
                         &mut self.texture_atlas,
@@ -395,7 +394,6 @@ impl Pipeline {
 
                     if let Some(atlas_entry) = vector_cache.upload(
                         device,
-                        queue,
                         encoder,
                         handle,
                         *color,

--- a/wgpu/src/image/atlas.rs
+++ b/wgpu/src/image/atlas.rs
@@ -74,9 +74,6 @@ impl Atlas {
             let current_size = self.layers.len();
             let entry = self.allocate(width, height)?;
 
-            dbg!(&entry);
-            dbg!(&self.layers);
-
             // We grow the internal texture after allocating if necessary
             let new_layers = self.layers.len() - current_size;
             self.grow(new_layers, device, encoder);

--- a/wgpu/src/image/raster.rs
+++ b/wgpu/src/image/raster.rs
@@ -63,7 +63,6 @@ impl Cache {
     pub fn upload(
         &mut self,
         device: &wgpu::Device,
-        queue: &wgpu::Queue,
         encoder: &mut wgpu::CommandEncoder,
         handle: &image::Handle,
         atlas: &mut Atlas,
@@ -73,8 +72,7 @@ impl Cache {
         if let Memory::Host(image) = memory {
             let (width, height) = image.dimensions();
 
-            let entry =
-                atlas.upload(device, queue, encoder, width, height, image)?;
+            let entry = atlas.upload(device, encoder, width, height, image)?;
 
             *memory = Memory::Device(entry);
         }

--- a/wgpu/src/image/vector.rs
+++ b/wgpu/src/image/vector.rs
@@ -74,7 +74,6 @@ impl Cache {
     pub fn upload(
         &mut self,
         device: &wgpu::Device,
-        queue: &wgpu::Queue,
         encoder: &mut wgpu::CommandEncoder,
         handle: &svg::Handle,
         color: Option<Color>,
@@ -138,8 +137,8 @@ impl Cache {
                     });
                 }
 
-                let allocation = atlas
-                    .upload(device, queue, encoder, width, height, &rgba)?;
+                let allocation =
+                    atlas.upload(device, encoder, width, height, &rgba)?;
 
                 log::debug!("allocating {} {}x{}", id, width, height);
 


### PR DESCRIPTION
The `CommandEncoder` is used to copy the contents of the old layers to the new ones, but `Queue` was used to upload new allocations.

The fix consists in using `CommandEncoder` for all the atlas operations.