### PR TITLE
runtime: Handle widget operations in `program::State` helper

### DIFF
--- a/runtime/src/program/state.rs
+++ b/runtime/src/program/state.rs
@@ -1,7 +1,7 @@
 use crate::core::event::{self, Event};
 use crate::core::mouse;
 use crate::core::renderer;
-use crate::core::widget::operation::{Operation, Outcome};
+use crate::core::widget::operation::{self, Operation};
 use crate::core::{Clipboard, Size};
 use crate::user_interface::{self, UserInterface};
 use crate::{Command, Debug, Program};
@@ -198,11 +198,11 @@ where
                 user_interface.operate(renderer, operation.as_mut());
 
                 match operation.finish() {
-                    Outcome::None => {}
-                    Outcome::Some(message) => {
+                    operation::Outcome::None => {}
+                    operation::Outcome::Some(message) => {
                         self.queued_messages.push(message)
                     }
-                    Outcome::Chain(next) => {
+                    operation::Outcome::Chain(next) => {
                         current_operation = Some(next);
                     }
                 };


### PR DESCRIPTION
This handles widget operations in the `State`-helper. As far as I am aware the shell/window-integrations all use the `UserInterface`-type directly, while the `State`-helper was initially conceived for foreign integrations, like the previously existing `integration_opengl` and `integration_wgpu` examples.
It seems like it hasn't gotten a lot of attention recently, although it is quite convenient for smaller integrations. (I am using this type in [`cosmic-comp`](https://github.com/pop-os/cosmic-comp) to render parts of the shell with iced.)

Given `State` is mostly a convenience type around the `UserInterface` building block and hides that behind it's api, so there is no way to call `UserInterface::operate` from the outside. Additionally it returns `Command`s created by the Widget-Tree unprocessed.
Any `Actions::Widget`-variants derived from these `Command`s containing `Operation`s are thus never processed by the internal `UserInterface` and cannot be passed in from the outside.

This PR fixes this short-coming and thus makes the `State`-helper more useful for integrations. I opted to handle this inside the helper, given that the only sensible thing to do with a `Command` is to convert it into `Action`s anyway (from my limited understanding). Additionally this keeps the `State` api quite simple (as was intended?).
As such `State::update` now filters `Action`s for widget operations and sends those back into the `UserInterface` before returning the rest in a similar vain to the commands previously.

I know I have skipped reaching out or opening an RFC, but I have no problem with this PR being rejected, if another way to solve this is preferred. It was a relatively small and easy change and quick to prototype.
I hope to get some discussion on how to best fix this limitation started. I am happy to solve this a different, e.g. if it would be preferred to add a `operate`-function to the `State`-type instead or make it possible to access the internal `Cache`/`UserInterface`.
Alternatively `State` could be dropped if not deemed useful enough any more, but for strongly advocate for keeping it for simpler integrations. It is a pretty nice api apart from this limitation. :)