### PR TITLE
`visible_bounds` operation for `Container`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Helpers to change viewport alignment of a `Scrollable`. [#1953](https://github.com/iced-rs/iced/pull/1953)
 - `scroll_to` widget operation. [#1796](https://github.com/iced-rs/iced/pull/1796)
 - `scroll_to` helper. [#1804](https://github.com/iced-rs/iced/pull/1804)
+- `visible_bounds` widget operation for `Container`. [#1971](https://github.com/iced-rs/iced/pull/1971)
 - Command to fetch window size. [#1927](https://github.com/iced-rs/iced/pull/1927)
 - Conversion support from `Fn` trait to custom theme. [#1861](https://github.com/iced-rs/iced/pull/1861)
 - Configurable border radii on relevant widgets. [#1869](https://github.com/iced-rs/iced/pull/1869)

--- a/core/src/element.rs
+++ b/core/src/element.rs
@@ -5,7 +5,9 @@ use crate::overlay;
 use crate::renderer;
 use crate::widget;
 use crate::widget::tree::{self, Tree};
-use crate::{Clipboard, Color, Layout, Length, Rectangle, Shell, Widget};
+use crate::{
+    Clipboard, Color, Layout, Length, Rectangle, Shell, Vector, Widget,
+};
 
 use std::any::Any;
 use std::borrow::Borrow;
@@ -325,11 +327,12 @@ where
             fn container(
                 &mut self,
                 id: Option<&widget::Id>,
+                bounds: Rectangle,
                 operate_on_children: &mut dyn FnMut(
                     &mut dyn widget::Operation<T>,
                 ),
             ) {
-                self.operation.container(id, &mut |operation| {
+                self.operation.container(id, bounds, &mut |operation| {
                     operate_on_children(&mut MapOperation { operation });
                 });
             }
@@ -346,8 +349,10 @@ where
                 &mut self,
                 state: &mut dyn widget::operation::Scrollable,
                 id: Option<&widget::Id>,
+                bounds: Rectangle,
+                translation: Vector,
             ) {
-                self.operation.scrollable(state, id);
+                self.operation.scrollable(state, id, bounds, translation);
             }
 
             fn text_input(

--- a/core/src/overlay/element.rs
+++ b/core/src/overlay/element.rs
@@ -172,11 +172,12 @@ where
             fn container(
                 &mut self,
                 id: Option<&widget::Id>,
+                bounds: Rectangle,
                 operate_on_children: &mut dyn FnMut(
                     &mut dyn widget::Operation<T>,
                 ),
             ) {
-                self.operation.container(id, &mut |operation| {
+                self.operation.container(id, bounds, &mut |operation| {
                     operate_on_children(&mut MapOperation { operation });
                 });
             }
@@ -193,8 +194,10 @@ where
                 &mut self,
                 state: &mut dyn widget::operation::Scrollable,
                 id: Option<&widget::Id>,
+                bounds: Rectangle,
+                translation: Vector,
             ) {
-                self.operation.scrollable(state, id);
+                self.operation.scrollable(state, id, bounds, translation);
             }
 
             fn text_input(

--- a/core/src/overlay/group.rs
+++ b/core/src/overlay/group.rs
@@ -138,7 +138,7 @@ where
         renderer: &Renderer,
         operation: &mut dyn widget::Operation<Message>,
     ) {
-        operation.container(None, &mut |operation| {
+        operation.container(None, layout.bounds(), &mut |operation| {
             self.children.iter_mut().zip(layout.children()).for_each(
                 |(child, layout)| {
                     child.operate(layout, renderer, operation);

--- a/core/src/rectangle.rs
+++ b/core/src/rectangle.rs
@@ -197,3 +197,18 @@ where
         }
     }
 }
+
+impl<T> std::ops::Sub<Vector<T>> for Rectangle<T>
+where
+    T: std::ops::Sub<Output = T>,
+{
+    type Output = Rectangle<T>;
+
+    fn sub(self, translation: Vector<T>) -> Self {
+        Rectangle {
+            x: self.x - translation.x,
+            y: self.y - translation.y,
+            ..self
+        }
+    }
+}

--- a/core/src/widget/operation/focusable.rs
+++ b/core/src/widget/operation/focusable.rs
@@ -1,6 +1,7 @@
 //! Operate on widgets that can be focused.
 use crate::widget::operation::{Operation, Outcome};
 use crate::widget::Id;
+use crate::Rectangle;
 
 /// The internal state of a widget that can be focused.
 pub trait Focusable {
@@ -45,6 +46,7 @@ pub fn focus<T>(target: Id) -> impl Operation<T> {
         fn container(
             &mut self,
             _id: Option<&Id>,
+            _bounds: Rectangle,
             operate_on_children: &mut dyn FnMut(&mut dyn Operation<T>),
         ) {
             operate_on_children(self)
@@ -80,6 +82,7 @@ where
         fn container(
             &mut self,
             _id: Option<&Id>,
+            _bounds: Rectangle,
             operate_on_children: &mut dyn FnMut(&mut dyn Operation<T>),
         ) {
             operate_on_children(self)
@@ -126,6 +129,7 @@ pub fn focus_previous<T>() -> impl Operation<T> {
         fn container(
             &mut self,
             _id: Option<&Id>,
+            _bounds: Rectangle,
             operate_on_children: &mut dyn FnMut(&mut dyn Operation<T>),
         ) {
             operate_on_children(self)
@@ -159,6 +163,7 @@ pub fn focus_next<T>() -> impl Operation<T> {
         fn container(
             &mut self,
             _id: Option<&Id>,
+            _bounds: Rectangle,
             operate_on_children: &mut dyn FnMut(&mut dyn Operation<T>),
         ) {
             operate_on_children(self)
@@ -185,6 +190,7 @@ pub fn find_focused() -> impl Operation<Id> {
         fn container(
             &mut self,
             _id: Option<&Id>,
+            _bounds: Rectangle,
             operate_on_children: &mut dyn FnMut(&mut dyn Operation<Id>),
         ) {
             operate_on_children(self)

--- a/core/src/widget/operation/scrollable.rs
+++ b/core/src/widget/operation/scrollable.rs
@@ -1,5 +1,6 @@
 //! Operate on widgets that can be scrolled.
 use crate::widget::{Id, Operation};
+use crate::{Rectangle, Vector};
 
 /// The internal state of a widget that can be scrolled.
 pub trait Scrollable {
@@ -22,12 +23,19 @@ pub fn snap_to<T>(target: Id, offset: RelativeOffset) -> impl Operation<T> {
         fn container(
             &mut self,
             _id: Option<&Id>,
+            _bounds: Rectangle,
             operate_on_children: &mut dyn FnMut(&mut dyn Operation<T>),
         ) {
             operate_on_children(self)
         }
 
-        fn scrollable(&mut self, state: &mut dyn Scrollable, id: Option<&Id>) {
+        fn scrollable(
+            &mut self,
+            state: &mut dyn Scrollable,
+            id: Option<&Id>,
+            _bounds: Rectangle,
+            _translation: Vector,
+        ) {
             if Some(&self.target) == id {
                 state.snap_to(self.offset);
             }
@@ -49,12 +57,19 @@ pub fn scroll_to<T>(target: Id, offset: AbsoluteOffset) -> impl Operation<T> {
         fn container(
             &mut self,
             _id: Option<&Id>,
+            _bounds: Rectangle,
             operate_on_children: &mut dyn FnMut(&mut dyn Operation<T>),
         ) {
             operate_on_children(self)
         }
 
-        fn scrollable(&mut self, state: &mut dyn Scrollable, id: Option<&Id>) {
+        fn scrollable(
+            &mut self,
+            state: &mut dyn Scrollable,
+            id: Option<&Id>,
+            _bounds: Rectangle,
+            _translation: Vector,
+        ) {
             if Some(&self.target) == id {
                 state.scroll_to(self.offset);
             }

--- a/core/src/widget/operation/text_input.rs
+++ b/core/src/widget/operation/text_input.rs
@@ -1,6 +1,7 @@
 //! Operate on widgets that have text input.
 use crate::widget::operation::Operation;
 use crate::widget::Id;
+use crate::Rectangle;
 
 /// The internal state of a widget that has text input.
 pub trait TextInput {
@@ -34,6 +35,7 @@ pub fn move_cursor_to_front<T>(target: Id) -> impl Operation<T> {
         fn container(
             &mut self,
             _id: Option<&Id>,
+            _bounds: Rectangle,
             operate_on_children: &mut dyn FnMut(&mut dyn Operation<T>),
         ) {
             operate_on_children(self)
@@ -63,6 +65,7 @@ pub fn move_cursor_to_end<T>(target: Id) -> impl Operation<T> {
         fn container(
             &mut self,
             _id: Option<&Id>,
+            _bounds: Rectangle,
             operate_on_children: &mut dyn FnMut(&mut dyn Operation<T>),
         ) {
             operate_on_children(self)
@@ -93,6 +96,7 @@ pub fn move_cursor_to<T>(target: Id, position: usize) -> impl Operation<T> {
         fn container(
             &mut self,
             _id: Option<&Id>,
+            _bounds: Rectangle,
             operate_on_children: &mut dyn FnMut(&mut dyn Operation<T>),
         ) {
             operate_on_children(self)
@@ -121,6 +125,7 @@ pub fn select_all<T>(target: Id) -> impl Operation<T> {
         fn container(
             &mut self,
             _id: Option<&Id>,
+            _bounds: Rectangle,
             operate_on_children: &mut dyn FnMut(&mut dyn Operation<T>),
         ) {
             operate_on_children(self)

--- a/examples/toast/src/main.rs
+++ b/examples/toast/src/main.rs
@@ -381,7 +381,7 @@ mod toast {
             renderer: &Renderer,
             operation: &mut dyn Operation<Message>,
         ) {
-            operation.container(None, &mut |operation| {
+            operation.container(None, layout.bounds(), &mut |operation| {
                 self.content.as_widget().operate(
                     &mut state.children[0],
                     layout,
@@ -622,7 +622,7 @@ mod toast {
             renderer: &Renderer,
             operation: &mut dyn widget::Operation<Message>,
         ) {
-            operation.container(None, &mut |operation| {
+            operation.container(None, layout.bounds(), &mut |operation| {
                 self.toasts
                     .iter()
                     .zip(self.state.iter_mut())

--- a/examples/visible_bounds/Cargo.toml
+++ b/examples/visible_bounds/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "visible_bounds"
+version = "0.1.0"
+authors = ["Héctor Ramón Jiménez <hector0193@gmail.com>"]
+edition = "2021"
+publish = false
+
+[dependencies]
+iced = { path = "../..", features = ["debug"] }
+once_cell = "1"

--- a/examples/visible_bounds/src/main.rs
+++ b/examples/visible_bounds/src/main.rs
@@ -5,6 +5,7 @@ use iced::theme::{self, Theme};
 use iced::widget::{
     column, container, horizontal_space, row, scrollable, text, vertical_space,
 };
+use iced::window;
 use iced::{
     Alignment, Application, Color, Command, Element, Event, Font, Length,
     Point, Rectangle, Settings,
@@ -23,6 +24,7 @@ struct Example {
 #[derive(Debug, Clone, Copy)]
 enum Message {
     MouseMoved(Point),
+    WindowResized,
     Scrolled(scrollable::Viewport),
     OuterBoundsFetched(Option<Rectangle>),
     InnerBoundsFetched(Option<Rectangle>),
@@ -56,12 +58,14 @@ impl Application for Example {
 
                 Command::none()
             }
-            Message::Scrolled(_) => Command::batch(vec![
-                container::visible_bounds(OUTER_CONTAINER.clone())
-                    .map(Message::OuterBoundsFetched),
-                container::visible_bounds(INNER_CONTAINER.clone())
-                    .map(Message::InnerBoundsFetched),
-            ]),
+            Message::Scrolled(_) | Message::WindowResized => {
+                Command::batch(vec![
+                    container::visible_bounds(OUTER_CONTAINER.clone())
+                        .map(Message::OuterBoundsFetched),
+                    container::visible_bounds(INNER_CONTAINER.clone())
+                        .map(Message::InnerBoundsFetched),
+                ])
+            }
             Message::OuterBoundsFetched(outer_bounds) => {
                 self.outer_bounds = outer_bounds;
 
@@ -162,6 +166,9 @@ impl Application for Example {
         subscription::events_with(|event, _| match event {
             Event::Mouse(mouse::Event::CursorMoved { position }) => {
                 Some(Message::MouseMoved(position))
+            }
+            Event::Window(window::Event::Resized { .. }) => {
+                Some(Message::WindowResized)
             }
             _ => None,
         })

--- a/examples/visible_bounds/src/main.rs
+++ b/examples/visible_bounds/src/main.rs
@@ -1,0 +1,151 @@
+use iced::executor;
+use iced::mouse;
+use iced::subscription::{self, Subscription};
+use iced::theme::{self, Theme};
+use iced::widget::{column, container, scrollable, text, vertical_space};
+use iced::{
+    Application, Command, Element, Event, Length, Point, Rectangle, Settings,
+};
+
+pub fn main() -> iced::Result {
+    Example::run(Settings::default())
+}
+
+struct Example {
+    mouse_position: Option<Point>,
+    outer_bounds: Option<Rectangle>,
+    inner_bounds: Option<Rectangle>,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Message {
+    MouseMoved(Point),
+    Scrolled(scrollable::Viewport),
+    OuterBoundsFetched(Option<Rectangle>),
+    InnerBoundsFetched(Option<Rectangle>),
+}
+
+impl Application for Example {
+    type Message = Message;
+    type Theme = Theme;
+    type Flags = ();
+    type Executor = executor::Default;
+
+    fn new(_flags: Self::Flags) -> (Self, Command<Message>) {
+        (
+            Self {
+                mouse_position: None,
+                outer_bounds: None,
+                inner_bounds: None,
+            },
+            Command::none(),
+        )
+    }
+
+    fn title(&self) -> String {
+        String::from("Visible bounds - Iced")
+    }
+
+    fn update(&mut self, message: Message) -> Command<Message> {
+        match message {
+            Message::MouseMoved(position) => {
+                self.mouse_position = Some(position);
+
+                Command::none()
+            }
+            Message::Scrolled(_) => Command::batch(vec![
+                container::visible_bounds(OUTER_CONTAINER.clone())
+                    .map(Message::OuterBoundsFetched),
+                container::visible_bounds(INNER_CONTAINER.clone())
+                    .map(Message::InnerBoundsFetched),
+            ]),
+            Message::OuterBoundsFetched(outer_bounds) => {
+                self.outer_bounds = outer_bounds;
+
+                Command::none()
+            }
+            Message::InnerBoundsFetched(inner_bounds) => {
+                self.inner_bounds = inner_bounds;
+
+                Command::none()
+            }
+        }
+    }
+
+    fn view(&self) -> Element<Message> {
+        let view_bounds = |label, bounds| {
+            text(format!(
+                "The {label} container is {}",
+                match bounds {
+                    Some(bounds) => format!("visible at {:?}", bounds),
+                    None => "not visible".to_string(),
+                }
+            ))
+        };
+
+        column![
+            text(format!(
+                "Mouse position is {}",
+                match self.mouse_position {
+                    Some(Point { x, y }) => format!("({x}, {y})"),
+                    None => "unknown".to_string(),
+                }
+            )),
+            view_bounds("outer", self.outer_bounds),
+            view_bounds("inner", self.inner_bounds),
+            scrollable(
+                column![
+                    text("Scroll me!"),
+                    vertical_space(400),
+                    container(text("I am the outer container!"))
+                        .id(OUTER_CONTAINER.clone())
+                        .padding(40)
+                        .style(theme::Container::Box),
+                    vertical_space(400),
+                    scrollable(
+                        column![
+                            text("Scroll me!"),
+                            vertical_space(400),
+                            container(text("I am the inner container!"))
+                                .id(INNER_CONTAINER.clone())
+                                .padding(40)
+                                .style(theme::Container::Box),
+                            vertical_space(400)
+                        ]
+                        .padding(20)
+                    )
+                    .on_scroll(Message::Scrolled)
+                    .width(Length::Fill)
+                    .height(300),
+                ]
+                .padding(20)
+            )
+            .on_scroll(Message::Scrolled)
+            .width(Length::Fill)
+            .height(300),
+        ]
+        .spacing(10)
+        .padding(20)
+        .into()
+    }
+
+    fn subscription(&self) -> Subscription<Message> {
+        subscription::events_with(|event, _| match event {
+            Event::Mouse(mouse::Event::CursorMoved { position }) => {
+                Some(Message::MouseMoved(position))
+            }
+            _ => None,
+        })
+    }
+
+    fn theme(&self) -> Theme {
+        Theme::Dark
+    }
+}
+
+use once_cell::sync::Lazy;
+
+static OUTER_CONTAINER: Lazy<container::Id> =
+    Lazy::new(|| container::Id::new("outer"));
+static INNER_CONTAINER: Lazy<container::Id> =
+    Lazy::new(|| container::Id::new("inner"));

--- a/examples/visible_bounds/src/main.rs
+++ b/examples/visible_bounds/src/main.rs
@@ -2,9 +2,12 @@ use iced::executor;
 use iced::mouse;
 use iced::subscription::{self, Subscription};
 use iced::theme::{self, Theme};
-use iced::widget::{column, container, scrollable, text, vertical_space};
+use iced::widget::{
+    column, container, horizontal_space, row, scrollable, text, vertical_space,
+};
 use iced::{
-    Application, Command, Element, Event, Length, Point, Rectangle, Settings,
+    Alignment, Application, Color, Command, Element, Event, Font, Length,
+    Point, Rectangle, Settings,
 };
 
 pub fn main() -> iced::Result {
@@ -73,26 +76,52 @@ impl Application for Example {
     }
 
     fn view(&self) -> Element<Message> {
-        let view_bounds = |label, bounds| {
-            text(format!(
-                "The {label} container is {}",
+        let data_row = |label, value, color| {
+            row![
+                text(label),
+                horizontal_space(Length::Fill),
+                text(value).font(Font::MONOSPACE).size(14).style(color),
+            ]
+            .height(40)
+            .align_items(Alignment::Center)
+        };
+
+        let view_bounds = |label, bounds: Option<Rectangle>| {
+            data_row(
+                label,
                 match bounds {
-                    Some(bounds) => format!("visible at {:?}", bounds),
+                    Some(bounds) => format!("{:?}", bounds),
                     None => "not visible".to_string(),
-                }
-            ))
+                },
+                if bounds
+                    .zip(self.mouse_position)
+                    .map(|(bounds, mouse_position)| {
+                        bounds.contains(mouse_position)
+                    })
+                    .unwrap_or_default()
+                {
+                    Color {
+                        g: 1.0,
+                        ..Color::BLACK
+                    }
+                    .into()
+                } else {
+                    theme::Text::Default
+                },
+            )
         };
 
         column![
-            text(format!(
-                "Mouse position is {}",
+            data_row(
+                "Mouse position",
                 match self.mouse_position {
                     Some(Point { x, y }) => format!("({x}, {y})"),
                     None => "unknown".to_string(),
-                }
-            )),
-            view_bounds("outer", self.outer_bounds),
-            view_bounds("inner", self.inner_bounds),
+                },
+                theme::Text::Default,
+            ),
+            view_bounds("Outer container", self.outer_bounds),
+            view_bounds("Inner container", self.inner_bounds),
             scrollable(
                 column![
                     text("Scroll me!"),

--- a/widget/src/button.rs
+++ b/widget/src/button.rs
@@ -181,7 +181,7 @@ where
         renderer: &Renderer,
         operation: &mut dyn Operation<Message>,
     ) {
-        operation.container(None, &mut |operation| {
+        operation.container(None, layout.bounds(), &mut |operation| {
             self.content.as_widget().operate(
                 &mut tree.children[0],
                 layout.children().next().unwrap(),

--- a/widget/src/column.rs
+++ b/widget/src/column.rs
@@ -148,7 +148,7 @@ where
         renderer: &Renderer,
         operation: &mut dyn Operation<Message>,
     ) {
-        operation.container(None, &mut |operation| {
+        operation.container(None, layout.bounds(), &mut |operation| {
             self.children
                 .iter()
                 .zip(&mut tree.children)

--- a/widget/src/lazy/component.rs
+++ b/widget/src/lazy/component.rs
@@ -7,7 +7,8 @@ use crate::core::renderer;
 use crate::core::widget;
 use crate::core::widget::tree::{self, Tree};
 use crate::core::{
-    self, Clipboard, Element, Length, Point, Rectangle, Shell, Size, Widget,
+    self, Clipboard, Element, Length, Point, Rectangle, Shell, Size, Vector,
+    Widget,
 };
 use crate::runtime::overlay::Nested;
 
@@ -340,11 +341,12 @@ where
             fn container(
                 &mut self,
                 id: Option<&widget::Id>,
+                bounds: Rectangle,
                 operate_on_children: &mut dyn FnMut(
                     &mut dyn widget::Operation<T>,
                 ),
             ) {
-                self.operation.container(id, &mut |operation| {
+                self.operation.container(id, bounds, &mut |operation| {
                     operate_on_children(&mut MapOperation { operation });
                 });
             }
@@ -369,8 +371,10 @@ where
                 &mut self,
                 state: &mut dyn widget::operation::Scrollable,
                 id: Option<&widget::Id>,
+                bounds: Rectangle,
+                translation: Vector,
             ) {
-                self.operation.scrollable(state, id);
+                self.operation.scrollable(state, id, bounds, translation);
             }
 
             fn custom(

--- a/widget/src/pane_grid.rs
+++ b/widget/src/pane_grid.rs
@@ -297,7 +297,7 @@ where
         renderer: &Renderer,
         operation: &mut dyn widget::Operation<Message>,
     ) {
-        operation.container(None, &mut |operation| {
+        operation.container(None, layout.bounds(), &mut |operation| {
             self.contents
                 .iter()
                 .zip(&mut tree.children)

--- a/widget/src/row.rs
+++ b/widget/src/row.rs
@@ -137,7 +137,7 @@ where
         renderer: &Renderer,
         operation: &mut dyn Operation<Message>,
     ) {
-        operation.container(None, &mut |operation| {
+        operation.container(None, layout.bounds(), &mut |operation| {
             self.children
                 .iter()
                 .zip(&mut tree.children)

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -254,10 +254,22 @@ where
     ) {
         let state = tree.state.downcast_mut::<State>();
 
-        operation.scrollable(state, self.id.as_ref().map(|id| &id.0));
+        let bounds = layout.bounds();
+        let content_layout = layout.children().next().unwrap();
+        let content_bounds = content_layout.bounds();
+        let translation =
+            state.translation(self.direction, bounds, content_bounds);
+
+        operation.scrollable(
+            state,
+            self.id.as_ref().map(|id| &id.0),
+            bounds,
+            translation,
+        );
 
         operation.container(
             self.id.as_ref().map(|id| &id.0),
+            bounds,
             &mut |operation| {
                 self.content.as_widget().operate(
                     &mut tree.children[0],


### PR DESCRIPTION
This PR introduces a brand new `visible_bounds` operation to `container` which can be used to obtain the visible screen bounds of a `Container` widget with an `Id`.

This operation can be very useful when combined with the `window::screenshot` command.

https://github.com/iced-rs/iced/assets/518289/e2280009-fdd0-447b-929b-cb1ee4b37843

Closes #1911.
