### PR TITLE
Reuse entries in `text::Cache`

### DIFF
--- a/core/src/renderer/null.rs
+++ b/core/src/renderer/null.rs
@@ -64,8 +64,8 @@ impl text::Renderer for Null {
         _font: Font,
         _bounds: Size,
         _shaping: text::Shaping,
-    ) -> (f32, f32) {
-        (0.0, 20.0)
+    ) -> Size {
+        Size::new(0.0, 20.0)
     }
 
     fn hit_test(

--- a/core/src/text.rs
+++ b/core/src/text.rs
@@ -163,7 +163,7 @@ pub trait Renderer: crate::Renderer {
         font: Self::Font,
         bounds: Size,
         shaping: Shaping,
-    ) -> (f32, f32);
+    ) -> Size;
 
     /// Measures the width of the text as if it were laid out in a single line.
     fn measure_width(
@@ -173,7 +173,7 @@ pub trait Renderer: crate::Renderer {
         font: Self::Font,
         shaping: Shaping,
     ) -> f32 {
-        let (width, _) = self.measure(
+        let bounds = self.measure(
             content,
             size,
             LineHeight::Absolute(Pixels(size)),
@@ -182,7 +182,7 @@ pub trait Renderer: crate::Renderer {
             shaping,
         );
 
-        width
+        bounds.width
     }
 
     /// Tests whether the provided point is within the boundaries of text

--- a/core/src/widget/text.rs
+++ b/core/src/widget/text.rs
@@ -5,7 +5,7 @@ use crate::mouse;
 use crate::renderer;
 use crate::text;
 use crate::widget::Tree;
-use crate::{Color, Element, Layout, Length, Pixels, Rectangle, Size, Widget};
+use crate::{Color, Element, Layout, Length, Pixels, Rectangle, Widget};
 
 use std::borrow::Cow;
 
@@ -139,18 +139,16 @@ where
 
         let size = self.size.unwrap_or_else(|| renderer.default_size());
 
-        let bounds = limits.max();
-
-        let (width, height) = renderer.measure(
+        let bounds = renderer.measure(
             &self.content,
             size,
             self.line_height,
             self.font.unwrap_or_else(|| renderer.default_font()),
-            bounds,
+            limits.max(),
             self.shaping,
         );
 
-        let size = limits.resolve(Size::new(width, height));
+        let size = limits.resolve(bounds);
 
         layout::Node::new(size)
     }

--- a/graphics/src/backend.rs
+++ b/graphics/src/backend.rs
@@ -38,7 +38,7 @@ pub trait Text {
         font: Font,
         bounds: Size,
         shaping: text::Shaping,
-    ) -> (f32, f32);
+    ) -> Size;
 
     /// Tests whether the provided point is within the boundaries of [`Text`]
     /// laid out with the given parameters, returning information about

--- a/graphics/src/renderer.rs
+++ b/graphics/src/renderer.rs
@@ -133,7 +133,7 @@ where
         font: Font,
         bounds: Size,
         shaping: text::Shaping,
-    ) -> (f32, f32) {
+    ) -> Size {
         self.backend().measure(
             content,
             size,

--- a/renderer/src/backend.rs
+++ b/renderer/src/backend.rs
@@ -42,7 +42,7 @@ impl backend::Text for Backend {
         font: Font,
         bounds: Size,
         shaping: text::Shaping,
-    ) -> (f32, f32) {
+    ) -> Size {
         delegate!(
             self,
             backend,

--- a/tiny_skia/src/backend.rs
+++ b/tiny_skia/src/backend.rs
@@ -787,7 +787,7 @@ impl backend::Text for Backend {
         font: Font,
         bounds: Size,
         shaping: text::Shaping,
-    ) -> (f32, f32) {
+    ) -> Size {
         self.text_pipeline.measure(
             contents,
             size,

--- a/tiny_skia/src/text.rs
+++ b/tiny_skia/src/text.rs
@@ -394,7 +394,7 @@ impl Cache {
 
             return (
                 *measured_hash,
-                self.entries.get_mut(&measured_hash).unwrap(),
+                self.entries.get_mut(measured_hash).unwrap(),
             );
         }
 

--- a/tiny_skia/src/text.rs
+++ b/tiny_skia/src/text.rs
@@ -138,7 +138,7 @@ impl Pipeline {
         font: Font,
         bounds: Size,
         shaping: Shaping,
-    ) -> (f32, f32) {
+    ) -> Size {
         let mut measurement_cache = self.cache.borrow_mut();
 
         let line_height = f32::from(line_height.to_absolute(Pixels(size)));
@@ -162,7 +162,7 @@ impl Pipeline {
                 (i + 1, buffer.line_w.max(max))
             });
 
-        (max_width, line_height * total_lines as f32)
+        Size::new(max_width, line_height * total_lines as f32)
     }
 
     pub fn hit_test(

--- a/tiny_skia/src/text.rs
+++ b/tiny_skia/src/text.rs
@@ -438,8 +438,10 @@ impl Cache {
         if self.trim_count > Self::TRIM_INTERVAL {
             self.entries
                 .retain(|key, _| self.recently_used.contains(key));
-            self.measurements
-                .retain(|key, _| self.recently_used.contains(key));
+            self.measurements.retain(|key, value| {
+                self.recently_used.contains(key)
+                    || self.recently_used.contains(value)
+            });
 
             self.recently_used.clear();
 

--- a/wgpu/src/backend.rs
+++ b/wgpu/src/backend.rs
@@ -355,7 +355,7 @@ impl backend::Text for Backend {
         font: Font,
         bounds: Size,
         shaping: core::text::Shaping,
-    ) -> (f32, f32) {
+    ) -> Size {
         self.text_pipeline.measure(
             contents,
             size,

--- a/wgpu/src/text.rs
+++ b/wgpu/src/text.rs
@@ -391,7 +391,7 @@ impl Cache {
 
             return (
                 *measured_hash,
-                self.entries.get_mut(&measured_hash).unwrap(),
+                self.entries.get_mut(measured_hash).unwrap(),
             );
         }
 

--- a/wgpu/src/text.rs
+++ b/wgpu/src/text.rs
@@ -113,15 +113,13 @@ impl Pipeline {
                 .iter()
                 .zip(keys.iter())
                 .filter_map(|(section, key)| {
-                    let buffer = cache.get(key).expect("Get cached buffer");
+                    let entry = cache.get(key).expect("Get cached buffer");
 
                     let x = section.bounds.x * scale_factor;
                     let y = section.bounds.y * scale_factor;
 
-                    let (max_width, total_height) = measure(buffer);
-
-                    let max_width = max_width * scale_factor;
-                    let total_height = total_height * scale_factor;
+                    let max_width = entry.bounds.width * scale_factor;
+                    let total_height = entry.bounds.height * scale_factor;
 
                     let left = match section.horizontal_alignment {
                         alignment::Horizontal::Left => x,
@@ -145,7 +143,7 @@ impl Pipeline {
                     let clip_bounds = bounds.intersection(&section_bounds)?;
 
                     Some(glyphon::TextArea {
-                        buffer,
+                        buffer: &entry.buffer,
                         left,
                         top,
                         scale: scale_factor,
@@ -239,12 +237,12 @@ impl Pipeline {
         font: Font,
         bounds: Size,
         shaping: Shaping,
-    ) -> (f32, f32) {
+    ) -> Size {
         let mut measurement_cache = self.cache.borrow_mut();
 
         let line_height = f32::from(line_height.to_absolute(Pixels(size)));
 
-        let (_, paragraph) = measurement_cache.allocate(
+        let (_, entry) = measurement_cache.allocate(
             &mut self.font_system.borrow_mut(),
             Key {
                 content,
@@ -256,7 +254,7 @@ impl Pipeline {
             },
         );
 
-        measure(paragraph)
+        entry.bounds
     }
 
     pub fn hit_test(
@@ -274,7 +272,7 @@ impl Pipeline {
 
         let line_height = f32::from(line_height.to_absolute(Pixels(size)));
 
-        let (_, paragraph) = measurement_cache.allocate(
+        let (_, entry) = measurement_cache.allocate(
             &mut self.font_system.borrow_mut(),
             Key {
                 content,
@@ -286,20 +284,20 @@ impl Pipeline {
             },
         );
 
-        let cursor = paragraph.hit(point.x, point.y)?;
+        let cursor = entry.buffer.hit(point.x, point.y)?;
 
         Some(Hit::CharOffset(cursor.index))
     }
 }
 
-fn measure(buffer: &glyphon::Buffer) -> (f32, f32) {
+fn measure(buffer: &glyphon::Buffer) -> Size {
     let (width, total_lines) = buffer
         .layout_runs()
         .fold((0.0, 0usize), |(width, total_lines), run| {
             (run.line_w.max(width), total_lines + 1)
         });
 
-    (width, total_lines as f32 * buffer.metrics().line_height)
+    Size::new(width, total_lines as f32 * buffer.metrics().line_height)
 }
 
 fn to_family(family: font::Family) -> glyphon::Family<'static> {
@@ -349,9 +347,15 @@ fn to_shaping(shaping: Shaping) -> glyphon::Shaping {
 }
 
 struct Cache {
-    entries: FxHashMap<KeyHash, glyphon::Buffer>,
+    entries: FxHashMap<KeyHash, Entry>,
+    bound_entries: FxHashMap<KeyHash, KeyHash>,
     recently_used: FxHashSet<KeyHash>,
     hasher: HashBuilder,
+}
+
+struct Entry {
+    buffer: glyphon::Buffer,
+    bounds: Size,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -364,12 +368,13 @@ impl Cache {
     fn new() -> Self {
         Self {
             entries: FxHashMap::default(),
+            bound_entries: FxHashMap::default(),
             recently_used: FxHashSet::default(),
             hasher: HashBuilder::default(),
         }
     }
 
-    fn get(&self, key: &KeyHash) -> Option<&glyphon::Buffer> {
+    fn get(&self, key: &KeyHash) -> Option<&Entry> {
         self.entries.get(key)
     }
 
@@ -377,20 +382,15 @@ impl Cache {
         &mut self,
         font_system: &mut glyphon::FontSystem,
         key: Key<'_>,
-    ) -> (KeyHash, &mut glyphon::Buffer) {
-        let hash = {
-            let mut hasher = self.hasher.build_hasher();
+    ) -> (KeyHash, &mut Entry) {
+        let hash = key.hash(self.hasher.build_hasher());
 
-            key.content.hash(&mut hasher);
-            key.size.to_bits().hash(&mut hasher);
-            key.line_height.to_bits().hash(&mut hasher);
-            key.font.hash(&mut hasher);
-            key.bounds.width.to_bits().hash(&mut hasher);
-            key.bounds.height.to_bits().hash(&mut hasher);
-            key.shaping.hash(&mut hasher);
+        if let Some(bound_hash) = self.bound_entries.get(&hash) {
+            let _ = self.recently_used.insert(hash);
+            let _ = self.recently_used.insert(*bound_hash);
 
-            hasher.finish()
-        };
+            return (*bound_hash, self.entries.get_mut(&bound_hash).unwrap());
+        }
 
         if let hash_map::Entry::Vacant(entry) = self.entries.entry(hash) {
             let metrics = glyphon::Metrics::new(key.size, key.line_height);
@@ -411,7 +411,16 @@ impl Cache {
                 to_shaping(key.shaping),
             );
 
-            let _ = entry.insert(buffer);
+            let bounds = measure(&buffer);
+
+            let _ = entry.insert(Entry { buffer, bounds });
+
+            if key.bounds != bounds {
+                let _ = self.bound_entries.insert(
+                    Key { bounds, ..key }.hash(self.hasher.build_hasher()),
+                    hash,
+                );
+            }
         }
 
         let _ = self.recently_used.insert(hash);
@@ -421,6 +430,8 @@ impl Cache {
 
     fn trim(&mut self) {
         self.entries
+            .retain(|key, _| self.recently_used.contains(key));
+        self.bound_entries
             .retain(|key, _| self.recently_used.contains(key));
 
         self.recently_used.clear();
@@ -435,6 +446,20 @@ struct Key<'a> {
     font: Font,
     bounds: Size,
     shaping: Shaping,
+}
+
+impl Key<'_> {
+    fn hash<H: Hasher>(self, mut hasher: H) -> KeyHash {
+        self.content.hash(&mut hasher);
+        self.size.to_bits().hash(&mut hasher);
+        self.line_height.to_bits().hash(&mut hasher);
+        self.font.hash(&mut hasher);
+        self.bounds.width.to_bits().hash(&mut hasher);
+        self.bounds.height.to_bits().hash(&mut hasher);
+        self.shaping.hash(&mut hasher);
+
+        hasher.finish()
+    }
 }
 
 type KeyHash = u64;

--- a/wgpu/src/text.rs
+++ b/wgpu/src/text.rs
@@ -385,14 +385,10 @@ impl Cache {
     ) -> (KeyHash, &mut Entry) {
         let hash = key.hash(self.hasher.build_hasher());
 
-        if let Some(measured_hash) = self.measurements.get(&hash) {
-            let _ = self.recently_used.insert(hash);
-            let _ = self.recently_used.insert(*measured_hash);
+        if let Some(hash) = self.measurements.get(&hash) {
+            let _ = self.recently_used.insert(*hash);
 
-            return (
-                *measured_hash,
-                self.entries.get_mut(measured_hash).unwrap(),
-            );
+            return (*hash, self.entries.get_mut(hash).unwrap());
         }
 
         if let hash_map::Entry::Vacant(entry) = self.entries.entry(hash) {
@@ -415,14 +411,21 @@ impl Cache {
             );
 
             let bounds = measure(&buffer);
-
             let _ = entry.insert(Entry { buffer, bounds });
 
-            if key.bounds != bounds {
-                let _ = self.measurements.insert(
-                    Key { bounds, ..key }.hash(self.hasher.build_hasher()),
-                    hash,
-                );
+            for bounds in [
+                bounds,
+                Size {
+                    width: key.bounds.width,
+                    ..bounds
+                },
+            ] {
+                if key.bounds != bounds {
+                    let _ = self.measurements.insert(
+                        Key { bounds, ..key }.hash(self.hasher.build_hasher()),
+                        hash,
+                    );
+                }
             }
         }
 
@@ -434,10 +437,8 @@ impl Cache {
     fn trim(&mut self) {
         self.entries
             .retain(|key, _| self.recently_used.contains(key));
-        self.measurements.retain(|key, value| {
-            self.recently_used.contains(key)
-                || self.recently_used.contains(value)
-        });
+        self.measurements
+            .retain(|_, value| self.recently_used.contains(value));
 
         self.recently_used.clear();
     }

--- a/wgpu/src/text.rs
+++ b/wgpu/src/text.rs
@@ -434,8 +434,10 @@ impl Cache {
     fn trim(&mut self) {
         self.entries
             .retain(|key, _| self.recently_used.contains(key));
-        self.measurements
-            .retain(|key, _| self.recently_used.contains(key));
+        self.measurements.retain(|key, value| {
+            self.recently_used.contains(key)
+                || self.recently_used.contains(value)
+        });
 
         self.recently_used.clear();
     }


### PR DESCRIPTION
This PR introduces a new `HashMap` in the `text::Cache` to allow reusing buffers that have already been measured during layouting.

Fixes #1933.