### PR TITLE
Add viewport to `Widget::on_event`

### DIFF
--- a/core/src/element.rs
+++ b/core/src/element.rs
@@ -380,6 +380,7 @@ where
         renderer: &Renderer,
         clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, B>,
+        viewport: &Rectangle,
     ) -> event::Status {
         let mut local_messages = Vec::new();
         let mut local_shell = Shell::new(&mut local_messages);
@@ -392,6 +393,7 @@ where
             renderer,
             clipboard,
             &mut local_shell,
+            viewport,
         );
 
         shell.merge(local_shell, &self.mapper);
@@ -511,10 +513,11 @@ where
         renderer: &Renderer,
         clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, Message>,
+        viewport: &Rectangle,
     ) -> event::Status {
-        self.element
-            .widget
-            .on_event(state, event, layout, cursor, renderer, clipboard, shell)
+        self.element.widget.on_event(
+            state, event, layout, cursor, renderer, clipboard, shell, viewport,
+        )
     }
 
     fn draw(

--- a/core/src/widget.rs
+++ b/core/src/widget.rs
@@ -115,6 +115,7 @@ where
         _renderer: &Renderer,
         _clipboard: &mut dyn Clipboard,
         _shell: &mut Shell<'_, Message>,
+        _viewport: &Rectangle,
     ) -> event::Status {
         event::Status::Ignored
     }

--- a/examples/loading_spinners/src/circular.rs
+++ b/examples/loading_spinners/src/circular.rs
@@ -272,6 +272,7 @@ where
         _renderer: &iced::Renderer<Theme>,
         _clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, Message>,
+        _viewport: &Rectangle,
     ) -> event::Status {
         const FRAME_RATE: u64 = 60;
 

--- a/examples/loading_spinners/src/linear.rs
+++ b/examples/loading_spinners/src/linear.rs
@@ -193,6 +193,7 @@ where
         _renderer: &Renderer,
         _clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, Message>,
+        _viewport: &Rectangle,
     ) -> event::Status {
         const FRAME_RATE: u64 = 60;
 

--- a/examples/modal/src/main.rs
+++ b/examples/modal/src/main.rs
@@ -300,6 +300,7 @@ mod modal {
             renderer: &Renderer,
             clipboard: &mut dyn Clipboard,
             shell: &mut Shell<'_, Message>,
+            viewport: &Rectangle,
         ) -> event::Status {
             self.base.as_widget_mut().on_event(
                 &mut state.children[0],
@@ -309,6 +310,7 @@ mod modal {
                 renderer,
                 clipboard,
                 shell,
+                viewport,
             )
         }
 
@@ -446,6 +448,7 @@ mod modal {
                 renderer,
                 clipboard,
                 shell,
+                &layout.bounds(),
             )
         }
 

--- a/examples/toast/src/main.rs
+++ b/examples/toast/src/main.rs
@@ -400,6 +400,7 @@ mod toast {
             renderer: &Renderer,
             clipboard: &mut dyn Clipboard,
             shell: &mut Shell<'_, Message>,
+            viewport: &Rectangle,
         ) -> event::Status {
             self.content.as_widget_mut().on_event(
                 &mut state.children[0],
@@ -409,6 +410,7 @@ mod toast {
                 renderer,
                 clipboard,
                 shell,
+                viewport,
             )
         }
 
@@ -559,6 +561,8 @@ mod toast {
                 }
             }
 
+            let viewport = layout.bounds();
+
             self.toasts
                 .iter_mut()
                 .zip(self.state.iter_mut())
@@ -576,6 +580,7 @@ mod toast {
                         renderer,
                         clipboard,
                         &mut local_shell,
+                        &viewport,
                     );
 
                     if !local_shell.is_empty() {

--- a/runtime/src/user_interface.rs
+++ b/runtime/src/user_interface.rs
@@ -284,6 +284,8 @@ where
             (cursor, vec![event::Status::Ignored; events.len()])
         };
 
+        let viewport = Rectangle::with_size(self.bounds);
+
         let _ = ManuallyDrop::into_inner(manual_overlay);
 
         let event_statuses = events
@@ -305,6 +307,7 @@ where
                     renderer,
                     clipboard,
                     &mut shell,
+                    &viewport,
                 );
 
                 if matches!(event_status, event::Status::Captured) {

--- a/widget/src/button.rs
+++ b/widget/src/button.rs
@@ -200,6 +200,7 @@ where
         renderer: &Renderer,
         clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, Message>,
+        viewport: &Rectangle,
     ) -> event::Status {
         if let event::Status::Captured = self.content.as_widget_mut().on_event(
             &mut tree.children[0],
@@ -209,6 +210,7 @@ where
             renderer,
             clipboard,
             shell,
+            viewport,
         ) {
             return event::Status::Captured;
         }

--- a/widget/src/canvas.rs
+++ b/widget/src/canvas.rs
@@ -147,6 +147,7 @@ where
         _renderer: &Renderer,
         _clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, Message>,
+        _viewport: &Rectangle,
     ) -> event::Status {
         let bounds = layout.bounds();
 

--- a/widget/src/checkbox.rs
+++ b/widget/src/checkbox.rs
@@ -208,6 +208,7 @@ where
         _renderer: &Renderer,
         _clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, Message>,
+        _viewport: &Rectangle,
     ) -> event::Status {
         match event {
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))

