### PR TITLE
Forward redraw requests in component overlay

### DIFF
--- a/widget/src/lazy/component.rs
+++ b/widget/src/lazy/component.rs
@@ -624,6 +624,10 @@ where
 
         local_shell.revalidate_layout(|| shell.invalidate_layout());
 
+        if let Some(redraw_request) = local_shell.redraw_request() {
+            shell.request_redraw(redraw_request);
+        }
+
         if !local_messages.is_empty() {
             let mut inner =
                 self.overlay.take().unwrap().0.take().unwrap().into_heads();


### PR DESCRIPTION
Currently the redraw request is not forwarded from a component's overlay to the containing shell, which prevents use of animations in component overlays. This PR resolves the issue by forwarding the redraw request.