### PR TITLE
Made Color struct serializable

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/iced-rs/iced"
 bitflags = "1.2"
 thiserror = "1"
 log = "0.4.17"
+serde = { version = "1.0", features = ["derive"] }
 twox-hash = { version = "1.5", default-features = false }
 
 [dependencies.palette]

--- a/core/src/color.rs
+++ b/core/src/color.rs
@@ -1,8 +1,10 @@
+use serde::{Serialize, Deserialize};
+
 #[cfg(feature = "palette")]
 use palette::rgb::{Srgb, Srgba};
 
 /// A color in the sRGB color space.
-#[derive(Debug, Clone, Copy, PartialEq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Default, Serialize, Deserialize)]
 pub struct Color {
     /// Red component, 0.0 - 1.0
     pub r: f32,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -22,7 +22,8 @@
     clippy::new_without_default,
     clippy::useless_conversion
 )]
-#![forbid(unsafe_code, rust_2018_idioms)]
+#![forbid(unsafe_code)]
+#![warn(rust_2018_idioms)]
 #![allow(clippy::inherent_to_string, clippy::type_complexity)]
 pub mod alignment;
 pub mod clipboard;


### PR DESCRIPTION
I needed to Serialize the color struct for configuration files. Not sure why the forbid rust 2018 idioms thing caused it to fail, because I changed that to warn and nothing came up, but that is what I had to do to make it compile