### PR TITLE
Add texture filtering options

### DIFF
--- a/core/src/image.rs
+++ b/core/src/image.rs
@@ -11,7 +11,7 @@ pub enum FilterMethod {
     /// Bilinear interpolation
     #[default]
     Linear,
-    /// Nearest Neighbor 
+    /// Nearest Neighbor
     Nearest,
 }
 

--- a/core/src/image.rs
+++ b/core/src/image.rs
@@ -5,11 +5,31 @@ use std::hash::{Hash, Hasher as _};
 use std::path::PathBuf;
 use std::sync::Arc;
 
+/// Image filter method
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FilterMethod {
+    /// Bilinear interpolation
+    #[default]
+    Linear,
+    /// Nearest Neighbor 
+    Nearest,
+}
+
+/// Texture filter settings
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TextureFilter {
+    /// Filter for scaling the image down.
+    pub min: FilterMethod,
+    /// Filter for scaling the image up.
+    pub mag: FilterMethod,
+}
+
 /// A handle of some image data.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Handle {
     id: u64,
     data: Data,
+    filter: TextureFilter,
 }
 
 impl Handle {
@@ -56,6 +76,7 @@ impl Handle {
         Handle {
             id: hasher.finish(),
             data,
+            filter: TextureFilter::default(),
         }
     }
 
@@ -67,6 +88,17 @@ impl Handle {
     /// Returns a reference to the image [`Data`].
     pub fn data(&self) -> &Data {
         &self.data
+    }
+
+    /// Returns a reference to the [`TextureFilter`].
+    pub fn filter(&self) -> &TextureFilter {
+        &self.filter
+    }
+
+    /// Sets the texture filtering methods.
+    pub fn set_filter(mut self, filter: TextureFilter) -> Self {
+        self.filter = filter;
+        self
     }
 }
 

--- a/core/src/image.rs
+++ b/core/src/image.rs
@@ -5,31 +5,11 @@ use std::hash::{Hash, Hasher as _};
 use std::path::PathBuf;
 use std::sync::Arc;
 
-/// Image filter method
-#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum FilterMethod {
-    /// Bilinear interpolation
-    #[default]
-    Linear,
-    /// Nearest Neighbor
-    Nearest,
-}
-
-/// Texture filter settings
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
-pub struct TextureFilter {
-    /// Filter for scaling the image down.
-    pub min: FilterMethod,
-    /// Filter for scaling the image up.
-    pub mag: FilterMethod,
-}
-
 /// A handle of some image data.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Handle {
     id: u64,
     data: Data,
-    filter: TextureFilter,
 }
 
 impl Handle {
@@ -76,7 +56,6 @@ impl Handle {
         Handle {
             id: hasher.finish(),
             data,
-            filter: TextureFilter::default(),
         }
     }
 
@@ -88,17 +67,6 @@ impl Handle {
     /// Returns a reference to the image [`Data`].
     pub fn data(&self) -> &Data {
         &self.data
-    }
-
-    /// Returns a reference to the [`TextureFilter`].
-    pub fn filter(&self) -> &TextureFilter {
-        &self.filter
-    }
-
-    /// Sets the texture filtering methods.
-    pub fn set_filter(mut self, filter: TextureFilter) -> Self {
-        self.filter = filter;
-        self
     }
 }
 
@@ -196,6 +164,16 @@ impl std::fmt::Debug for Data {
     }
 }
 
+/// Image filtering strategy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum FilterMethod {
+    /// Bilinear interpolation.
+    #[default]
+    Linear,
+    /// Nearest neighbor.
+    Nearest,
+}
+
 /// A [`Renderer`] that can render raster graphics.
 ///
 /// [renderer]: crate::renderer
@@ -210,5 +188,10 @@ pub trait Renderer: crate::Renderer {
 
     /// Draws an image with the given [`Handle`] and inside the provided
     /// `bounds`.
-    fn draw(&mut self, handle: Self::Handle, bounds: Rectangle);
+    fn draw(
+        &mut self,
+        handle: Self::Handle,
+        filter_method: FilterMethod,
+        bounds: Rectangle,
+    );
 }

