### PR TITLE
Expose methods to change viewport alignment

### DIFF
--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -554,7 +554,14 @@ pub fn update<Message>(
 
             state.scroll(delta, direction, bounds, content_bounds);
 
-            notify_on_scroll(state, on_scroll, bounds, content_bounds, shell);
+            notify_on_scroll(
+                state,
+                on_scroll,
+                bounds,
+                content_bounds,
+                direction,
+                shell,
+            );
 
             return event::Status::Captured;
         }
@@ -592,6 +599,7 @@ pub fn update<Message>(
                             on_scroll,
                             bounds,
                             content_bounds,
+                            direction,
                             shell,
                         );
                     }
@@ -637,6 +645,7 @@ pub fn update<Message>(
                         on_scroll,
                         bounds,
                         content_bounds,
+                        direction,
                         shell,
                     );
 
@@ -672,6 +681,7 @@ pub fn update<Message>(
                         on_scroll,
                         bounds,
                         content_bounds,
+                        direction,
                         shell,
                     );
                 }
@@ -712,6 +722,7 @@ pub fn update<Message>(
                         on_scroll,
                         bounds,
                         content_bounds,
+                        direction,
                         shell,
                     );
                 }
@@ -747,6 +758,7 @@ pub fn update<Message>(
                         on_scroll,
                         bounds,
                         content_bounds,
+                        direction,
                         shell,
                     );
 
@@ -962,6 +974,7 @@ fn notify_on_scroll<Message>(
     on_scroll: &Option<Box<dyn Fn(Viewport) -> Message + '_>>,
     bounds: Rectangle,
     content_bounds: Rectangle,
+    direction: Direction,
     shell: &mut Shell<'_, Message>,
 ) {
     if let Some(on_scroll) = on_scroll {
@@ -971,11 +984,23 @@ fn notify_on_scroll<Message>(
             return;
         }
 
+        let horizontal_alignment = direction
+            .horizontal()
+            .map(|p| p.alignment)
+            .unwrap_or_default();
+
+        let vertical_alignment = direction
+            .vertical()
+            .map(|p| p.alignment)
+            .unwrap_or_default();
+
         let viewport = Viewport {
             offset_x: state.offset_x,
             offset_y: state.offset_y,
             bounds,
             content_bounds,
+            vertical_alignment,
+            horizontal_alignment,
         };
 
         // Don't publish redundant viewports to shell
@@ -1080,6 +1105,8 @@ pub struct Viewport {
     offset_y: Offset,
     bounds: Rectangle,
     content_bounds: Rectangle,
+    vertical_alignment: Alignment,
+    horizontal_alignment: Alignment,
 }
 
 impl Viewport {
@@ -1103,6 +1130,36 @@ impl Viewport {
         let y = y / (self.content_bounds.height - self.bounds.height);
 
         RelativeOffset { x, y }
+    }
+
+    /// Returns a new [`Viewport`] with the supplied vertical [`Alignment`].
+    pub fn with_vertical_alignment(self, alignment: Alignment) -> Self {
+        if self.vertical_alignment != alignment {
+            let relative = 1.0 - self.relative_offset().y;
+
+            Self {
+                offset_y: Offset::Relative(relative),
+                vertical_alignment: alignment,
+                ..self
+            }
+        } else {
+            self
+        }
+    }
+
+    /// Returns a new [`Viewport`] with the supplied horizontal [`Alignment`].
+    pub fn with_horizontal_alignment(self, alignment: Alignment) -> Self {
+        if self.horizontal_alignment != alignment {
+            let relative = 1.0 - self.relative_offset().x;
+
+            Self {
+                offset_x: Offset::Relative(relative),
+                horizontal_alignment: alignment,
+                ..self
+            }
+        } else {
+            self
+        }
     }
 }
 


### PR DESCRIPTION
As discussed in #1912, consumers need to be able to calculate new viewport offsets when swapping between alignments.

This exposes two new `with_<direction>_alignment` methods. If user wants to keep the scrollable's viewport anchored in the same position while swapping alignments, they can call `viewport.with_alignment(new_alignment)` and return the new viewport's `relative_offset` to `scroll_to`. 