### PR TITLE
Add app id setting for linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Conversion support from `Fn` trait to custom theme. [#1861](https://github.com/iced-rs/iced/pull/1861)
 - Configurable border radii on relevant widgets. [#1869](https://github.com/iced-rs/iced/pull/1869)
 - `border_radius` styling to `Slider` rail. [#1892](https://github.com/iced-rs/iced/pull/1892)
+- `application_id` in `PlatformSpecific` settings for Linux. [#1963](https://github.com/iced-rs/iced/pull/1963)
 - Aliased entries in `text::Cache`. [#1934](https://github.com/iced-rs/iced/pull/1934)
 - Text cache modes. [#1938](https://github.com/iced-rs/iced/pull/1938)
 - `operate` method for `program::State`. [#1913](https://github.com/iced-rs/iced/pull/1913)

--- a/winit/src/settings.rs
+++ b/winit/src/settings.rs
@@ -7,6 +7,10 @@ mod platform;
 #[path = "settings/macos.rs"]
 mod platform;
 
+#[cfg(target_os = "linux")]
+#[path = "settings/linux.rs"]
+mod platform;
+
 #[cfg(target_arch = "wasm32")]
 #[path = "settings/wasm.rs"]
 mod platform;
@@ -14,6 +18,7 @@ mod platform;
 #[cfg(not(any(
     target_os = "windows",
     target_os = "macos",
+    target_os = "linux",
     target_arch = "wasm32"
 )))]
 #[path = "settings/other.rs"]
@@ -150,7 +155,6 @@ impl Window {
         }
 
         #[cfg(any(
-            target_os = "linux",
             target_os = "dragonfly",
             target_os = "freebsd",
             target_os = "netbsd",
@@ -190,6 +194,28 @@ impl Window {
                 .with_fullsize_content_view(
                     self.platform_specific.fullsize_content_view,
                 );
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            #[cfg(feature = "x11")]
+            {
+                use winit::platform::x11::WindowBuilderExtX11;
+
+                window_builder = window_builder.with_name(
+                    &self.platform_specific.application_id,
+                    &self.platform_specific.application_id,
+                );
+            }
+            #[cfg(feature = "wayland")]
+            {
+                use winit::platform::wayland::WindowBuilderExtWayland;
+
+                window_builder = window_builder.with_name(
+                    &self.platform_specific.application_id,
+                    &self.platform_specific.application_id,
+                );
+            }
         }
 
         window_builder

--- a/winit/src/settings/linux.rs
+++ b/winit/src/settings/linux.rs
@@ -1,0 +1,11 @@
+//! Platform specific settings for Linux.
+
+/// The platform specific window settings of an application.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct PlatformSpecific {
+    /// Sets the application id of the window.
+    ///
+    /// As a best practice, it is suggested to select an application id that match
+    /// the basename of the application’s .desktop file.
+    pub application_id: String,
+}


### PR DESCRIPTION
This adds a new platform specific window setting on linux to set `application_id`. This allows the user to reliably tie their application to the XDG spec for `.desktop` file, where icon can be specified. 

Without this, the application id (on X11, this is WMClass) is set to the executable name so renaming the application breaks proper `.desktop` usage. 