### PR TITLE
Fix `translation` in `layout` of `Nested` overlay

### DIFF
--- a/runtime/src/overlay/nested.rs
+++ b/runtime/src/overlay/nested.rs
@@ -42,7 +42,7 @@ where
         where
             Renderer: renderer::Renderer,
         {
-            let translation = position - element.position();
+            let translation = position - Point::ORIGIN;
 
             let node = element.layout(renderer, bounds, translation);
 


### PR DESCRIPTION
Fixes #1923.