### PR TITLE
cycle `combo_box` with keybinds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Nix instructions to `DEPENDENCIES.md`. [#1859](https://github.com/iced-rs/iced/pull/1859)
 - Loading spinners example. [#1902](https://github.com/iced-rs/iced/pull/1902)
 - Workflow that verifies `CHANGELOG` is always up-to-date. [#1970](https://github.com/iced-rs/iced/pull/1970)
+- Keybinds to cycle `ComboBox` options. [#1991](https://github.com/iced-rs/iced/pull/1991)
 
 ### Changed
 - Updated `wgpu` to `0.16`. [#1807](https://github.com/iced-rs/iced/pull/1807)

--- a/widget/src/combo_box.rs
+++ b/widget/src/combo_box.rs
@@ -529,7 +529,7 @@ where
                         {
                             if let Some(index) = &mut menu.hovered_option {
                                 if *index
-                                    == state
+                                    >= state
                                         .filtered_options
                                         .options
                                         .len()

--- a/widget/src/combo_box.rs
+++ b/widget/src/combo_box.rs
@@ -468,11 +468,13 @@ where
 
                 if let Event::Keyboard(keyboard::Event::KeyPressed {
                     key_code,
+                    modifiers,
                     ..
                 }) = event
                 {
-                    match key_code {
-                        keyboard::KeyCode::Enter => {
+                    let shift_modifer = modifiers.shift();
+                    match (key_code, shift_modifer) {
+                        (keyboard::KeyCode::Enter, _) => {
                             if let Some(index) = &menu.hovered_option {
                                 if let Some(option) =
                                     state.filtered_options.options.get(*index)
@@ -483,9 +485,19 @@ where
 
                             event_status = event::Status::Captured;
                         }
-                        keyboard::KeyCode::Up => {
+
+                        (keyboard::KeyCode::Up, _)
+                        | (keyboard::KeyCode::Tab, true) => {
                             if let Some(index) = &mut menu.hovered_option {
-                                *index = index.saturating_sub(1);
+                                if *index == 0 {
+                                    *index = state
+                                        .filtered_options
+                                        .options
+                                        .len()
+                                        .saturating_sub(1);
+                                } else {
+                                    *index = index.saturating_sub(1);
+                                }
                             } else {
                                 menu.hovered_option = Some(0);
                             }
@@ -511,15 +523,28 @@ where
 
                             event_status = event::Status::Captured;
                         }
-                        keyboard::KeyCode::Down => {
+                        (keyboard::KeyCode::Down, _)
+                        | (keyboard::KeyCode::Tab, false)
+                            if !modifiers.shift() =>
+                        {
                             if let Some(index) = &mut menu.hovered_option {
-                                *index = index.saturating_add(1).min(
-                                    state
+                                if *index
+                                    == state
                                         .filtered_options
                                         .options
                                         .len()
-                                        .saturating_sub(1),
-                                );
+                                        .saturating_sub(1)
+                                {
+                                    *index = 0;
+                                } else {
+                                    *index = index.saturating_add(1).min(
+                                        state
+                                            .filtered_options
+                                            .options
+                                            .len()
+                                            .saturating_sub(1),
+                                    );
+                                }
                             } else {
                                 menu.hovered_option = Some(0);
                             }


### PR DESCRIPTION
A few keybinds optimizations for `combo_box`:

1. When pressing <kbd>↑</kbd> at the very first entry you cycle to bottom
2. When pressing <kbd>↓</kbd> at the very last entry you cycle to top
3. Add support for <kbd>Tab</kbd> and <kbd>Shift</kbd>+<kbd>Tab</kbd> which does the same as  <kbd>↓</kbd> and <kbd>↑</kbd>.