### PR TITLE
Update `ouroboros` dependency

### DIFF
--- a/widget/Cargo.toml
+++ b/widget/Cargo.toml
@@ -28,7 +28,7 @@ version = "0.8"
 path = "../style"
 
 [dependencies.ouroboros]
-version = "0.13"
+version = "0.17"
 optional = true
 
 [dependencies.qrcode]

--- a/widget/src/lazy.rs
+++ b/widget/src/lazy.rs
@@ -279,11 +279,7 @@ where
 }
 
 #[self_referencing]
-struct Inner<'a, Message, Renderer>
-where
-    Message: 'a,
-    Renderer: 'a,
-{
+struct Inner<'a, Message: 'a, Renderer: 'a> {
     cell: Rc<RefCell<Option<Element<'static, Message, Renderer>>>>,
     element: Element<'static, Message, Renderer>,
     tree: &'a mut Tree,


### PR DESCRIPTION
Apparently, `< 0.16` versions are unsound.