### PR TITLE
Add scrollable alignment option

### DIFF
--- a/examples/scrollable/src/main.rs
+++ b/examples/scrollable/src/main.rs
@@ -20,6 +20,7 @@ struct ScrollableDemo {
     scrollbar_margin: u16,
     scroller_width: u16,
     current_scroll_offset: scrollable::RelativeOffset,
+    alignment: scrollable::Alignment,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Copy)]
@@ -32,6 +33,7 @@ enum Direction {
 #[derive(Debug, Clone)]
 enum Message {
     SwitchDirection(Direction),
+    AlignmentChanged(scrollable::Alignment),
     ScrollbarWidthChanged(u16),
     ScrollbarMarginChanged(u16),
     ScrollerWidthChanged(u16),
@@ -54,6 +56,7 @@ impl Application for ScrollableDemo {
                 scrollbar_margin: 0,
                 scroller_width: 10,
                 current_scroll_offset: scrollable::RelativeOffset::START,
+                alignment: scrollable::Alignment::Start,
             },
             Command::none(),
         )
@@ -68,6 +71,15 @@ impl Application for ScrollableDemo {
             Message::SwitchDirection(direction) => {
                 self.current_scroll_offset = scrollable::RelativeOffset::START;
                 self.scrollable_direction = direction;
+
+                scrollable::snap_to(
+                    SCROLLABLE_ID.clone(),
+                    self.current_scroll_offset,
+                )
+            }
+            Message::AlignmentChanged(alignment) => {
+                self.current_scroll_offset = scrollable::RelativeOffset::START;
+                self.alignment = alignment;
 
                 scrollable::snap_to(
                     SCROLLABLE_ID.clone(),
@@ -165,10 +177,33 @@ impl Application for ScrollableDemo {
         .spacing(10)
         .width(Length::Fill);
 
-        let scroll_controls =
-            row![scroll_slider_controls, scroll_orientation_controls]
-                .spacing(20)
-                .width(Length::Fill);
+        let scroll_alignment_controls = column(vec![
+            text("Scrollable alignment:").into(),
+            radio(
+                "Start",
+                scrollable::Alignment::Start,
+                Some(self.alignment),
+                Message::AlignmentChanged,
+            )
+            .into(),
+            radio(
+                "End",
+                scrollable::Alignment::End,
+                Some(self.alignment),
+                Message::AlignmentChanged,
+            )
+            .into(),
+        ])
+        .spacing(10)
+        .width(Length::Fill);
+
+        let scroll_controls = row![
+            scroll_slider_controls,
+            scroll_orientation_controls,
+            scroll_alignment_controls
+        ]
+        .spacing(20)
+        .width(Length::Fill);
 
         let scroll_to_end_button = || {
             button("Scroll to end")
@@ -204,7 +239,8 @@ impl Application for ScrollableDemo {
                     Properties::new()
                         .width(self.scrollbar_width)
                         .margin(self.scrollbar_margin)
-                        .scroller_width(self.scroller_width),
+                        .scroller_width(self.scroller_width)
+                        .alignment(self.alignment),
                 ))
                 .id(SCROLLABLE_ID.clone())
                 .on_scroll(Message::Scrolled),
@@ -228,7 +264,8 @@ impl Application for ScrollableDemo {
                     Properties::new()
                         .width(self.scrollbar_width)
                         .margin(self.scrollbar_margin)
-                        .scroller_width(self.scroller_width),
+                        .scroller_width(self.scroller_width)
+                        .alignment(self.alignment),
                 ))
                 .style(theme::Scrollable::custom(ScrollbarCustomStyle))
                 .id(SCROLLABLE_ID.clone())
@@ -269,7 +306,8 @@ impl Application for ScrollableDemo {
                     let properties = Properties::new()
                         .width(self.scrollbar_width)
                         .margin(self.scrollbar_margin)
-                        .scroller_width(self.scroller_width);
+                        .scroller_width(self.scroller_width)
+                        .alignment(self.alignment);
 
                     scrollable::Direction::Both {
                         horizontal: properties,

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -1099,8 +1099,10 @@ impl Offset {
 pub struct Viewport {
     offset_x: Offset,
     offset_y: Offset,
-    bounds: Rectangle,
-    content_bounds: Rectangle,
+    /// The viewport bounds of the [`Scrollable`].
+    pub bounds: Rectangle,
+    /// The content bounds of the [`Scrollable`].
+    pub content_bounds: Rectangle,
 }
 
 impl Viewport {

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -577,7 +577,15 @@ pub fn update<Message>(
                 content_bounds,
             );
 
-            notify_on_scroll(state, on_scroll, bounds, content_bounds, shell);
+            notify_on_scroll(
+                state,
+                on_scroll,
+                bounds,
+                content_bounds,
+                horizontal_alignment,
+                vertical_alignment,
+                shell,
+            );
 
             return event::Status::Captured;
         }
@@ -623,6 +631,8 @@ pub fn update<Message>(
                             on_scroll,
                             bounds,
                             content_bounds,
+                            horizontal_alignment,
+                            vertical_alignment,
                             shell,
                         );
                     }
@@ -669,6 +679,8 @@ pub fn update<Message>(
                         on_scroll,
                         bounds,
                         content_bounds,
+                        horizontal_alignment,
+                        vertical_alignment,
                         shell,
                     );
 
@@ -705,6 +717,8 @@ pub fn update<Message>(
                         on_scroll,
                         bounds,
                         content_bounds,
+                        horizontal_alignment,
+                        vertical_alignment,
                         shell,
                     );
                 }
@@ -746,6 +760,8 @@ pub fn update<Message>(
                         on_scroll,
                         bounds,
                         content_bounds,
+                        horizontal_alignment,
+                        vertical_alignment,
                         shell,
                     );
                 }
@@ -782,6 +798,8 @@ pub fn update<Message>(
                         on_scroll,
                         bounds,
                         content_bounds,
+                        horizontal_alignment,
+                        vertical_alignment,
                         shell,
                     );
 
@@ -997,6 +1015,8 @@ fn notify_on_scroll<Message>(
     on_scroll: &Option<Box<dyn Fn(Viewport) -> Message + '_>>,
     bounds: Rectangle,
     content_bounds: Rectangle,
+    horizontal_alignment: Alignment,
+    vertical_alignment: Alignment,
     shell: &mut Shell<'_, Message>,
 ) {
     if let Some(on_scroll) = on_scroll {
@@ -1011,6 +1031,8 @@ fn notify_on_scroll<Message>(
             offset_y: state.offset_y,
             bounds,
             content_bounds,
+            horizontal_alignment,
+            vertical_alignment,
         };
 
         // Don't publish redundant viewports to shell
@@ -1103,6 +1125,10 @@ pub struct Viewport {
     pub bounds: Rectangle,
     /// The content bounds of the [`Scrollable`].
     pub content_bounds: Rectangle,
+    /// The horizontal [`Alignment`] of the [`Scrollable`].
+    pub horizontal_alignment: Alignment,
+    /// The vertical [`Alignment`] of the [`Scrollable`].
+    pub vertical_alignment: Alignment,
 }
 
 impl Viewport {

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -1058,7 +1058,7 @@ impl Offset {
         }
     }
 
-    fn absolute_from_start(
+    fn translation(
         self,
         viewport: f32,
         content: f32,
@@ -1219,7 +1219,7 @@ impl State {
     ) -> Vector {
         Vector::new(
             if let Some(horizontal) = direction.horizontal() {
-                self.offset_x.absolute_from_start(
+                self.offset_x.translation(
                     bounds.width,
                     content_bounds.width,
                     horizontal.alignment,
@@ -1228,7 +1228,7 @@ impl State {
                 0.0
             },
             if let Some(vertical) = direction.vertical() {
-                self.offset_y.absolute_from_start(
+                self.offset_y.translation(
                     bounds.height,
                     content_bounds.height,
                     vertical.alignment,

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -1476,20 +1476,14 @@ pub(super) mod internals {
             grabbed_at: f32,
             cursor_position: Point,
         ) -> f32 {
-            let pct = if cursor_position.x < 0.0 && cursor_position.y < 0.0 {
-                // cursor position is unavailable! Set to either end or beginning of scrollbar depending
-                // on where the thumb currently is in the track
-                (self.scroller.bounds.y / self.total_bounds.height).round()
-            } else {
-                (cursor_position.y
-                    - self.bounds.y
-                    - self.scroller.bounds.height * grabbed_at)
-                    / (self.bounds.height - self.scroller.bounds.height)
-            };
+            let percentage = (cursor_position.y
+                - self.bounds.y
+                - self.scroller.bounds.height * grabbed_at)
+                / (self.bounds.height - self.scroller.bounds.height);
 
             match self.alignment {
-                Alignment::Start => pct,
-                Alignment::End => 1.0 - pct,
+                Alignment::Start => percentage,
+                Alignment::End => 1.0 - percentage,
             }
         }
 
@@ -1499,18 +1493,14 @@ pub(super) mod internals {
             grabbed_at: f32,
             cursor_position: Point,
         ) -> f32 {
-            let pct = if cursor_position.x < 0.0 && cursor_position.y < 0.0 {
-                (self.scroller.bounds.x / self.total_bounds.width).round()
-            } else {
-                (cursor_position.x
-                    - self.bounds.x
-                    - self.scroller.bounds.width * grabbed_at)
-                    / (self.bounds.width - self.scroller.bounds.width)
-            };
+            let percentage = (cursor_position.x
+                - self.bounds.x
+                - self.scroller.bounds.width * grabbed_at)
+                / (self.bounds.width - self.scroller.bounds.width);
 
             match self.alignment {
-                Alignment::Start => pct,
-                Alignment::End => 1.0 - pct,
+                Alignment::Start => percentage,
+                Alignment::End => 1.0 - percentage,
             }
         }
     }

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -198,15 +198,6 @@ pub enum Alignment {
     End,
 }
 
-impl Alignment {
-    fn aligned(self, offset: f32, viewport: f32, content: f32) -> f32 {
-        match self {
-            Alignment::Start => offset,
-            Alignment::End => ((content - viewport).max(0.0) - offset).max(0.0),
-        }
-    }
-}
-
 impl<'a, Message, Renderer> Widget<Message, Renderer>
     for Scrollable<'a, Message, Renderer>
 where
@@ -385,13 +376,12 @@ where
                 let bounds = layout.bounds();
                 let content_layout = layout.children().next().unwrap();
                 let content_bounds = content_layout.bounds();
-                let offset = tree.state.downcast_ref::<State>().offset(
-                    self.direction,
-                    bounds,
-                    content_bounds,
-                );
+                let translation = tree
+                    .state
+                    .downcast_ref::<State>()
+                    .translation(self.direction, bounds, content_bounds);
 
-                overlay.translate(Vector::new(-offset.x, -offset.y))
+                overlay.translate(Vector::new(-translation.x, -translation.y))
             })
     }
 }
@@ -522,7 +512,7 @@ pub fn update<Message>(
             {
                 mouse::Cursor::Available(
                     cursor_position
-                        + state.offset(direction, bounds, content_bounds),
+                        + state.translation(direction, bounds, content_bounds),
                 )
             }
             _ => mouse::Cursor::Unavailable,
@@ -798,13 +788,13 @@ pub fn mouse_interaction(
     {
         mouse::Interaction::Idle
     } else {
-        let offset = state.offset(direction, bounds, content_bounds);
+        let translation = state.translation(direction, bounds, content_bounds);
 
         let cursor = match cursor_over_scrollable {
             Some(cursor_position)
                 if !(mouse_over_x_scrollbar || mouse_over_y_scrollbar) =>
             {
-                mouse::Cursor::Available(cursor_position + offset)
+                mouse::Cursor::Available(cursor_position + translation)
             }
             _ => mouse::Cursor::Unavailable,
         };
@@ -813,8 +803,8 @@ pub fn mouse_interaction(
             content_layout,
             cursor,
             &Rectangle {
-                y: bounds.y + offset.y,
-                x: bounds.x + offset.x,
+                y: bounds.y + translation.y,
+                x: bounds.x + translation.x,
                 ..bounds
             },
         )
@@ -845,13 +835,13 @@ pub fn draw<Renderer>(
     let (mouse_over_y_scrollbar, mouse_over_x_scrollbar) =
         scrollbars.is_mouse_over(cursor);
 
-    let offset = state.offset(direction, bounds, content_bounds);
+    let translation = state.translation(direction, bounds, content_bounds);
 
     let cursor = match cursor_over_scrollable {
         Some(cursor_position)
             if !(mouse_over_x_scrollbar || mouse_over_y_scrollbar) =>
         {
-            mouse::Cursor::Available(cursor_position + offset)
+            mouse::Cursor::Available(cursor_position + translation)
         }
         _ => mouse::Cursor::Unavailable,
     };
@@ -860,15 +850,15 @@ pub fn draw<Renderer>(
     if scrollbars.active() {
         renderer.with_layer(bounds, |renderer| {
             renderer.with_translation(
-                Vector::new(-offset.x, -offset.y),
+                Vector::new(-translation.x, -translation.y),
                 |renderer| {
                     draw_content(
                         renderer,
                         content_layout,
                         cursor,
                         &Rectangle {
-                            y: bounds.y + offset.y,
-                            x: bounds.x + offset.x,
+                            y: bounds.y + translation.y,
+                            x: bounds.x + translation.x,
                             ..bounds
                         },
                     );
@@ -959,8 +949,8 @@ pub fn draw<Renderer>(
             content_layout,
             cursor,
             &Rectangle {
-                x: bounds.x + offset.x,
-                y: bounds.y + offset.y,
+                x: bounds.x + translation.x,
+                y: bounds.y + translation.y,
                 ..bounds
             },
         );
@@ -1065,6 +1055,20 @@ impl Offset {
             Offset::Relative(percentage) => {
                 ((content - viewport) * percentage).max(0.0)
             }
+        }
+    }
+
+    fn absolute_from_start(
+        self,
+        viewport: f32,
+        content: f32,
+        alignment: Alignment,
+    ) -> f32 {
+        let offset = self.absolute(viewport, content);
+
+        match alignment {
+            Alignment::Start => offset,
+            Alignment::End => ((content - viewport).max(0.0) - offset).max(0.0),
         }
     }
 }
@@ -1205,9 +1209,9 @@ impl State {
         );
     }
 
-    /// Returns the scrolling offset of the [`State`], given a [`Direction`],
+    /// Returns the scrolling translation of the [`State`], given a [`Direction`],
     /// the bounds of the [`Scrollable`] and its contents.
-    pub fn offset(
+    fn translation(
         &self,
         direction: Direction,
         bounds: Rectangle,
@@ -1215,20 +1219,19 @@ impl State {
     ) -> Vector {
         Vector::new(
             if let Some(horizontal) = direction.horizontal() {
-                horizontal.alignment.aligned(
-                    self.offset_x.absolute(bounds.width, content_bounds.width),
+                self.offset_x.absolute_from_start(
                     bounds.width,
                     content_bounds.width,
+                    horizontal.alignment,
                 )
             } else {
                 0.0
             },
             if let Some(vertical) = direction.vertical() {
-                vertical.alignment.aligned(
-                    self.offset_y
-                        .absolute(bounds.height, content_bounds.height),
+                self.offset_y.absolute_from_start(
                     bounds.height,
                     content_bounds.height,
+                    vertical.alignment,
                 )
             } else {
                 0.0
@@ -1258,7 +1261,7 @@ impl Scrollbars {
         bounds: Rectangle,
         content_bounds: Rectangle,
     ) -> Self {
-        let offset = state.offset(direction, bounds, content_bounds);
+        let translation = state.translation(direction, bounds, content_bounds);
 
         let show_scrollbar_x = direction
             .horizontal()
@@ -1305,7 +1308,7 @@ impl Scrollbars {
             let ratio = bounds.height / content_bounds.height;
             // min height for easier grabbing with super tall content
             let scroller_height = (bounds.height * ratio).max(2.0);
-            let scroller_offset = offset.y * ratio;
+            let scroller_offset = translation.y * ratio;
 
             let scroller_bounds = Rectangle {
                 x: bounds.x + bounds.width
@@ -1366,7 +1369,7 @@ impl Scrollbars {
             let ratio = bounds.width / content_bounds.width;
             // min width for easier grabbing with extra wide content
             let scroller_length = (bounds.width * ratio).max(2.0);
-            let scroller_offset = offset.x * ratio;
+            let scroller_offset = translation.x * ratio;
 
             let scroller_bounds = Rectangle {
                 x: (scrollbar_bounds.x + scroller_offset - scrollbar_y_width)

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -577,15 +577,7 @@ pub fn update<Message>(
                 content_bounds,
             );
 
-            notify_on_scroll(
-                state,
-                on_scroll,
-                bounds,
-                content_bounds,
-                horizontal_alignment,
-                vertical_alignment,
-                shell,
-            );
+            notify_on_scroll(state, on_scroll, bounds, content_bounds, shell);
 
             return event::Status::Captured;
         }
@@ -631,8 +623,6 @@ pub fn update<Message>(
                             on_scroll,
                             bounds,
                             content_bounds,
-                            horizontal_alignment,
-                            vertical_alignment,
                             shell,
                         );
                     }
@@ -679,8 +669,6 @@ pub fn update<Message>(
                         on_scroll,
                         bounds,
                         content_bounds,
-                        horizontal_alignment,
-                        vertical_alignment,
                         shell,
                     );
 
@@ -717,8 +705,6 @@ pub fn update<Message>(
                         on_scroll,
                         bounds,
                         content_bounds,
-                        horizontal_alignment,
-                        vertical_alignment,
                         shell,
                     );
                 }
@@ -760,8 +746,6 @@ pub fn update<Message>(
                         on_scroll,
                         bounds,
                         content_bounds,
-                        horizontal_alignment,
-                        vertical_alignment,
                         shell,
                     );
                 }
@@ -798,8 +782,6 @@ pub fn update<Message>(
                         on_scroll,
                         bounds,
                         content_bounds,
-                        horizontal_alignment,
-                        vertical_alignment,
                         shell,
                     );
 
@@ -1015,8 +997,6 @@ fn notify_on_scroll<Message>(
     on_scroll: &Option<Box<dyn Fn(Viewport) -> Message + '_>>,
     bounds: Rectangle,
     content_bounds: Rectangle,
-    horizontal_alignment: Alignment,
-    vertical_alignment: Alignment,
     shell: &mut Shell<'_, Message>,
 ) {
     if let Some(on_scroll) = on_scroll {
@@ -1031,8 +1011,6 @@ fn notify_on_scroll<Message>(
             offset_y: state.offset_y,
             bounds,
             content_bounds,
-            horizontal_alignment,
-            vertical_alignment,
         };
 
         // Don't publish redundant viewports to shell
@@ -1121,14 +1099,8 @@ impl Offset {
 pub struct Viewport {
     offset_x: Offset,
     offset_y: Offset,
-    /// The viewport bounds of the [`Scrollable`].
-    pub bounds: Rectangle,
-    /// The content bounds of the [`Scrollable`].
-    pub content_bounds: Rectangle,
-    /// The horizontal [`Alignment`] of the [`Scrollable`].
-    pub horizontal_alignment: Alignment,
-    /// The vertical [`Alignment`] of the [`Scrollable`].
-    pub vertical_alignment: Alignment,
+    bounds: Rectangle,
+    content_bounds: Rectangle,
 }
 
 impl Viewport {

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -295,7 +295,7 @@ where
             cursor,
             clipboard,
             shell,
-            &self.direction,
+            self.direction,
             &self.on_scroll,
             |event, layout, cursor, clipboard, shell| {
                 self.content.as_widget_mut().on_event(
@@ -327,7 +327,7 @@ where
             theme,
             layout,
             cursor,
-            &self.direction,
+            self.direction,
             &self.style,
             |renderer, layout, cursor, viewport| {
                 self.content.as_widget().draw(
@@ -355,7 +355,7 @@ where
             tree.state.downcast_ref::<State>(),
             layout,
             cursor,
-            &self.direction,
+            self.direction,
             |layout, cursor, viewport| {
                 self.content.as_widget().mouse_interaction(
                     &tree.children[0],
@@ -386,7 +386,7 @@ where
                 let content_layout = layout.children().next().unwrap();
                 let content_bounds = content_layout.bounds();
                 let offset = tree.state.downcast_ref::<State>().offset(
-                    &self.direction,
+                    self.direction,
                     bounds,
                     content_bounds,
                 );
@@ -494,7 +494,7 @@ pub fn update<Message>(
     cursor: mouse::Cursor,
     clipboard: &mut dyn Clipboard,
     shell: &mut Shell<'_, Message>,
-    direction: &Direction,
+    direction: Direction,
     on_scroll: &Option<Box<dyn Fn(Viewport) -> Message + '_>>,
     update_content: impl FnOnce(
         Event,
@@ -511,15 +511,6 @@ pub fn update<Message>(
     let content_bounds = content.bounds();
 
     let scrollbars = Scrollbars::new(state, direction, bounds, content_bounds);
-
-    let horizontal_alignment = direction
-        .horizontal()
-        .map(|p| p.alignment)
-        .unwrap_or_default();
-    let vertical_alignment = direction
-        .vertical()
-        .map(|p| p.alignment)
-        .unwrap_or_default();
 
     let (mouse_over_y_scrollbar, mouse_over_x_scrollbar) =
         scrollbars.is_mouse_over(cursor);
@@ -571,11 +562,7 @@ pub fn update<Message>(
                 mouse::ScrollDelta::Pixels { x, y } => Vector::new(x, y),
             };
 
-            state.scroll(
-                aligned_delta(delta, vertical_alignment, horizontal_alignment),
-                bounds,
-                content_bounds,
-            );
+            state.scroll(delta, direction, bounds, content_bounds);
 
             notify_on_scroll(state, on_scroll, bounds, content_bounds, shell);
 
@@ -606,15 +593,7 @@ pub fn update<Message>(
                             cursor_position.y - scroll_box_touched_at.y,
                         );
 
-                        state.scroll(
-                            aligned_delta(
-                                delta,
-                                vertical_alignment,
-                                horizontal_alignment,
-                            ),
-                            bounds,
-                            content_bounds,
-                        );
+                        state.scroll(delta, direction, bounds, content_bounds);
 
                         state.scroll_area_touched_at = Some(cursor_position);
 
@@ -658,7 +637,6 @@ pub fn update<Message>(
                         scrollbar.scroll_percentage_y(
                             scroller_grabbed_at,
                             cursor_position,
-                            vertical_alignment,
                         ),
                         bounds,
                         content_bounds,
@@ -692,7 +670,6 @@ pub fn update<Message>(
                         scrollbar.scroll_percentage_y(
                             scroller_grabbed_at,
                             cursor_position,
-                            vertical_alignment,
                         ),
                         bounds,
                         content_bounds,
@@ -735,7 +712,6 @@ pub fn update<Message>(
                         scrollbar.scroll_percentage_x(
                             scroller_grabbed_at,
                             cursor_position,
-                            horizontal_alignment,
                         ),
                         bounds,
                         content_bounds,
@@ -769,7 +745,6 @@ pub fn update<Message>(
                         scrollbar.scroll_percentage_x(
                             scroller_grabbed_at,
                             cursor_position,
-                            horizontal_alignment,
                         ),
                         bounds,
                         content_bounds,
@@ -800,7 +775,7 @@ pub fn mouse_interaction(
     state: &State,
     layout: Layout<'_>,
     cursor: mouse::Cursor,
-    direction: &Direction,
+    direction: Direction,
     content_interaction: impl FnOnce(
         Layout<'_>,
         mouse::Cursor,
@@ -853,7 +828,7 @@ pub fn draw<Renderer>(
     theme: &Renderer::Theme,
     layout: Layout<'_>,
     cursor: mouse::Cursor,
-    direction: &Direction,
+    direction: Direction,
     style: &<Renderer::Theme as StyleSheet>::Style,
     draw_content: impl FnOnce(&mut Renderer, Layout<'_>, mouse::Cursor, &Rectangle),
 ) where
@@ -1138,9 +1113,30 @@ impl State {
     pub fn scroll(
         &mut self,
         delta: Vector<f32>,
+        direction: Direction,
         bounds: Rectangle,
         content_bounds: Rectangle,
     ) {
+        let horizontal_alignment = direction
+            .horizontal()
+            .map(|p| p.alignment)
+            .unwrap_or_default();
+
+        let vertical_alignment = direction
+            .vertical()
+            .map(|p| p.alignment)
+            .unwrap_or_default();
+
+        let align = |alignment: Alignment, delta: f32| match alignment {
+            Alignment::Start => delta,
+            Alignment::End => -delta,
+        };
+
+        let delta = Vector::new(
+            align(horizontal_alignment, delta.x),
+            align(vertical_alignment, delta.y),
+        );
+
         if bounds.height < content_bounds.height {
             self.offset_y = Offset::Absolute(
                 (self.offset_y.absolute(bounds.height, content_bounds.height)
@@ -1213,7 +1209,7 @@ impl State {
     /// the bounds of the [`Scrollable`] and its contents.
     pub fn offset(
         &self,
-        direction: &Direction,
+        direction: Direction,
         bounds: Rectangle,
         content_bounds: Rectangle,
     ) -> Vector {
@@ -1258,7 +1254,7 @@ impl Scrollbars {
     /// Create y and/or x scrollbar(s) if content is overflowing the [`Scrollable`] bounds.
     fn new(
         state: &State,
-        direction: &Direction,
+        direction: Direction,
         bounds: Rectangle,
         content_bounds: Rectangle,
     ) -> Self {
@@ -1327,6 +1323,7 @@ impl Scrollbars {
                 scroller: internals::Scroller {
                     bounds: scroller_bounds,
                 },
+                alignment: vertical.alignment,
             })
         } else {
             None
@@ -1387,6 +1384,7 @@ impl Scrollbars {
                 scroller: internals::Scroller {
                     bounds: scroller_bounds,
                 },
+                alignment: horizontal.alignment,
             })
         } else {
             None
@@ -1450,39 +1448,17 @@ impl Scrollbars {
     }
 }
 
-fn aligned_delta(
-    delta: Vector,
-    vertical_alignment: Alignment,
-    horizontal_alignment: Alignment,
-) -> Vector {
-    let align = |alignment: Alignment, delta: f32| match alignment {
-        Alignment::Start => delta,
-        Alignment::End => -delta,
-    };
-
-    Vector::new(
-        align(horizontal_alignment, delta.x),
-        align(vertical_alignment, delta.y),
-    )
-}
-
 pub(super) mod internals {
     use crate::core::{Point, Rectangle};
 
     use super::Alignment;
 
-    /// The scrollbar of a [`Scrollable`].
     #[derive(Debug, Copy, Clone)]
     pub struct Scrollbar {
-        /// The total bounds of the [`Scrollbar`], including the scrollbar, the scroller,
-        /// and the scrollbar margin.
         pub total_bounds: Rectangle,
-
-        /// The bounds of just the [`Scrollbar`].
         pub bounds: Rectangle,
-
-        /// The state of this scrollbar's [`Scroller`].
         pub scroller: Scroller,
+        pub alignment: Alignment,
     }
 
     impl Scrollbar {
@@ -1496,7 +1472,6 @@ pub(super) mod internals {
             &self,
             grabbed_at: f32,
             cursor_position: Point,
-            alignment: Alignment,
         ) -> f32 {
             let pct = if cursor_position.x < 0.0 && cursor_position.y < 0.0 {
                 // cursor position is unavailable! Set to either end or beginning of scrollbar depending
@@ -1509,7 +1484,7 @@ pub(super) mod internals {
                     / (self.bounds.height - self.scroller.bounds.height)
             };
 
-            match alignment {
+            match self.alignment {
                 Alignment::Start => pct,
                 Alignment::End => 1.0 - pct,
             }
@@ -1520,7 +1495,6 @@ pub(super) mod internals {
             &self,
             grabbed_at: f32,
             cursor_position: Point,
-            alignment: Alignment,
         ) -> f32 {
             let pct = if cursor_position.x < 0.0 && cursor_position.y < 0.0 {
                 (self.scroller.bounds.x / self.total_bounds.width).round()
@@ -1531,7 +1505,7 @@ pub(super) mod internals {
                     / (self.bounds.width - self.scroller.bounds.width)
             };
 
-            match alignment {
+            match self.alignment {
                 Alignment::Start => pct,
                 Alignment::End => 1.0 - pct,
             }


### PR DESCRIPTION
This PR adds a new `Alignment` option to both directions of the scrollable. 

It's sometimes preferred to have the content aligned to the end of the scrollable by default, where the offsets are based on the end of the scrollable. New content getting added will cause the scrollable to expand up instead of down. `Alignment::End` enables this behavior. 