### PR TITLE
[Feature] Pane Grid: drag & drop panes to the edges

### DIFF
--- a/examples/pane_grid/src/main.rs
+++ b/examples/pane_grid/src/main.rs
@@ -108,10 +108,15 @@ impl Application for Example {
             Message::Dragged(pane_grid::DragEvent::Dropped {
                 pane,
                 target,
-                region,
-            }) => {
-                self.panes.split_with(&target, &pane, region);
-            }
+            }) => match target {
+                pane_grid::Target::PaneGrid(edge) => {
+                    self.panes.move_to_edge(&pane, edge)
+                }
+                pane_grid::Target::Pane {
+                    pane: target,
+                    region,
+                } => self.panes.split_with(&target, &pane, region),
+            },
             Message::Dragged(_) => {}
             Message::TogglePin(pane) => {
                 if let Some(Pane { is_pinned, .. }) = self.panes.get_mut(&pane)

--- a/examples/pane_grid/src/main.rs
+++ b/examples/pane_grid/src/main.rs
@@ -108,14 +108,9 @@ impl Application for Example {
             Message::Dragged(pane_grid::DragEvent::Dropped {
                 pane,
                 target,
-            }) => match target {
-                pane_grid::Target::Edge(edge) => {
-                    self.panes.move_to_edge(&pane, edge)
-                }
-                pane_grid::Target::Pane(target, region) => {
-                    self.panes.split_with(&target, &pane, region)
-                }
-            },
+            }) => {
+                self.panes.drop(&pane, target);
+            }
             Message::Dragged(_) => {}
             Message::TogglePin(pane) => {
                 if let Some(Pane { is_pinned, .. }) = self.panes.get_mut(&pane)

--- a/examples/pane_grid/src/main.rs
+++ b/examples/pane_grid/src/main.rs
@@ -109,13 +109,12 @@ impl Application for Example {
                 pane,
                 target,
             }) => match target {
-                pane_grid::Target::PaneGrid(edge) => {
+                pane_grid::Target::Edge(edge) => {
                     self.panes.move_to_edge(&pane, edge)
                 }
-                pane_grid::Target::Pane {
-                    pane: target,
-                    region,
-                } => self.panes.split_with(&target, &pane, region),
+                pane_grid::Target::Pane(target, region) => {
+                    self.panes.split_with(&target, &pane, region)
+                }
             },
             Message::Dragged(_) => {}
             Message::TogglePin(pane) => {

--- a/style/src/pane_grid.rs
+++ b/style/src/pane_grid.rs
@@ -31,7 +31,7 @@ pub trait StyleSheet {
     /// The supported style of the [`StyleSheet`].
     type Style: Default;
 
-    /// The [`Region`] to draw when a pane is hovered.
+    /// The [`Appearance`] to draw when a pane is hovered.
     fn hovered_region(&self, style: &Self::Style) -> Appearance;
 
     /// The [`Line`] to draw when a split is picked.

--- a/widget/src/pane_grid.rs
+++ b/widget/src/pane_grid.rs
@@ -843,9 +843,13 @@ pub fn draw<Renderer, T>(
 
     let mut render_picked_pane = None;
 
-    let cursor_in_edge = cursor
-        .position()
-        .and_then(|cursor_position| in_edge(layout, cursor_position));
+    let pane_in_edge = if picked_pane.is_some() {
+        cursor
+            .position()
+            .and_then(|cursor_position| in_edge(layout, cursor_position))
+    } else {
+        None
+    };
 
     for ((id, pane), pane_layout) in contents.zip(layout.children()) {
         match picked_pane {
@@ -862,7 +866,7 @@ pub fn draw<Renderer, T>(
                     viewport,
                 );
 
-                if picked_pane.is_some() && cursor_in_edge.is_none() {
+                if picked_pane.is_some() && pane_in_edge.is_none() {
                     if let Some(region) =
                         cursor.position().and_then(|cursor_position| {
                             layout_region(pane_layout, cursor_position)
@@ -897,21 +901,19 @@ pub fn draw<Renderer, T>(
         }
     }
 
-    if picked_pane.is_some() {
-        if let Some(edge) = cursor_in_edge {
-            let hovered_region_style = theme.hovered_region(style);
-            let bounds = edge_bounds(layout, edge);
+    if let Some(edge) = pane_in_edge {
+        let hovered_region_style = theme.hovered_region(style);
+        let bounds = edge_bounds(layout, edge);
 
-            renderer.fill_quad(
-                renderer::Quad {
-                    bounds,
-                    border_radius: hovered_region_style.border_radius.into(),
-                    border_width: hovered_region_style.border_width,
-                    border_color: hovered_region_style.border_color,
-                },
-                theme.hovered_region(style).background,
-            );
-        }
+        renderer.fill_quad(
+            renderer::Quad {
+                bounds,
+                border_radius: hovered_region_style.border_radius.into(),
+                border_width: hovered_region_style.border_width,
+                border_color: hovered_region_style.border_color,
+            },
+            theme.hovered_region(style).background,
+        );
     }
 
     // Render picked pane last

--- a/widget/src/pane_grid.rs
+++ b/widget/src/pane_grid.rs
@@ -905,7 +905,7 @@ pub fn draw<Renderer, T>(
         renderer.fill_quad(
             renderer::Quad {
                 bounds,
-                border_radius: hovered_region_style.border_radius.into(),
+                border_radius: hovered_region_style.border_radius,
                 border_width: hovered_region_style.border_width,
                 border_color: hovered_region_style.border_color,
             },

--- a/widget/src/pane_grid.rs
+++ b/widget/src/pane_grid.rs
@@ -587,7 +587,7 @@ pub fn update<'a, Message, T: Draggable>(
                         {
                             DragEvent::Dropped {
                                 pane,
-                                target: Target::PaneGrid(edge),
+                                target: Target::Edge(edge),
                             }
                         } else {
                             let dropped_region = contents
@@ -604,10 +604,7 @@ pub fn update<'a, Message, T: Draggable>(
                                 {
                                     DragEvent::Dropped {
                                         pane,
-                                        target: Target::Pane {
-                                            pane: target,
-                                            region,
-                                        },
+                                        target: Target::Pane(target, region),
                                     }
                                 }
                                 _ => DragEvent::Canceled { pane },
@@ -1094,15 +1091,10 @@ pub enum DragEvent {
 /// The [`Target`] area a pane can be dropped on.
 #[derive(Debug, Clone, Copy)]
 pub enum Target {
-    /// The [`Edge`} of the full [`PaneGrid`].
-    PaneGrid(Edge),
+    /// An [`Edge`] of the full [`PaneGrid`].
+    Edge(Edge),
     /// A single [`Pane`] of the [`PaneGrid`].
-    Pane {
-        /// The targetted [`Pane`].
-        pane: Pane,
-        /// The targetted area of the [`Pane`].
-        region: Region,
-    },
+    Pane(Pane, Region),
 }
 
 /// The region of a [`Pane`].

--- a/widget/src/pane_grid/node.rs
+++ b/widget/src/pane_grid/node.rs
@@ -120,6 +120,16 @@ impl Node {
         };
     }
 
+    pub(crate) fn split_inverse(&mut self, id: Split, axis: Axis, pane: Pane) {
+        *self = Node::Split {
+            id,
+            axis,
+            ratio: 0.5,
+            a: Box::new(Node::Pane(pane)),
+            b: Box::new(self.clone()),
+        };
+    }
+
     pub(crate) fn update(&mut self, f: &impl Fn(&mut Node)) {
         if let Node::Split { a, b, .. } = self {
             a.update(f);

--- a/widget/src/pane_grid/state.rs
+++ b/widget/src/pane_grid/state.rs
@@ -3,7 +3,7 @@
 //! [`PaneGrid`]: crate::widget::PaneGrid
 use crate::core::{Point, Size};
 use crate::pane_grid::{
-    Axis, Configuration, Direction, Edge, Node, Pane, Region, Split,
+    Axis, Configuration, Direction, Edge, Node, Pane, Region, Split, Target,
 };
 
 use std::collections::HashMap;
@@ -148,6 +148,39 @@ impl<T> State<T> {
         self.split_node(axis, Some(pane), state, false)
     }
 
+    /// Split a target [`Pane`] with a given [`Pane`] on a given [`Region`].
+    ///
+    /// Panes will be swapped by default for [`Region::Center`].
+    pub fn split_with(&mut self, target: &Pane, pane: &Pane, region: Region) {
+        match region {
+            Region::Center => self.swap(pane, target),
+            Region::Edge(edge) => match edge {
+                Edge::Top => {
+                    self.split_and_swap(Axis::Horizontal, target, pane, true)
+                }
+                Edge::Bottom => {
+                    self.split_and_swap(Axis::Horizontal, target, pane, false)
+                }
+                Edge::Left => {
+                    self.split_and_swap(Axis::Vertical, target, pane, true)
+                }
+                Edge::Right => {
+                    self.split_and_swap(Axis::Vertical, target, pane, false)
+                }
+            },
+        }
+    }
+
+    /// Drops the given [`Pane`] into the provided [`Target`].
+    pub fn drop(&mut self, pane: &Pane, target: Target) {
+        match target {
+            Target::Edge(edge) => self.move_to_edge(pane, edge),
+            Target::Pane(target, region) => {
+                self.split_with(&target, pane, region)
+            }
+        }
+    }
+
     fn split_node(
         &mut self,
         axis: Axis,
@@ -184,29 +217,6 @@ impl<T> State<T> {
         let _ = self.maximized.take();
 
         Some((new_pane, new_split))
-    }
-
-    /// Split a target [`Pane`] with a given [`Pane`] on a given [`Region`].
-    ///
-    /// Panes will be swapped by default for [`Region::Center`].
-    pub fn split_with(&mut self, target: &Pane, pane: &Pane, region: Region) {
-        match region {
-            Region::Center => self.swap(pane, target),
-            Region::Edge(edge) => match edge {
-                Edge::Top => {
-                    self.split_and_swap(Axis::Horizontal, target, pane, true)
-                }
-                Edge::Bottom => {
-                    self.split_and_swap(Axis::Horizontal, target, pane, false)
-                }
-                Edge::Left => {
-                    self.split_and_swap(Axis::Vertical, target, pane, true)
-                }
-                Edge::Right => {
-                    self.split_and_swap(Axis::Vertical, target, pane, false)
-                }
-            },
-        }
     }
 
     fn split_and_swap(


### PR DESCRIPTION
## Summary

Previously, in order to create a new column or row on a `PaneGrid`, a client would necessarily have to create and remove panes, as it was only able to split existing panes.

Following #1856, this change adds the ability to drag & drop panes of a `PaneGrid` to its edges in order to enhance even more an easy layout customisation of the grid.

## Implementation

`DragEvent::Dropped` instead of `Pane` and `Region` parameters, now holds a `Target` that can either be `Target::PaneGrid` (new variant, that wraps an `Edge`) or `Target::Pane` (which holds the previous parameters).

Users of `PaneGrid` can call `pane_grid::State::move_to_edge(pane, edge)` in order to create a new row/column depending on the `edge` with that `pane`'s `state`.  This will split the major `Node` of the grid in order to create said row/column.

Hovered `PaneGrid` edges are detected and highlighted with the minimum thickness of either the total grid height or width ratio of `1/25`. I feel it is a good balance after some experimentation, but I'm up to change this.

## Demo

https://github.com/iced-rs/iced/assets/51237625/d5944df5-fd63-44ac-8dfb-2960b64e1018