### PR TITLE
Text cache modes

### DIFF
--- a/core/src/renderer.rs
+++ b/core/src/renderer.rs
@@ -5,12 +5,25 @@ mod null;
 #[cfg(debug_assertions)]
 pub use null::Null;
 
-use crate::{Background, BorderRadius, Color, Rectangle, Vector};
+use crate::layout;
+use crate::{Background, BorderRadius, Color, Element, Rectangle, Vector};
 
 /// A component that can be used by widgets to draw themselves on a screen.
 pub trait Renderer: Sized {
     /// The supported theme of the [`Renderer`].
     type Theme;
+
+    /// Lays out the elements of a user interface.
+    ///
+    /// You should override this if you need to perform any operations before or
+    /// after layouting. For instance, trimming the measurements cache.
+    fn layout<Message>(
+        &mut self,
+        element: &Element<'_, Message, Self>,
+        limits: &layout::Limits,
+    ) -> layout::Node {
+        element.as_widget().layout(self, limits)
+    }
 
     /// Draws the primitives recorded in the given closure in a new layer.
     ///

--- a/graphics/src/backend.rs
+++ b/graphics/src/backend.rs
@@ -12,6 +12,13 @@ use std::borrow::Cow;
 pub trait Backend {
     /// The custom kind of primitives this [`Backend`] supports.
     type Primitive;
+
+    /// Trims the measurements cache.
+    ///
+    /// This method is currently necessary to properly trim the text cache in
+    /// `iced_wgpu` and `iced_glow` because of limitations in the text rendering
+    /// pipeline. It will be removed in the future.
+    fn trim_measurements(&mut self) {}
 }
 
 /// A graphics backend that supports text rendering.

--- a/graphics/src/renderer.rs
+++ b/graphics/src/renderer.rs
@@ -93,6 +93,8 @@ impl<B: Backend, T> iced_core::Renderer for Renderer<B, T> {
         element: &Element<'_, Message, Self>,
         limits: &layout::Limits,
     ) -> layout::Node {
+        self.backend.trim_measurements();
+
         element.as_widget().layout(self, limits)
     }
 

--- a/graphics/src/renderer.rs
+++ b/graphics/src/renderer.rs
@@ -3,10 +3,13 @@ use crate::backend::{self, Backend};
 use crate::Primitive;
 
 use iced_core::image;
+use iced_core::layout;
 use iced_core::renderer;
 use iced_core::svg;
 use iced_core::text::{self, Text};
-use iced_core::{Background, Color, Font, Point, Rectangle, Size, Vector};
+use iced_core::{
+    Background, Color, Element, Font, Point, Rectangle, Size, Vector,
+};
 
 use std::borrow::Cow;
 use std::marker::PhantomData;
@@ -84,6 +87,14 @@ impl<B: Backend, T> Renderer<B, T> {
 
 impl<B: Backend, T> iced_core::Renderer for Renderer<B, T> {
     type Theme = T;
+
+    fn layout<Message>(
+        &mut self,
+        element: &Element<'_, Message, Self>,
+        limits: &layout::Limits,
+    ) -> layout::Node {
+        element.as_widget().layout(self, limits)
+    }
 
     fn with_layer(&mut self, bounds: Rectangle, f: impl FnOnce(&mut Self)) {
         let current = self.start_layer();

--- a/runtime/src/user_interface.rs
+++ b/runtime/src/user_interface.rs
@@ -95,9 +95,8 @@ where
         let Cache { mut state } = cache;
         state.diff(root.as_widget());
 
-        let base = root
-            .as_widget()
-            .layout(renderer, &layout::Limits::new(Size::ZERO, bounds));
+        let base =
+            renderer.layout(&root, &layout::Limits::new(Size::ZERO, bounds));
 
         UserInterface {
             root,
@@ -227,8 +226,8 @@ where
                 if shell.is_layout_invalid() {
                     let _ = ManuallyDrop::into_inner(manual_overlay);
 
-                    self.base = self.root.as_widget().layout(
-                        renderer,
+                    self.base = renderer.layout(
+                        &self.root,
                         &layout::Limits::new(Size::ZERO, self.bounds),
                     );
 
@@ -323,8 +322,8 @@ where
                 }
 
                 shell.revalidate_layout(|| {
-                    self.base = self.root.as_widget().layout(
-                        renderer,
+                    self.base = renderer.layout(
+                        &self.root,
                         &layout::Limits::new(Size::ZERO, self.bounds),
                     );
 

--- a/wgpu/src/backend.rs
+++ b/wgpu/src/backend.rs
@@ -337,6 +337,10 @@ impl Backend {
 
 impl crate::graphics::Backend for Backend {
     type Primitive = primitive::Custom;
+
+    fn trim_measurements(&mut self) {
+        self.text_pipeline.trim_measurements();
+    }
 }
 
 impl backend::Text for Backend {


### PR DESCRIPTION
This PR splits trimming of the unified text cache based on the `Purpose` of the entries to avoid clearing measurements when redrawing multiple times between relayouts.