--- a/examples/tour/src/main.rs
+++ b/examples/tour/src/main.rs
@@ -1,4 +1,4 @@
-use iced::alignment;
+use iced::alignment::{self, Alignment};
 use iced::theme;
 use iced::widget::{
     checkbox, column, container, horizontal_space, image, radio, row,
@@ -126,7 +126,10 @@ impl Steps {
                 Step::Toggler {
                     can_continue: false,
                 },
-                Step::Image { width: 300 },
+                Step::Image {
+                    width: 300,
+                    filter_method: image::FilterMethod::Linear,
+                },
                 Step::Scrollable,
                 Step::TextInput {
                     value: String::new(),
@@ -195,6 +198,7 @@ enum Step {
     },
     Image {
         width: u16,
+        filter_method: image::FilterMethod,
     },
     Scrollable,
     TextInput {
@@ -215,6 +219,7 @@ pub enum StepMessage {
     TextColorChanged(Color),
     LanguageSelected(Language),
     ImageWidthChanged(u16),
+    ImageUseNearestToggled(bool),
     InputChanged(String),
     ToggleSecureInput(bool),
     ToggleTextInputIcon(bool),
@@ -263,6 +268,15 @@ impl<'a> Step {
             StepMessage::ImageWidthChanged(new_width) => {
                 if let Step::Image { width, .. } = self {
                     *width = new_width;
+                }
+            }
+            StepMessage::ImageUseNearestToggled(use_nearest) => {
+                if let Step::Image { filter_method, .. } = self {
+                    *filter_method = if use_nearest {
+                        image::FilterMethod::Nearest
+                    } else {
+                        image::FilterMethod::Linear
+                    };
                 }
             }
             StepMessage::InputChanged(new_value) => {
@@ -330,7 +344,10 @@ impl<'a> Step {
             Step::Toggler { can_continue } => Self::toggler(*can_continue),
             Step::Slider { value } => Self::slider(*value),
             Step::Text { size, color } => Self::text(*size, *color),
-            Step::Image { width } => Self::image(*width),
+            Step::Image {
+                width,
+                filter_method,
+            } => Self::image(*width, *filter_method),
             Step::RowsAndColumns { layout, spacing } => {
                 Self::rows_and_columns(*layout, *spacing)
             }
@@ -525,16 +542,25 @@ impl<'a> Step {
             )
     }
 
-    fn image(width: u16) -> Column<'a, StepMessage> {
+    fn image(
+        width: u16,
+        filter_method: image::FilterMethod,
+    ) -> Column<'a, StepMessage> {
         Self::container("Image")
             .push("An image that tries to keep its aspect ratio.")
-            .push(ferris(width))
+            .push(ferris(width, filter_method))
             .push(slider(100..=500, width, StepMessage::ImageWidthChanged))
             .push(
                 text(format!("Width: {width} px"))
                     .width(Length::Fill)
                     .horizontal_alignment(alignment::Horizontal::Center),
             )
+            .push(checkbox(
+                "Use nearest interpolation",
+                filter_method == image::FilterMethod::Nearest,
+                StepMessage::ImageUseNearestToggled,
+            ))
+            .align_items(Alignment::Center)
     }
 
     fn scrollable() -> Column<'a, StepMessage> {
@@ -555,7 +581,7 @@ impl<'a> Step {
                     .horizontal_alignment(alignment::Horizontal::Center),
             )
             .push(vertical_space(4096))
-            .push(ferris(300))
+            .push(ferris(300, image::FilterMethod::Linear))
             .push(
                 text("You made it!")
                     .width(Length::Fill)
@@ -646,7 +672,10 @@ impl<'a> Step {
     }
 }
 
-fn ferris<'a>(width: u16) -> Container<'a, StepMessage> {
+fn ferris<'a>(
+    width: u16,
+    filter_method: image::FilterMethod,
+) -> Container<'a, StepMessage> {
     container(
         // This should go away once we unify resource loading on native
         // platforms
@@ -655,6 +684,7 @@ fn ferris<'a>(width: u16) -> Container<'a, StepMessage> {
         } else {
             image(format!("{}/images/ferris.png", env!("CARGO_MANIFEST_DIR")))
         }
+        .filter_method(filter_method)
         .width(width),
     )
     .width(Length::Fill)

--- a/graphics/src/primitive.rs
+++ b/graphics/src/primitive.rs
@@ -68,6 +68,8 @@ pub enum Primitive<T> {
     Image {
         /// The handle of the image
         handle: image::Handle,
+        /// The filter method of the image
+        filter_method: image::FilterMethod,
         /// The bounds of the image
         bounds: Rectangle,
     },

--- a/graphics/src/renderer.rs
+++ b/graphics/src/renderer.rs
@@ -215,8 +215,17 @@ where
         self.backend().dimensions(handle)
     }
 
-    fn draw(&mut self, handle: image::Handle, bounds: Rectangle) {
-        self.primitives.push(Primitive::Image { handle, bounds });
+    fn draw(
+        &mut self,
+        handle: image::Handle,
+        filter_method: image::FilterMethod,
+        bounds: Rectangle,
+    ) {
+        self.primitives.push(Primitive::Image {
+            handle,
+            filter_method,
+            bounds,
+        });
     }
 }
 

--- a/renderer/src/lib.rs
+++ b/renderer/src/lib.rs
@@ -214,8 +214,13 @@ impl<T> crate::core::image::Renderer for Renderer<T> {
         delegate!(self, renderer, renderer.dimensions(handle))
     }
 
-    fn draw(&mut self, handle: crate::core::image::Handle, bounds: Rectangle) {
-        delegate!(self, renderer, renderer.draw(handle, bounds));
+    fn draw(
+        &mut self,
+        handle: crate::core::image::Handle,
+        filter_method: crate::core::image::FilterMethod,
+        bounds: Rectangle,
+    ) {
+        delegate!(self, renderer, renderer.draw(handle, filter_method, bounds));
     }
 }
 

--- a/tiny_skia/src/backend.rs
+++ b/tiny_skia/src/backend.rs
@@ -445,7 +445,11 @@ impl Backend {
                 );
             }
             #[cfg(feature = "image")]