--- a/widget/src/column.rs
+++ b/widget/src/column.rs
@@ -170,6 +170,7 @@ where
         renderer: &Renderer,
         clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, Message>,
+        viewport: &Rectangle,
     ) -> event::Status {
         self.children
             .iter_mut()
@@ -184,6 +185,7 @@ where
                     renderer,
                     clipboard,
                     shell,
+                    viewport,
                 )
             })
             .fold(event::Status::Ignored, event::Status::merge)

--- a/widget/src/container.rs
+++ b/widget/src/container.rs
@@ -200,6 +200,7 @@ where
         renderer: &Renderer,
         clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, Message>,
+        viewport: &Rectangle,
     ) -> event::Status {
         self.content.as_widget_mut().on_event(
             &mut tree.children[0],
@@ -209,6 +210,7 @@ where
             renderer,
             clipboard,
             shell,
+            viewport,
         )
     }
 

--- a/widget/src/image/viewer.rs
+++ b/widget/src/image/viewer.rs
@@ -148,6 +148,7 @@ where
         renderer: &Renderer,
         _clipboard: &mut dyn Clipboard,
         _shell: &mut Shell<'_, Message>,
+        _viewport: &Rectangle,
     ) -> event::Status {
         let bounds = layout.bounds();
 

--- a/widget/src/lazy.rs
+++ b/widget/src/lazy.rs
@@ -186,6 +186,7 @@ where
         renderer: &Renderer,
         clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, Message>,
+        viewport: &Rectangle,
     ) -> event::Status {
         self.with_element_mut(|element| {
             element.as_widget_mut().on_event(
@@ -196,6 +197,7 @@ where
                 renderer,
                 clipboard,
                 shell,
+                viewport,
             )
         })
     }

--- a/widget/src/lazy/component.rs
+++ b/widget/src/lazy/component.rs
@@ -270,6 +270,7 @@ where
         renderer: &Renderer,
         clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, Message>,
+        viewport: &Rectangle,
     ) -> event::Status {
         let mut local_messages = Vec::new();
         let mut local_shell = Shell::new(&mut local_messages);
@@ -284,6 +285,7 @@ where
                 renderer,
                 clipboard,
                 &mut local_shell,
+                viewport,
             )
         });
 

--- a/widget/src/lazy/responsive.rs
+++ b/widget/src/lazy/responsive.rs
@@ -182,6 +182,7 @@ where
         renderer: &Renderer,
         clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, Message>,
+        viewport: &Rectangle,
     ) -> event::Status {
         let state = tree.state.downcast_mut::<State>();
         let mut content = self.content.borrow_mut();
@@ -203,6 +204,7 @@ where
                     renderer,
                     clipboard,
                     &mut local_shell,
+                    viewport,
                 )
             },
         );

--- a/widget/src/mouse_area.rs
+++ b/widget/src/mouse_area.rs
@@ -150,6 +150,7 @@ where
         renderer: &Renderer,
         clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, Message>,
+        viewport: &Rectangle,
     ) -> event::Status {
         if let event::Status::Captured = self.content.as_widget_mut().on_event(
             &mut tree.children[0],
@@ -159,6 +160,7 @@ where
             renderer,
             clipboard,
             shell,
+            viewport,
         ) {
             return event::Status::Captured;
         }

--- a/widget/src/overlay/menu.rs
+++ b/widget/src/overlay/menu.rs
@@ -268,8 +268,11 @@ where
         clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, Message>,
     ) -> event::Status {
+        let bounds = layout.bounds();
+
         self.container.on_event(
             self.state, event, layout, cursor, renderer, clipboard, shell,
+            &bounds,
         )
     }
 
@@ -377,6 +380,7 @@ where
         renderer: &Renderer,
         _clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, Message>,
+        _viewport: &Rectangle,
     ) -> event::Status {
         match event {
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) => {

--- a/widget/src/pane_grid.rs
+++ b/widget/src/pane_grid.rs
@@ -317,6 +317,7 @@ where
         renderer: &Renderer,
         clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, Message>,
+        viewport: &Rectangle,
     ) -> event::Status {
         let action = tree.state.downcast_mut::<state::Action>();
 
@@ -357,6 +358,7 @@ where
                     renderer,
                     clipboard,
                     shell,
+                    viewport,
                     is_picked,
                 )
             })

--- a/widget/src/pane_grid/content.rs
+++ b/widget/src/pane_grid/content.rs
@@ -222,6 +222,7 @@ where
         renderer: &Renderer,
         clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, Message>,
+        viewport: &Rectangle,
         is_picked: bool,
     ) -> event::Status {
         let mut event_status = event::Status::Ignored;
@@ -237,6 +238,7 @@ where
                 renderer,
                 clipboard,
                 shell,
+                viewport,
             );
 
             children.next().unwrap()
@@ -255,6 +257,7 @@ where
                 renderer,
                 clipboard,
                 shell,
