### PR TITLE
add platform specific settings for x11

### DIFF
--- a/winit/src/settings.rs
+++ b/winit/src/settings.rs
@@ -7,6 +7,16 @@ mod platform;
 #[path = "settings/macos.rs"]
 mod platform;
 
+#[cfg(any(
+    target_os = "linux",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd",
+))]
+#[path = "settings/unix.rs"]
+mod platform;
+
 #[cfg(target_arch = "wasm32")]
 #[path = "settings/wasm.rs"]
 mod platform;
@@ -14,6 +24,11 @@ mod platform;
 #[cfg(not(any(
     target_os = "windows",
     target_os = "macos",
+    target_os = "linux",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd",
     target_arch = "wasm32"
 )))]
 #[path = "settings/other.rs"]
@@ -158,12 +173,16 @@ impl Window {
         ))]
         {
             // `with_name` is available on both `WindowBuilderExtWayland` and `WindowBuilderExtX11` and they do
-            // exactly the same thing. We arbitrarily choose `WindowBuilderExtWayland` here.
-            use ::winit::platform::wayland::WindowBuilderExtWayland;
+            // exactly the same thing. We arbitrarily choose `WindowBuilderExtX11` here.
+            use winit::platform::x11::WindowBuilderExtX11;
 
             if let Some(id) = _id {
                 window_builder = window_builder.with_name(id.clone(), id);
             }
+
+            window_builder = window_builder.with_x11_window_type(
+                self.platform_specific.x11_window_type.clone(),
+            )
         }
 
         #[cfg(target_os = "windows")]

--- a/winit/src/settings/unix.rs
+++ b/winit/src/settings/unix.rs
@@ -1,0 +1,12 @@
+//! Platform specific settings for unix-like systems (except macOS).
+
+#[cfg(feature = "x11")]
+use winit::platform::x11::XWindowType;
+
+/// The platform specific window settings of an application.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct PlatformSpecific {
+    /// Build window with `_NET_WM_WINDOW_TYPE` hints; defaults to `Normal`. Only relevant on X11.
+    #[cfg(feature = "x11")]
+    pub x11_window_type: Vec<XWindowType>,
+}


### PR DESCRIPTION
I use the i3 window manager and wanted to make an iced window floating by default by using X11 window type hints.
I added a `PlatformSpecific` struct for unix-like systems so that you can pass the window type to the Application::run function like this
```
MyApp::run(Settings {
        window: iced::window::Settings {
            platform_specific: iced::window::PlatformSpecific {
                x11_window_type: vec![
                    winit::platform::x11::XWindowType::Notification,
                    winit::platform::x11::XWindowType::Utility,
                ],
            },
            ..iced::window::Settings::default()
        },
        ..Settings::default()
    })
```
This makes the image floating (with some extra settings not shown to set the size and position)
![image](https://github.com/iced-rs/iced/assets/25843078/11b74ceb-65c3-4a49-8597-6df99d91dc76)


I would also add the rest of the fields of winit's [PlatformSpecificWindowBuilderAttributes](https://github.com/rust-windowing/winit/blob/4652d4810548cb48c89964e7b81f8fc59686a4d3/src/platform_impl/linux/mod.rs#L88) for linux. But before I continue I wanted to get some clarification about conditional compilation.
