### PR TITLE
wip: animations for default widgets

### DIFF
--- a/core/src/color.rs
+++ b/core/src/color.rs
@@ -131,6 +131,22 @@ impl Color {
     pub fn inverse(self) -> Color {
         Color::new(1.0f32 - self.r, 1.0f32 - self.g, 1.0f32 - self.b, self.a)
     }
+
+    /// Mix with another color with the given ratio (from 0 to 1)
+    pub fn mix(&mut self, other: Color, ratio: f32) {
+        if ratio >= 1.0 {
+            self.r = other.r;
+            self.g = other.g;
+            self.b = other.b;
+            self.a = other.a;
+        } else if ratio > 0.0 {
+            let self_ratio = 1.0 - ratio;
+            self.r = self.r * self_ratio + other.r * ratio;
+            self.g = self.g * self_ratio + other.g * ratio;
+            self.b = self.b * self_ratio + other.b * ratio;
+            self.a = self.a * self_ratio + other.a * ratio;
+        }
+    }
 }
 
 impl From<[f32; 3]> for Color {
@@ -252,5 +268,12 @@ mod tests {
                 a: 1.0
             }
         );
+
+        // Mix two colors
+        let white = Color::WHITE;
+        let black = Color::BLACK;
+        let mut darkgrey = white;
+        darkgrey.mix(black, 0.75);
+        assert_eq!(darkgrey, Color::from_rgba(0.25, 0.25, 0.25, 1.0));
     }
 }

--- a/examples/animations/Cargo.toml
+++ b/examples/animations/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "animations"
+version = "0.1.0"
+authors = ["LazyTanuki"]
+edition = "2021"
+publish = false
+
+[dependencies]
+iced = { path = "../..", features = ["debug"] }
+# iced = "0.9"
+iced_aw = { git = "https://github.com/iced-rs/iced_aw", branch = "main", features = ["tabs"] }

--- a/examples/animations/README.md
+++ b/examples/animations/README.md
@@ -1,0 +1,8 @@
+## Animations
+
+An application to showcase Iced widgets that have default animations.
+
+The __[`main`]__ file contains all the code of the example.
+
+[`main`]: src/main.rs
+[TodoMVC]: http://todomvc.com/

--- a/examples/animations/src/main.rs
+++ b/examples/animations/src/main.rs
@@ -1,0 +1,88 @@
+use iced::widget::{button, column, radio, text_input, Toggler};
+use iced::{Element, Sandbox, Settings};
+
+pub fn main() -> iced::Result {
+    Animations::run(Settings::default())
+}
+
+struct Animations {
+    _animation_multiplier: i32,
+    radio1: Option<usize>,
+    radio2: Option<usize>,
+    input_text: String,
+    toggled: bool,
+}
+
+#[derive(Debug, Clone)]
+enum Message {
+    ButtonPressed,
+    RadioPressed(usize),
+    TextSubmitted,
+    TextChanged(String),
+    Toggle(bool),
+}
+
+impl Sandbox for Animations {
+    type Message = Message;
+
+    fn new() -> Self {
+        Self {
+            _animation_multiplier: 0,
+            radio1: None,
+            radio2: None,
+            input_text: "".into(),
+            toggled: false,
+        }
+    }
+
+    fn theme(&self) -> iced::Theme {
+        iced::Theme::Dark
+    }
+
+    fn title(&self) -> String {
+        String::from("Counter - Iced")
+    }
+
+    fn update(&mut self, message: Message) {
+        match message {
+            Message::RadioPressed(i) => match i {
+                1 => {
+                    self.radio1 = Some(1);
+                    self.radio2 = None;
+                }
+                2 => {
+                    self.radio2 = Some(2);
+                    self.radio1 = None;
+                }
+                _ => {}
+            },
+            Message::TextChanged(txt) => {
+                self.input_text = txt;
+            }
+            Message::Toggle(t) => self.toggled = t,
+            Message::TextSubmitted | Message::ButtonPressed => {}
+        }
+    }
+
+    fn view(&self) -> Element<Message> {
+        column![
+            text_input("Insert some text here...", &self.input_text)
+                .on_submit(Message::TextSubmitted)
+                .on_input(|txt| Message::TextChanged(txt)),
+            button("Press me").on_press(Message::ButtonPressed),
+            radio("Click me 1", 1, self.radio1, |i| {
+                Message::RadioPressed(i)
+            }),
+            radio("Click me 2", 2, self.radio2, |i| {
+                Message::RadioPressed(i)
+            }),
+            Toggler::new(Some("Toggle me".into()), self.toggled, |t| {
+                Message::Toggle(t)
+            })
+        ]
+        .spacing(10)
+        .padding(50)
+        .max_width(300)
+        .into()
+    }
+}

