### PR TITLE
Minor grammar correction

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -69,8 +69,8 @@ body:
   - type: dropdown
     id: os
     attributes:
-      label: Operative System
-      description: Which operative system are you using?
+      label: Operating System
+      description: Which operating system are you using?
       options:
         - Windows
         - macOS


### PR DESCRIPTION
This morning I was improving the issue templates of my repo, taking inspiration from your bug report template.
While doing so, I noticed a minor grammar error.
The correct version in English is _Operating_ System.