### PR TITLE
Update `resvg` to `0.35` and `tiny-skia` to `0.10`

### DIFF
--- a/tiny_skia/Cargo.toml
+++ b/tiny_skia/Cargo.toml
@@ -34,5 +34,5 @@ version = "1.6.1"
 features = ["std"]
 
 [dependencies.resvg]
-version = "0.34"
+version = "0.35"
 optional = true

--- a/tiny_skia/Cargo.toml
+++ b/tiny_skia/Cargo.toml
@@ -11,7 +11,7 @@ geometry = ["iced_graphics/geometry"]
 [dependencies]
 raw-window-handle = "0.5"
 softbuffer = "0.2"
-tiny-skia = "0.9"
+tiny-skia = "0.10"
 bytemuck = "1"
 rustc-hash = "1.1"
 kurbo = "0.9"
@@ -34,5 +34,5 @@ version = "1.6.1"
 features = ["std"]
 
 [dependencies.resvg]
-version = "0.32"
+version = "0.34"
 optional = true

--- a/tiny_skia/src/backend.rs
+++ b/tiny_skia/src/backend.rs
@@ -753,7 +753,15 @@ fn adjust_clip_mask(clip_mask: &mut tiny_skia::Mask, bounds: Rectangle) {
 
     let path = {
         let mut builder = tiny_skia::PathBuilder::new();
-        builder.push_rect(bounds.x, bounds.y, bounds.width, bounds.height);
+        builder.push_rect(
+            tiny_skia::Rect::from_xywh(
+                bounds.x,
+                bounds.y,
+                bounds.width,
+                bounds.height,
+            )
+            .unwrap(),
+        );
 
         builder.finish().unwrap()
     };

--- a/tiny_skia/src/raster.rs
+++ b/tiny_skia/src/raster.rs
@@ -2,6 +2,7 @@ use crate::core::image as raster;
 use crate::core::{Rectangle, Size};
 use crate::graphics;
 
+use bytemuck::cast;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::cell::RefCell;
 use std::collections::hash_map;
@@ -80,9 +81,8 @@ impl Cache {
             for (i, pixel) in image.pixels().enumerate() {
                 let [r, g, b, a] = pixel.0;
 
-                buffer[i] = tiny_skia::ColorU8::from_rgba(b, g, r, a)
-                    .premultiply()
-                    .get();
+                buffer[i] = cast(tiny_skia::ColorU8::from_rgba(b, g, r, a)
+                    .premultiply());
             }
 
             entry.insert(Some(Entry {

--- a/tiny_skia/src/raster.rs
+++ b/tiny_skia/src/raster.rs
@@ -2,7 +2,6 @@ use crate::core::image as raster;
 use crate::core::{Rectangle, Size};
 use crate::graphics;
 
-use bytemuck::cast;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::cell::RefCell;
 use std::collections::hash_map;
@@ -81,8 +80,9 @@ impl Cache {
             for (i, pixel) in image.pixels().enumerate() {
                 let [r, g, b, a] = pixel.0;
 
-                buffer[i] = cast(tiny_skia::ColorU8::from_rgba(b, g, r, a)
-                    .premultiply());
+                buffer[i] = bytemuck::cast(
+                    tiny_skia::ColorU8::from_rgba(b, g, r, a).premultiply(),
+                );
             }
 
             entry.insert(Some(Entry {

--- a/tiny_skia/src/text.rs
+++ b/tiny_skia/src/text.rs
@@ -3,7 +3,6 @@ use crate::core::font::{self, Font};
 use crate::core::text::{Hit, LineHeight, Shaping};
 use crate::core::{Color, Pixels, Point, Rectangle, Size};
 
-use bytemuck::cast;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::borrow::Cow;
 use std::cell::RefCell;
@@ -289,7 +288,7 @@ impl GlyphCache {
 
                     for _y in 0..image.placement.height {
                         for _x in 0..image.placement.width {
-                            buffer[i] = cast(
+                            buffer[i] = bytemuck::cast(
                                 tiny_skia::ColorU8::from_rgba(
                                     b,
                                     g,
@@ -309,7 +308,7 @@ impl GlyphCache {
                     for _y in 0..image.placement.height {
                         for _x in 0..image.placement.width {
                             // TODO: Blend alpha
-                            buffer[i >> 2] = cast(
+                            buffer[i >> 2] = bytemuck::cast(
                                 tiny_skia::ColorU8::from_rgba(
                                     image.data[i + 2],
                                     image.data[i + 1],

--- a/tiny_skia/src/text.rs
+++ b/tiny_skia/src/text.rs
@@ -3,6 +3,7 @@ use crate::core::font::{self, Font};
 use crate::core::text::{Hit, LineHeight, Shaping};
 use crate::core::{Color, Pixels, Point, Rectangle, Size};
 
+use bytemuck::cast;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::borrow::Cow;
 use std::cell::RefCell;
@@ -288,14 +289,15 @@ impl GlyphCache {
 
                     for _y in 0..image.placement.height {
                         for _x in 0..image.placement.width {
-                            buffer[i] = tiny_skia::ColorU8::from_rgba(
-                                b,
-                                g,
-                                r,
-                                image.data[i],
-                            )
-                            .premultiply()
-                            .get();
+                            buffer[i] = cast(
+                                tiny_skia::ColorU8::from_rgba(
+                                    b,
+                                    g,
+                                    r,
+                                    image.data[i],
+                                )
+                                .premultiply(),
+                            );
 
                             i += 1;
                         }
@@ -307,14 +309,15 @@ impl GlyphCache {
                     for _y in 0..image.placement.height {
                         for _x in 0..image.placement.width {
                             // TODO: Blend alpha
-                            buffer[i >> 2] = tiny_skia::ColorU8::from_rgba(
-                                image.data[i + 2],
-                                image.data[i + 1],
-                                image.data[i],
-                                image.data[i + 3],
-                            )
-                            .premultiply()
-                            .get();
+                            buffer[i >> 2] = cast(
+                                tiny_skia::ColorU8::from_rgba(
+                                    image.data[i + 2],
+                                    image.data[i + 1],
+                                    image.data[i],
+                                    image.data[i + 3],
+                                )
+                                .premultiply(),
+                            );
 
                             i += 4;
                         }

--- a/tiny_skia/src/vector.rs
+++ b/tiny_skia/src/vector.rs
@@ -1,7 +1,6 @@
 use crate::core::svg::{Data, Handle};
 use crate::core::{Color, Rectangle, Size};
 
-use bytemuck::cast;
 use resvg::usvg;
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -157,7 +156,7 @@ impl Cache {
                 for pixel in
                     bytemuck::cast_slice_mut::<u8, u32>(image.data_mut())
                 {
-                    *pixel = cast(
+                    *pixel = bytemuck::cast(
                         tiny_skia::ColorU8::from_rgba(
                             b,
                             g,

--- a/tiny_skia/src/vector.rs
+++ b/tiny_skia/src/vector.rs
@@ -1,6 +1,7 @@
 use crate::core::svg::{Data, Handle};
 use crate::core::{Color, Rectangle, Size};
 
+use bytemuck::cast;
 use resvg::usvg;
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -130,30 +131,41 @@ impl Cache {
 
             let mut image = tiny_skia::Pixmap::new(size.width, size.height)?;
 
-            resvg::render(
-                tree,
-                if size.width > size.height {
-                    resvg::FitTo::Width(size.width)
-                } else {
-                    resvg::FitTo::Height(size.height)
-                },
-                tiny_skia::Transform::default(),
-                image.as_mut(),
-            )?;
+            let tree_size = tree.size.to_int_size();
+            let target_size;
+            if size.width > size.height {
+                target_size = tree_size.scale_to_width(size.width);
+            } else {
+                target_size = tree_size.scale_to_height(size.height);
+            }
+            let transform;
+            if let Some(target_size) = target_size {
+                let tree_size = tree_size.to_size();
+                let target_size = target_size.to_size();
+                transform = tiny_skia::Transform::from_scale(
+                    target_size.width() / tree_size.width(),
+                    target_size.height() / tree_size.height(),
+                );
+            } else {
+                transform = tiny_skia::Transform::default();
+            }
+
+            resvg::Tree::from_usvg(tree).render(transform, &mut image.as_mut());
 
             if let Some([r, g, b, _]) = key.color {
                 // Apply color filter
                 for pixel in
                     bytemuck::cast_slice_mut::<u8, u32>(image.data_mut())
                 {
-                    *pixel = tiny_skia::ColorU8::from_rgba(
-                        b,
-                        g,
-                        r,
-                        (*pixel >> 24) as u8,
-                    )
-                    .premultiply()
-                    .get();
+                    *pixel = cast(
+                        tiny_skia::ColorU8::from_rgba(
+                            b,
+                            g,
+                            r,
+                            (*pixel >> 24) as u8,
+                        )
+                        .premultiply(),
+                    );
                 }
             } else {
                 // Swap R and B channels for `softbuffer` presentation

--- a/tiny_skia/src/vector.rs
+++ b/tiny_skia/src/vector.rs
@@ -131,23 +131,24 @@ impl Cache {
             let mut image = tiny_skia::Pixmap::new(size.width, size.height)?;
 
             let tree_size = tree.size.to_int_size();
-            let target_size;
-            if size.width > size.height {
-                target_size = tree_size.scale_to_width(size.width);
+
+            let target_size = if size.width > size.height {
+                tree_size.scale_to_width(size.width)
             } else {
-                target_size = tree_size.scale_to_height(size.height);
-            }
-            let transform;
-            if let Some(target_size) = target_size {
+                tree_size.scale_to_height(size.height)
+            };
+
+            let transform = if let Some(target_size) = target_size {
                 let tree_size = tree_size.to_size();
                 let target_size = target_size.to_size();
-                transform = tiny_skia::Transform::from_scale(
+
+                tiny_skia::Transform::from_scale(
                     target_size.width() / tree_size.width(),
                     target_size.height() / tree_size.height(),
-                );
+                )
             } else {
-                transform = tiny_skia::Transform::default();
-            }
+                tiny_skia::Transform::default()
+            };
 
             resvg::Tree::from_usvg(tree).render(transform, &mut image.as_mut());
 

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -55,7 +55,7 @@ version = "1.0"
 optional = true
 
 [dependencies.resvg]
-version = "0.32"
+version = "0.34"
 optional = true
 
 [dependencies.tracing]

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -55,7 +55,7 @@ version = "1.0"
 optional = true
 
 [dependencies.resvg]
-version = "0.34"
+version = "0.35"
 optional = true
 
 [dependencies.tracing]

--- a/wgpu/src/image/vector.rs
+++ b/wgpu/src/image/vector.rs
@@ -114,16 +114,27 @@ impl Cache {
                 // It would be cool to be able to smooth resize the `svg` example.
                 let mut img = tiny_skia::Pixmap::new(width, height)?;
 
-                resvg::render(
-                    tree,
-                    if width > height {
-                        resvg::FitTo::Width(width)
-                    } else {
-                        resvg::FitTo::Height(height)
-                    },
-                    tiny_skia::Transform::default(),
-                    img.as_mut(),
-                )?;
+                let tree_size = tree.size.to_int_size();
+                let target_size;
+                if width > height {
+                    target_size = tree_size.scale_to_width(width);
+                } else {
+                    target_size = tree_size.scale_to_height(height);
+                }
+                let transform;
+                if let Some(target_size) = target_size {
+                    let tree_size = tree_size.to_size();
+                    let target_size = target_size.to_size();
+                    transform = tiny_skia::Transform::from_scale(
+                        target_size.width() / tree_size.width(),
+                        target_size.height() / tree_size.height(),
+                    );
+                } else {
+                    transform = tiny_skia::Transform::default();
+                }
+
+                resvg::Tree::from_usvg(tree)
+                    .render(transform, &mut img.as_mut());
 
                 let mut rgba = img.take();
 

--- a/wgpu/src/image/vector.rs
+++ b/wgpu/src/image/vector.rs
@@ -115,23 +115,24 @@ impl Cache {
                 let mut img = tiny_skia::Pixmap::new(width, height)?;
 
                 let tree_size = tree.size.to_int_size();
-                let target_size;
-                if width > height {
-                    target_size = tree_size.scale_to_width(width);
+
+                let target_size = if width > height {
+                    tree_size.scale_to_width(width)
                 } else {
-                    target_size = tree_size.scale_to_height(height);
-                }
-                let transform;
-                if let Some(target_size) = target_size {
+                    tree_size.scale_to_height(height)
+                };
+
+                let transform = if let Some(target_size) = target_size {
                     let tree_size = tree_size.to_size();
                     let target_size = target_size.to_size();
-                    transform = tiny_skia::Transform::from_scale(
+
+                    tiny_skia::Transform::from_scale(
                         target_size.width() / tree_size.width(),
                         target_size.height() / tree_size.height(),
-                    );
+                    )
                 } else {
-                    transform = tiny_skia::Transform::default();
-                }
+                    tiny_skia::Transform::default()
+                };
 
                 resvg::Tree::from_usvg(tree)
                     .render(transform, &mut img.as_mut());


### PR DESCRIPTION
This PR upgrades resvg to 0.34 and tiny_skia to 0.10. Most of the changes are minor API adjustments. The one significant change is that resvg removed FitTo so I have rewritten iced's use of that based on what resvg does in it's command line renderer.

Tests pass and all the examples look right to me with a caveat: I'm testing with the wgpu feature turned off because that is not working on my system for reasons I haven't figured out yet. So someone who has that working should validate that things look right in wgpu.