--- a/style/src/animation.rs
+++ b/style/src/animation.rs
@@ -2,7 +2,7 @@
 
 /// Hover animation of the widget
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
-pub struct HoverAnimation {
+pub struct HoverPressedAnimation {
     /// Animation direction: forward means it goes from non-hovered to hovered state
     pub direction: AnimationDirection,
     /// The instant the animation was started at (`None` if it is not running)
@@ -18,29 +18,11 @@ pub struct HoverAnimation {
 /// The type of effect for the animation
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub enum AnimationEffect {
-    /// The background color of the widget fades into the "hovered" color when hovered
+    /// The background color of the widget fades into the other color when hovered or pressed
     #[default]
     Fade,
-}
-
-/// Hover animation of the widget
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum PressedAnimation {
-    /// The background color of the widget fades into the "pressed" color when pressed
-    Fade(Fade),
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Default)]
-/// Fade.. animation
-pub struct Fade {
-    /// Animation direction: forward means it goes from non-hovered to hovered state
-    pub direction: AnimationDirection,
-    /// The instant the animation was started at (`None` if it is not running)
-    pub started_at: Option<std::time::Instant>,
-    /// The progress of the animationn, between 0.0 and 1.0
-    pub animation_progress: f32,
-    /// The progress the animation has been started at
-    pub initial_progress: f32,
+    /// The background color of the widget instantly changes into the other color when hovered or pressed
+    None,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
@@ -53,7 +35,15 @@ pub enum AnimationDirection {
     Backward,
 }
 
-impl HoverAnimation {
+impl HoverPressedAnimation {
+    /// Create a hover animation with the given transision effect
+    pub fn new(effect: AnimationEffect) -> Self {
+        Self {
+            effect,
+            ..Default::default()
+        }
+    }
+
     /// Check if the animation is running
     pub fn is_running(&self) -> bool {
         self.started_at.is_some()
@@ -97,6 +87,7 @@ impl HoverAnimation {
                                 .clamp(0.0, 1.0);
                         }
                     },
+                    AnimationEffect::None => {}
                 }
             }
             return true;

--- a/style/src/animation.rs
+++ b/style/src/animation.rs
@@ -49,6 +49,14 @@ impl HoverPressedAnimation {
         self.started_at.is_some()
     }
 
+    /// Reset the animation
+    pub fn reset(&mut self) {
+        self.direction = AnimationDirection::Forward;
+        self.started_at = None;
+        self.animation_progress = 0.0;
+        self.initial_progress = 0.0;
+    }
+
     /// Update the animation progress, if necessary, and returns the need to request a redraw.
     pub fn on_redraw_request_update(
         &mut self,
@@ -134,7 +142,7 @@ impl HoverPressedAnimation {
         }
     }
 
-    /// Start the animation when pressed
+    /// Start the animation when pressed.
     pub fn on_press(&mut self) {
         self.started_at = Some(std::time::Instant::now());
         self.direction = AnimationDirection::Forward;
@@ -142,10 +150,18 @@ impl HoverPressedAnimation {
         self.initial_progress = 0.0;
     }
 
-    /// End the animation when released
+    /// End the animation when released.
     pub fn on_released(&mut self) {
         self.started_at = Some(std::time::Instant::now());
         self.direction = AnimationDirection::Backward;
         self.initial_progress = self.animation_progress;
+    }
+
+    /// End the animation (go backgwards), skipping the forward phase.
+    pub fn on_activate(&mut self) {
+        self.started_at = Some(std::time::Instant::now());
+        self.direction = AnimationDirection::Backward;
+        self.initial_progress = 1.0;
+        self.animation_progress = 1.0;
     }
 }

--- a/style/src/animation.rs
+++ b/style/src/animation.rs
@@ -61,7 +61,7 @@ impl HoverPressedAnimation {
                 self.animation_progress = 1.0;
             }
 
-            // Reset if ended
+            // Reset the animation once it has gone forward and now fully backward
             if self.animation_progress == 0.0
                 && self.direction == AnimationDirection::Backward
             {
@@ -132,5 +132,20 @@ impl HoverPressedAnimation {
         } else {
             false
         }
+    }
+
+    /// Start the animation when pressed
+    pub fn on_press(&mut self) {
+        self.started_at = Some(std::time::Instant::now());
+        self.direction = AnimationDirection::Forward;
+        self.animation_progress = 0.0;
+        self.initial_progress = 0.0;
+    }
+
+    /// End the animation when released
+    pub fn on_released(&mut self) {
+        self.started_at = Some(std::time::Instant::now());
+        self.direction = AnimationDirection::Backward;
+        self.initial_progress = self.animation_progress;
     }
 }

--- a/style/src/animation.rs
+++ b/style/src/animation.rs
@@ -1,0 +1,24 @@
+//! Add animations to widgets.
+
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+/// Direction of the animation
+pub enum AnimationDirection {
+    #[default]
+    /// The animation goes forward
+    Forward,
+    /// The animation goes backward
+    Backward,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+/// Hover animation
+pub struct Hover {
+    /// Animation direction: forward means it goes from non-hovered to hovered state
+    pub direction: AnimationDirection,
+    /// The instant the animation was started at
+    pub started_at: std::time::Instant,
+    /// The progress of the animationn, between 0.0 and 1.0
+    pub animation_progress: f32,
+    /// The progress the animation has been started at
+    pub initial_progress: f32,
+}

--- a/style/src/animation.rs
+++ b/style/src/animation.rs
@@ -1,5 +1,48 @@
 //! Add animations to widgets.
 
+/// Hover animation of the widget
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct HoverAnimation {
+    /// Animation direction: forward means it goes from non-hovered to hovered state
+    pub direction: AnimationDirection,
+    /// The instant the animation was started at (`None` if it is not running)
+    pub started_at: Option<std::time::Instant>,
+    /// The progress of the animationn, between 0.0 and 1.0
+    pub animation_progress: f32,
+    /// The progress the animation has been started at
+    pub initial_progress: f32,
+    /// The type of effect for the animation
+    pub effect: AnimationEffect,
+}
+
+/// The type of effect for the animation
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub enum AnimationEffect {
+    /// The background color of the widget fades into the "hovered" color when hovered
+    #[default]
+    Fade,
+}
+
+/// Hover animation of the widget
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum PressedAnimation {
+    /// The background color of the widget fades into the "pressed" color when pressed
+    Fade(Fade),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+/// Fade.. animation
+pub struct Fade {
+    /// Animation direction: forward means it goes from non-hovered to hovered state
+    pub direction: AnimationDirection,
+    /// The instant the animation was started at (`None` if it is not running)
+    pub started_at: Option<std::time::Instant>,
+    /// The progress of the animationn, between 0.0 and 1.0
+    pub animation_progress: f32,
+    /// The progress the animation has been started at
+    pub initial_progress: f32,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 /// Direction of the animation
 pub enum AnimationDirection {
@@ -10,15 +53,93 @@ pub enum AnimationDirection {
     Backward,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
-/// Hover animation
-pub struct Hover {
-    /// Animation direction: forward means it goes from non-hovered to hovered state
-    pub direction: AnimationDirection,
-    /// The instant the animation was started at
-    pub started_at: std::time::Instant,
-    /// The progress of the animationn, between 0.0 and 1.0
-    pub animation_progress: f32,
-    /// The progress the animation has been started at
-    pub initial_progress: f32,
+impl HoverAnimation {
+    /// Check if the animation is running
+    pub fn is_running(&self) -> bool {
+        self.started_at.is_some()
+    }
+
+    /// Update the animation progress, if necessary, and returns the need to request a redraw.
+    pub fn on_redraw_request_update(
+        &mut self,
+        animation_duration_ms: u16,
+        now: std::time::Instant,
+    ) -> bool {
+        // Is the animation running ?
+        if let Some(started_at) = self.started_at {
+            if self.animation_progress >= 1.0 || animation_duration_ms == 0 {
+                self.animation_progress = 1.0;
+            }
+
+            // Reset if ended
+            if self.animation_progress == 0.0
+                && self.direction == AnimationDirection::Backward
+            {
+                self.started_at = None;
+            } else {
+                // Evaluate new progress
+                match &mut self.effect {
+                    AnimationEffect::Fade => match self.direction {
+                        AnimationDirection::Forward => {
+                            let progress_since_start =
+                                ((now - started_at).as_millis() as f64)
+                                    / (animation_duration_ms as f64);
+                            self.animation_progress = (self.initial_progress
+                                + progress_since_start as f32)
+                                .clamp(0.0, 1.0);
+                        }
+                        AnimationDirection::Backward => {
+                            let progress_since_start =
+                                ((now - started_at).as_millis() as f64)
+                                    / (animation_duration_ms as f64);
+                            self.animation_progress = (self.initial_progress
+                                - progress_since_start as f32)
+                                .clamp(0.0, 1.0);
+                        }
+                    },
+                }
+            }
+            return true;
+        }
+        false
+    }
+
+    /// Update the hovered state and return the need to request a redraw.
+    pub fn on_cursor_moved_update(&mut self, is_mouse_over: bool) -> bool {
+        if is_mouse_over {
+            // Is it already running ?
+            if self.started_at.is_some() {
+                // This is when the cursor re-enters the widget's area before the animation finishes
+                if self.direction == AnimationDirection::Backward {
+                    // Change animation direction
+                    self.direction = AnimationDirection::Forward;
+                    // Start from where the animation was at
+                    self.initial_progress = self.animation_progress;
+                    self.started_at = Some(std::time::Instant::now());
+                }
+            } else {
+                // Start the animation
+                self.direction = AnimationDirection::Forward;
+                self.started_at = Some(std::time::Instant::now());
+                self.animation_progress = 0.0;
+                self.initial_progress = 0.0;
+            }
+            self.animation_progress != 1.0
+        } else if self.started_at.is_some() {
+            // This is when the cursor leaves the widget's area
+            match self.direction {
+                AnimationDirection::Forward => {
+                    // Change animation direction
+                    self.direction = AnimationDirection::Backward;
+                    // Start from where the animation was at
+                    self.initial_progress = self.animation_progress;
+                    self.started_at = Some(std::time::Instant::now());
+                    true
+                }
+                AnimationDirection::Backward => true,
+            }
+        } else {
+            false
+        }
+    }
 }

--- a/style/src/button.rs
+++ b/style/src/button.rs
@@ -43,7 +43,7 @@ pub trait StyleSheet {
     fn hovered(
         &self,
         style: &Self::Style,
-        _hover: &crate::animation::HoverPressedAnimation,
+        _hover_animation: &crate::animation::HoverPressedAnimation,
     ) -> Appearance {
         let active = self.active(style);
 
@@ -54,7 +54,11 @@ pub trait StyleSheet {
     }
 
     /// Produces the pressed [`Appearance`] of a button.
-    fn pressed(&self, style: &Self::Style) -> Appearance {
+    fn pressed(
+        &self,
+        style: &Self::Style,
+        _pressed_animation: &crate::animation::HoverPressedAnimation,
+    ) -> Appearance {
         Appearance {
             shadow_offset: Vector::default(),
             ..self.active(style)

--- a/style/src/button.rs
+++ b/style/src/button.rs
@@ -40,7 +40,11 @@ pub trait StyleSheet {
     fn active(&self, style: &Self::Style) -> Appearance;
 
     /// Produces the hovered [`Appearance`] of a button.
-    fn hovered(&self, style: &Self::Style) -> Appearance {
+    fn hovered(
+        &self,
+        style: &Self::Style,
+        _hovered_style_ratio: Option<f32>,
+    ) -> Appearance {
         let active = self.active(style);
 
         Appearance {

--- a/style/src/button.rs
+++ b/style/src/button.rs
@@ -1,7 +1,8 @@
 //! Change the apperance of a button.
-use std::time::Instant;
 
 use iced_core::{Background, Color, Vector};
+
+use crate::animation::Hover;
 
 /// The appearance of a button.
 #[derive(Debug, Clone, Copy)]
@@ -31,29 +32,6 @@ impl std::default::Default for Appearance {
             text_color: Color::BLACK,
         }
     }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Default)]
-/// Direction of the animation
-pub enum AnimationDirection {
-    #[default]
-    /// The animation goes forward
-    Forward,
-    /// The animation goes backward
-    Backward,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq)]
-/// Hover animation
-pub struct Hover {
-    /// Animation direction: forward means it goes from non-hovered to hovered state
-    pub direction: AnimationDirection,
-    /// The instant the animation was started at
-    pub started_at: Instant,
-    /// The progress of the animationn, between 0.0 and 1.0
-    pub animation_progress: f32,
-    /// The progress the animation has been started at
-    pub initial_progress: f32,
 }
 
 /// A set of rules that dictate the style of a button.

--- a/style/src/button.rs
+++ b/style/src/button.rs
@@ -1,4 +1,6 @@
 //! Change the apperance of a button.
+use std::time::Instant;
+
 use iced_core::{Background, Color, Vector};
 
 /// The appearance of a button.
@@ -31,6 +33,29 @@ impl std::default::Default for Appearance {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+/// Direction of the animation
+pub enum AnimationDirection {
+    #[default]
+    /// The animation goes forward
+    Forward,
+    /// The animation goes backward
+    Backward,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+/// Hover animation
+pub struct Hover {
+    /// Animation direction: forward means it goes from non-hovered to hovered state
+    pub direction: AnimationDirection,
+    /// The instant the animation was started at
+    pub started_at: Instant,
+    /// The progress of the animationn, between 0.0 and 1.0
+    pub animation_progress: f32,
+    /// The progress the animation has been started at
+    pub initial_progress: f32,
+}
+
 /// A set of rules that dictate the style of a button.
 pub trait StyleSheet {
     /// The supported style of the [`StyleSheet`].
@@ -43,7 +68,7 @@ pub trait StyleSheet {
     fn hovered(
         &self,
         style: &Self::Style,
-        _hovered_style_ratio: Option<f32>,
+        _hover: Option<Hover>,
     ) -> Appearance {
         let active = self.active(style);
 

--- a/style/src/button.rs
+++ b/style/src/button.rs
@@ -1,8 +1,5 @@
 //! Change the apperance of a button.
-
 use iced_core::{Background, Color, Vector};
-
-use crate::animation::HoverAnimation;
 
 /// The appearance of a button.
 #[derive(Debug, Clone, Copy)]
@@ -46,7 +43,7 @@ pub trait StyleSheet {
     fn hovered(
         &self,
         style: &Self::Style,
-        _hover: &HoverAnimation,
+        _hover: &crate::animation::HoverAnimation,
     ) -> Appearance {
         let active = self.active(style);
 

--- a/style/src/button.rs
+++ b/style/src/button.rs
@@ -43,7 +43,7 @@ pub trait StyleSheet {
     fn hovered(
         &self,
         style: &Self::Style,
-        _hover: &crate::animation::HoverAnimation,
+        _hover: &crate::animation::HoverPressedAnimation,
     ) -> Appearance {
         let active = self.active(style);
 

--- a/style/src/button.rs
+++ b/style/src/button.rs
@@ -2,7 +2,7 @@
 
 use iced_core::{Background, Color, Vector};
 
-use crate::animation::Hover;
+use crate::animation::HoverAnimation;
 
 /// The appearance of a button.
 #[derive(Debug, Clone, Copy)]
@@ -46,7 +46,7 @@ pub trait StyleSheet {
     fn hovered(
         &self,
         style: &Self::Style,
-        _hover: Option<Hover>,
+        _hover: &HoverAnimation,
     ) -> Appearance {
         let active = self.active(style);
 

--- a/style/src/lib.rs
+++ b/style/src/lib.rs
@@ -20,6 +20,7 @@
 #![allow(clippy::inherent_to_string, clippy::type_complexity)]
 pub use iced_core as core;
 
+pub mod animation;
 pub mod application;
 pub mod button;
 pub mod checkbox;

--- a/style/src/radio.rs
+++ b/style/src/radio.rs
@@ -1,6 +1,8 @@
 //! Change the appearance of radio buttons.
 use iced_core::{Background, Color};
 
+use crate::animation;
+
 /// The appearance of a radio button.
 #[derive(Debug, Clone, Copy)]
 pub struct Appearance {
@@ -22,8 +24,18 @@ pub trait StyleSheet {
     type Style: Default;
 
     /// Produces the active [`Appearance`] of a radio button.
-    fn active(&self, style: &Self::Style, is_selected: bool) -> Appearance;
+    fn active(
+        &self,
+        style: &Self::Style,
+        is_selected: bool,
+        pressed_animation: &animation::HoverPressedAnimation,
+    ) -> Appearance;
 
     /// Produces the hovered [`Appearance`] of a radio button.
-    fn hovered(&self, style: &Self::Style, is_selected: bool) -> Appearance;
+    fn hovered(
+        &self,
+        style: &Self::Style,
+        is_selected: bool,
+        hover_animation: &animation::HoverPressedAnimation,
+    ) -> Appearance;
 }

--- a/style/src/theme.rs
+++ b/style/src/theme.rs
@@ -729,6 +729,7 @@ impl toggler::StyleSheet for Theme {
         &self,
         style: &Self::Style,
         is_active: bool,
+        pressed_animation: &crate::animation::HoverPressedAnimation,
     ) -> toggler::Appearance {
         match style {
             Toggler::Default => {
@@ -736,9 +737,19 @@ impl toggler::StyleSheet for Theme {
 
                 toggler::Appearance {
                     background: if is_active {
-                        palette.primary.strong.color
+                        let mut color = palette.background.strong.color;
+                        color.mix(
+                            palette.primary.strong.color,
+                            pressed_animation.animation_progress,
+                        );
+                        color
                     } else {
-                        palette.background.strong.color
+                        let mut color = palette.primary.strong.color;
+                        color.mix(
+                            palette.background.strong.color,
+                            1.0 - pressed_animation.animation_progress,
+                        );
+                        color
                     },
                     background_border: None,
                     foreground: if is_active {
@@ -749,7 +760,9 @@ impl toggler::StyleSheet for Theme {
                     foreground_border: None,
                 }
             }
-            Toggler::Custom(custom) => custom.active(self, is_active),
+            Toggler::Custom(custom) => {
+                custom.active(self, is_active, pressed_animation)
+            }
         }
     }
 
@@ -757,6 +770,7 @@ impl toggler::StyleSheet for Theme {
         &self,
         style: &Self::Style,
         is_active: bool,
+        pressed_animation: &crate::animation::HoverPressedAnimation,
     ) -> toggler::Appearance {
         match style {
             Toggler::Default => {
@@ -771,10 +785,12 @@ impl toggler::StyleSheet for Theme {
                     } else {
                         palette.background.weak.color
                     },
-                    ..self.active(style, is_active)
+                    ..self.active(style, is_active, pressed_animation)
                 }
             }
-            Toggler::Custom(custom) => custom.hovered(self, is_active),
+            Toggler::Custom(custom) => {
+                custom.hovered(self, is_active, pressed_animation)
+            }
         }
     }
 }

--- a/style/src/theme.rs
+++ b/style/src/theme.rs
@@ -196,14 +196,17 @@ impl button::StyleSheet for Theme {
             (active.background, background.as_mut())
         {
             match hover_animation.effect {
-                animation::AnimationEffect::Fade => match active_background {
-                    Background::Color(active_background_color) => {
-                        background_color.mix(
-                            active_background_color,
-                            1.0 - hover_animation.animation_progress,
-                        );
+                animation::AnimationEffect::Linear
+                | animation::AnimationEffect::EaseOut => {
+                    match active_background {
+                        Background::Color(active_background_color) => {
+                            background_color.mix(
+                                active_background_color,
+                                1.0 - hover_animation.animation_progress,
+                            );
+                        }
                     }
-                },
+                }
                 animation::AnimationEffect::None => {}
             }
         }
@@ -239,14 +242,17 @@ impl button::StyleSheet for Theme {
             (active.background, background.as_mut())
         {
             match pressed_animation.effect {
-                animation::AnimationEffect::Fade => match active_background {
-                    Background::Color(active_background_color) => {
-                        background_color.mix(
-                            active_background_color,
-                            pressed_animation.animation_progress,
-                        );
+                animation::AnimationEffect::Linear
+                | animation::AnimationEffect::EaseOut => {
+                    match active_background {
+                        Background::Color(active_background_color) => {
+                            background_color.mix(
+                                active_background_color,
+                                pressed_animation.animation_progress,
+                            );
+                        }
                     }
-                },
+                }
                 animation::AnimationEffect::None => {}
             }
         }
@@ -649,7 +655,8 @@ impl radio::StyleSheet for Theme {
 
                 if is_selected {
                     match pressed_animation.effect {
-                        animation::AnimationEffect::Fade => {
+                        animation::AnimationEffect::Linear
+                        | animation::AnimationEffect::EaseOut => {
                             dot_color.mix(
                                 Color::TRANSPARENT,
                                 pressed_animation.animation_progress,
@@ -687,15 +694,17 @@ impl radio::StyleSheet for Theme {
 
                 // Mix the hovered and active styles backgrounds according to the animation state
                 match hover_animation.effect {
-                    animation::AnimationEffect::Fade => match active.background
-                    {
-                        Background::Color(active_background_color) => {
-                            background_color.mix(
-                                active_background_color,
-                                1.0 - hover_animation.animation_progress,
-                            );
+                    animation::AnimationEffect::Linear
+                    | animation::AnimationEffect::EaseOut => {
+                        match active.background {
+                            Background::Color(active_background_color) => {
+                                background_color.mix(
+                                    active_background_color,
+                                    1.0 - hover_animation.animation_progress,
+                                );
+                            }
                         }
-                    },
+                    }
                     animation::AnimationEffect::None => {}
                 }
 

--- a/style/src/theme.rs
+++ b/style/src/theme.rs
@@ -4,9 +4,9 @@ pub mod palette;
 use self::palette::Extended;
 pub use self::palette::Palette;
 
+use crate::animation;
 use crate::application;
 use crate::button;
-use crate::button::Hover;
 use crate::checkbox;
 use crate::container;
 use crate::core::widget::text;
@@ -173,7 +173,7 @@ impl button::StyleSheet for Theme {
     fn hovered(
         &self,
         style: &Self::Style,
-        hover: Option<Hover>,
+        hover: Option<animation::Hover>,
     ) -> button::Appearance {
         let palette = self.extended_palette();
 

--- a/style/src/theme.rs
+++ b/style/src/theme.rs
@@ -173,12 +173,12 @@ impl button::StyleSheet for Theme {
     fn hovered(
         &self,
         style: &Self::Style,
-        hover: Option<animation::Hover>,
+        hover_animation: &animation::HoverAnimation,
     ) -> button::Appearance {
         let palette = self.extended_palette();
 
         if let Button::Custom(custom) = style {
-            return custom.hovered(self, hover);
+            return custom.hovered(self, hover_animation);
         }
 
         let active = self.active(style);
@@ -192,16 +192,18 @@ impl button::StyleSheet for Theme {
         };
 
         // Mix the hovered and active styles backgrounds according to the animation state
-        if let (Some(hover), Some(active_background), Some(background_color)) =
-            (hover, active.background, background.as_mut())
+        if let (Some(active_background), Some(background_color)) =
+            (active.background, background.as_mut())
         {
-            match active_background {
-                Background::Color(active_background_color) => {
-                    background_color.mix(
-                        active_background_color,
-                        1.0 - hover.animation_progress,
-                    );
-                }
+            match hover_animation.effect {
+                animation::AnimationEffect::Fade => match active_background {
+                    Background::Color(active_background_color) => {
+                        background_color.mix(
+                            active_background_color,
+                            1.0 - hover_animation.animation_progress,
+                        );
+                    }
+                },
             }
         }
 

--- a/style/src/theme.rs
+++ b/style/src/theme.rs
@@ -173,7 +173,7 @@ impl button::StyleSheet for Theme {
     fn hovered(
         &self,
         style: &Self::Style,
-        hover_animation: &animation::HoverAnimation,
+        hover_animation: &animation::HoverPressedAnimation,
     ) -> button::Appearance {
         let palette = self.extended_palette();
 
@@ -204,6 +204,7 @@ impl button::StyleSheet for Theme {
                         );
                     }
                 },
+                animation::AnimationEffect::None => {}
             }
         }
 

--- a/style/src/theme.rs
+++ b/style/src/theme.rs
@@ -6,6 +6,7 @@ pub use self::palette::Palette;
 
 use crate::application;
 use crate::button;
+use crate::button::Hover;
 use crate::checkbox;
 use crate::container;
 use crate::core::widget::text;
@@ -172,12 +173,12 @@ impl button::StyleSheet for Theme {
     fn hovered(
         &self,
         style: &Self::Style,
-        hovered_style_ratio: Option<f32>,
+        hover: Option<Hover>,
     ) -> button::Appearance {
         let palette = self.extended_palette();
 
         if let Button::Custom(custom) = style {
-            return custom.hovered(self, hovered_style_ratio);
+            return custom.hovered(self, hover);
         }
 
         let active = self.active(style);
@@ -191,17 +192,14 @@ impl button::StyleSheet for Theme {
         };
 
         // Mix the hovered and active styles backgrounds according to the animation state
-        if let (
-            Some(hovered_style_ratio),
-            Some(active_background),
-            Some(background_color),
-        ) = (hovered_style_ratio, active.background, background.as_mut())
+        if let (Some(hover), Some(active_background), Some(background_color)) =
+            (hover, active.background, background.as_mut())
         {
             match active_background {
                 Background::Color(active_background_color) => {
                     background_color.mix(
                         active_background_color,
-                        1.0 - hovered_style_ratio,
+                        1.0 - hover.animation_progress,
                     );
                 }
             }

--- a/style/src/theme.rs
+++ b/style/src/theme.rs
@@ -169,22 +169,43 @@ impl button::StyleSheet for Theme {
         }
     }
 
-    fn hovered(&self, style: &Self::Style) -> button::Appearance {
+    fn hovered(
+        &self,
+        style: &Self::Style,
+        hovered_style_ratio: Option<f32>,
+    ) -> button::Appearance {
         let palette = self.extended_palette();
 
         if let Button::Custom(custom) = style {
-            return custom.hovered(self);
+            return custom.hovered(self, hovered_style_ratio);
         }
 
         let active = self.active(style);
 
-        let background = match style {
+        let mut background = match style {
             Button::Primary => Some(palette.primary.base.color),
             Button::Secondary => Some(palette.background.strong.color),
             Button::Positive => Some(palette.success.strong.color),
             Button::Destructive => Some(palette.danger.strong.color),
             Button::Text | Button::Custom(_) => None,
         };
+
+        // Mix the hovered and active styles backgrounds according to the animation state
+        if let (
+            Some(hovered_style_ratio),
+            Some(active_background),
+            Some(background_color),
+        ) = (hovered_style_ratio, active.background, background.as_mut())
+        {
+            match active_background {
+                Background::Color(active_background_color) => {
+                    background_color.mix(
+                        active_background_color,
+                        1.0 - hovered_style_ratio,
+                    );
+                }
+            }
+        }
 
         button::Appearance {
             background: background.map(Background::from),

--- a/style/src/toggler.rs
+++ b/style/src/toggler.rs
@@ -22,10 +22,20 @@ pub trait StyleSheet {
     /// Returns the active [`Appearance`] of the toggler for the provided [`Style`].
     ///
     /// [`Style`]: Self::Style
-    fn active(&self, style: &Self::Style, is_active: bool) -> Appearance;
+    fn active(
+        &self,
+        style: &Self::Style,
+        is_active: bool,
+        _pressed_animation: &crate::animation::HoverPressedAnimation,
+    ) -> Appearance;
 
     /// Returns the hovered [`Appearance`] of the toggler for the provided [`Style`].
     ///
     /// [`Style`]: Self::Style
-    fn hovered(&self, style: &Self::Style, is_active: bool) -> Appearance;
+    fn hovered(
+        &self,
+        style: &Self::Style,
+        is_active: bool,
+        _pressed_animation: &crate::animation::HoverPressedAnimation,
+    ) -> Appearance;
 }

--- a/widget/src/button.rs
+++ b/widget/src/button.rs
@@ -16,7 +16,7 @@ use crate::core::{
 };
 use crate::core::window;
 
-use iced_style::animation::{Fade, HoverAnimation, PressedAnimation};
+use iced_style::animation::{AnimationEffect, HoverPressedAnimation};
 pub use iced_style::button::{Appearance, StyleSheet};
 
 /// A generic widget that produces a message when pressed.
@@ -66,8 +66,8 @@ where
     padding: Padding,
     style: <Renderer::Theme as StyleSheet>::Style,
     animation_duration_ms: u16,
-    hover_animation: HoverAnimation,
-    pressed_animation: PressedAnimation,
+    hover_animation_effect: AnimationEffect,
+    pressed_animation_effect: AnimationEffect,
 }
 
 impl<'a, Message, Renderer> Button<'a, Message, Renderer>
@@ -85,8 +85,8 @@ where
             padding: Padding::new(5.0),
             style: <Renderer::Theme as StyleSheet>::Style::default(),
             animation_duration_ms: 150,
-            hover_animation: HoverAnimation::default(),
-            pressed_animation: PressedAnimation::Fade(Fade::default()),
+            hover_animation_effect: AnimationEffect::Fade,
+            pressed_animation_effect: AnimationEffect::Fade,
         }
     }
 
@@ -131,18 +131,21 @@ where
         self
     }
 
-    /// Sets the animation when hovering the [`Button`].
-    pub fn hover_animation(mut self, hover_animation: HoverAnimation) -> Self {
-        self.hover_animation = hover_animation;
+    /// Sets the animation effect when hovering the [`Button`].
+    pub fn hover_animation_effect(
+        mut self,
+        hover_animation_effect: AnimationEffect,
+    ) -> Self {
+        self.hover_animation_effect = hover_animation_effect;
         self
     }
 
-    /// Sets the animation when pressing the [`Button`].
-    pub fn press_animation(
+    /// Sets the animation effect when pressing the [`Button`].
+    pub fn pressed_animation_effect(
         mut self,
-        pressed_animation: PressedAnimation,
+        pressed_animation_effect: AnimationEffect,
     ) -> Self {
-        self.pressed_animation = pressed_animation;
+        self.pressed_animation_effect = pressed_animation_effect;
         self
     }
 }
@@ -160,8 +163,8 @@ where
 
     fn state(&self) -> tree::State {
         tree::State::new(State::new(
-            self.hover_animation,
-            self.pressed_animation,
+            HoverPressedAnimation::new(self.hover_animation_effect),
+            HoverPressedAnimation::new(self.hover_animation_effect),
         ))
     }
 
@@ -325,15 +328,15 @@ where
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct State {
     is_pressed: bool,
-    hovered_animation: HoverAnimation,
-    pressed_animation: PressedAnimation,
+    hovered_animation: HoverPressedAnimation,
+    pressed_animation: HoverPressedAnimation,
 }
 
 impl State {
     /// Creates a new [`State`].
     pub fn new(
-        hovered_animation: HoverAnimation,
-        pressed_animation: PressedAnimation,
+        hovered_animation: HoverPressedAnimation,
+        pressed_animation: HoverPressedAnimation,
     ) -> State {
         State {
             is_pressed: false,

--- a/widget/src/button.rs
+++ b/widget/src/button.rs
@@ -85,8 +85,8 @@ where
             padding: Padding::new(5.0),
             style: <Renderer::Theme as StyleSheet>::Style::default(),
             animation_duration_ms: 250,
-            hover_animation_effect: AnimationEffect::Fade,
-            pressed_animation_effect: AnimationEffect::Fade,
+            hover_animation_effect: AnimationEffect::EaseOut,
+            pressed_animation_effect: AnimationEffect::EaseOut,
         }
     }
 

--- a/widget/src/button.rs
+++ b/widget/src/button.rs
@@ -16,9 +16,7 @@ use crate::core::{
 };
 use crate::core::window;
 
-use iced_style::animation::{
-    AnimationDirection, AnimationEffect, Fade, HoverAnimation, PressedAnimation,
-};
+use iced_style::animation::{Fade, HoverAnimation, PressedAnimation};
 pub use iced_style::button::{Appearance, StyleSheet};
 
 /// A generic widget that produces a message when pressed.
@@ -266,10 +264,10 @@ where
         let styling = draw(
             renderer,
             bounds,
+            cursor_position,
             self.on_press.is_some(),
             theme,
             &self.style,
-            cursor_position,
             || tree.state.downcast_ref::<State>(),
         );
 
@@ -426,12 +424,12 @@ pub fn update<'a, Message: Clone>(
 pub fn draw<'a, Renderer: crate::core::Renderer>(
     renderer: &mut Renderer,
     bounds: Rectangle,
+    cursor_position: Point,
     is_enabled: bool,
     style_sheet: &dyn StyleSheet<
         Style = <Renderer::Theme as StyleSheet>::Style,
     >,
     style: &<Renderer::Theme as StyleSheet>::Style,
-    cursor_position: Point,
     state: impl FnOnce() -> &'a State,
 ) -> Appearance
 where

--- a/widget/src/button.rs
+++ b/widget/src/button.rs
@@ -10,11 +10,11 @@ use crate::core::renderer;
 use crate::core::touch;
 use crate::core::widget::tree::{self, Tree};
 use crate::core::widget::Operation;
+use crate::core::window;
 use crate::core::{
     Background, Clipboard, Color, Element, Layout, Length, Padding, Point,
     Rectangle, Shell, Vector, Widget,
 };
-use crate::core::window;
 
 use iced_style::animation::{AnimationEffect, HoverPressedAnimation};
 pub use iced_style::button::{Appearance, StyleSheet};
@@ -85,8 +85,8 @@ where
             padding: Padding::new(5.0),
             style: <Renderer::Theme as StyleSheet>::Style::default(),
             animation_duration_ms: 250,
-            hover_animation_effect: AnimationEffect::EaseOut,
-            pressed_animation_effect: AnimationEffect::EaseOut,
+            hover_animation_effect: AnimationEffect::Fade,
+            pressed_animation_effect: AnimationEffect::Fade,
         }
     }
 
@@ -451,11 +451,11 @@ where
     Renderer::Theme: StyleSheet,
 {
     let state = state();
-    let is_hovered = bounds.contains(cursor_position);
+    let is_mouse_over = bounds.contains(cursor_position);
 
     let styling = if !is_enabled {
         style_sheet.disabled(style)
-    } else if is_hovered || state.hovered_animation.is_running() {
+    } else if is_mouse_over || state.hovered_animation.is_running() {
         if state.is_pressed || state.pressed_animation.is_running() {
             style_sheet.pressed(style, &state.pressed_animation)
         } else {

--- a/widget/src/button.rs
+++ b/widget/src/button.rs
@@ -1,7 +1,6 @@
 //! Allow your users to perform actions by pressing a button.
 //!
 //! A [`Button`] has some local [`State`].
-use std::time::Instant;
 
 use crate::core::event::{self, Event};
 use crate::core::layout;
@@ -17,7 +16,7 @@ use crate::core::{
 };
 use crate::core::window;
 
-use iced_style::button::{AnimationDirection, Hover};
+use iced_style::animation::{AnimationDirection, Hover};
 pub use iced_style::button::{Appearance, StyleSheet};
 
 /// A generic widget that produces a message when pressed.

--- a/widget/src/radio.rs
+++ b/widget/src/radio.rs
@@ -134,7 +134,7 @@ where
             font: None,
             style: Default::default(),
             animation_duration_ms: 250,
-            hover_animation_effect: AnimationEffect::Fade,
+            hover_animation_effect: AnimationEffect::EaseOut,
         }
     }
 

--- a/widget/src/text_input/cursor.rs
+++ b/widget/src/text_input/cursor.rs
@@ -7,6 +7,16 @@ pub struct Cursor {
     state: State,
 }
 
+/// The animation styles for the [`Cursor`].
+#[derive(Debug, Clone, Copy, Default)]
+pub enum CursorAnimation {
+    /// Blink the cursor (visible then not visible in a loop)
+    Blink,
+    /// Fade from visible to invisible in a loop
+    #[default]
+    Fade,
+}
+
 /// The state of a [`Cursor`].
 #[derive(Debug, Copy, Clone)]
 pub enum State {

--- a/widget/src/toggler.rs
+++ b/widget/src/toggler.rs
@@ -93,7 +93,7 @@ where
             font: None,
             style: Default::default(),
             animation_duration: 250,
-            pressed_animation_effect: AnimationEffect::Fade,
+            pressed_animation_effect: AnimationEffect::EaseOut,
         }
     }
 


### PR DESCRIPTION
Hi!

This WIP implements default animations for default widgets. The goal here is to make Iced application appear smooth when hovering / clicking things, without breaking the API. It is also possible to keep the actual behavior (using a simple enum), although I do not know which should be default.
This heavily uses the new frame subscription API.
This is one thing that I was missing since transitioning from GTK, where you don't really need to worry about animations but can still end up with something that looks nice and smooth.

# Current progress

## Buttons

Buttons have smooth color transitions when hovered and pressed.

https://github.com/iced-rs/iced/assets/43273245/4d000c71-3eca-4b0a-8326-e647ed1bf42d

Things to discuss and fix:

- [ ] Buttons look for cursor movement events to know whether they're being hovered or not. Could this be replaced by a new `Hovered` event in the `update()` function?
- [ ] When clicking a button that is moved on click, it is possible that it is hovered anymore. However, if the mouse does not move, it will not be aware of it and will remain highlighted until the cursor moves again.

## Text input (cursor)

In the text input, the cursor will fade-blink. It will however remain a full opacity while typing

https://github.com/iced-rs/iced/assets/43273245/101e9de9-55a2-49eb-8836-1b5d2d3b72f6

## Radio buttons

Radio buttons have smooth color transitions when hovered and pressed.

https://github.com/iced-rs/iced/assets/43273245/571a9a7c-451e-4e46-9591-fbc1825bbe96

## Togglers

Togglers have smooth color and movements transitions when pressed.

https://github.com/iced-rs/iced/assets/43273245/0af06664-739f-4c04-91dd-ef061f3530a6

# To do

- [ ] checkboxes
- [ ] scrollables
- [ ] sliders
- [ ] ...

# Interferences

I stumbled upon [cosmic-time](https://github.com/pop-os/cosmic-time), which implements a framework for animations in iced. From what I understand, it is made for more complex animations to be implemented by the user, whereas my goal is to bring default animations to Iced. However, I do not know if it would be better to use what has been made for cosmic-time for this or not. Or maybe this WIP is better suited to be used in cosmic-time after all.

I think default animations would be great, at least to be on par with GTK, but that's just IMO!
Thanks!