### PR TITLE
fix: when clearing damaged surface with background color blend mode should be Source only

### DIFF
--- a/tiny_skia/src/backend.rs
+++ b/tiny_skia/src/backend.rs
@@ -91,6 +91,7 @@ impl Backend {
                         background_color,
                     )),
                     anti_alias: false,
+                    blend_mode: tiny_skia::BlendMode::Source,
                     ..Default::default()
                 },
                 tiny_skia::FillRule::default(),


### PR DESCRIPTION
This is most noticeable when using a background color which is fully transparent, but should also cause issues with any partially transparent background color.