### PR TITLE
Make the subscription::channel function take a FnOnce non Sync closure

### DIFF
--- a/futures/src/subscription.rs
+++ b/futures/src/subscription.rs
@@ -417,7 +417,7 @@ where
 pub fn channel<I, Fut, Message>(
     id: I,
     size: usize,
-    f: impl Fn(mpsc::Sender<Message>) -> Fut + MaybeSend + Sync + 'static,
+    f: impl FnOnce(mpsc::Sender<Message>) -> Fut + MaybeSend + 'static,
 ) -> Subscription<Message>
 where
     I: Hash + 'static,


### PR DESCRIPTION
This gives the user more flexibility on the implementation of the closure passed into the `subscription::channel` function. Specifically, it allows a `std::sync::mpsc::Sender<T>` (and other non-Sync types) to be passed into the closure without requiring it to be cloned inside the normal closure but outside the async closure. Also it allows it to be a `Sender` instead of a `SyncSender`.

For example [this code](https://pastebin.com/HsTGZRmM) compiles with this patch but not without it. Without this patch I have to use a `SyncSender` (or tokio) and make another clone of the sender inside the normal closure but outside the async closure [like this](https://pastebin.com/mLXBPU87).

hecrj, you may remember seeing similar code before. This is slightly modified from [this discord question](https://discord.com/channels/628993209984614400/1114719092822245458/1114719092822245458).

Please note: I'm new to the iced code base and still learning about concurrency in rust. I'm going by intuition and the compiler saying this works. So I realize there may be reasons this should not be done.