### PR TITLE
[Fix] Make gradient pack fn public for iced_graphics::Gradient

### DIFF
--- a/graphics/src/gradient.rs
+++ b/graphics/src/gradient.rs
@@ -116,13 +116,17 @@ impl Linear {
         data[42] = self.end.x;
         data[43] = self.end.y;
 
-        Packed { data }
+        Packed(data)
     }
 }
 
 /// Packed [`Gradient`] data for use in shader code.
-#[derive(Debug)]
-pub struct Packed {
-    /// The packed [`Gradient`] data.
-    pub data: [f32; 44],
+#[derive(Debug, Copy, Clone, PartialEq)]
+#[repr(C)]
+pub struct Packed([f32; 44]);
+
+impl From<[f32; 44]> for Packed {
+    fn from(value: [f32; 44]) -> Self {
+        Self(value)
+    }
 }

--- a/graphics/src/gradient.rs
+++ b/graphics/src/gradient.rs
@@ -25,7 +25,7 @@ impl From<Linear> for Gradient {
 
 impl Gradient {
     /// Packs the [`Gradient`] for use in shader code.
-    pub fn pack(&self) -> [f32; 44] {
+    pub fn pack(&self) -> Packed {
         match self {
             Gradient::Linear(linear) => linear.pack(),
         }
@@ -96,26 +96,33 @@ impl Linear {
     }
 
     /// Packs the [`Gradient`] for use in shader code.
-    pub fn pack(&self) -> [f32; 44] {
-        let mut pack: [f32; 44] = [0.0; 44];
+    pub fn pack(&self) -> Packed {
+        let mut data: [f32; 44] = [0.0; 44];
 
         for (index, stop) in self.stops.iter().enumerate() {
             let [r, g, b, a] =
                 stop.map_or(Color::default(), |s| s.color).into_linear();
 
-            pack[index * 4] = r;
-            pack[(index * 4) + 1] = g;
-            pack[(index * 4) + 2] = b;
-            pack[(index * 4) + 3] = a;
+            data[index * 4] = r;
+            data[(index * 4) + 1] = g;
+            data[(index * 4) + 2] = b;
+            data[(index * 4) + 3] = a;
 
-            pack[32 + index] = stop.map_or(2.0, |s| s.offset);
+            data[32 + index] = stop.map_or(2.0, |s| s.offset);
         }
 
-        pack[40] = self.start.x;
-        pack[41] = self.start.y;
-        pack[42] = self.end.x;
-        pack[43] = self.end.y;
+        data[40] = self.start.x;
+        data[41] = self.start.y;
+        data[42] = self.end.x;
+        data[43] = self.end.y;
 
-        pack
+        Packed { data }
     }
+}
+
+/// Packed [`Gradient`] data for use in shader code.
+#[derive(Debug)]
+pub struct Packed {
+    /// The packed [`Gradient`] data.
+    pub data: [f32; 44],
 }

--- a/graphics/src/gradient.rs
+++ b/graphics/src/gradient.rs
@@ -23,6 +23,15 @@ impl From<Linear> for Gradient {
     }
 }
 
+impl Gradient {
+    /// Packs the [`Gradient`] for use in shader code.
+    pub fn pack(&self) -> [f32; 44] {
+        match self {
+            Gradient::Linear(linear) => linear.pack(),
+        }
+    }
+}
+
 /// A linear gradient that can be used in the style of [`Fill`] or [`Stroke`].
 ///
 /// [`Fill`]: crate::geometry::Fill;
@@ -84,5 +93,29 @@ impl Linear {
         }
 
         self
+    }
+
+    /// Packs the [`Gradient`] for use in shader code.
+    pub fn pack(&self) -> [f32; 44] {
+        let mut pack: [f32; 44] = [0.0; 44];
+
+        for (index, stop) in self.stops.iter().enumerate() {
+            let [r, g, b, a] =
+                stop.map_or(Color::default(), |s| s.color).into_linear();
+
+            pack[index * 4] = r;
+            pack[(index * 4) + 1] = g;
+            pack[(index * 4) + 2] = b;
+            pack[(index * 4) + 3] = a;
+
+            pack[32 + index] = stop.map_or(2.0, |s| s.offset);
+        }
+
+        pack[40] = self.start.x;
+        pack[41] = self.start.y;
+        pack[42] = self.end.x;
+        pack[43] = self.end.y;
+
+        pack
     }
 }

--- a/graphics/src/primitive.rs
+++ b/graphics/src/primitive.rs
@@ -4,6 +4,7 @@ use crate::core::image;
 use crate::core::svg;
 use crate::core::text;
 use crate::core::{Background, Color, Font, Rectangle, Size, Vector};
+use crate::gradient;
 
 use bytemuck::{Pod, Zeroable};
 use std::sync::Arc;
@@ -258,7 +259,7 @@ pub struct GradientVertex2D {
     pub position: [f32; 2],
 
     /// The packed vertex data of the gradient.
-    pub gradient: [f32; 44],
+    pub gradient: gradient::Packed,
 }
 
 #[allow(unsafe_code)]

--- a/wgpu/src/geometry.rs
+++ b/wgpu/src/geometry.rs
@@ -7,6 +7,7 @@ use crate::graphics::geometry::{
 use crate::graphics::primitive::{self, Primitive};
 use crate::graphics::Gradient;
 
+use iced_graphics::gradient;
 use lyon::geom::euclid;
 use lyon::tessellation;
 use std::borrow::Cow;
@@ -490,7 +491,7 @@ impl Frame {
 }
 
 struct GradientVertex2DBuilder {
-    gradient: [f32; 44],
+    gradient: gradient::Packed,
 }
 
 impl tessellation::FillVertexConstructor<primitive::GradientVertex2D>
@@ -504,7 +505,7 @@ impl tessellation::FillVertexConstructor<primitive::GradientVertex2D>
 
         primitive::GradientVertex2D {
             position: [position.x, position.y],
-            gradient: self.gradient,
+            gradient: self.gradient.data,
         }
     }
 }
@@ -520,7 +521,7 @@ impl tessellation::StrokeVertexConstructor<primitive::GradientVertex2D>
 
         primitive::GradientVertex2D {
             position: [position.x, position.y],
-            gradient: self.gradient,
+            gradient: self.gradient.data,
         }
     }
 }