-            Primitive::Image { handle, bounds } => {
+            Primitive::Image {
+                handle,
+                filter_method,
+                bounds,
+            } => {
                 let physical_bounds = (*bounds + translation) * scale_factor;
 
                 if !clip_bounds.intersects(&physical_bounds) {
@@ -461,8 +465,14 @@ impl Backend {
                 )
                 .post_scale(scale_factor, scale_factor);
 
-                self.raster_pipeline
-                    .draw(handle, *bounds, pixels, transform, clip_mask);
+                self.raster_pipeline.draw(
+                    handle,
+                    *filter_method,
+                    *bounds,
+                    pixels,
+                    transform,
+                    clip_mask,
+                );
             }
             #[cfg(not(feature = "image"))]
             Primitive::Image { .. } => {

--- a/tiny_skia/src/raster.rs
+++ b/tiny_skia/src/raster.rs
@@ -39,12 +39,17 @@ impl Pipeline {
 
             let transform = transform.pre_scale(width_scale, height_scale);
 
+            let quality = match handle.filter().mag {
+                raster::FilterMethod::Linear => tiny_skia::FilterQuality::Bilinear,
+                raster::FilterMethod::Nearest => tiny_skia::FilterQuality::Nearest,
+            };
+
             pixels.draw_pixmap(
                 (bounds.x / width_scale) as i32,
                 (bounds.y / height_scale) as i32,
                 image,
                 &tiny_skia::PixmapPaint {
-                    quality: tiny_skia::FilterQuality::Bilinear,
+                    quality: quality,
                     ..Default::default()
                 },
                 transform,

--- a/tiny_skia/src/raster.rs
+++ b/tiny_skia/src/raster.rs
@@ -40,8 +40,12 @@ impl Pipeline {
             let transform = transform.pre_scale(width_scale, height_scale);
 
             let quality = match handle.filter().mag {
-                raster::FilterMethod::Linear => tiny_skia::FilterQuality::Bilinear,
-                raster::FilterMethod::Nearest => tiny_skia::FilterQuality::Nearest,
+                raster::FilterMethod::Linear => {
+                    tiny_skia::FilterQuality::Bilinear
+                }
+                raster::FilterMethod::Nearest => {
+                    tiny_skia::FilterQuality::Nearest
+                }
             };
 
             pixels.draw_pixmap(
@@ -49,7 +53,7 @@ impl Pipeline {
                 (bounds.y / height_scale) as i32,
                 image,
                 &tiny_skia::PixmapPaint {
-                    quality: quality,
+                    quality,
                     ..Default::default()
                 },
                 transform,

--- a/tiny_skia/src/raster.rs
+++ b/tiny_skia/src/raster.rs
@@ -28,6 +28,7 @@ impl Pipeline {
     pub fn draw(
         &mut self,
         handle: &raster::Handle,
+        filter_method: raster::FilterMethod,
         bounds: Rectangle,
         pixels: &mut tiny_skia::PixmapMut<'_>,
         transform: tiny_skia::Transform,
@@ -39,7 +40,7 @@ impl Pipeline {
 
             let transform = transform.pre_scale(width_scale, height_scale);
 
-            let quality = match handle.filter().mag {
+            let quality = match filter_method {
                 raster::FilterMethod::Linear => {
                     tiny_skia::FilterQuality::Bilinear
                 }

--- a/wgpu/src/image.rs
+++ b/wgpu/src/image.rs
@@ -494,9 +494,8 @@ impl Pipeline {
         render_pass: &mut wgpu::RenderPass<'a>,
     ) {
         if let Some(layer_group) = self.layers.get(layer) {
-            for (i, layer) in layer_group.iter().enumerate() {
+            for layer in layer_group.iter() {
                 if let Some(layer) = layer {
-                    println!("Render {i}");
                     render_pass.set_pipeline(&self.pipeline);
 
                     render_pass.set_scissor_rect(

--- a/wgpu/src/image.rs
+++ b/wgpu/src/image.rs
@@ -131,7 +131,7 @@ impl Data {
                     binding: 0,
                     resource: wgpu::BindingResource::Buffer(
                         wgpu::BufferBinding {
-                            buffer: &uniforms,
+                            buffer: uniforms,
                             offset: 0,
                             size: None,
                         },
@@ -517,8 +517,8 @@ impl Pipeline {
         layer.prepare(
             device,
             queue,
-            &nearest_instances,
-            &linear_instances,
+            nearest_instances,
+            linear_instances,
             transformation,
         );
 

--- a/wgpu/src/layer.rs
+++ b/wgpu/src/layer.rs
@@ -186,11 +186,16 @@ impl<'a> Layer<'a> {
 
                 layer.quads.add(quad, background);
             }
-            Primitive::Image { handle, bounds } => {
+            Primitive::Image {
+                handle,
+                filter_method,
+                bounds,
+            } => {
                 let layer = &mut layers[current_layer];
 
                 layer.images.push(Image::Raster {
                     handle: handle.clone(),
+                    filter_method: *filter_method,
                     bounds: *bounds + translation,
                 });
             }

--- a/wgpu/src/layer/image.rs
+++ b/wgpu/src/layer/image.rs
@@ -10,6 +10,9 @@ pub enum Image {
         /// The handle of a raster image.
         handle: image::Handle,
 
+        /// The filter method of a raster image.
+        filter_method: image::FilterMethod,
+
         /// The bounds of the image.
         bounds: Rectangle,
     },

--- a/widget/src/image.rs
+++ b/widget/src/image.rs
@@ -13,7 +13,7 @@ use crate::core::{
 
 use std::hash::Hash;
 
-pub use image::{Handle, TextureFilter, FilterMethod};
+pub use image::{FilterMethod, Handle, TextureFilter};
 
 /// Creates a new [`Viewer`] with the given image `Handle`.
 pub fn viewer<Handle>(handle: Handle) -> Viewer<Handle> {

--- a/widget/src/image.rs
+++ b/widget/src/image.rs
@@ -13,7 +13,7 @@ use crate::core::{
 
 use std::hash::Hash;
 
-pub use image::Handle;
+pub use image::{Handle, TextureFilter, FilterMethod};
 
 /// Creates a new [`Viewer`] with the given image `Handle`.
 pub fn viewer<Handle>(handle: Handle) -> Viewer<Handle> {

--- a/widget/src/image.rs
+++ b/widget/src/image.rs
@@ -13,7 +13,7 @@ use crate::core::{
 
 use std::hash::Hash;
 
-pub use image::{FilterMethod, Handle, TextureFilter};
+pub use image::{FilterMethod, Handle};
 
 /// Creates a new [`Viewer`] with the given image `Handle`.
 pub fn viewer<Handle>(handle: Handle) -> Viewer<Handle> {
@@ -37,6 +37,7 @@ pub struct Image<Handle> {
     width: Length,
     height: Length,
     content_fit: ContentFit,
+    filter_method: FilterMethod,
 }
 
 impl<Handle> Image<Handle> {
@@ -47,6 +48,7 @@ impl<Handle> Image<Handle> {
             width: Length::Shrink,
             height: Length::Shrink,
             content_fit: ContentFit::Contain,
+            filter_method: FilterMethod::default(),
         }
     }
 
@@ -65,11 +67,15 @@ impl<Handle> Image<Handle> {
     /// Sets the [`ContentFit`] of the [`Image`].
     ///
     /// Defaults to [`ContentFit::Contain`]
-    pub fn content_fit(self, content_fit: ContentFit) -> Self {
-        Self {
-            content_fit,
-            ..self
-        }
+    pub fn content_fit(mut self, content_fit: ContentFit) -> Self {
+        self.content_fit = content_fit;
+        self
+    }
+
+    /// Sets the [`FilterMethod`] of the [`Image`].
+    pub fn filter_method(mut self, filter_method: FilterMethod) -> Self {
+        self.filter_method = filter_method;
+        self
     }
 }
 
@@ -119,6 +125,7 @@ pub fn draw<Renderer, Handle>(
     layout: Layout<'_>,
     handle: &Handle,
     content_fit: ContentFit,
+    filter_method: FilterMethod,
 ) where
     Renderer: image::Renderer<Handle = Handle>,
     Handle: Clone + Hash,
@@ -141,7 +148,7 @@ pub fn draw<Renderer, Handle>(
             ..bounds
         };
 
-        renderer.draw(handle.clone(), drawing_bounds + offset);
+        renderer.draw(handle.clone(), filter_method, drawing_bounds + offset);
     };
 
     if adjusted_fit.width > bounds.width || adjusted_fit.height > bounds.height
@@ -191,7 +198,13 @@ where
         _cursor: mouse::Cursor,
         _viewport: &Rectangle,
     ) {
-        draw(renderer, layout, &self.handle, self.content_fit);
+        draw(
+            renderer,
+            layout,
+            &self.handle,
+            self.content_fit,
+            self.filter_method,
+        );
     }
 }
 

--- a/widget/src/image/viewer.rs
+++ b/widget/src/image/viewer.rs
@@ -22,19 +22,21 @@ pub struct Viewer<Handle> {
     max_scale: f32,
     scale_step: f32,
     handle: Handle,
+    filter_method: image::FilterMethod,
 }
 
 impl<Handle> Viewer<Handle> {
     /// Creates a new [`Viewer`] with the given [`State`].
     pub fn new(handle: Handle) -> Self {
         Viewer {
+            handle,
             padding: 0.0,
             width: Length::Shrink,
             height: Length::Shrink,
             min_scale: 0.25,
             max_scale: 10.0,
             scale_step: 0.10,
-            handle,
+            filter_method: image::FilterMethod::default(),
         }
     }
 
@@ -329,6 +331,7 @@ where
                 image::Renderer::draw(
                     renderer,
                     self.handle.clone(),
+                    self.filter_method,
                     Rectangle {
                         x: bounds.x,
                         y: bounds.y,


### PR DESCRIPTION
Adds the possibility to add Texture filtering options to an image handle (should work with tiny_skia and wgpu) (Original Issue: https://github.com/iced-rs/iced/issues/557 )

This is necessary when rendering smaller Pixelart or when trying to implement pixelbased image manipulation (As I am currently trying). 
I asked on [Discord](https://discord.com/channels/628993209984614400/1101825996715462707/1101825996715462707) and since nobody seemed to work at it I gave it a try.

I know it adds a little complexity to the rendering of images and imposes a rendering order of images with different filter options (Even though only inside a layer?) so if you think the feature is not interesting enough to justify these drawbacks its fine.
Just wanted to provide it. If its not completely unfitting I'd be happy to take feedback, since I am not very experienced with the graphics part.

Fixes #557.