### PR TITLE
[Feature] Enhance PaneGrid to split panes by drag & drop

### DIFF
--- a/examples/pane_grid/src/main.rs
+++ b/examples/pane_grid/src/main.rs
@@ -108,8 +108,12 @@ impl Application for Example {
             Message::Dragged(pane_grid::DragEvent::Dropped {
                 pane,
                 target,
+                region,
             }) => {
-                self.panes.swap(&pane, &target);
+                if let Some(state) = self.panes.get(&pane) {
+                    let pane = (*state, &pane);
+                    self.panes.split_with(&target, pane, region);
+                }
             }
             Message::Dragged(_) => {}
             Message::TogglePin(pane) => {
@@ -255,6 +259,7 @@ fn handle_hotkey(key_code: keyboard::KeyCode) -> Option<Message> {
     }
 }
 
+#[derive(Clone, Copy)]
 struct Pane {
     id: usize,
     pub is_pinned: bool,

--- a/examples/pane_grid/src/main.rs
+++ b/examples/pane_grid/src/main.rs
@@ -110,10 +110,7 @@ impl Application for Example {
                 target,
                 region,
             }) => {
-                if let Some(state) = self.panes.get(&pane) {
-                    let pane = (*state, &pane);
-                    self.panes.split_with(&target, pane, region);
-                }
+                self.panes.split_with(&target, &pane, region);
             }
             Message::Dragged(_) => {}
             Message::TogglePin(pane) => {

--- a/style/src/pane_grid.rs
+++ b/style/src/pane_grid.rs
@@ -1,24 +1,9 @@
 //! Change the appearance of a pane grid.
 use iced_core::{Background, Color};
 
-/// A set of rules that dictate the style of a container.
-pub trait StyleSheet {
-    /// The supported style of the [`StyleSheet`].
-    type Style: Default;
-
-    /// The [`Region`] to draw when a pane is hovered.
-    fn hovered_region(&self, style: &Self::Style) -> Region;
-
-    /// The [`Line`] to draw when a split is picked.
-    fn picked_split(&self, style: &Self::Style) -> Option<Line>;
-
-    /// The [`Line`] to draw when a split is hovered.
-    fn hovered_split(&self, style: &Self::Style) -> Option<Line>;
-}
-
 /// The appearance of the hovered region of a pane grid.
 #[derive(Debug, Clone, Copy)]
-pub struct Region {
+pub struct Appearance {
     /// The [`Background`] of the hovered pane region.
     pub background: Background,
     /// The border width of the hovered pane region.
@@ -39,4 +24,19 @@ pub struct Line {
 
     /// The width of the [`Line`].
     pub width: f32,
+}
+
+/// A set of rules that dictate the style of a container.
+pub trait StyleSheet {
+    /// The supported style of the [`StyleSheet`].
+    type Style: Default;
+
+    /// The [`Region`] to draw when a pane is hovered.
+    fn hovered_region(&self, style: &Self::Style) -> Appearance;
+
+    /// The [`Line`] to draw when a split is picked.
+    fn picked_split(&self, style: &Self::Style) -> Option<Line>;
+
+    /// The [`Line`] to draw when a split is hovered.
+    fn hovered_split(&self, style: &Self::Style) -> Option<Line>;
 }

--- a/style/src/pane_grid.rs
+++ b/style/src/pane_grid.rs
@@ -1,16 +1,32 @@
 //! Change the appearance of a pane grid.
-use iced_core::Color;
+use iced_core::{Background, Color};
 
 /// A set of rules that dictate the style of a container.
 pub trait StyleSheet {
     /// The supported style of the [`StyleSheet`].
     type Style: Default;
 
+    /// The [`Region`] to draw when a pane is hovered.
+    fn hovered_region(&self, style: &Self::Style) -> Region;
+
     /// The [`Line`] to draw when a split is picked.
     fn picked_split(&self, style: &Self::Style) -> Option<Line>;
 
     /// The [`Line`] to draw when a split is hovered.
     fn hovered_split(&self, style: &Self::Style) -> Option<Line>;
+}
+
+/// The appearance of the hovered region of a pane grid.
+#[derive(Debug, Clone, Copy)]
+pub struct Region {
+    /// The [`Background`] of the hovered pane region.
+    pub background: Background,
+    /// The border width of the hovered pane region.
+    pub border_width: f32,
+    /// The border [`Color`] of the hovered pane region.
+    pub border_color: Color,
+    /// The border radius of the hovered pane region.
+    pub border_radius: f32,
 }
 
 /// A line.

--- a/style/src/theme.rs
+++ b/style/src/theme.rs
@@ -703,6 +703,25 @@ pub enum PaneGrid {
 impl pane_grid::StyleSheet for Theme {
     type Style = PaneGrid;
 
+    fn hovered_region(&self, style: &Self::Style) -> pane_grid::Region {
+        match style {
+            PaneGrid::Default => {
+                let palette = self.extended_palette();
+
+                pane_grid::Region {
+                    background: Background::Color(Color {
+                        a: 0.5,
+                        ..palette.primary.base.color
+                    }),
+                    border_width: 2.0,
+                    border_color: palette.primary.strong.color,
+                    border_radius: 0.0,
+                }
+            }
+            PaneGrid::Custom(custom) => custom.hovered_region(self),
+        }
+    }
+
     fn picked_split(&self, style: &Self::Style) -> Option<pane_grid::Line> {
         match style {
             PaneGrid::Default => {

--- a/style/src/theme.rs
+++ b/style/src/theme.rs
@@ -703,12 +703,12 @@ pub enum PaneGrid {
 impl pane_grid::StyleSheet for Theme {
     type Style = PaneGrid;
 
-    fn hovered_region(&self, style: &Self::Style) -> pane_grid::Region {
+    fn hovered_region(&self, style: &Self::Style) -> pane_grid::Appearance {
         match style {
             PaneGrid::Default => {
                 let palette = self.extended_palette();
 
-                pane_grid::Region {
+                pane_grid::Appearance {
                     background: Background::Color(Color {
                         a: 0.5,
                         ..palette.primary.base.color

--- a/widget/src/pane_grid.rs
+++ b/widget/src/pane_grid.rs
@@ -30,7 +30,7 @@ pub use split::Split;
 pub use state::State;
 pub use title_bar::TitleBar;
 
-pub use crate::style::pane_grid::{Line, StyleSheet};
+pub use crate::style::pane_grid::{Appearance, Line, StyleSheet};
 
 use crate::container;
 use crate::core::event::{self, Event};

--- a/widget/src/pane_grid/state.rs
+++ b/widget/src/pane_grid/state.rs
@@ -170,17 +170,9 @@ impl<T> State<T> {
     /// Split a target [`Pane`] with a given [`Pane`] on a given [`Region`].
     ///
     /// Panes will be swapped by default for [`Region::Center`].
-    pub fn split_with(
-        &mut self,
-        target: &Pane,
-        pane: (T, &Pane),
-        region: Region,
-    ) {
+    pub fn split_with(&mut self, target: &Pane, pane: &Pane, region: Region) {
         match region {
-            Region::Center => {
-                let (_, pane) = pane;
-                self.swap(pane, target);
-            }
+            Region::Center => self.swap(pane, target),
             Region::Top => {
                 self.split_and_swap(Axis::Horizontal, target, pane, true)
             }
@@ -200,17 +192,15 @@ impl<T> State<T> {
         &mut self,
         axis: Axis,
         target: &Pane,
-        pane: (T, &Pane),
+        pane: &Pane,
         invert: bool,
     ) {
-        let (state, pane) = pane;
-
-        if let Some((new_pane, _)) = self.split(axis, target, state) {
-            if invert {
-                self.swap(target, &new_pane);
+        if let Some((state, _)) = self.close(pane) {
+            if let Some((new_pane, _)) = self.split(axis, target, state) {
+                if invert {
+                    self.swap(target, &new_pane);
+                }
             }
-
-            let _ = self.close(pane);
         }
     }
 

--- a/widget/src/pane_grid/state.rs
+++ b/widget/src/pane_grid/state.rs
@@ -193,11 +193,11 @@ impl<T> State<T> {
         axis: Axis,
         target: &Pane,
         pane: &Pane,
-        invert: bool,
+        swap: bool,
     ) {
         if let Some((state, _)) = self.close(pane) {
             if let Some((new_pane, _)) = self.split(axis, target, state) {
-                if invert {
+                if swap {
                     self.swap(target, &new_pane);
                 }
             }


### PR DESCRIPTION
## Summary 

Previously, dropping a pane onto another would just swap them. This leads users of `PaneGrid` needing to manually create splits first and then swap panes (and most probably closing unnecessary ones) in order to change the layout of the grid.

This change adds functionality to `PaneGrid` in order to be able to split a pane with another by simply dragging and dropping the pane in a certain region of the target pane.

## Implementation

Introduced `Region` parameter to `pane_grid::DragEvent::Dropped` that is the target pane area (top, left, bottom, right, center) where the dragged pane is hovering on. Panes were divided in thirds. Left and right sides have priority over top and bottom.

Users of `PaneGrid` can call `pane_grid::State::split_with(target, pane, region)` in order to split the target with a given pane on a given region of the target. 

The `Region` of the hovered target dropping area is highlighted with a given `style` in order for users to easily see how the panes will be displayed.

## Demo

https://github.com/iced-rs/iced/assets/51237625/edd4a8da-fd14-418d-ac28-b1f3782b1827

