### PR TITLE
Backend-specific primitives

### DIFF
--- a/core/src/renderer.rs
+++ b/core/src/renderer.rs
@@ -5,25 +5,12 @@ mod null;
 #[cfg(debug_assertions)]
 pub use null::Null;
 
-use crate::layout;
-use crate::{Background, BorderRadius, Color, Element, Rectangle, Vector};
+use crate::{Background, BorderRadius, Color, Rectangle, Vector};
 
 /// A component that can be used by widgets to draw themselves on a screen.
 pub trait Renderer: Sized {
     /// The supported theme of the [`Renderer`].
     type Theme;
-
-    /// Lays out the elements of a user interface.
-    ///
-    /// You should override this if you need to perform any operations before or
-    /// after layouting. For instance, trimming the measurements cache.
-    fn layout<Message>(
-        &mut self,
-        element: &Element<'_, Message, Self>,
-        limits: &layout::Limits,
-    ) -> layout::Node {
-        element.as_widget().layout(self, limits)
-    }
 
     /// Draws the primitives recorded in the given closure in a new layer.
     ///

--- a/examples/geometry/Cargo.toml
+++ b/examples/geometry/Cargo.toml
@@ -7,4 +7,3 @@ publish = false
 
 [dependencies]
 iced = { path = "../..", features = ["advanced"] }
-iced_graphics = { path = "../../graphics" }

--- a/examples/geometry/src/main.rs
+++ b/examples/geometry/src/main.rs
@@ -1,9 +1,8 @@
 //! This example showcases a simple native custom widget that renders using
 //! arbitrary low-level geometry.
 mod rainbow {
-    use iced_graphics::primitive::{ColoredVertex2D, Primitive};
-
     use iced::advanced::graphics::color;
+    use iced::advanced::graphics::primitive::{ColoredVertex2D, Primitive};
     use iced::advanced::layout::{self, Layout};
     use iced::advanced::renderer;
     use iced::advanced::widget::{self, Widget};
@@ -46,8 +45,8 @@ mod rainbow {
             cursor: mouse::Cursor,
             _viewport: &Rectangle,
         ) {
+            use iced::advanced::graphics::primitive::Mesh2D;
             use iced::advanced::Renderer as _;
-            use iced_graphics::primitive::Mesh2D;
 
             let bounds = layout.bounds();
 
@@ -135,7 +134,7 @@ mod rainbow {
             renderer.with_translation(
                 Vector::new(bounds.x, bounds.y),
                 |renderer| {
-                    renderer.draw_primitive(mesh);
+                    renderer.draw_with_wgpu(mesh);
                 },
             );
         }

--- a/examples/geometry/src/main.rs
+++ b/examples/geometry/src/main.rs
@@ -2,7 +2,6 @@
 //! arbitrary low-level geometry.
 mod rainbow {
     use iced::advanced::graphics::color;
-    use iced::advanced::graphics::primitive::{ColoredVertex2D, Primitive};
     use iced::advanced::layout::{self, Layout};
     use iced::advanced::renderer;
     use iced::advanced::widget::{self, Widget};
@@ -45,7 +44,7 @@ mod rainbow {
             cursor: mouse::Cursor,
             _viewport: &Rectangle,
         ) {
-            use iced::advanced::graphics::primitive::Mesh2D;
+            use iced::advanced::graphics::mesh::{self, Mesh, SolidVertex2D};
             use iced::advanced::Renderer as _;
 
             let bounds = layout.bounds();
@@ -77,43 +76,43 @@ mod rainbow {
             let posn_bl = [0.0, bounds.height];
             let posn_l = [0.0, bounds.height / 2.0];
 
-            let mesh = Primitive::SolidMesh {
+            let mesh = Mesh::Solid {
                 size: bounds.size(),
-                buffers: Mesh2D {
+                buffers: mesh::Indexed {
                     vertices: vec![
-                        ColoredVertex2D {
+                        SolidVertex2D {
                             position: posn_center,
                             color: color::pack([1.0, 1.0, 1.0, 1.0]),
                         },
-                        ColoredVertex2D {
+                        SolidVertex2D {
                             position: posn_tl,
                             color: color::pack(color_r),
                         },
-                        ColoredVertex2D {
+                        SolidVertex2D {
                             position: posn_t,
                             color: color::pack(color_o),
                         },
-                        ColoredVertex2D {
+                        SolidVertex2D {
                             position: posn_tr,
                             color: color::pack(color_y),
                         },
-                        ColoredVertex2D {
+                        SolidVertex2D {
                             position: posn_r,
                             color: color::pack(color_g),
                         },
-                        ColoredVertex2D {
+                        SolidVertex2D {
                             position: posn_br,
                             color: color::pack(color_gb),
                         },
-                        ColoredVertex2D {
+                        SolidVertex2D {
                             position: posn_b,
                             color: color::pack(color_b),
                         },
-                        ColoredVertex2D {
+                        SolidVertex2D {
                             position: posn_bl,
                             color: color::pack(color_i),
                         },
-                        ColoredVertex2D {
+                        SolidVertex2D {
                             position: posn_l,
                             color: color::pack(color_v),
                         },
@@ -134,7 +133,7 @@ mod rainbow {
             renderer.with_translation(
                 Vector::new(bounds.x, bounds.y),
                 |renderer| {
-                    renderer.draw_with_wgpu(mesh);
+                    renderer.draw_mesh(mesh);
                 },
             );
         }

--- a/examples/loading_spinners/src/circular.rs
+++ b/examples/loading_spinners/src/circular.rs
@@ -358,7 +358,9 @@ where
         renderer.with_translation(
             Vector::new(bounds.x, bounds.y),
             |renderer| {
-                renderer.draw_primitive(geometry.0);
+                use iced::advanced::graphics::geometry::Renderer as _;
+
+                renderer.draw(vec![geometry]);
             },
         );
     }

--- a/graphics/Cargo.toml
+++ b/graphics/Cargo.toml
@@ -32,10 +32,6 @@ features = ["derive"]
 version = "0.9"
 path = "../core"
 
-[dependencies.tiny-skia]
-version = "0.9"
-optional = true
-
 [dependencies.image]
 version = "0.24"
 optional = true

--- a/graphics/src/backend.rs
+++ b/graphics/src/backend.rs
@@ -10,6 +10,7 @@ use std::borrow::Cow;
 ///
 /// [`Renderer`]: crate::Renderer
 pub trait Backend {
+    /// The custom kind of primitives this [`Backend`] supports.
     type Primitive;
 }
 

--- a/graphics/src/backend.rs
+++ b/graphics/src/backend.rs
@@ -6,6 +6,13 @@ use iced_core::{Font, Point, Size};
 
 use std::borrow::Cow;
 
+/// The graphics backend of a [`Renderer`].
+///
+/// [`Renderer`]: crate::Renderer
+pub trait Backend {
+    type Primitive;
+}
+
 /// A graphics backend that supports text rendering.
 pub trait Text {
     /// The icon font of the backend.

--- a/graphics/src/damage.rs
+++ b/graphics/src/damage.rs
@@ -5,6 +5,7 @@ use crate::Primitive;
 
 use std::sync::Arc;
 
+/// A type that has some damage bounds.
 pub trait Damage: PartialEq {
     /// Returns the bounds of the [`Damage`].
     fn bounds(&self) -> Rectangle;

--- a/graphics/src/damage.rs
+++ b/graphics/src/damage.rs
@@ -43,9 +43,6 @@ impl<T: Damage> Damage for Primitive<T> {
             | Self::Image { bounds, .. }
             | Self::Svg { bounds, .. } => bounds.expand(1.0),
             Self::Clip { bounds, .. } => bounds.expand(1.0),
-            Self::SolidMesh { size, .. } | Self::GradientMesh { size, .. } => {
-                Rectangle::with_size(*size)
-            }
             Self::Group { primitives } => primitives
                 .iter()
                 .map(Self::bounds)

--- a/graphics/src/geometry.rs
+++ b/graphics/src/geometry.rs
@@ -14,20 +14,10 @@ pub use text::Text;
 
 pub use crate::gradient::{self, Gradient};
 
-use crate::Primitive;
-
-/// A bunch of shapes that can be drawn.
-#[derive(Debug, Clone)]
-pub struct Geometry(pub Primitive);
-
-impl From<Geometry> for Primitive {
-    fn from(geometry: Geometry) -> Self {
-        geometry.0
-    }
-}
-
 /// A renderer capable of drawing some [`Geometry`].
 pub trait Renderer: crate::core::Renderer {
+    type Geometry;
+
     /// Draws the given layers of [`Geometry`].
-    fn draw(&mut self, layers: Vec<Geometry>);
+    fn draw(&mut self, layers: Vec<Self::Geometry>);
 }

--- a/graphics/src/geometry.rs
+++ b/graphics/src/geometry.rs
@@ -16,6 +16,7 @@ pub use crate::gradient::{self, Gradient};
 
 /// A renderer capable of drawing some [`Geometry`].
 pub trait Renderer: crate::core::Renderer {
+    /// The kind of geometry this renderer can draw.
     type Geometry;
 
     /// Draws the given layers of [`Geometry`].

--- a/graphics/src/gradient.rs
+++ b/graphics/src/gradient.rs
@@ -7,6 +7,7 @@ use crate::color;
 use crate::core::gradient::ColorStop;
 use crate::core::{self, Color, Point, Rectangle};
 
+use bytemuck::{Pod, Zeroable};
 use half::f16;
 use std::cmp::Ordering;
 
@@ -135,7 +136,7 @@ impl Linear {
 }
 
 /// Packed [`Gradient`] data for use in shader code.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Zeroable, Pod)]
 #[repr(C)]
 pub struct Packed {
     // 8 colors, each channel = 16 bit float, 2 colors packed into 1 u32

--- a/graphics/src/lib.rs
+++ b/graphics/src/lib.rs
@@ -8,8 +8,8 @@
     html_logo_url = "https://raw.githubusercontent.com/iced-rs/iced/9ab6923e943f784985e9ef9ca28b10278297225d/docs/logo.svg"
 )]
 #![deny(
-    missing_debug_implementations,
-    missing_docs,
+    //missing_debug_implementations,
+    //missing_docs,
     unsafe_code,
     unused_results,
     clippy::extra_unused_lifetimes,
@@ -41,15 +41,14 @@ pub mod geometry;
 pub mod image;
 
 pub use antialiasing::Antialiasing;
+pub use backend::Backend;
 pub use compositor::Compositor;
+pub use damage::Damage;
 pub use error::Error;
 pub use gradient::Gradient;
 pub use primitive::Primitive;
 pub use renderer::Renderer;
 pub use transformation::Transformation;
 pub use viewport::Viewport;
-
-#[cfg(feature = "geometry")]
-pub use geometry::Geometry;
 
 pub use iced_core as core;

--- a/graphics/src/lib.rs
+++ b/graphics/src/lib.rs
@@ -8,8 +8,8 @@
     html_logo_url = "https://raw.githubusercontent.com/iced-rs/iced/9ab6923e943f784985e9ef9ca28b10278297225d/docs/logo.svg"
 )]
 #![deny(
-    //missing_debug_implementations,
-    //missing_docs,
+    missing_debug_implementations,
+    missing_docs,
     unsafe_code,
     unused_results,
     clippy::extra_unused_lifetimes,
@@ -23,6 +23,7 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 mod antialiasing;
 mod error;
+mod primitive;
 mod transformation;
 mod viewport;
 
@@ -32,7 +33,6 @@ pub mod compositor;
 pub mod damage;
 pub mod gradient;
 pub mod mesh;
-pub mod primitive;
 pub mod renderer;
 
 #[cfg(feature = "geometry")]

--- a/graphics/src/lib.rs
+++ b/graphics/src/lib.rs
@@ -31,6 +31,7 @@ pub mod color;
 pub mod compositor;
 pub mod damage;
 pub mod gradient;
+pub mod mesh;
 pub mod primitive;
 pub mod renderer;
 
@@ -46,6 +47,7 @@ pub use compositor::Compositor;
 pub use damage::Damage;
 pub use error::Error;
 pub use gradient::Gradient;
+pub use mesh::Mesh;
 pub use primitive::Primitive;
 pub use renderer::Renderer;
 pub use transformation::Transformation;

--- a/graphics/src/mesh.rs
+++ b/graphics/src/mesh.rs
@@ -1,0 +1,75 @@
+use crate::color;
+use crate::core::{Rectangle, Size};
+use crate::gradient;
+use crate::Damage;
+
+use bytemuck::{Pod, Zeroable};
+
+/// A low-level primitive to render a mesh of triangles.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Mesh {
+    /// A mesh with a solid color.
+    Solid {
+        /// The vertices and indices of the mesh.
+        buffers: Indexed<SolidVertex2D>,
+
+        /// The size of the drawable region of the mesh.
+        ///
+        /// Any geometry that falls out of this region will be clipped.
+        size: Size,
+    },
+    /// A mesh with a gradient.
+    Gradient {
+        /// The vertices and indices of the mesh.
+        buffers: Indexed<GradientVertex2D>,
+
+        /// The size of the drawable region of the mesh.
+        ///
+        /// Any geometry that falls out of this region will be clipped.
+        size: Size,
+    },
+}
+
+impl Damage for Mesh {
+    fn bounds(&self) -> Rectangle {
+        match self {
+            Self::Solid { size, .. } | Self::Gradient { size, .. } => {
+                Rectangle::with_size(*size)
+            }
+        }
+    }
+}
+
+/// A set of [`Vertex2D`] and indices representing a list of triangles.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Indexed<T> {
+    /// The vertices of the mesh
+    pub vertices: Vec<T>,
+
+    /// The list of vertex indices that defines the triangles of the mesh.
+    ///
+    /// Therefore, this list should always have a length that is a multiple of 3.
+    pub indices: Vec<u32>,
+}
+
+/// A two-dimensional vertex with a color.
+#[derive(Copy, Clone, Debug, PartialEq, Zeroable, Pod)]
+#[repr(C)]
+pub struct SolidVertex2D {
+    /// The vertex position in 2D space.
+    pub position: [f32; 2],
+
+    /// The color of the vertex in __linear__ RGBA.
+    pub color: color::Packed,
+}
+
+/// A vertex which contains 2D position & packed gradient data.
+#[derive(Copy, Clone, Debug, PartialEq, Zeroable, Pod)]
+#[repr(C)]
+pub struct GradientVertex2D {
+    /// The vertex position in 2D space.
+    pub position: [f32; 2],
+
+    /// The packed vertex data of the gradient.
+    pub gradient: gradient::Packed,
+}

--- a/graphics/src/mesh.rs
+++ b/graphics/src/mesh.rs
@@ -1,3 +1,4 @@
+//! Draw triangles!
 use crate::color;
 use crate::core::{Rectangle, Size};
 use crate::gradient;

--- a/graphics/src/primitive.rs
+++ b/graphics/src/primitive.rs
@@ -1,13 +1,10 @@
 //! Draw using different graphical primitives.
-use crate::color;
 use crate::core::alignment;
 use crate::core::image;
 use crate::core::svg;
 use crate::core::text;
-use crate::core::{Background, Color, Font, Rectangle, Size, Vector};
-use crate::gradient;
+use crate::core::{Background, Color, Font, Rectangle, Vector};
 
-use bytemuck::{Pod, Zeroable};
 use std::sync::Arc;
 
 /// A rendering primitive.
@@ -65,30 +62,6 @@ pub enum Primitive<T> {
         /// The bounds of the viewport
         bounds: Rectangle,
     },
-    /// A low-level primitive to render a mesh of triangles with a solid color.
-    ///
-    /// It can be used to render many kinds of geometry freely.
-    SolidMesh {
-        /// The vertices and indices of the mesh.
-        buffers: Mesh2D<ColoredVertex2D>,
-
-        /// The size of the drawable region of the mesh.
-        ///
-        /// Any geometry that falls out of this region will be clipped.
-        size: Size,
-    },
-    /// A low-level primitive to render a mesh of triangles with a gradient.
-    ///
-    /// It can be used to render many kinds of geometry freely.
-    GradientMesh {
-        /// The vertices and indices of the mesh.
-        buffers: Mesh2D<GradientVertex2D>,
-
-        /// The size of the drawable region of the mesh.
-        ///
-        /// Any geometry that falls out of this region will be clipped.
-        size: Size,
-    },
     /// A group of primitives
     Group {
         /// The primitives of the group
@@ -143,43 +116,3 @@ impl<T> Primitive<T> {
         }
     }
 }
-
-/// A set of [`Vertex2D`] and indices representing a list of triangles.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Mesh2D<T> {
-    /// The vertices of the mesh
-    pub vertices: Vec<T>,
-
-    /// The list of vertex indices that defines the triangles of the mesh.
-    ///
-    /// Therefore, this list should always have a length that is a multiple of 3.
-    pub indices: Vec<u32>,
-}
-
-/// A two-dimensional vertex with a color.
-#[derive(Copy, Clone, Debug, PartialEq, Zeroable, Pod)]
-#[repr(C)]
-pub struct ColoredVertex2D {
-    /// The vertex position in 2D space.
-    pub position: [f32; 2],
-
-    /// The color of the vertex in __linear__ RGBA.
-    pub color: color::Packed,
-}
-
-/// A vertex which contains 2D position & packed gradient data.
-#[derive(Copy, Clone, Debug, PartialEq)]
-#[repr(C)]
-pub struct GradientVertex2D {
-    /// The vertex position in 2D space.
-    pub position: [f32; 2],
-
-    /// The packed vertex data of the gradient.
-    pub gradient: gradient::Packed,
-}
-
-#[allow(unsafe_code)]
-unsafe impl Zeroable for GradientVertex2D {}
-
-#[allow(unsafe_code)]
-unsafe impl Pod for GradientVertex2D {}

--- a/graphics/src/renderer.rs
+++ b/graphics/src/renderer.rs
@@ -3,13 +3,10 @@ use crate::backend::{self, Backend};
 use crate::Primitive;
 
 use iced_core::image;
-use iced_core::layout;
 use iced_core::renderer;
 use iced_core::svg;
 use iced_core::text::{self, Text};
-use iced_core::{
-    Background, Color, Element, Font, Point, Rectangle, Size, Vector,
-};
+use iced_core::{Background, Color, Font, Point, Rectangle, Size, Vector};
 
 use std::borrow::Cow;
 use std::marker::PhantomData;
@@ -83,14 +80,6 @@ impl<B: Backend, T> Renderer<B, T> {
 
 impl<B: Backend, T> iced_core::Renderer for Renderer<B, T> {
     type Theme = T;
-
-    fn layout<Message>(
-        &mut self,
-        element: &Element<'_, Message, Self>,
-        limits: &layout::Limits,
-    ) -> layout::Node {
-        element.as_widget().layout(self, limits)
-    }
 
     fn with_layer(&mut self, bounds: Rectangle, f: impl FnOnce(&mut Self)) {
         let current = self.start_layer();

--- a/graphics/src/renderer.rs
+++ b/graphics/src/renderer.rs
@@ -1,5 +1,5 @@
 //! Create a renderer from a [`Backend`].
-use crate::backend;
+use crate::backend::{self, Backend};
 use crate::Primitive;
 
 use iced_core::image;
@@ -16,13 +16,13 @@ use std::marker::PhantomData;
 
 /// A backend-agnostic renderer that supports all the built-in widgets.
 #[derive(Debug)]
-pub struct Renderer<B, Theme> {
+pub struct Renderer<B: Backend, Theme> {
     backend: B,
-    primitives: Vec<Primitive>,
+    primitives: Vec<Primitive<B::Primitive>>,
     theme: PhantomData<Theme>,
 }
 
-impl<B, T> Renderer<B, T> {
+impl<B: Backend, T> Renderer<B, T> {
     /// Creates a new [`Renderer`] from the given [`Backend`].
     pub fn new(backend: B) -> Self {
         Self {
@@ -38,7 +38,7 @@ impl<B, T> Renderer<B, T> {
     }
 
     /// Enqueues the given [`Primitive`] in the [`Renderer`] for drawing.
-    pub fn draw_primitive(&mut self, primitive: Primitive) {
+    pub fn draw_primitive(&mut self, primitive: Primitive<B::Primitive>) {
         self.primitives.push(primitive);
     }
 
@@ -46,13 +46,42 @@ impl<B, T> Renderer<B, T> {
     /// of the [`Renderer`].
     pub fn with_primitives<O>(
         &mut self,
-        f: impl FnOnce(&mut B, &[Primitive]) -> O,
+        f: impl FnOnce(&mut B, &[Primitive<B::Primitive>]) -> O,
     ) -> O {
         f(&mut self.backend, &self.primitives)
     }
+
+    pub fn start_layer(&mut self) -> Vec<Primitive<B::Primitive>> {
+        std::mem::take(&mut self.primitives)
+    }
+
+    pub fn end_layer(
+        &mut self,
+        primitives: Vec<Primitive<B::Primitive>>,
+        bounds: Rectangle,
+    ) {
+        let layer = std::mem::replace(&mut self.primitives, primitives);
+
+        self.primitives.push(Primitive::group(layer).clip(bounds));
+    }
+
+    pub fn start_translation(&mut self) -> Vec<Primitive<B::Primitive>> {
+        std::mem::take(&mut self.primitives)
+    }
+
+    pub fn end_translation(
+        &mut self,
+        primitives: Vec<Primitive<B::Primitive>>,
+        translation: Vector,
+    ) {
+        let layer = std::mem::replace(&mut self.primitives, primitives);
+
+        self.primitives
+            .push(Primitive::group(layer).translate(translation));
+    }
 }
 
-impl<B, T> iced_core::Renderer for Renderer<B, T> {
+impl<B: Backend, T> iced_core::Renderer for Renderer<B, T> {
     type Theme = T;
 
     fn layout<Message>(
@@ -64,13 +93,11 @@ impl<B, T> iced_core::Renderer for Renderer<B, T> {
     }
 
     fn with_layer(&mut self, bounds: Rectangle, f: impl FnOnce(&mut Self)) {
-        let current = std::mem::take(&mut self.primitives);
+        let current = self.start_layer();
 
         f(self);
 
-        let layer = std::mem::replace(&mut self.primitives, current);
-
-        self.primitives.push(Primitive::group(layer).clip(bounds));
+        self.end_layer(current, bounds);
     }
 
     fn with_translation(
@@ -78,14 +105,11 @@ impl<B, T> iced_core::Renderer for Renderer<B, T> {
         translation: Vector,
         f: impl FnOnce(&mut Self),
     ) {
-        let current = std::mem::take(&mut self.primitives);
+        let current = self.start_translation();
 
         f(self);
 
-        let layer = std::mem::replace(&mut self.primitives, current);
-
-        self.primitives
-            .push(Primitive::group(layer).translate(translation));
+        self.end_translation(current, translation);
     }
 
     fn fill_quad(
@@ -109,7 +133,7 @@ impl<B, T> iced_core::Renderer for Renderer<B, T> {
 
 impl<B, T> text::Renderer for Renderer<B, T>
 where
-    B: backend::Text,
+    B: Backend + backend::Text,
 {
     type Font = Font;
 
@@ -188,7 +212,7 @@ where
 
 impl<B, T> image::Renderer for Renderer<B, T>
 where
-    B: backend::Image,
+    B: Backend + backend::Image,
 {
     type Handle = image::Handle;
 
@@ -203,7 +227,7 @@ where
 
 impl<B, T> svg::Renderer for Renderer<B, T>
 where
-    B: backend::Svg,
+    B: Backend + backend::Svg,
 {
     fn dimensions(&self, handle: &svg::Handle) -> Size<u32> {
         self.backend().viewport_dimensions(handle)
@@ -220,13 +244,5 @@ where
             color,
             bounds,
         })
-    }
-}
-
-#[cfg(feature = "geometry")]
-impl<B, T> crate::geometry::Renderer for Renderer<B, T> {
-    fn draw(&mut self, layers: Vec<crate::Geometry>) {
-        self.primitives
-            .extend(layers.into_iter().map(crate::Geometry::into));
     }
 }

--- a/graphics/src/renderer.rs
+++ b/graphics/src/renderer.rs
@@ -48,10 +48,12 @@ impl<B: Backend, T> Renderer<B, T> {
         f(&mut self.backend, &self.primitives)
     }
 
+    /// Starts recording a new layer.
     pub fn start_layer(&mut self) -> Vec<Primitive<B::Primitive>> {
         std::mem::take(&mut self.primitives)
     }
 
+    /// Ends the recording of a layer.
     pub fn end_layer(
         &mut self,
         primitives: Vec<Primitive<B::Primitive>>,
@@ -62,10 +64,12 @@ impl<B: Backend, T> Renderer<B, T> {
         self.primitives.push(Primitive::group(layer).clip(bounds));
     }
 
+    /// Starts recording a translation.
     pub fn start_translation(&mut self) -> Vec<Primitive<B::Primitive>> {
         std::mem::take(&mut self.primitives)
     }
 
+    /// Ends the recording of a translation.
     pub fn end_translation(
         &mut self,
         primitives: Vec<Primitive<B::Primitive>>,

--- a/renderer/Cargo.toml
+++ b/renderer/Cargo.toml
@@ -14,6 +14,7 @@ web-colors = ["iced_wgpu?/web-colors"]
 [dependencies]
 raw-window-handle = "0.5"
 thiserror = "1"
+log = "0.4"
 
 [dependencies.iced_graphics]
 version = "0.8"

--- a/renderer/src/geometry/cache.rs
+++ b/renderer/src/geometry/cache.rs
@@ -1,6 +1,5 @@
 use crate::core::Size;
 use crate::geometry::{Frame, Geometry};
-use crate::graphics::Primitive;
 use crate::Renderer;
 
 use std::cell::RefCell;
@@ -21,8 +20,15 @@ enum State {
     Empty,
     Filled {
         bounds: Size,
-        primitive: Arc<Primitive>,
+        primitive: Internal,
     },
+}
+
+#[derive(Debug, Clone)]
+enum Internal {
+    TinySkia(Arc<iced_tiny_skia::Primitive>),
+    #[cfg(feature = "wgpu")]
+    Wgpu(Arc<iced_wgpu::Primitive>),
 }
 
 impl Cache {
@@ -62,9 +68,21 @@ impl Cache {
         } = self.state.borrow().deref()
         {
             if *cached_bounds == bounds {
-                return Geometry(Primitive::Cache {
-                    content: primitive.clone(),
-                });
+                match primitive {
+                    Internal::TinySkia(primitive) => {
+                        return Geometry::TinySkia(
+                            iced_tiny_skia::Primitive::Cache {
+                                content: primitive.clone(),
+                            },
+                        );
+                    }
+                    #[cfg(feature = "wgpu")]
+                    Internal::Wgpu(primitive) => {
+                        return Geometry::Wgpu(iced_wgpu::Primitive::Cache {
+                            content: primitive.clone(),
+                        });
+                    }
+                }
             }
         }
 
@@ -74,7 +92,15 @@ impl Cache {
         let primitive = {
             let geometry = frame.into_geometry();
 
-            Arc::new(geometry.0)
+            match geometry {
+                Geometry::TinySkia(primitive) => {
+                    Internal::TinySkia(Arc::new(primitive))
+                }
+                #[cfg(feature = "wgpu")]
+                Geometry::Wgpu(primitive) => {
+                    Internal::Wgpu(Arc::new(primitive))
+                }
+            }
         };
 
         *self.state.borrow_mut() = State::Filled {
@@ -82,6 +108,18 @@ impl Cache {
             primitive: primitive.clone(),
         };
 
-        Geometry(Primitive::Cache { content: primitive })
+        match primitive {
+            Internal::TinySkia(primitive) => {
+                Geometry::TinySkia(iced_tiny_skia::Primitive::Cache {
+                    content: primitive,
+                })
+            }
+            #[cfg(feature = "wgpu")]
+            Internal::Wgpu(primitive) => {
+                Geometry::Wgpu(iced_wgpu::Primitive::Cache {
+                    content: primitive,
+                })
+            }
+        }
     }
 }

--- a/renderer/src/lib.rs
+++ b/renderer/src/lib.rs
@@ -17,6 +17,7 @@ pub use geometry::Geometry;
 use crate::core::renderer;
 use crate::core::text::{self, Text};
 use crate::core::{Background, Font, Point, Rectangle, Size, Vector};
+use crate::graphics::Mesh;
 
 use std::borrow::Cow;
 
@@ -40,10 +41,17 @@ macro_rules! delegate {
 }
 
 impl<T> Renderer<T> {
-    #[cfg(feature = "wgpu")]
-    pub fn draw_with_wgpu(&mut self, primitive: iced_wgpu::Primitive) {
-        if let Self::Wgpu(renderer) = self {
-            renderer.draw_primitive(primitive);
+    pub fn draw_mesh(&mut self, mesh: Mesh) {
+        match self {
+            Self::TinySkia(_) => {
+                log::warn!("Unsupported mesh primitive: {:?}", mesh)
+            }
+            #[cfg(feature = "wgpu")]
+            Self::Wgpu(renderer) => {
+                renderer.draw_primitive(iced_wgpu::Primitive::Custom(
+                    iced_wgpu::primitive::Custom::Mesh(mesh),
+                ));
+            }
         }
     }
 }

--- a/renderer/src/lib.rs
+++ b/renderer/src/lib.rs
@@ -3,17 +3,259 @@ pub mod compositor;
 #[cfg(feature = "geometry")]
 pub mod geometry;
 
-mod backend;
 mod settings;
 
 pub use iced_graphics as graphics;
 pub use iced_graphics::core;
 
-pub use backend::Backend;
 pub use compositor::Compositor;
 pub use settings::Settings;
+
+#[cfg(feature = "geometry")]
+pub use geometry::Geometry;
+
+use crate::core::renderer;
+use crate::core::text::{self, Text};
+use crate::core::{Background, Font, Point, Rectangle, Size, Vector};
+
+use std::borrow::Cow;
 
 /// The default graphics renderer for [`iced`].
 ///
 /// [`iced`]: https://github.com/iced-rs/iced
-pub type Renderer<Theme> = iced_graphics::Renderer<Backend, Theme>;
+pub enum Renderer<Theme> {
+    TinySkia(iced_tiny_skia::Renderer<Theme>),
+    #[cfg(feature = "wgpu")]
+    Wgpu(iced_wgpu::Renderer<Theme>),
+}
+
+macro_rules! delegate {
+    ($renderer:expr, $name:ident, $body:expr) => {
+        match $renderer {
+            Self::TinySkia($name) => $body,
+            #[cfg(feature = "wgpu")]
+            Self::Wgpu($name) => $body,
+        }
+    };
+}
+
+impl<T> Renderer<T> {
+    #[cfg(feature = "wgpu")]
+    pub fn draw_with_wgpu(&mut self, primitive: iced_wgpu::Primitive) {
+        if let Self::Wgpu(renderer) = self {
+            renderer.draw_primitive(primitive);
+        }
+    }
+}
+
+impl<T> core::Renderer for Renderer<T> {
+    type Theme = T;
+
+    fn with_layer(&mut self, bounds: Rectangle, f: impl FnOnce(&mut Self)) {
+        match self {
+            Self::TinySkia(renderer) => {
+                let primitives = renderer.start_layer();
+
+                f(self);
+
+                match self {
+                    Self::TinySkia(renderer) => {
+                        renderer.end_layer(primitives, bounds);
+                    }
+                    #[cfg(feature = "wgpu")]
+                    _ => unreachable!(),
+                }
+            }
+            #[cfg(feature = "wgpu")]
+            Self::Wgpu(renderer) => {
+                let primitives = renderer.start_layer();
+
+                f(self);
+
+                match self {
+                    #[cfg(feature = "wgpu")]
+                    Self::Wgpu(renderer) => {
+                        renderer.end_layer(primitives, bounds);
+                    }
+                    _ => unreachable!(),
+                }
+            }
+        }
+    }
+
+    fn with_translation(
+        &mut self,
+        translation: Vector,
+        f: impl FnOnce(&mut Self),
+    ) {
+        match self {
+            Self::TinySkia(renderer) => {
+                let primitives = renderer.start_translation();
+
+                f(self);
+
+                match self {
+                    Self::TinySkia(renderer) => {
+                        renderer.end_translation(primitives, translation);
+                    }
+                    #[cfg(feature = "wgpu")]
+                    _ => unreachable!(),
+                }
+            }
+            #[cfg(feature = "wgpu")]
+            Self::Wgpu(renderer) => {
+                let primitives = renderer.start_translation();
+
+                f(self);
+
+                match self {
+                    #[cfg(feature = "wgpu")]
+                    Self::Wgpu(renderer) => {
+                        renderer.end_translation(primitives, translation);
+                    }
+                    _ => unreachable!(),
+                }
+            }
+        }
+    }
+
+    fn fill_quad(
+        &mut self,
+        quad: renderer::Quad,
+        background: impl Into<Background>,
+    ) {
+        delegate!(self, renderer, renderer.fill_quad(quad, background));
+    }
+
+    fn clear(&mut self) {
+        delegate!(self, renderer, renderer.clear());
+    }
+}
+
+impl<T> text::Renderer for Renderer<T> {
+    type Font = Font;
+
+    const ICON_FONT: Font = iced_tiny_skia::Renderer::<T>::ICON_FONT;
+    const CHECKMARK_ICON: char = iced_tiny_skia::Renderer::<T>::CHECKMARK_ICON;
+    const ARROW_DOWN_ICON: char =
+        iced_tiny_skia::Renderer::<T>::ARROW_DOWN_ICON;
+
+    fn default_font(&self) -> Self::Font {
+        delegate!(self, renderer, renderer.default_font())
+    }
+
+    fn default_size(&self) -> f32 {
+        delegate!(self, renderer, renderer.default_size())
+    }
+
+    fn measure(
+        &self,
+        content: &str,
+        size: f32,
+        line_height: text::LineHeight,
+        font: Font,
+        bounds: Size,
+        shaping: text::Shaping,
+    ) -> Size {
+        delegate!(
+            self,
+            renderer,
+            renderer.measure(content, size, line_height, font, bounds, shaping)
+        )
+    }
+
+    fn hit_test(
+        &self,
+        content: &str,
+        size: f32,
+        line_height: text::LineHeight,
+        font: Font,
+        bounds: Size,
+        shaping: text::Shaping,
+        point: Point,
+        nearest_only: bool,
+    ) -> Option<text::Hit> {
+        delegate!(
+            self,
+            renderer,
+            renderer.hit_test(
+                content,
+                size,
+                line_height,
+                font,
+                bounds,
+                shaping,
+                point,
+                nearest_only
+            )
+        )
+    }
+
+    fn load_font(&mut self, bytes: Cow<'static, [u8]>) {
+        delegate!(self, renderer, renderer.load_font(bytes));
+    }
+
+    fn fill_text(&mut self, text: Text<'_, Self::Font>) {
+        delegate!(self, renderer, renderer.fill_text(text));
+    }
+}
+
+#[cfg(feature = "image")]
+impl<T> crate::core::image::Renderer for Renderer<T> {
+    type Handle = crate::core::image::Handle;
+
+    fn dimensions(&self, handle: &crate::core::image::Handle) -> Size<u32> {
+        delegate!(self, renderer, renderer.dimensions(handle))
+    }
+
+    fn draw(&mut self, handle: crate::core::image::Handle, bounds: Rectangle) {
+        delegate!(self, renderer, renderer.draw(handle, bounds));
+    }
+}
+
+#[cfg(feature = "svg")]
+impl<T> crate::core::svg::Renderer for Renderer<T> {
+    fn dimensions(&self, handle: &crate::core::svg::Handle) -> Size<u32> {
+        delegate!(self, renderer, renderer.dimensions(handle))
+    }
+
+    fn draw(
+        &mut self,
+        handle: crate::core::svg::Handle,
+        color: Option<crate::core::Color>,
+        bounds: Rectangle,
+    ) {
+        delegate!(self, renderer, renderer.draw(handle, color, bounds))
+    }
+}
+
+#[cfg(feature = "geometry")]
+impl<T> crate::graphics::geometry::Renderer for Renderer<T> {
+    type Geometry = crate::Geometry;
+
+    fn draw(&mut self, layers: Vec<Self::Geometry>) {
+        match self {
+            Self::TinySkia(renderer) => {
+                for layer in layers {
+                    match layer {
+                        crate::Geometry::TinySkia(primitive) => {
+                            renderer.draw_primitive(primitive);
+                        }
+                        _ => unreachable!(),
+                    }
+                }
+            }
+            #[cfg(feature = "wgpu")]
+            Self::Wgpu(renderer) => {
+                for layer in layers {
+                    match layer {
+                        crate::Geometry::Wgpu(primitive) => {
+                            renderer.draw_primitive(primitive);
+                        }
+                        _ => unreachable!(),
+                    }
+                }
+            }
+        }
+    }
+}

--- a/runtime/src/user_interface.rs
+++ b/runtime/src/user_interface.rs
@@ -95,8 +95,9 @@ where
         let Cache { mut state } = cache;
         state.diff(root.as_widget());
 
-        let base =
-            renderer.layout(&root, &layout::Limits::new(Size::ZERO, bounds));
+        let base = root
+            .as_widget()
+            .layout(renderer, &layout::Limits::new(Size::ZERO, bounds));
 
         UserInterface {
             root,
@@ -226,8 +227,8 @@ where
                 if shell.is_layout_invalid() {
                     let _ = ManuallyDrop::into_inner(manual_overlay);
 
-                    self.base = renderer.layout(
-                        &self.root,
+                    self.base = self.root.as_widget().layout(
+                        renderer,
                         &layout::Limits::new(Size::ZERO, self.bounds),
                     );
 
@@ -322,8 +323,8 @@ where
                 }
 
                 shell.revalidate_layout(|| {
-                    self.base = renderer.layout(
-                        &self.root,
+                    self.base = self.root.as_widget().layout(
+                        renderer,
                         &layout::Limits::new(Size::ZERO, self.bounds),
                     );
 

--- a/tiny_skia/Cargo.toml
+++ b/tiny_skia/Cargo.toml
@@ -20,7 +20,6 @@ log = "0.4"
 [dependencies.iced_graphics]
 version = "0.8"
 path = "../graphics"
-features = ["tiny-skia"]
 
 [dependencies.cosmic-text]
 git = "https://github.com/hecrj/cosmic-text.git"

--- a/tiny_skia/src/backend.rs
+++ b/tiny_skia/src/backend.rs
@@ -595,14 +595,6 @@ impl Backend {
                     translation,
                 );
             }
-            Primitive::SolidMesh { .. } | Primitive::GradientMesh { .. } => {
-                // Not supported!
-                // TODO: Draw a placeholder (?)
-                log::warn!(
-                    "Unsupported primitive in `iced_tiny_skia`: {:?}",
-                    primitive
-                );
-            }
         }
     }
 }

--- a/tiny_skia/src/backend.rs
+++ b/tiny_skia/src/backend.rs
@@ -2,7 +2,8 @@ use crate::core::text;
 use crate::core::Gradient;
 use crate::core::{Background, Color, Font, Point, Rectangle, Size, Vector};
 use crate::graphics::backend;
-use crate::graphics::{Primitive, Viewport};
+use crate::graphics::{Damage, Viewport};
+use crate::primitive::{self, Primitive};
 use crate::Settings;
 
 use std::borrow::Cow;
@@ -419,6 +420,13 @@ impl Backend {
                 self.raster_pipeline
                     .draw(handle, *bounds, pixels, transform, clip_mask);
             }
+            #[cfg(not(feature = "image"))]
+            Primitive::Image { .. } => {
+                log::warn!(
+                    "Unsupported primitive in `iced_tiny_skia`: {:?}",
+                    primitive
+                );
+            }
             #[cfg(feature = "svg")]
             Primitive::Svg {
                 handle,
@@ -442,12 +450,19 @@ impl Backend {
                     clip_mask,
                 );
             }
-            Primitive::Fill {
+            #[cfg(not(feature = "svg"))]
+            Primitive::Svg { .. } => {
+                log::warn!(
+                    "Unsupported primitive in `iced_tiny_skia`: {:?}",
+                    primitive
+                );
+            }
+            Primitive::Custom(primitive::Custom::Fill {
                 path,
                 paint,
                 rule,
                 transform,
-            } => {
+            }) => {
                 let bounds = path.bounds();
 
                 let physical_bounds = (Rectangle {
@@ -475,12 +490,12 @@ impl Backend {
                     clip_mask,
                 );
             }
-            Primitive::Stroke {
+            Primitive::Custom(primitive::Custom::Stroke {
                 path,
                 paint,
                 stroke,
                 transform,
-            } => {
+            }) => {
                 let bounds = path.bounds();
 
                 let physical_bounds = (Rectangle {
@@ -583,13 +598,6 @@ impl Backend {
             Primitive::SolidMesh { .. } | Primitive::GradientMesh { .. } => {
                 // Not supported!
                 // TODO: Draw a placeholder (?)
-                log::warn!(
-                    "Unsupported primitive in `iced_tiny_skia`: {:?}",
-                    primitive
-                );
-            }
-            _ => {
-                // Not supported!
                 log::warn!(
                     "Unsupported primitive in `iced_tiny_skia`: {:?}",
                     primitive
@@ -764,6 +772,10 @@ fn adjust_clip_mask(clip_mask: &mut tiny_skia::Mask, bounds: Rectangle) {
         false,
         tiny_skia::Transform::default(),
     );
+}
+
+impl iced_graphics::Backend for Backend {
+    type Primitive = primitive::Custom;
 }
 
 impl backend::Text for Backend {

--- a/tiny_skia/src/geometry.rs
+++ b/tiny_skia/src/geometry.rs
@@ -3,7 +3,7 @@ use crate::graphics::geometry::fill::{self, Fill};
 use crate::graphics::geometry::stroke::{self, Stroke};
 use crate::graphics::geometry::{Path, Style, Text};
 use crate::graphics::Gradient;
-use crate::graphics::Primitive;
+use crate::primitive::{self, Primitive};
 
 pub struct Frame {
     size: Size,
@@ -42,12 +42,13 @@ impl Frame {
         let Some(path) = convert_path(path) else { return };
         let fill = fill.into();
 
-        self.primitives.push(Primitive::Fill {
-            path,
-            paint: into_paint(fill.style),
-            rule: into_fill_rule(fill.rule),
-            transform: self.transform,
-        });
+        self.primitives
+            .push(Primitive::Custom(primitive::Custom::Fill {
+                path,
+                paint: into_paint(fill.style),
+                rule: into_fill_rule(fill.rule),
+                transform: self.transform,
+            }));
     }
 
     pub fn fill_rectangle(
@@ -59,15 +60,16 @@ impl Frame {
         let Some(path) = convert_path(&Path::rectangle(top_left, size)) else { return };
         let fill = fill.into();
 
-        self.primitives.push(Primitive::Fill {
-            path,
-            paint: tiny_skia::Paint {
-                anti_alias: false,
-                ..into_paint(fill.style)
-            },
-            rule: into_fill_rule(fill.rule),
-            transform: self.transform,
-        });
+        self.primitives
+            .push(Primitive::Custom(primitive::Custom::Fill {
+                path,
+                paint: tiny_skia::Paint {
+                    anti_alias: false,
+                    ..into_paint(fill.style)
+                },
+                rule: into_fill_rule(fill.rule),
+                transform: self.transform,
+            }));
     }
 
     pub fn stroke<'a>(&mut self, path: &Path, stroke: impl Into<Stroke<'a>>) {
@@ -76,12 +78,13 @@ impl Frame {
         let stroke = stroke.into();
         let skia_stroke = into_stroke(&stroke);
 
-        self.primitives.push(Primitive::Stroke {
-            path,
-            paint: into_paint(stroke.style),
-            stroke: skia_stroke,
-            transform: self.transform,
-        });
+        self.primitives
+            .push(Primitive::Custom(primitive::Custom::Stroke {
+                path,
+                paint: into_paint(stroke.style),
+                stroke: skia_stroke,
+                transform: self.transform,
+            }));
     }
 
     pub fn fill_text(&mut self, text: impl Into<Text>) {

--- a/tiny_skia/src/lib.rs
+++ b/tiny_skia/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod window;
 
 mod backend;
+mod primitive;
 mod settings;
 mod text;
 
@@ -17,6 +18,7 @@ pub use iced_graphics as graphics;
 pub use iced_graphics::core;
 
 pub use backend::Backend;
+pub use primitive::Primitive;
 pub use settings::Settings;
 
 /// A [`tiny-skia`] graphics renderer for [`iced`].

--- a/tiny_skia/src/primitive.rs
+++ b/tiny_skia/src/primitive.rs
@@ -1,0 +1,48 @@
+use crate::core::Rectangle;
+use crate::graphics::Damage;
+
+pub type Primitive = crate::graphics::Primitive<Custom>;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Custom {
+    /// A path filled with some paint.
+    Fill {
+        /// The path to fill.
+        path: tiny_skia::Path,
+        /// The paint to use.
+        paint: tiny_skia::Paint<'static>,
+        /// The fill rule to follow.
+        rule: tiny_skia::FillRule,
+        /// The transform to apply to the path.
+        transform: tiny_skia::Transform,
+    },
+    /// A path stroked with some paint.
+    Stroke {
+        /// The path to stroke.
+        path: tiny_skia::Path,
+        /// The paint to use.
+        paint: tiny_skia::Paint<'static>,
+        /// The stroke settings.
+        stroke: tiny_skia::Stroke,
+        /// The transform to apply to the path.
+        transform: tiny_skia::Transform,
+    },
+}
+
+impl Damage for Custom {
+    fn bounds(&self) -> Rectangle {
+        match self {
+            Self::Fill { path, .. } | Self::Stroke { path, .. } => {
+                let bounds = path.bounds();
+
+                Rectangle {
+                    x: bounds.x(),
+                    y: bounds.y(),
+                    width: bounds.width(),
+                    height: bounds.height(),
+                }
+                .expand(1.0)
+            }
+        }
+    }
+}

--- a/tiny_skia/src/window/compositor.rs
+++ b/tiny_skia/src/window/compositor.rs
@@ -1,8 +1,8 @@
 use crate::core::{Color, Rectangle, Size};
 use crate::graphics::compositor::{self, Information};
 use crate::graphics::damage;
-use crate::graphics::{Error, Primitive, Viewport};
-use crate::{Backend, Renderer, Settings};
+use crate::graphics::{Error, Viewport};
+use crate::{Backend, Primitive, Renderer, Settings};
 
 use raw_window_handle::{HasRawDisplayHandle, HasRawWindowHandle};
 use std::marker::PhantomData;

--- a/wgpu/src/backend.rs
+++ b/wgpu/src/backend.rs
@@ -2,7 +2,8 @@ use crate::core;
 use crate::core::{Color, Font, Point, Size};
 use crate::graphics::backend;
 use crate::graphics::color;
-use crate::graphics::{Primitive, Transformation, Viewport};
+use crate::graphics::{Transformation, Viewport};
+use crate::primitive::{self, Primitive};
 use crate::quad;
 use crate::text;
 use crate::triangle;
@@ -332,6 +333,10 @@ impl Backend {
 
         let _ = ManuallyDrop::into_inner(render_pass);
     }
+}
+
+impl crate::graphics::Backend for Backend {
+    type Primitive = primitive::Custom;
 }
 
 impl backend::Text for Backend {

--- a/wgpu/src/geometry.rs
+++ b/wgpu/src/geometry.rs
@@ -5,10 +5,10 @@ use crate::graphics::geometry::fill::{self, Fill};
 use crate::graphics::geometry::{
     LineCap, LineDash, LineJoin, Path, Stroke, Style, Text,
 };
-use crate::graphics::primitive::{self, Primitive};
-use crate::graphics::Gradient;
+use crate::graphics::gradient::{self, Gradient};
+use crate::graphics::primitive;
+use crate::Primitive;
 
-use iced_graphics::gradient;
 use lyon::geom::euclid;
 use lyon::tessellation;
 use std::borrow::Cow;

--- a/wgpu/src/layer.rs
+++ b/wgpu/src/layer.rs
@@ -12,8 +12,9 @@ use crate::core;
 use crate::core::alignment;
 use crate::core::{Color, Font, Point, Rectangle, Size, Vector};
 use crate::graphics::color;
-use crate::graphics::{Primitive, Viewport};
+use crate::graphics::Viewport;
 use crate::quad::{self, Quad};
+use crate::Primitive;
 
 /// A group of primitives that should be clipped together.
 #[derive(Debug)]
@@ -262,13 +263,7 @@ impl<'a> Layer<'a> {
                     current_layer,
                 );
             }
-            _ => {
-                // Not supported!
-                log::warn!(
-                    "Unsupported primitive in `iced_wgpu`: {:?}",
-                    primitive
-                );
-            }
+            Primitive::Custom(()) => {}
         }
     }
 }

--- a/wgpu/src/layer/mesh.rs
+++ b/wgpu/src/layer/mesh.rs
@@ -1,6 +1,6 @@
 //! A collection of triangle primitives.
 use crate::core::{Point, Rectangle};
-use crate::graphics::primitive;
+use crate::graphics::mesh;
 
 /// A mesh of triangles.
 #[derive(Debug, Clone, Copy)]
@@ -11,7 +11,7 @@ pub enum Mesh<'a> {
         origin: Point,
 
         /// The vertex and index buffers of the [`Mesh`].
-        buffers: &'a primitive::Mesh2D<primitive::ColoredVertex2D>,
+        buffers: &'a mesh::Indexed<mesh::SolidVertex2D>,
 
         /// The clipping bounds of the [`Mesh`].
         clip_bounds: Rectangle<f32>,
@@ -22,7 +22,7 @@ pub enum Mesh<'a> {
         origin: Point,
 
         /// The vertex and index buffers of the [`Mesh`].
-        buffers: &'a primitive::Mesh2D<primitive::GradientVertex2D>,
+        buffers: &'a mesh::Indexed<mesh::GradientVertex2D>,
 
         /// The clipping bounds of the [`Mesh`].
         clip_bounds: Rectangle<f32>,

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -24,8 +24,8 @@
     html_logo_url = "https://raw.githubusercontent.com/iced-rs/iced/9ab6923e943f784985e9ef9ca28b10278297225d/docs/logo.svg"
 )]
 #![deny(
-    //missing_debug_implementations,
-    //missing_docs,
+    missing_debug_implementations,
+    missing_docs,
     unsafe_code,
     unused_results,
     clippy::extra_unused_lifetimes,

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -38,6 +38,7 @@
 #![allow(clippy::inherent_to_string, clippy::type_complexity)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 pub mod layer;
+pub mod primitive;
 pub mod settings;
 pub mod window;
 
@@ -47,7 +48,6 @@ pub mod geometry;
 mod backend;
 mod buffer;
 mod color;
-mod primitive;
 mod quad;
 mod text;
 mod triangle;

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -24,8 +24,8 @@
     html_logo_url = "https://raw.githubusercontent.com/iced-rs/iced/9ab6923e943f784985e9ef9ca28b10278297225d/docs/logo.svg"
 )]
 #![deny(
-    missing_debug_implementations,
-    missing_docs,
+    //missing_debug_implementations,
+    //missing_docs,
     unsafe_code,
     unused_results,
     clippy::extra_unused_lifetimes,
@@ -47,6 +47,7 @@ pub mod geometry;
 mod backend;
 mod buffer;
 mod color;
+mod primitive;
 mod quad;
 mod text;
 mod triangle;
@@ -60,6 +61,7 @@ pub use wgpu;
 
 pub use backend::Backend;
 pub use layer::Layer;
+pub use primitive::Primitive;
 pub use settings::Settings;
 
 #[cfg(any(feature = "image", feature = "svg"))]

--- a/wgpu/src/primitive.rs
+++ b/wgpu/src/primitive.rs
@@ -1,3 +1,17 @@
+use crate::core::Rectangle;
+use crate::graphics::{Damage, Mesh};
+
 pub type Primitive = crate::graphics::Primitive<Custom>;
 
-pub type Custom = ();
+#[derive(Debug, Clone, PartialEq)]
+pub enum Custom {
+    Mesh(Mesh),
+}
+
+impl Damage for Custom {
+    fn bounds(&self) -> Rectangle {
+        match self {
+            Self::Mesh(mesh) => mesh.bounds(),
+        }
+    }
+}

--- a/wgpu/src/primitive.rs
+++ b/wgpu/src/primitive.rs
@@ -1,10 +1,14 @@
+//! Draw using different graphical primitives.
 use crate::core::Rectangle;
 use crate::graphics::{Damage, Mesh};
 
+/// The graphical primitives supported by `iced_wgpu`.
 pub type Primitive = crate::graphics::Primitive<Custom>;
 
+/// The custom primitives supported by `iced_wgpu`.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Custom {
+    /// A mesh primitive.
     Mesh(Mesh),
 }
 

--- a/wgpu/src/primitive.rs
+++ b/wgpu/src/primitive.rs
@@ -1,0 +1,3 @@
+pub type Primitive = crate::graphics::Primitive<Custom>;
+
+pub type Custom = ();

--- a/wgpu/src/triangle.rs
+++ b/wgpu/src/triangle.rs
@@ -393,7 +393,7 @@ impl Uniforms {
 }
 
 mod solid {
-    use crate::graphics::primitive;
+    use crate::graphics::mesh;
     use crate::graphics::Antialiasing;
     use crate::triangle;
     use crate::Buffer;
@@ -406,7 +406,7 @@ mod solid {
 
     #[derive(Debug)]
     pub struct Layer {
-        pub vertices: Buffer<primitive::ColoredVertex2D>,
+        pub vertices: Buffer<mesh::SolidVertex2D>,
         pub uniforms: Buffer<triangle::Uniforms>,
         pub constants: wgpu::BindGroup,
     }
@@ -493,38 +493,40 @@ mod solid {
                     ),
                 });
 
-            let pipeline = device.create_render_pipeline(
-                &wgpu::RenderPipelineDescriptor {
-                    label: Some("iced_wgpu::triangle::solid pipeline"),
-                    layout: Some(&layout),
-                    vertex: wgpu::VertexState {
-                        module: &shader,
-                        entry_point: "solid_vs_main",
-                        buffers: &[wgpu::VertexBufferLayout {
-                            array_stride: std::mem::size_of::<
-                                primitive::ColoredVertex2D,
-                            >()
-                                as u64,
-                            step_mode: wgpu::VertexStepMode::Vertex,
-                            attributes: &wgpu::vertex_attr_array!(
-                                // Position
-                                0 => Float32x2,
-                                // Color
-                                1 => Float32x4,
-                            ),
-                        }],
+            let pipeline =
+                device.create_render_pipeline(
+                    &wgpu::RenderPipelineDescriptor {
+                        label: Some("iced_wgpu::triangle::solid pipeline"),
+                        layout: Some(&layout),
+                        vertex: wgpu::VertexState {
+                            module: &shader,
+                            entry_point: "solid_vs_main",
+                            buffers: &[wgpu::VertexBufferLayout {
+                                array_stride: std::mem::size_of::<
+                                    mesh::SolidVertex2D,
+                                >(
+                                )
+                                    as u64,
+                                step_mode: wgpu::VertexStepMode::Vertex,
+                                attributes: &wgpu::vertex_attr_array!(
+                                    // Position
+                                    0 => Float32x2,
+                                    // Color
+                                    1 => Float32x4,
+                                ),
+                            }],
+                        },
+                        fragment: Some(wgpu::FragmentState {
+                            module: &shader,
+                            entry_point: "solid_fs_main",
+                            targets: &[triangle::fragment_target(format)],
+                        }),
+                        primitive: triangle::primitive_state(),
+                        depth_stencil: None,
+                        multisample: triangle::multisample_state(antialiasing),
+                        multiview: None,
                     },
-                    fragment: Some(wgpu::FragmentState {
-                        module: &shader,
-                        entry_point: "solid_fs_main",
-                        targets: &[triangle::fragment_target(format)],
-                    }),
-                    primitive: triangle::primitive_state(),
-                    depth_stencil: None,
-                    multisample: triangle::multisample_state(antialiasing),
-                    multiview: None,
-                },
-            );
+                );
 
             Self {
                 pipeline,
@@ -535,7 +537,8 @@ mod solid {
 }
 
 mod gradient {
-    use crate::graphics::{primitive, Antialiasing};
+    use crate::graphics::mesh;
+    use crate::graphics::Antialiasing;
     use crate::triangle;
     use crate::Buffer;
 
@@ -547,7 +550,7 @@ mod gradient {
 
     #[derive(Debug)]
     pub struct Layer {
-        pub vertices: Buffer<primitive::GradientVertex2D>,
+        pub vertices: Buffer<mesh::GradientVertex2D>,
         pub uniforms: Buffer<triangle::Uniforms>,
         pub constants: wgpu::BindGroup,
     }
@@ -645,7 +648,7 @@ mod gradient {
                         entry_point: "gradient_vs_main",
                         buffers: &[wgpu::VertexBufferLayout {
                             array_stride: std::mem::size_of::<
-                                primitive::GradientVertex2D,
+                                mesh::GradientVertex2D,
                             >()
                                 as u64,
                             step_mode: wgpu::VertexStepMode::Vertex,

--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -3,8 +3,8 @@ use crate::core::{Color, Size};
 use crate::graphics;
 use crate::graphics::color;
 use crate::graphics::compositor;
-use crate::graphics::{Error, Primitive, Viewport};
-use crate::{Backend, Renderer, Settings};
+use crate::graphics::{Error, Viewport};
+use crate::{Backend, Primitive, Renderer, Settings};
 
 use futures::stream::{self, StreamExt};
 

--- a/widget/src/canvas/program.rs
+++ b/widget/src/canvas/program.rs
@@ -1,7 +1,7 @@
 use crate::canvas::event::{self, Event};
 use crate::canvas::mouse;
 use crate::core::Rectangle;
-use crate::graphics::geometry::{self, Geometry};
+use crate::graphics::geometry;
 
 /// The state and logic of a [`Canvas`].
 ///
@@ -51,7 +51,7 @@ where
         theme: &Renderer::Theme,
         bounds: Rectangle,
         cursor: mouse::Cursor,
-    ) -> Vec<Geometry>;
+    ) -> Vec<Renderer::Geometry>;
 
     /// Returns the current mouse interaction of the [`Program`].
     ///
@@ -93,7 +93,7 @@ where
         theme: &Renderer::Theme,
         bounds: Rectangle,
         cursor: mouse::Cursor,
-    ) -> Vec<Geometry> {
+    ) -> Vec<Renderer::Geometry> {
         T::draw(self, state, renderer, theme, bounds, cursor)
     }
 

--- a/widget/src/qr_code.rs
+++ b/widget/src/qr_code.rs
@@ -7,6 +7,7 @@ use crate::core::widget::Tree;
 use crate::core::{
     Color, Element, Layout, Length, Point, Rectangle, Size, Vector, Widget,
 };
+use crate::graphics::geometry::Renderer as _;
 use crate::Renderer;
 use thiserror::Error;
 
@@ -121,7 +122,7 @@ impl<'a, Message, Theme> Widget<Message, Renderer<Theme>> for QRCode<'a> {
         let translation = Vector::new(bounds.x, bounds.y);
 
         renderer.with_translation(translation, |renderer| {
-            renderer.draw_primitive(geometry.0);
+            renderer.draw(vec![geometry]);
         });
     }
 }


### PR DESCRIPTION
This PR introduces a new `Custom` generic type and variant to `Primitive` in `iced_graphics`.

Graphical backends can now define their custom primitive type. As a result, we can properly decouple the `tiny-skia` dependency from `iced_graphics`.

This should also lay the foundations for choosing a completely custom, unofficial renderer at runtime.