--- a/wgpu/src/geometry.rs
+++ b/wgpu/src/geometry.rs
@@ -74,7 +74,7 @@ impl BufferStack {
                 Box::new(tessellation::BuffersBuilder::new(
                     buffer,
                     GradientVertex2DBuilder {
-                        gradient: pack_gradient(gradient),
+                        gradient: gradient.pack(),
                     },
                 ))
             }
@@ -97,7 +97,7 @@ impl BufferStack {
                 Box::new(tessellation::BuffersBuilder::new(
                     buffer,
                     GradientVertex2DBuilder {
-                        gradient: pack_gradient(gradient),
+                        gradient: gradient.pack(),
                     },
                 ))
             }
@@ -622,43 +622,4 @@ pub(super) fn dashed(path: &Path, line_dash: LineDash<'_>) -> Path {
             },
         );
     })
-}
-
-/// Packs the [`Gradient`] for use in shader code.
-fn pack_gradient(gradient: &Gradient) -> [f32; 44] {
-    match gradient {
-        Gradient::Linear(linear) => {
-            let mut pack: [f32; 44] = [0.0; 44];
-            let mut offsets: [f32; 8] = [2.0; 8];
-
-            for (index, stop) in linear.stops.iter().enumerate() {
-                let [r, g, b, a] = stop
-                    .map_or(crate::core::Color::default(), |s| s.color)
-                    .into_linear();
-
-                pack[index * 4] = r;
-                pack[(index * 4) + 1] = g;
-                pack[(index * 4) + 2] = b;
-                pack[(index * 4) + 3] = a;
-
-                offsets[index] = stop.map_or(2.0, |s| s.offset);
-            }
-
-            pack[32] = offsets[0];
-            pack[33] = offsets[1];
-            pack[34] = offsets[2];
-            pack[35] = offsets[3];
-            pack[36] = offsets[4];
-            pack[37] = offsets[5];
-            pack[38] = offsets[6];
-            pack[39] = offsets[7];
-
-            pack[40] = linear.start.x;
-            pack[41] = linear.start.y;
-            pack[42] = linear.end.x;
-            pack[43] = linear.end.y;
-
-            pack
-        }
-    }
 }

--- a/wgpu/src/geometry.rs
+++ b/wgpu/src/geometry.rs
@@ -505,7 +505,7 @@ impl tessellation::FillVertexConstructor<primitive::GradientVertex2D>
 
         primitive::GradientVertex2D {
             position: [position.x, position.y],
-            gradient: self.gradient.data,
+            gradient: self.gradient,
         }
     }
 }
@@ -521,7 +521,7 @@ impl tessellation::StrokeVertexConstructor<primitive::GradientVertex2D>
 
         primitive::GradientVertex2D {
             position: [position.x, position.y],
-            gradient: self.gradient.data,
+            gradient: self.gradient,
         }
     }
 }

