### PR TITLE
Add Nix instructions to README

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -1,0 +1,33 @@
+# Dependencies
+
+Iced requires some system dependencies to work, and not
+all operating systems come with them installed.
+
+You can follow the provided instructions for your system to
+get them, if your system isn't here, add it!
+
+## NixOS
+
+You can add this `shell.nix` to your project and use it by running `nix-shell`:
+
+```nix
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell rec {
+  buildInputs = with pkgs; [
+    expat
+    fontconfig
+    freetype
+    freetype.dev
+    libGL
+    pkgconfig
+    xorg.libX11
+    xorg.libXcursor
+    xorg.libXi
+    xorg.libXrandr
+  ];
+
+  LD_LIBRARY_PATH =
+    builtins.foldl' (a: b: "${a}:${b}/lib") "${pkgs.vulkan-loader}/lib" buildInputs;
+}
+```

--- a/README.md
+++ b/README.md
@@ -63,6 +63,40 @@ __Iced is currently experimental software.__ [Take a look at the roadmap],
 [check out the issues]: https://github.com/iced-rs/iced/issues
 [feel free to contribute!]: #contributing--feedback
 
+## Dependencies
+
+Iced requires some system dependencies to work, and not
+all operating systems come with them installed.
+
+You can follow the provided instructions for your system to
+get them, if your system isn't here, add it!
+
+### NixOS
+
+You can add this `shell.nix` to your project and use it by running `nix-shell`:
+
+```nix
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell rec {
+  buildInputs = with pkgs; [
+    expat
+    fontconfig
+    freetype
+    freetype.dev
+    libGL
+    pkgconfig
+    xorg.libX11
+    xorg.libXcursor
+    xorg.libXi
+    xorg.libXrandr
+  ];
+
+  LD_LIBRARY_PATH =
+    builtins.foldl' (a: b: "${a}:${b}/lib") "${pkgs.vulkan-loader}/lib" buildInputs;
+}
+```
+
 ## Installation
 
 Add `iced` as a dependency in your `Cargo.toml`:

--- a/README.md
+++ b/README.md
@@ -63,40 +63,6 @@ __Iced is currently experimental software.__ [Take a look at the roadmap],
 [check out the issues]: https://github.com/iced-rs/iced/issues
 [feel free to contribute!]: #contributing--feedback
 
-## Dependencies
-
-Iced requires some system dependencies to work, and not
-all operating systems come with them installed.
-
-You can follow the provided instructions for your system to
-get them, if your system isn't here, add it!
-
-### NixOS
-
-You can add this `shell.nix` to your project and use it by running `nix-shell`:
-
-```nix
-{ pkgs ? import <nixpkgs> {} }:
-
-pkgs.mkShell rec {
-  buildInputs = with pkgs; [
-    expat
-    fontconfig
-    freetype
-    freetype.dev
-    libGL
-    pkgconfig
-    xorg.libX11
-    xorg.libXcursor
-    xorg.libXi
-    xorg.libXrandr
-  ];
-
-  LD_LIBRARY_PATH =
-    builtins.foldl' (a: b: "${a}:${b}/lib") "${pkgs.vulkan-loader}/lib" buildInputs;
-}
-```
-
 ## Installation
 
 Add `iced` as a dependency in your `Cargo.toml`:


### PR DESCRIPTION
We should add instructions for Ubuntu, Arch, Windows and MacOS too, just NixOS on its own feels weird.