### PR TITLE
Upgrade `palette` dependency

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,7 +14,7 @@ log = "0.4.17"
 twox-hash = { version = "1.5", default-features = false }
 
 [dependencies.palette]
-version = "0.6"
+version = "0.7"
 optional = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -19,3 +19,6 @@ optional = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 instant = "0.1"
+
+[dev-dependencies]
+approx = "0.5"

--- a/core/src/color.rs
+++ b/core/src/color.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "palette")]
-use palette::rgb::{Rgb, Rgba};
+use palette::rgb::{Srgb, Srgba};
 
 /// A color in the sRGB color space.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
@@ -184,33 +184,33 @@ macro_rules! color {
 
 #[cfg(feature = "palette")]
 /// Converts from palette's `Rgba` type to a [`Color`].
-impl From<Rgba> for Color {
-    fn from(rgba: Rgba) -> Self {
+impl From<Srgba> for Color {
+    fn from(rgba: Srgba) -> Self {
         Color::new(rgba.red, rgba.green, rgba.blue, rgba.alpha)
     }
 }
 
 #[cfg(feature = "palette")]
 /// Converts from [`Color`] to palette's `Rgba` type.
-impl From<Color> for Rgba {
+impl From<Color> for Srgba {
     fn from(c: Color) -> Self {
-        Rgba::new(c.r, c.g, c.b, c.a)
+        Srgba::new(c.r, c.g, c.b, c.a)
     }
 }
 
 #[cfg(feature = "palette")]
 /// Converts from palette's `Rgb` type to a [`Color`].
-impl From<Rgb> for Color {
-    fn from(rgb: Rgb) -> Self {
+impl From<Srgb> for Color {
+    fn from(rgb: Srgb) -> Self {
         Color::new(rgb.red, rgb.green, rgb.blue, 1.0)
     }
 }
 
 #[cfg(feature = "palette")]
 /// Converts from [`Color`] to palette's `Rgb` type.
-impl From<Color> for Rgb {
+impl From<Color> for Srgb {
     fn from(c: Color) -> Self {
-        Rgb::new(c.r, c.g, c.b)
+        Srgb::new(c.r, c.g, c.b)
     }
 }
 
@@ -223,8 +223,8 @@ mod tests {
     #[test]
     fn srgba_traits() {
         let c = Color::from_rgb(0.5, 0.4, 0.3);
-        // Round-trip conversion to the palette:Rgba type
-        let s: Rgba = c.into();
+        // Round-trip conversion to the palette::Srgba type
+        let s: Srgba = c.into();
         let r: Color = s.into();
         assert_eq!(c, r);
     }
@@ -235,14 +235,15 @@ mod tests {
         let c2 = Color::from_rgb(0.2, 0.5, 0.3);
 
         // Convert to linear color for manipulation
-        let l1 = Rgba::from(c1).into_linear();
-        let l2 = Rgba::from(c2).into_linear();
+        let l1 = Srgba::from(c1).into_linear();
+        let l2 = Srgba::from(c2).into_linear();
 
-        // Take the lighter of each of the RGB components
+        // Take the lighter of each of the sRGB components
         let lighter = l1.lighten(l2);
 
         // Convert back to our Color
-        let r: Color = Rgba::from_linear(lighter).into();
+        let r: Color = Srgba::from_linear(lighter).into();
+
         assert_eq!(
             r,
             Color {

--- a/core/src/color.rs
+++ b/core/src/color.rs
@@ -231,6 +231,8 @@ mod tests {
 
     #[test]
     fn color_manipulation() {
+        use approx::assert_relative_eq;
+
         let c1 = Color::from_rgb(0.5, 0.4, 0.3);
         let c2 = Color::from_rgb(0.2, 0.5, 0.3);
 
@@ -242,16 +244,11 @@ mod tests {
         let lighter = l1.lighten(l2);
 
         // Convert back to our Color
-        let r: Color = Srgba::from_linear(lighter).into();
+        let result: Color = Srgba::from_linear(lighter).into();
 
-        assert_eq!(
-            r,
-            Color {
-                r: 0.5,
-                g: 0.5,
-                b: 0.3,
-                a: 1.0
-            }
-        );
+        assert_relative_eq!(result.r, 0.5);
+        assert_relative_eq!(result.g, 0.5);
+        assert_relative_eq!(result.b, 0.3);
+        assert_relative_eq!(result.a, 1.0);
     }
 }

--- a/core/src/color.rs
+++ b/core/src/color.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "palette")]
-use palette::rgb::{Srgb, Srgba};
+use palette::rgb::{Rgb, Rgba};
 
 /// A color in the sRGB color space.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
@@ -183,34 +183,34 @@ macro_rules! color {
 }
 
 #[cfg(feature = "palette")]
-/// Converts from palette's `Srgba` type to a [`Color`].
-impl From<Srgba> for Color {
-    fn from(srgba: Srgba) -> Self {
-        Color::new(srgba.red, srgba.green, srgba.blue, srgba.alpha)
+/// Converts from palette's `Rgba` type to a [`Color`].
+impl From<Rgba> for Color {
+    fn from(rgba: Rgba) -> Self {
+        Color::new(rgba.red, rgba.green, rgba.blue, rgba.alpha)
     }
 }
 
 #[cfg(feature = "palette")]
-/// Converts from [`Color`] to palette's `Srgba` type.
-impl From<Color> for Srgba {
+/// Converts from [`Color`] to palette's `Rgba` type.
+impl From<Color> for Rgba {
     fn from(c: Color) -> Self {
-        Srgba::new(c.r, c.g, c.b, c.a)
+        Rgba::new(c.r, c.g, c.b, c.a)
     }
 }
 
 #[cfg(feature = "palette")]
-/// Converts from palette's `Srgb` type to a [`Color`].
-impl From<Srgb> for Color {
-    fn from(srgb: Srgb) -> Self {
-        Color::new(srgb.red, srgb.green, srgb.blue, 1.0)
+/// Converts from palette's `Rgb` type to a [`Color`].
+impl From<Rgb> for Color {
+    fn from(rgb: Rgb) -> Self {
+        Color::new(rgb.red, rgb.green, rgb.blue, 1.0)
     }
 }
 
 #[cfg(feature = "palette")]
-/// Converts from [`Color`] to palette's `Srgb` type.
-impl From<Color> for Srgb {
+/// Converts from [`Color`] to palette's `Rgb` type.
+impl From<Color> for Rgb {
     fn from(c: Color) -> Self {
-        Srgb::new(c.r, c.g, c.b)
+        Rgb::new(c.r, c.g, c.b)
     }
 }
 
@@ -218,13 +218,13 @@ impl From<Color> for Srgb {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use palette::Blend;
+    use palette::blend::Blend;
 
     #[test]
     fn srgba_traits() {
         let c = Color::from_rgb(0.5, 0.4, 0.3);
-        // Round-trip conversion to the palette:Srgba type
-        let s: Srgba = c.into();
+        // Round-trip conversion to the palette:Rgba type
+        let s: Rgba = c.into();
         let r: Color = s.into();
         assert_eq!(c, r);
     }
@@ -235,14 +235,14 @@ mod tests {
         let c2 = Color::from_rgb(0.2, 0.5, 0.3);
 
         // Convert to linear color for manipulation
-        let l1 = Srgba::from(c1).into_linear();
-        let l2 = Srgba::from(c2).into_linear();
+        let l1 = Rgba::from(c1).into_linear();
+        let l2 = Rgba::from(c2).into_linear();
 
         // Take the lighter of each of the RGB components
         let lighter = l1.lighten(l2);
 
         // Convert back to our Color
-        let r: Color = Srgba::from_linear(lighter).into();
+        let r: Color = Rgba::from_linear(lighter).into();
         assert_eq!(
             r,
             Color {

--- a/examples/checkbox/src/main.rs
+++ b/examples/checkbox/src/main.rs
@@ -31,7 +31,7 @@ impl Application for Example {
     fn new(_flags: Self::Flags) -> (Self, Command<Message>) {
         (
             Self::default(),
-            font::load(include_bytes!("../fonts/icons.ttf").as_ref())
+            font::load(include_bytes!("../fonts/icons.ttf").as_slice())
                 .map(Message::FontLoaded),
         )
     }

--- a/examples/color_palette/Cargo.toml
+++ b/examples/color_palette/Cargo.toml
@@ -7,4 +7,4 @@ publish = false
 
 [dependencies]
 iced = { path = "../..", features = ["canvas", "palette"] }
-palette = "0.6.0"
+palette = "0.7.0"

--- a/examples/color_palette/src/main.rs
+++ b/examples/color_palette/src/main.rs
@@ -4,7 +4,9 @@ use iced::{
     alignment, Alignment, Color, Element, Length, Point, Rectangle, Renderer,
     Sandbox, Settings, Size, Vector,
 };
-use palette::{self, convert::FromColor, Hsl, Srgb};
+use palette::{
+    self, convert::FromColor, rgb::Rgb, Darken, Hsl, Lighten, ShiftHue,
+};
 use std::marker::PhantomData;
 use std::ops::RangeInclusive;
 
@@ -49,12 +51,12 @@ impl Sandbox for ColorPalette {
 
     fn update(&mut self, message: Message) {
         let srgb = match message {
-            Message::RgbColorChanged(rgb) => palette::Srgb::from(rgb),
-            Message::HslColorChanged(hsl) => palette::Srgb::from_color(hsl),
-            Message::HsvColorChanged(hsv) => palette::Srgb::from_color(hsv),
-            Message::HwbColorChanged(hwb) => palette::Srgb::from_color(hwb),
-            Message::LabColorChanged(lab) => palette::Srgb::from_color(lab),
-            Message::LchColorChanged(lch) => palette::Srgb::from_color(lch),
+            Message::RgbColorChanged(rgb) => Rgb::from(rgb),
+            Message::HslColorChanged(hsl) => Rgb::from_color(hsl),
+            Message::HsvColorChanged(hsv) => Rgb::from_color(hsv),
+            Message::HwbColorChanged(hwb) => Rgb::from_color(hwb),
+            Message::LabColorChanged(lab) => Rgb::from_color(lab),
+            Message::LchColorChanged(lch) => Rgb::from_color(lch),
         };
 
         self.theme = Theme::new(srgb);
@@ -63,7 +65,7 @@ impl Sandbox for ColorPalette {
     fn view(&self) -> Element<Message> {
         let base = self.theme.base;
 
-        let srgb = palette::Srgb::from(base);
+        let srgb = Rgb::from(base);
         let hsl = palette::Hsl::from_color(srgb);
         let hsv = palette::Hsv::from_color(srgb);
         let hwb = palette::Hwb::from_color(srgb);
@@ -95,12 +97,10 @@ struct Theme {
 
 impl Theme {
     pub fn new(base: impl Into<Color>) -> Theme {
-        use palette::{Hue, Shade};
-
         let base = base.into();
 
         // Convert to HSL color for manipulation
-        let hsl = Hsl::from_color(Srgb::from(base));
+        let hsl = Hsl::from_color(Rgb::from(base));
 
         let lower = [
             hsl.shift_hue(-135.0).lighten(0.075),
@@ -119,12 +119,12 @@ impl Theme {
         Theme {
             lower: lower
                 .iter()
-                .map(|&color| Srgb::from_color(color).into())
+                .map(|&color| Rgb::from_color(color).into())
                 .collect(),
             base,
             higher: higher
                 .iter()
-                .map(|&color| Srgb::from_color(color).into())
+                .map(|&color| Rgb::from_color(color).into())
                 .collect(),
             canvas_cache: canvas::Cache::default(),
         }
@@ -209,14 +209,14 @@ impl Theme {
 
         text.vertical_alignment = alignment::Vertical::Bottom;
 
-        let hsl = Hsl::from_color(Srgb::from(self.base));
+        let hsl = Hsl::from_color(Rgb::from(self.base));
         for i in 0..self.len() {
             let pct = (i as f32 + 1.0) / (self.len() as f32 + 1.0);
             let graded = Hsl {
                 lightness: 1.0 - pct,
                 ..hsl
             };
-            let color: Color = Srgb::from_color(graded).into();
+            let color: Color = Rgb::from_color(graded).into();
 
             let anchor = Point {
                 x: (i as f32) * box_size.width,
@@ -352,7 +352,7 @@ impl ColorSpace for palette::Hsl {
 
     fn components(&self) -> [f32; 3] {
         [
-            self.hue.to_positive_degrees(),
+            self.hue.into_positive_degrees(),
             self.saturation,
             self.lightness,
         ]
@@ -361,7 +361,7 @@ impl ColorSpace for palette::Hsl {
     fn to_string(&self) -> String {
         format!(
             "hsl({:.1}, {:.1}%, {:.1}%)",
-            self.hue.to_positive_degrees(),
+            self.hue.into_positive_degrees(),
             100.0 * self.saturation,
             100.0 * self.lightness
         )
@@ -378,13 +378,17 @@ impl ColorSpace for palette::Hsv {
     }
 
     fn components(&self) -> [f32; 3] {
-        [self.hue.to_positive_degrees(), self.saturation, self.value]
+        [
+            self.hue.into_positive_degrees(),
+            self.saturation,
+            self.value,
+        ]
     }
 
     fn to_string(&self) -> String {
         format!(
             "hsv({:.1}, {:.1}%, {:.1}%)",
-            self.hue.to_positive_degrees(),
+            self.hue.into_positive_degrees(),
             100.0 * self.saturation,
             100.0 * self.value
         )
@@ -406,7 +410,7 @@ impl ColorSpace for palette::Hwb {
 
     fn components(&self) -> [f32; 3] {
         [
-            self.hue.to_positive_degrees(),
+            self.hue.into_positive_degrees(),
             self.whiteness,
             self.blackness,
         ]
@@ -415,7 +419,7 @@ impl ColorSpace for palette::Hwb {
     fn to_string(&self) -> String {
         format!(
             "hwb({:.1}, {:.1}%, {:.1}%)",
-            self.hue.to_positive_degrees(),
+            self.hue.into_positive_degrees(),
             100.0 * self.whiteness,
             100.0 * self.blackness
         )
@@ -450,7 +454,7 @@ impl ColorSpace for palette::Lch {
     }
 
     fn components(&self) -> [f32; 3] {
-        [self.l, self.chroma, self.hue.to_positive_degrees()]
+        [self.l, self.chroma, self.hue.into_positive_degrees()]
     }
 
     fn to_string(&self) -> String {
@@ -458,7 +462,7 @@ impl ColorSpace for palette::Lch {
             "Lch({:.1}, {:.1}, {:.1})",
             self.l,
             self.chroma,
-            self.hue.to_positive_degrees()
+            self.hue.into_positive_degrees()
         )
     }
 }

--- a/style/Cargo.toml
+++ b/style/Cargo.toml
@@ -16,7 +16,7 @@ path = "../core"
 features = ["palette"]
 
 [dependencies.palette]
-version = "0.6"
+version = "0.7"
 
 [dependencies.once_cell]
 version = "1.15"

--- a/style/src/theme/palette.rs
+++ b/style/src/theme/palette.rs
@@ -2,7 +2,9 @@
 use iced_core::Color;
 
 use once_cell::sync::Lazy;
-use palette::{FromColor, Hsl, Mix, RelativeContrast, Srgb};
+use palette::color_difference::Wcag21RelativeContrast;
+use palette::rgb::Rgb;
+use palette::{FromColor, Hsl, Mix};
 
 /// A color palette.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -298,11 +300,11 @@ fn deviate(color: Color, amount: f32) -> Color {
 }
 
 fn mix(a: Color, b: Color, factor: f32) -> Color {
-    let a_lin = Srgb::from(a).into_linear();
-    let b_lin = Srgb::from(b).into_linear();
+    let a_lin = Rgb::from(a).into_linear();
+    let b_lin = Rgb::from(b).into_linear();
 
-    let mixed = a_lin.mix(&b_lin, factor);
-    Srgb::from_linear(mixed).into()
+    let mixed = a_lin.mix(b_lin, factor);
+    Rgb::from_linear(mixed).into()
 }
 
 fn readable(background: Color, text: Color) -> Color {
@@ -320,16 +322,16 @@ fn is_dark(color: Color) -> bool {
 }
 
 fn is_readable(a: Color, b: Color) -> bool {
-    let a_srgb = Srgb::from(a);
-    let b_srgb = Srgb::from(b);
+    let a_srgb = Rgb::from(a);
+    let b_srgb = Rgb::from(b);
 
-    a_srgb.has_enhanced_contrast_text(&b_srgb)
+    a_srgb.has_enhanced_contrast_text(b_srgb)
 }
 
 fn to_hsl(color: Color) -> Hsl {
-    Hsl::from_color(Srgb::from(color))
+    Hsl::from_color(Rgb::from(color))
 }
 
 fn from_hsl(hsl: Hsl) -> Color {
-    Srgb::from_color(hsl).into()
+    Rgb::from_color(hsl).into()
 }


### PR DESCRIPTION
- Upgrades `palette` to 0.7 across the library
- Fixes breakages
  - Use `rgb::Rgb` instead of `Srgb` directly
  - `RelativeContrast` trait has been deprecated in favor of `color_difference::Wcag21RelativeContrast`
  - `Hue::to_positive_degrees()` -> `Hue::into_positive_degrees()`