--- a/wgpu/src/layer.rs
+++ b/wgpu/src/layer.rs
@@ -183,7 +183,7 @@ impl<'a> Layer<'a> {
                     }
                     Background::Gradient(gradient) => {
                         let quad = quad::Gradient {
-                            gradient: pack_gradient(
+                            gradient: gradient::pack(
                                 gradient,
                                 Rectangle::new(
                                     quad.position.into(),
@@ -308,38 +308,6 @@ impl<'a> Layer<'a> {
                     primitive
                 );
             }
-        }
-    }
-}
-
-/// Packs the [`Gradient`] for use in shader code.
-fn pack_gradient(
-    gradient: &core::Gradient,
-    bounds: Rectangle,
-) -> gradient::Packed {
-    match gradient {
-        core::Gradient::Linear(linear) => {
-            let mut data: [f32; 44] = [0.0; 44];
-
-            for (index, stop) in linear.stops.iter().enumerate() {
-                let [r, g, b, a] =
-                    stop.map_or(Color::default(), |s| s.color).into_linear();
-
-                data[index * 4] = r;
-                data[(index * 4) + 1] = g;
-                data[(index * 4) + 2] = b;
-                data[(index * 4) + 3] = a;
-                data[32 + index] = stop.map_or(2.0, |s| s.offset);
-            }
-
-            let (start, end) = linear.angle.to_distance(&bounds);
-
-            data[40] = start.x;
-            data[41] = start.y;
-            data[42] = end.x;
-            data[43] = end.y;
-
-            data.into()
         }
     }
 }

--- a/wgpu/src/layer.rs
+++ b/wgpu/src/layer.rs
@@ -13,6 +13,7 @@ pub use text::Text;
 use crate::core;
 use crate::core::alignment;
 use crate::core::{Background, Color, Font, Point, Rectangle, Size, Vector};
+use crate::graphics::gradient;
 use crate::graphics::{Primitive, Viewport};
 
 /// A group of primitives that should be clipped together.
@@ -312,30 +313,33 @@ impl<'a> Layer<'a> {
 }
 
 /// Packs the [`Gradient`] for use in shader code.
-fn pack_gradient(gradient: &core::Gradient, bounds: Rectangle) -> [f32; 44] {
+fn pack_gradient(
+    gradient: &core::Gradient,
+    bounds: Rectangle,
+) -> gradient::Packed {
     match gradient {
         core::Gradient::Linear(linear) => {
-            let mut pack: [f32; 44] = [0.0; 44];
+            let mut data: [f32; 44] = [0.0; 44];
 
             for (index, stop) in linear.stops.iter().enumerate() {
                 let [r, g, b, a] =
                     stop.map_or(Color::default(), |s| s.color).into_linear();
 
-                pack[index * 4] = r;
-                pack[(index * 4) + 1] = g;
-                pack[(index * 4) + 2] = b;
-                pack[(index * 4) + 3] = a;
-                pack[32 + index] = stop.map_or(2.0, |s| s.offset);
+                data[index * 4] = r;
+                data[(index * 4) + 1] = g;
+                data[(index * 4) + 2] = b;
+                data[(index * 4) + 3] = a;
+                data[32 + index] = stop.map_or(2.0, |s| s.offset);
             }
 
             let (start, end) = linear.angle.to_distance(&bounds);
 
-            pack[40] = start.x;
-            pack[41] = start.y;
-            pack[42] = end.x;
-            pack[43] = end.y;
+            data[40] = start.x;
+            data[41] = start.y;
+            data[42] = end.x;
+            data[43] = end.y;
 
-            pack
+            data.into()
         }
     }
 }

--- a/wgpu/src/layer/quad.rs
+++ b/wgpu/src/layer/quad.rs
@@ -1,5 +1,5 @@
 //! A rectangle with certain styled properties.
-
+use crate::graphics::gradient;
 use bytemuck::{Pod, Zeroable};
 
 /// The properties of a quad.
@@ -38,7 +38,7 @@ pub struct Solid {
 #[repr(C)]
 pub struct Gradient {
     /// The background gradient data of the quad.
-    pub gradient: [f32; 44],
+    pub gradient: gradient::Packed,
 
     /// The [`Quad`] data of the [`Gradient`].
     pub quad: Quad,


### PR DESCRIPTION
**Changes:**
- Moved `pack_gradient` to a pub method of `iced_graphics::Gradient` named `pack`. This allows users to pack gradient data when creating their own `Primitive::GradientMesh` with `GradientVertex2D`.

The `pack_gradient` fn for `iced::core::Gradient` is unchanged as it's internal.