### PR TITLE
Only scroll w/ wheel if over scrollable

### DIFF
--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -482,6 +482,10 @@ pub fn update<Message>(
 
     match event {
         Event::Mouse(mouse::Event::WheelScrolled { delta }) => {
+            if cursor_over_scrollable.is_none() {
+                return event::Status::Ignored;
+            }
+
             let delta = match delta {
                 mouse::ScrollDelta::Lines { x, y } => {
                     // TODO: Configurable speed/friction (?)


### PR DESCRIPTION
Fixes a regression from #1904 where scrollable should only scroll via wheel if mouse is over it.