### PR TITLE
RFC: Improve text measuring in tiny_skia

### DIFF
--- a/tiny_skia/src/text.rs
+++ b/tiny_skia/src/text.rs
@@ -163,14 +163,11 @@ impl Pipeline {
             },
         );
 
-        let (total_lines, max_width) = paragraph
+        paragraph
             .layout_runs()
-            .enumerate()
-            .fold((0, 0.0), |(_, max), (i, buffer)| {
-                (i + 1, buffer.line_w.max(max))
-            });
-
-        (max_width, line_height * total_lines as f32)
+            .fold((0.0, 0.0), |(max, _), buffer| {
+                (buffer.line_w.max(max), buffer.line_y)
+            })
     }
 
     pub fn hit_test(


### PR DESCRIPTION
It appears that the `Backend.measure` function in `iced_tiny_skia` measures the width of a given `Buffer` correctly, but not it's height. It doesn't take into account characters that could overflow, or characters that are not perfectly within the given font size.

I *believe* that making the changes proposed in this PR would remedy this issue, but I'm not entirely sure. Hence the RFC.

Thank you for your consideration 