### PR TITLE
Fix/scrollable touch input stuck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Clippy docs keyword quoting. [#2091](https://github.com/iced-rs/iced/pull/2091)
 - Clippy map transformations. [#2090](https://github.com/iced-rs/iced/pull/2090)
 - Inline format args for ease of reading. [#2089](https://github.com/iced-rs/iced/pull/2089)
+- Stuck scrolling in `Scrollable` with touch events. [#1940](https://github.com/iced-rs/iced/pull/1940)
 
 Many thanks to...
 

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -525,7 +525,7 @@ pub fn update<Message>(
     let (mouse_over_y_scrollbar, mouse_over_x_scrollbar) =
         scrollbars.is_mouse_over(cursor);
 
-    let event_status = {
+    let mut event_status = {
         let cursor = match cursor_over_scrollable {
             Some(cursor_position)
                 if !(mouse_over_x_scrollbar || mouse_over_y_scrollbar) =>
@@ -589,7 +589,7 @@ pub fn update<Message>(
 
             notify_on_scroll(state, on_scroll, bounds, content_bounds, shell);
 
-            return event::Status::Captured;
+            event_status = event::Status::Captured;
         }
         Event::Touch(event)
             if state.scroll_area_touched_at.is_some()
@@ -635,7 +635,7 @@ pub fn update<Message>(
                 }
             }
 
-            return event::Status::Captured;
+            event_status = event::Status::Captured;
         }
         _ => {}
     }
@@ -647,7 +647,7 @@ pub fn update<Message>(
             | Event::Touch(touch::Event::FingerLost { .. }) => {
                 state.y_scroller_grabbed_at = None;
 
-                return event::Status::Captured;
+                event_status = event::Status::Captured;
             }
             Event::Mouse(mouse::Event::CursorMoved { .. })
             | Event::Touch(touch::Event::FingerMoved { .. }) => {
@@ -673,7 +673,7 @@ pub fn update<Message>(
                         shell,
                     );
 
-                    return event::Status::Captured;
+                    event_status = event::Status::Captured;
                 }
             }
             _ => {}
@@ -709,7 +709,7 @@ pub fn update<Message>(
                     );
                 }
 
-                return event::Status::Captured;
+                event_status = event::Status::Captured;
             }
             _ => {}
         }
@@ -722,7 +722,7 @@ pub fn update<Message>(
             | Event::Touch(touch::Event::FingerLost { .. }) => {
                 state.x_scroller_grabbed_at = None;
 
-                return event::Status::Captured;
+                event_status = event::Status::Captured;
             }
             Event::Mouse(mouse::Event::CursorMoved { .. })
             | Event::Touch(touch::Event::FingerMoved { .. }) => {
@@ -749,7 +749,7 @@ pub fn update<Message>(
                     );
                 }
 
-                return event::Status::Captured;
+                event_status = event::Status::Captured;
             }
             _ => {}
         }
@@ -783,14 +783,14 @@ pub fn update<Message>(
                         shell,
                     );
 
-                    return event::Status::Captured;
+                    event_status = event::Status::Captured;
                 }
             }
             _ => {}
         }
     }
 
-    event::Status::Ignored
+    event_status
 }
 
 /// Computes the current [`mouse::Interaction`] of a [`Scrollable`].


### PR DESCRIPTION
Should fix this scrollable touch input bug. The main "problem" seems to be exiting the event handler on a un-touch/touch loss returning immediately after handling it, even though later in the code the event is handled again. I have defaulted the return value to ignore and only return immediately when absolutely necessary, so that the various portions of the event handlers do not have to "fight" over the event.



https://github.com/iced-rs/iced/assets/29180043/19879875-ed63-437c-817f-311947c3f6be