+                viewport,
             )
         };
 

--- a/widget/src/pane_grid/title_bar.rs
+++ b/widget/src/pane_grid/title_bar.rs
@@ -304,6 +304,7 @@ where
         renderer: &Renderer,
         clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, Message>,
+        viewport: &Rectangle,
     ) -> event::Status {
         let mut children = layout.children();
         let padded = children.next().unwrap();
@@ -328,6 +329,7 @@ where
                 renderer,
                 clipboard,
                 shell,
+                viewport,
             )
         } else {
             event::Status::Ignored
@@ -342,6 +344,7 @@ where
                 renderer,
                 clipboard,
                 shell,
+                viewport,
             )
         } else {
             event::Status::Ignored

--- a/widget/src/pick_list.rs
+++ b/widget/src/pick_list.rs
@@ -200,6 +200,7 @@ where
         _renderer: &Renderer,
         _clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, Message>,
+        _viewport: &Rectangle,
     ) -> event::Status {
         update(
             event,

--- a/widget/src/radio.rs
+++ b/widget/src/radio.rs
@@ -233,6 +233,7 @@ where
         _renderer: &Renderer,
         _clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, Message>,
+        _viewport: &Rectangle,
     ) -> event::Status {
         match event {
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))

--- a/widget/src/row.rs
+++ b/widget/src/row.rs
@@ -159,6 +159,7 @@ where
         renderer: &Renderer,
         clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, Message>,
+        viewport: &Rectangle,
     ) -> event::Status {
         self.children
             .iter_mut()
@@ -173,6 +174,7 @@ where
                     renderer,
                     clipboard,
                     shell,
+                    viewport,
                 )
             })
             .fold(event::Status::Ignored, event::Status::merge)

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -278,6 +278,7 @@ where
         renderer: &Renderer,
         clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, Message>,
+        _viewport: &Rectangle,
     ) -> event::Status {
         update(
             tree.state.downcast_mut::<State>(),
@@ -288,7 +289,7 @@ where
             shell,
             self.direction,
             &self.on_scroll,
-            |event, layout, cursor, clipboard, shell| {
+            |event, layout, cursor, clipboard, shell, viewport| {
                 self.content.as_widget_mut().on_event(
                     &mut tree.children[0],
                     event,
@@ -297,6 +298,7 @@ where
                     renderer,
                     clipboard,
                     shell,
+                    viewport,
                 )
             },
         )
@@ -492,6 +494,7 @@ pub fn update<Message>(
         mouse::Cursor,
         &mut dyn Clipboard,
         &mut Shell<'_, Message>,
+        &Rectangle,
     ) -> event::Status,
 ) -> event::Status {
     let bounds = layout.bounds();
@@ -518,7 +521,20 @@ pub fn update<Message>(
             _ => mouse::Cursor::Unavailable,
         };
 
-        update_content(event.clone(), content, cursor, clipboard, shell)
+        let translation = state.translation(direction, bounds, content_bounds);
+
+        update_content(
+            event.clone(),
+            content,
+            cursor,
+            clipboard,
+            shell,
+            &Rectangle {
+                y: bounds.y + translation.y,
+                x: bounds.x + translation.x,
+                ..bounds
+            },
+        )
     };
 
     if let event::Status::Captured = event_status {

--- a/widget/src/slider.rs
+++ b/widget/src/slider.rs
@@ -187,6 +187,7 @@ where
         _renderer: &Renderer,
         _clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, Message>,
+        _viewport: &Rectangle,
     ) -> event::Status {
         update(
             event,

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -302,6 +302,7 @@ where
         renderer: &Renderer,
         clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, Message>,
+        _viewport: &Rectangle,
     ) -> event::Status {
         update(
             event,

--- a/widget/src/toggler.rs
+++ b/widget/src/toggler.rs
@@ -207,6 +207,7 @@ where
         _renderer: &Renderer,
         _clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, Message>,
+        _viewport: &Rectangle,
     ) -> event::Status {
         match event {
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))

--- a/widget/src/tooltip.rs
+++ b/widget/src/tooltip.rs
@@ -147,6 +147,7 @@ where
         renderer: &Renderer,
         clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, Message>,
+        viewport: &Rectangle,
     ) -> event::Status {
         let state = tree.state.downcast_mut::<State>();
 
@@ -163,6 +164,7 @@ where
             renderer,
             clipboard,
             shell,
+            viewport,
         )
     }
 

--- a/widget/src/vertical_slider.rs
+++ b/widget/src/vertical_slider.rs
@@ -184,6 +184,7 @@ where
         _renderer: &Renderer,
         _clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, Message>,
+        _viewport: &Rectangle,
     ) -> event::Status {
         update(
             event,


### PR DESCRIPTION
As a widget creator, I want to be able to access viewport in `on_event` to understand if the widget is within view or not. This will allow me to cull expensive event logic for widgets not visible. It will also allow me to create new widgets that can emit messages when they become visible in the viewport (during `RedrawRequested`).

This specifically allows for creating some nice optimizations and behavior around elements inside a `scrollable`.  