### PR TITLE
Fix wrong color channels

### DIFF
--- a/tiny_skia/src/backend.rs
+++ b/tiny_skia/src/backend.rs
@@ -210,9 +210,9 @@ impl Backend {
                                             tiny_skia::GradientStop::new(
                                                 stop.offset,
                                                 tiny_skia::Color::from_rgba(
-                                                    stop.color.b,
-                                                    stop.color.g,
                                                     stop.color.r,
+                                                    stop.color.g,
+                                                    stop.color.b,
                                                     stop.color.a,
                                                 )
                                                 .expect("Create color"),
@@ -600,7 +600,7 @@ impl Backend {
 }
 
 fn into_color(color: Color) -> tiny_skia::Color {
-    tiny_skia::Color::from_rgba(color.b, color.g, color.r, color.a)
+    tiny_skia::Color::from_rgba(color.r, color.g, color.b, color.a)
         .expect("Convert color from iced to tiny_skia")
 }
 

--- a/tiny_skia/src/geometry.rs
+++ b/tiny_skia/src/geometry.rs
@@ -230,7 +230,7 @@ pub fn into_paint(style: Style) -> tiny_skia::Paint<'static> {
     tiny_skia::Paint {
         shader: match style {
             Style::Solid(color) => tiny_skia::Shader::SolidColor(
-                tiny_skia::Color::from_rgba(color.b, color.g, color.r, color.a)
+                tiny_skia::Color::from_rgba(color.r, color.g, color.b, color.a)
                     .expect("Create color"),
             ),
             Style::Gradient(gradient) => match gradient {
@@ -243,9 +243,9 @@ pub fn into_paint(style: Style) -> tiny_skia::Paint<'static> {
                             tiny_skia::GradientStop::new(
                                 stop.offset,
                                 tiny_skia::Color::from_rgba(
-                                    stop.color.b,
-                                    stop.color.g,
                                     stop.color.r,
+                                    stop.color.g,
+                                    stop.color.b,
                                     stop.color.a,
                                 )
                                 .expect("Create color"),


### PR DESCRIPTION
`tiny-skia` renderer does not work as expected due to wrong color channels.