### PR TITLE
feat(text_input): For ignored events, pass Ignored

### DIFF
--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -878,12 +878,9 @@ where
                         state.keyboard_modifiers =
                             keyboard::Modifiers::default();
                     }
-                    keyboard::KeyCode::Tab
-                    | keyboard::KeyCode::Up
-                    | keyboard::KeyCode::Down => {
+                    _ => {
                         return event::Status::Ignored;
                     }
-                    _ => {}
                 }
 
                 return event::Status::Captured;
@@ -897,12 +894,7 @@ where
                     keyboard::KeyCode::V => {
                         state.is_pasting = None;
                     }
-                    keyboard::KeyCode::Tab
-                    | keyboard::KeyCode::Up
-                    | keyboard::KeyCode::Down => {
-                        return event::Status::Ignored;
-                    }
-                    _ => {}
+                    _ => return event::Status::Ignored,
                 }
 
                 return event::Status::Captured;


### PR DESCRIPTION
For a [small side-project of mine](https://github.com/titoeb/mrc-workout-creator) I wanted to implement the following feature: On my GUI, I have three text inputs on top and I wanted that pressing F1 would focus the first text input, F2 would focus the second text input ect, even if another text input is focused. 

That was working fine, when no other text input was focused, but as soon as one was focused the Event of pressing F1, F2, F3 was just caught by the text-input without doing anything with them or passing them as ignored. Currently [only Tab, Up and Down](https://github.com/iced-rs/iced/blob/640e13943c04754ef74e11db470b6c9470640623/widget/src/text_input.rs#L881-L884)-events are not caught by the text-input. 

In this PR, for all Events of type `Event::Keyboard(keyboard::Event::KeyReleased{...})` or `Event::Keyboard(keyboard::Event::KeyPressed{...})` that are not explicitly handled, the text input will return `event::Status::Ignored`. 

For my local example this worked fine without impacting the functionality of the `TextInput` but I don´t know if that collides with the overall architecture of the crate.