### PR TITLE
Small gradient optimization

### DIFF
--- a/core/src/color.rs
+++ b/core/src/color.rs
@@ -120,6 +120,18 @@ impl Color {
         ]
     }
 
+    /// Converts the [`Color`] into a `u32` value containing its RGBA8 components.
+    pub fn into_u32(self) -> u32 {
+        let [r, g, b, a] = self.into_rgba8();
+
+        let r = (r as u32) << 24;
+        let g = (g as u32) << 16;
+        let b = (b as u32) << 8;
+        let a = a as u32;
+
+        r | g | b | a
+    }
+
     /// Inverts the [`Color`] in-place.
     pub fn invert(&mut self) {
         self.r = 1.0f32 - self.r;
@@ -142,19 +154,6 @@ impl From<[f32; 3]> for Color {
 impl From<[f32; 4]> for Color {
     fn from([r, g, b, a]: [f32; 4]) -> Self {
         Color::new(r, g, b, a)
-    }
-}
-
-impl Into<u32> for Color {
-    fn into(self) -> u32 {
-        let [r, g, b, a] = self.into_rgba8();
-
-        let r = (r as u32) << 24;
-        let g = (g as u32) << 16;
-        let b = (b as u32) << 8;
-        let a = a as u32;
-
-        r | g | b | a
     }
 }
 

--- a/core/src/color.rs
+++ b/core/src/color.rs
@@ -120,37 +120,6 @@ impl Color {
         ]
     }
 
-    /// Converts the [`Color`] into a `u32` value containing its RGBA8 components.
-    pub fn into_u32(self) -> u32 {
-        let [r, g, b, a] = self.into_rgba8();
-
-        let r = (r as u32) << 24;
-        let g = (g as u32) << 16;
-        let b = (b as u32) << 8;
-        let a = a as u32;
-
-        r | g | b | a
-    }
-
-    /// Converts the [`Color`] into a `u32` value containing its linear RGBA8 components.
-    pub fn into_linear_u32(self) -> u32 {
-        let [r, g, b, a] = self.into_linear();
-
-        let [r, g, b, a] = [
-            (r * 255.0).round() as u8,
-            (g * 255.0).round() as u8,
-            (b * 255.0).round() as u8,
-            (a * 255.0).round() as u8,
-        ];
-
-        let r = (r as u32) << 24;
-        let g = (g as u32) << 16;
-        let b = (b as u32) << 8;
-        let a = a as u32;
-
-        r | g | b | a
-    }
-
     /// Inverts the [`Color`] in-place.
     pub fn invert(&mut self) {
         self.r = 1.0f32 - self.r;

--- a/core/src/color.rs
+++ b/core/src/color.rs
@@ -145,6 +145,19 @@ impl From<[f32; 4]> for Color {
     }
 }
 
+impl Into<u32> for Color {
+    fn into(self) -> u32 {
+        let [r, g, b, a] = self.into_rgba8();
+
+        let r = (r as u32) << 24;
+        let g = (g as u32) << 16;
+        let b = (b as u32) << 8;
+        let a = a as u32;
+
+        r | g | b | a
+    }
+}
+
 /// Creates a [`Color`] with shorter and cleaner syntax.
 ///
 /// # Examples

--- a/core/src/color.rs
+++ b/core/src/color.rs
@@ -132,6 +132,25 @@ impl Color {
         r | g | b | a
     }
 
+    /// Converts the [`Color`] into a `u32` value containing its linear RGBA8 components.
+    pub fn into_linear_u32(self) -> u32 {
+        let [r, g, b, a] = self.into_linear();
+
+        let [r, g, b, a] = [
+            (r * 255.0).round() as u8,
+            (g * 255.0).round() as u8,
+            (b * 255.0).round() as u8,
+            (a * 255.0).round() as u8,
+        ];
+
+        let r = (r as u32) << 24;
+        let g = (g as u32) << 16;
+        let b = (b as u32) << 8;
+        let a = a as u32;
+
+        r | g | b | a
+    }
+
     /// Inverts the [`Color`] in-place.
     pub fn invert(&mut self) {
         self.r = 1.0f32 - self.r;

--- a/graphics/Cargo.toml
+++ b/graphics/Cargo.toml
@@ -18,6 +18,7 @@ web-colors = []
 
 [dependencies]
 glam = "0.24"
+half = "2.2.1"
 log = "0.4"
 raw-window-handle = "0.5"
 thiserror = "1.0"

--- a/graphics/src/gradient.rs
+++ b/graphics/src/gradient.rs
@@ -103,11 +103,17 @@ impl Linear {
         let mut offsets = [0.0f32; 8];
 
         for (index, stop) in self.stops.iter().enumerate() {
-            let (color, offset) = stop
-                .map_or((Color::default().into_u32(), 2.0), |s| {
-                    (s.color.into_u32(), s.offset)
-                });
-            colors[index] = color;
+            let (color, offset) =
+                stop.map_or((Color::default(), 2.0), |s| (s.color, s.offset));
+
+            if color::GAMMA_CORRECTION {
+                //correct colors, convert to linear before uploading to GPU
+                colors[index] = color.into_linear_u32();
+            } else {
+                //web colors, don't convert to linear before uploading to GPU
+                colors[index] = color.into_u32();
+            }
+
             offsets[index] = offset;
         }
 
@@ -139,16 +145,17 @@ pub fn pack(gradient: &core::Gradient, bounds: Rectangle) -> Packed {
             let mut offsets = [0.0f32; 8];
 
             for (index, stop) in linear.stops.iter().enumerate() {
-                // let [r, g, b, a] =
-                //     color::pack(stop.map_or(Color::default(), |s| s.color))
-                //         .components();
-
                 let (color, offset) = stop
-                    .map_or((Color::default().into_u32(), 2.0), |s| {
-                        (s.color.into_u32(), s.offset)
-                    });
+                    .map_or((Color::default(), 2.0), |s| (s.color, s.offset));
 
-                colors[index] = color;
+                if color::GAMMA_CORRECTION {
+                    //correct colors, convert to linear before uploading to GPU
+                    colors[index] = color.into_linear_u32();
+                } else {
+                    //web colors, don't convert to linear before uploading to GPU
+                    colors[index] = color.into_u32();
+                }
+
                 offsets[index] = offset;
             }
 

--- a/wgpu/src/quad/gradient.rs
+++ b/wgpu/src/quad/gradient.rs
@@ -96,36 +96,24 @@ impl Pipeline {
                                 as u64,
                             step_mode: wgpu::VertexStepMode::Instance,
                             attributes: &wgpu::vertex_attr_array!(
-                                // Color 1
-                                1 => Float32x4,
-                                // Color 2
-                                2 => Float32x4,
-                                // Color 3
-                                3 => Float32x4,
-                                // Color 4
-                                4 => Float32x4,
-                                // Color 5
-                                5 => Float32x4,
-                                // Color 6
-                                6 => Float32x4,
-                                // Color 7
-                                7 => Float32x4,
-                                // Color 8
-                                8 => Float32x4,
+                                // Colors 1-4
+                                1 => Uint32x4,
+                                // Colors 5-8
+                                2 => Uint32x4,
                                 // Offsets 1-4
-                                9 => Float32x4,
+                                3 => Float32x4,
                                 // Offsets 5-8
-                                10 => Float32x4,
+                                4 => Float32x4,
                                 // Direction
-                                11 => Float32x4,
+                                5 => Float32x4,
                                 // Position & Scale
-                                12 => Float32x4,
+                                6 => Float32x4,
                                 // Border color
-                                13 => Float32x4,
+                                7 => Float32x4,
                                 // Border radius
-                                14 => Float32x4,
+                                8 => Float32x4,
                                 // Border width
-                                15 => Float32
+                                9 => Float32
                             ),
                         },
                     ],

--- a/wgpu/src/quad/gradient.rs
+++ b/wgpu/src/quad/gradient.rs
@@ -96,24 +96,26 @@ impl Pipeline {
                                 as u64,
                             step_mode: wgpu::VertexStepMode::Instance,
                             attributes: &wgpu::vertex_attr_array!(
-                                // Colors 1-4
+                                // Colors 1-2
                                 1 => Uint32x4,
-                                // Colors 5-8
+                                // Colors 3-4
                                 2 => Uint32x4,
-                                // Offsets 1-4
-                                3 => Float32x4,
-                                // Offsets 5-8
-                                4 => Float32x4,
+                                // Colors 5-6
+                                3 => Uint32x4,
+                                // Colors 7-8
+                                4 => Uint32x4,
+                                // Offsets 1-8
+                                5 => Uint32x4,
                                 // Direction
-                                5 => Float32x4,
-                                // Position & Scale
                                 6 => Float32x4,
-                                // Border color
+                                // Position & Scale
                                 7 => Float32x4,
-                                // Border radius
+                                // Border color
                                 8 => Float32x4,
+                                // Border radius
+                                9 => Float32x4,
                                 // Border width
-                                9 => Float32
+                                10 => Float32
                             ),
                         },
                     ],

--- a/wgpu/src/shader/quad.wgsl
+++ b/wgpu/src/shader/quad.wgsl
@@ -38,17 +38,10 @@ fn select_border_radius(radi: vec4<f32>, position: vec2<f32>, center: vec2<f32>)
     return rx;
 }
 
-fn l(c: f32) -> f32 {
-    if (c < 0.04045) {
-        return c / 12.92;
-    } else {
-        return pow(((c + 0.055) / 1.055), 2.4);
-    };
-}
+fn unpack_u32(color: u32) -> vec4<f32> {
+    let u = unpack4x8unorm(color);
 
-fn to_linear(color: u32) -> vec4<f32> {
-    let c = unpack4x8unorm(color); //unpacks as a b g r
-    return vec4<f32>(l(c.w), l(c.z), l(c.y), c.x);
+    return vec4<f32>(u.w, u.z, u.y, u.x);
 }
 
 struct SolidVertexInput {
@@ -269,14 +262,14 @@ fn gradient(
 @fragment
 fn gradient_fs_main(input: GradientVertexOutput) -> @location(0) vec4<f32> {
     let colors = array<vec4<f32>, 8>(
-        to_linear(input.colors_1.x),
-        to_linear(input.colors_1.y),
-        to_linear(input.colors_1.z),
-        to_linear(input.colors_1.w),
-        to_linear(input.colors_2.x),
-        to_linear(input.colors_2.y),
-        to_linear(input.colors_2.z),
-        to_linear(input.colors_2.w),
+        unpack_u32(input.colors_1.x),
+        unpack_u32(input.colors_1.y),
+        unpack_u32(input.colors_1.z),
+        unpack_u32(input.colors_1.w),
+        unpack_u32(input.colors_2.x),
+        unpack_u32(input.colors_2.y),
+        unpack_u32(input.colors_2.z),
+        unpack_u32(input.colors_2.w),
     );
 
     var offsets = array<f32, 8>(

--- a/wgpu/src/shader/triangle.wgsl
+++ b/wgpu/src/shader/triangle.wgsl
@@ -4,17 +4,10 @@ struct Globals {
 
 @group(0) @binding(0) var<uniform> globals: Globals;
 
-fn l(c: f32) -> f32 {
-    if (c < 0.04045) {
-        return c / 12.92;
-    } else {
-        return pow(((c + 0.055) / 1.055), 2.4);
-    };
-}
+fn unpack_u32(color: u32) -> vec4<f32> {
+    let u = unpack4x8unorm(color);
 
-fn to_linear(color: u32) -> vec4<f32> {
-    let c = unpack4x8unorm(color); //unpacks as a b g r
-    return vec4<f32>(l(c.w), l(c.z), l(c.y), c.x);
+    return vec4<f32>(u.w, u.z, u.y, u.x);
 }
 
 struct SolidVertexInput {
@@ -130,14 +123,14 @@ fn gradient(
 @fragment
 fn gradient_fs_main(input: GradientVertexOutput) -> @location(0) vec4<f32> {
     let colors = array<vec4<f32>, 8>(
-        to_linear(input.colors_1.x),
-        to_linear(input.colors_1.y),
-        to_linear(input.colors_1.z),
-        to_linear(input.colors_1.w),
-        to_linear(input.colors_2.x),
-        to_linear(input.colors_2.y),
-        to_linear(input.colors_2.z),
-        to_linear(input.colors_2.w),
+        unpack_u32(input.colors_1.x),
+        unpack_u32(input.colors_1.y),
+        unpack_u32(input.colors_1.z),
+        unpack_u32(input.colors_1.w),
+        unpack_u32(input.colors_2.x),
+        unpack_u32(input.colors_2.y),
+        unpack_u32(input.colors_2.z),
+        unpack_u32(input.colors_2.w),
     );
 
     var offsets = array<f32, 8>(

--- a/wgpu/src/triangle.rs
+++ b/wgpu/src/triangle.rs
@@ -652,28 +652,16 @@ mod gradient {
                             attributes: &wgpu::vertex_attr_array!(
                                 // Position
                                 0 => Float32x2,
-                                // Color 1
-                                1 => Float32x4,
-                                // Color 2
-                                2 => Float32x4,
-                                // Color 3
-                                3 => Float32x4,
-                                // Color 4
-                                4 => Float32x4,
-                                // Color 5
-                                5 => Float32x4,
-                                // Color 6
-                                6 => Float32x4,
-                                // Color 7
-                                7 => Float32x4,
-                                // Color 8
-                                8 => Float32x4,
+                                // Colors 1-4
+                                1 => Uint32x4,
+                                // Colors 5-8,
+                                2 => Uint32x4,
                                 // Offsets 1-4
-                                9 => Float32x4,
+                                3 => Float32x4,
                                 // Offsets 5-8
-                                10 => Float32x4,
+                                4 => Float32x4,
                                 // Direction
-                                11 => Float32x4
+                                5 => Float32x4
                             ),
                         }],
                     },

--- a/wgpu/src/triangle.rs
+++ b/wgpu/src/triangle.rs
@@ -652,16 +652,18 @@ mod gradient {
                             attributes: &wgpu::vertex_attr_array!(
                                 // Position
                                 0 => Float32x2,
-                                // Colors 1-4
+                                // Colors 1-2
                                 1 => Uint32x4,
-                                // Colors 5-8,
+                                // Colors 3-4
                                 2 => Uint32x4,
-                                // Offsets 1-4
-                                3 => Float32x4,
-                                // Offsets 5-8
-                                4 => Float32x4,
+                                // Colors 5-6
+                                3 => Uint32x4,
+                                // Colors 7-8
+                                4 => Uint32x4,
+                                // Offsets
+                                5 => Uint32x4,
                                 // Direction
-                                5 => Float32x4
+                                6 => Float32x4
                             ),
                         }],
                     },


### PR DESCRIPTION
Packed colors into a u32 and unpack'd in shader to free up some space in gradient data. This will improve performance by reducing data transfer latency. Overall gain = 96 bytes per gradient vertex.

Ultimately I'd like to rewrite the gradient pipeline to use a texture to store data (no storage buffers if we want WASM support) and pass an index/length to the shader, but I will do that further down the line. Besides just being a performance gain, this will unblock #1882.