### PR TITLE
Don't clip raw overlay bounds

### DIFF
--- a/runtime/src/user_interface.rs
+++ b/runtime/src/user_interface.rs
@@ -513,17 +513,13 @@ where
                             renderer,
                         );
 
-                        let overlay_bounds = layout.bounds();
-
-                        renderer.with_layer(overlay_bounds, |renderer| {
-                            overlay.draw(
-                                renderer,
-                                theme,
-                                style,
-                                Layout::new(layout),
-                                cursor,
-                            );
-                        });
+                        overlay.draw(
+                            renderer,
+                            theme,
+                            style,
+                            Layout::new(layout),
+                            cursor,
+                        );
 
                         if cursor
                             .position()


### PR DESCRIPTION
User interface wraps the root overlay in `overlay::Nested`. Clipping here w/ the `Nested` overlay bounds always clipped at (0, 0) position instead of the correct position of the child overlay. The child is clipped properly already within `Nested::draw`.

I've confirmed `modal` and `toast` examples still work. This bug was found by updating the `iced_aw` `FloatingElement` to `master` and not being able to get it to work because it has a translation away from (0,0) so the clip bounds were never over they correct area. This patch fixes it. 