### PR TITLE
Add Layout operation to `Container`

### DIFF
--- a/core/src/widget/operation.rs
+++ b/core/src/widget/operation.rs
@@ -1,5 +1,6 @@
 //! Query or update internal widget state.
 pub mod focusable;
+pub mod layout;
 pub mod scrollable;
 pub mod text_input;
 
@@ -7,7 +8,7 @@ pub use focusable::Focusable;
 pub use scrollable::Scrollable;
 pub use text_input::TextInput;
 
-use crate::widget::Id;
+use crate::{widget::Id, Rectangle};
 
 use std::any::Any;
 use std::fmt;
@@ -34,6 +35,9 @@ pub trait Operation<T> {
 
     /// Operates on a widget that has text input.
     fn text_input(&mut self, _state: &mut dyn TextInput, _id: Option<&Id>) {}
+
+    /// Queries a a widget for its layout.
+    fn layout(&mut self, _layout_bounds: Rectangle, _id: Option<&Id>) {}
 
     /// Operates on a custom widget with some state.
     fn custom(&mut self, _state: &mut dyn Any, _id: Option<&Id>) {}
@@ -135,6 +139,14 @@ where
                     self.operation.text_input(state, id);
                 }
 
+                fn layout(
+                    &mut self,
+                    layout_bounds: Rectangle,
+                    id: Option<&Id>,
+                ) {
+                    self.operation.layout(layout_bounds, id);
+                }
+
                 fn custom(&mut self, state: &mut dyn Any, id: Option<&Id>) {
                     self.operation.custom(state, id);
                 }
@@ -158,6 +170,10 @@ where
 
         fn text_input(&mut self, state: &mut dyn TextInput, id: Option<&Id>) {
             self.operation.text_input(state, id);
+        }
+
+        fn layout(&mut self, layout_bounds: Rectangle, id: Option<&Id>) {
+            self.operation.layout(layout_bounds, id);
         }
 
         fn custom(&mut self, state: &mut dyn Any, id: Option<&Id>) {

--- a/core/src/widget/operation/layout.rs
+++ b/core/src/widget/operation/layout.rs
@@ -1,0 +1,41 @@
+//! Operate on widgets that can be focused.
+use crate::widget::operation::{Operation, Outcome, Rectangle};
+use crate::widget::Id;
+
+/// Produces an [`Operation`] that returns a layout of the widget
+/// with the matching ID.
+pub fn layout(target: Id) -> impl Operation<Rectangle> {
+    struct Layout {
+        target: Id,
+        layout: Option<Rectangle>,
+    }
+
+    impl Operation<Rectangle> for Layout {
+        fn layout(&mut self, layout: Rectangle, id: Option<&Id>) {
+            if id.is_some() && id.unwrap() == &self.target {
+                self.layout = Some(layout);
+            }
+        }
+
+        fn container(
+            &mut self,
+            _id: Option<&Id>,
+            operate_on_children: &mut dyn FnMut(&mut dyn Operation<Rectangle>),
+        ) {
+            operate_on_children(self)
+        }
+
+        fn finish(&self) -> Outcome<Rectangle> {
+            if let Some(layout) = self.layout {
+                Outcome::Some(layout)
+            } else {
+                Outcome::None
+            }
+        }
+    }
+
+    Layout {
+        target,
+        layout: None,
+    }
+}

--- a/widget/src/container.rs
+++ b/widget/src/container.rs
@@ -5,11 +5,13 @@ use crate::core::layout;
 use crate::core::mouse;
 use crate::core::overlay;
 use crate::core::renderer;
-use crate::core::widget::{self, Operation, Tree};
+use crate::core::widget::{self, operation, Operation, Tree};
 use crate::core::{
     Background, Clipboard, Color, Element, Layout, Length, Padding, Pixels,
     Point, Rectangle, Shell, Widget,
 };
+use crate::runtime::Command;
+use iced_runtime::futures::MaybeSend;
 
 pub use iced_style::container::{Appearance, StyleSheet};
 
@@ -178,6 +180,8 @@ where
         renderer: &Renderer,
         operation: &mut dyn Operation<Message>,
     ) {
+        operation.layout(layout.bounds(), self.id.as_ref().map(|id| &id.0));
+
         operation.container(
             self.id.as_ref().map(|id| &id.0),
             &mut |operation| {
@@ -365,4 +369,12 @@ impl From<Id> for widget::Id {
     fn from(id: Id) -> Self {
         id.0
     }
+}
+
+/// Produces a [`Command`] that focuses the [`TextInput`] with the given [`Id`].
+pub fn get_layout<Message: 'static>(
+    id: Id,
+    f: impl Fn(Rectangle) -> Message + 'static + MaybeSend + Sync + Clone,
+) -> Command<Message> {
+    Command::widget(operation::layout::layout(id.0)).map(f)
 }


### PR DESCRIPTION
An operation that will return a message to the application with the dimensions of the widget as a `Rectangle`.

`container::get_layout(CONTAINER_ID.clone(), Message::GotLayout)`

The only slightly unusual think about this operation is that creating the operation requires the return message. But this API is the same as `Command::Perform`, and operations are just `Commands`, so I believe this should be fine.