### PR TITLE
Subpixel glyph positioning and layout linearity

### DIFF
--- a/graphics/src/backend.rs
+++ b/graphics/src/backend.rs
@@ -6,18 +6,6 @@ use iced_core::{Font, Point, Size};
 
 use std::borrow::Cow;
 
-/// The graphics backend of a [`Renderer`].
-///
-/// [`Renderer`]: crate::Renderer
-pub trait Backend {
-    /// Trims the measurements cache.
-    ///
-    /// This method is currently necessary to properly trim the text cache in
-    /// `iced_wgpu` and `iced_glow` because of limitations in the text rendering
-    /// pipeline. It will be removed in the future.
-    fn trim_measurements(&mut self) {}
-}
-
 /// A graphics backend that supports text rendering.
 pub trait Text {
     /// The icon font of the backend.

--- a/graphics/src/lib.rs
+++ b/graphics/src/lib.rs
@@ -41,7 +41,6 @@ pub mod geometry;
 pub mod image;
 
 pub use antialiasing::Antialiasing;
-pub use backend::Backend;
 pub use compositor::Compositor;
 pub use error::Error;
 pub use gradient::Gradient;

--- a/graphics/src/renderer.rs
+++ b/graphics/src/renderer.rs
@@ -1,5 +1,5 @@
 //! Create a renderer from a [`Backend`].
-use crate::backend::{self, Backend};
+use crate::backend;
 use crate::Primitive;
 
 use iced_core::image;
@@ -16,13 +16,13 @@ use std::marker::PhantomData;
 
 /// A backend-agnostic renderer that supports all the built-in widgets.
 #[derive(Debug)]
-pub struct Renderer<B: Backend, Theme> {
+pub struct Renderer<B, Theme> {
     backend: B,
     primitives: Vec<Primitive>,
     theme: PhantomData<Theme>,
 }
 
-impl<B: Backend, T> Renderer<B, T> {
+impl<B, T> Renderer<B, T> {
     /// Creates a new [`Renderer`] from the given [`Backend`].
     pub fn new(backend: B) -> Self {
         Self {
@@ -52,10 +52,7 @@ impl<B: Backend, T> Renderer<B, T> {
     }
 }
 
-impl<B, T> iced_core::Renderer for Renderer<B, T>
-where
-    B: Backend,
-{
+impl<B, T> iced_core::Renderer for Renderer<B, T> {
     type Theme = T;
 
     fn layout<Message>(
@@ -63,11 +60,7 @@ where
         element: &Element<'_, Message, Self>,
         limits: &layout::Limits,
     ) -> layout::Node {
-        let layout = element.as_widget().layout(self, limits);
-
-        self.backend.trim_measurements();
-
-        layout
+        element.as_widget().layout(self, limits)
     }
 
     fn with_layer(&mut self, bounds: Rectangle, f: impl FnOnce(&mut Self)) {
@@ -116,7 +109,7 @@ where
 
 impl<B, T> text::Renderer for Renderer<B, T>
 where
-    B: Backend + backend::Text,
+    B: backend::Text,
 {
     type Font = Font;
 
@@ -195,7 +188,7 @@ where
 
 impl<B, T> image::Renderer for Renderer<B, T>
 where
-    B: Backend + backend::Image,
+    B: backend::Image,
 {
     type Handle = image::Handle;
 
@@ -210,7 +203,7 @@ where
 
 impl<B, T> svg::Renderer for Renderer<B, T>
 where
-    B: Backend + backend::Svg,
+    B: backend::Svg,
 {
     fn dimensions(&self, handle: &svg::Handle) -> Size<u32> {
         self.backend().viewport_dimensions(handle)
@@ -231,10 +224,7 @@ where
 }
 
 #[cfg(feature = "geometry")]
-impl<B, T> crate::geometry::Renderer for Renderer<B, T>
-where
-    B: Backend,
-{
+impl<B, T> crate::geometry::Renderer for Renderer<B, T> {
     fn draw(&mut self, layers: Vec<crate::Geometry>) {
         self.primitives
             .extend(layers.into_iter().map(crate::Geometry::into));

--- a/renderer/src/backend.rs
+++ b/renderer/src/backend.rs
@@ -21,12 +21,6 @@ macro_rules! delegate {
     };
 }
 
-impl iced_graphics::Backend for Backend {
-    fn trim_measurements(&mut self) {
-        delegate!(self, backend, backend.trim_measurements());
-    }
-}
-
 impl backend::Text for Backend {
     const ICON_FONT: Font = Font::with_name("Iced-Icons");
     const CHECKMARK_ICON: char = '\u{f00c}';

--- a/tiny_skia/Cargo.toml
+++ b/tiny_skia/Cargo.toml
@@ -24,7 +24,7 @@ features = ["tiny-skia"]
 
 [dependencies.cosmic-text]
 git = "https://github.com/hecrj/cosmic-text.git"
-rev = "e8b10fd675832cb9c1cc9de30922beb4cf883876"
+rev = "c3cd24dc972bb8fd55d016c81ac9fa637e0a4ada"
 
 [dependencies.twox-hash]
 version = "1.6"

--- a/tiny_skia/src/backend.rs
+++ b/tiny_skia/src/backend.rs
@@ -658,12 +658,6 @@ fn adjust_clip_mask(clip_mask: &mut tiny_skia::Mask, bounds: Rectangle) {
     );
 }
 
-impl iced_graphics::Backend for Backend {
-    fn trim_measurements(&mut self) {
-        self.text_pipeline.trim_measurement_cache();
-    }
-}
-
 impl backend::Text for Backend {
     const ICON_FONT: Font = Font::with_name("Iced-Icons");
     const CHECKMARK_ICON: char = '\u{f00c}';

--- a/tiny_skia/src/text.rs
+++ b/tiny_skia/src/text.rs
@@ -36,6 +36,8 @@ impl Pipeline {
         self.font_system.get_mut().db_mut().load_font_source(
             cosmic_text::fontdb::Source::Binary(Arc::new(bytes.into_owned())),
         );
+
+        self.cache = RefCell::new(Cache::new());
     }
 
     pub fn draw(

--- a/tiny_skia/src/text.rs
+++ b/tiny_skia/src/text.rs
@@ -14,8 +14,7 @@ use std::sync::Arc;
 pub struct Pipeline {
     font_system: RefCell<cosmic_text::FontSystem>,
     glyph_cache: GlyphCache,
-    measurement_cache: RefCell<Cache>,
-    render_cache: Cache,
+    cache: RefCell<Cache>,
 }
 
 impl Pipeline {
@@ -29,8 +28,7 @@ impl Pipeline {
                 .into_iter(),
             )),
             glyph_cache: GlyphCache::new(),
-            measurement_cache: RefCell::new(Cache::new()),
-            render_cache: Cache::new(),
+            cache: RefCell::new(Cache::new()),
         }
     }
 
@@ -55,20 +53,11 @@ impl Pipeline {
         pixels: &mut tiny_skia::PixmapMut<'_>,
         clip_mask: Option<&tiny_skia::Mask>,
     ) {
-        let line_height =
-            f32::from(line_height.to_absolute(Pixels(size))) * scale_factor;
-
-        let bounds = bounds * scale_factor;
-        let size = size * scale_factor;
+        let line_height = f32::from(line_height.to_absolute(Pixels(size)));
 
         let font_system = self.font_system.get_mut();
         let key = Key {
-            bounds: {
-                let size = bounds.size();
-
-                // TODO: Reuse buffers from layouting
-                Size::new(size.width.ceil(), size.height.ceil())
-            },
+            bounds: bounds.size(),
             content,
             font,
             size,
@@ -76,7 +65,7 @@ impl Pipeline {
             shaping,
         };
 
-        let (_, buffer) = self.render_cache.allocate(font_system, key);
+        let (_, buffer) = self.cache.get_mut().allocate(font_system, key);
 
         let (total_lines, max_width) = buffer
             .layout_runs()
@@ -85,7 +74,10 @@ impl Pipeline {
                 (i + 1, buffer.line_w.max(max))
             });
 
-        let total_height = total_lines as f32 * line_height;
+        let total_height = total_lines as f32 * line_height * scale_factor;
+        let max_width = max_width * scale_factor;
+
+        let bounds = bounds * scale_factor;
 
         let x = match horizontal_alignment {
             alignment::Horizontal::Left => bounds.x,
@@ -99,16 +91,14 @@ impl Pipeline {
             alignment::Vertical::Bottom => bounds.y - total_height,
         };
 
-        // TODO: Subpixel glyph positioning
-        let x = x.round() as i32;
-        let y = y.round() as i32;
-
         let mut swash = cosmic_text::SwashCache::new();
 
         for run in buffer.layout_runs() {
             for glyph in run.glyphs {
+                let physical_glyph = glyph.physical((x, y), scale_factor);
+
                 if let Some((buffer, placement)) = self.glyph_cache.allocate(
-                    glyph.cache_key,
+                    physical_glyph.cache_key,
                     color,
                     font_system,
                     &mut swash,
@@ -121,8 +111,9 @@ impl Pipeline {
                     .expect("Create glyph pixel map");
 
                     pixels.draw_pixmap(
-                        x + glyph.x_int + placement.left,
-                        y - glyph.y_int - placement.top + run.line_y as i32,
+                        physical_glyph.x + placement.left,
+                        physical_glyph.y - placement.top
+                            + (run.line_y * scale_factor).round() as i32,
                         pixmap,
                         &tiny_skia::PixmapPaint::default(),
                         tiny_skia::Transform::identity(),
@@ -134,7 +125,7 @@ impl Pipeline {
     }
 
     pub fn trim_cache(&mut self) {
-        self.render_cache.trim();
+        self.cache.get_mut().trim();
         self.glyph_cache.trim();
     }
 
@@ -147,7 +138,7 @@ impl Pipeline {
         bounds: Size,
         shaping: Shaping,
     ) -> (f32, f32) {
-        let mut measurement_cache = self.measurement_cache.borrow_mut();
+        let mut measurement_cache = self.cache.borrow_mut();
 
         let line_height = f32::from(line_height.to_absolute(Pixels(size)));
 
@@ -184,7 +175,7 @@ impl Pipeline {
         point: Point,
         _nearest_only: bool,
     ) -> Option<Hit> {
-        let mut measurement_cache = self.measurement_cache.borrow_mut();
+        let mut measurement_cache = self.cache.borrow_mut();
 
         let line_height = f32::from(line_height.to_absolute(Pixels(size)));
 
@@ -203,10 +194,6 @@ impl Pipeline {
         let cursor = paragraph.hit(point.x, point.y)?;
 
         Some(Hit::CharOffset(cursor.index))
-    }
-
-    pub fn trim_measurement_cache(&mut self) {
-        self.measurement_cache.borrow_mut().trim();
     }
 }
 

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -45,7 +45,7 @@ path = "../graphics"
 [dependencies.glyphon]
 version = "0.2"
 git = "https://github.com/hecrj/glyphon.git"
-rev = "8dbf36020e5759fa9144517b321372266160113e"
+rev = "8324f20158a62f8520bad4ed09f6aa5552f8f2a6"
 
 [dependencies.glam]
 version = "0.24"

--- a/wgpu/src/backend.rs
+++ b/wgpu/src/backend.rs
@@ -334,12 +334,6 @@ impl Backend {
     }
 }
 
-impl iced_graphics::Backend for Backend {
-    fn trim_measurements(&mut self) {
-        self.text_pipeline.trim_measurement_cache()
-    }
-}
-
 impl backend::Text for Backend {
     const ICON_FONT: Font = Font::with_name("Iced-Icons");
     const CHECKMARK_ICON: char = '\u{f00c}';

--- a/wgpu/src/text.rs
+++ b/wgpu/src/text.rs
@@ -54,6 +54,8 @@ impl Pipeline {
         let _ = self.font_system.get_mut().db_mut().load_font_source(
             glyphon::fontdb::Source::Binary(Arc::new(bytes.into_owned())),
         );
+
+        self.cache = RefCell::new(Cache::new());
     }
 
     pub fn prepare(


### PR DESCRIPTION
Depends on https://github.com/pop-os/cosmic-text/pull/143.

The changes in this PR leverage the layout linearity properties from `cosmic-text` to unify the measurement and rendering caches in our text pipelines, offsetting and scaling glyphs during rendering.

This should fix any layout inconsistencies between measuring (in logical units) and rendering (in physical units).

Fixes #308.