### PR TITLE
Fix `iced_wgpu` freezing on empty layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Tooltip` overlay position inside `Scrollable`. [#1978](https://github.com/iced-rs/iced/pull/1978)
 - `BorderRadius` not exposed in root crate. [#1972](https://github.com/iced-rs/iced/pull/1972)
 - Outdated `ROADMAP`. [#1958](https://github.com/iced-rs/iced/pull/1958)
+- `iced_wgpu` freezing on empty layers. [#1996](https://github.com/iced-rs/iced/pull/1996)
 
 Many thanks to...
 

--- a/wgpu/src/backend.rs
+++ b/wgpu/src/backend.rs
@@ -236,7 +236,7 @@ impl Backend {
             let bounds = (layer.bounds * scale_factor).snap();
 
             if bounds.width < 1 || bounds.height < 1 {
-                return;
+                continue;
             }
 
             if !layer.quads.is_empty() {

--- a/wgpu/src/backend.rs
+++ b/wgpu/src/backend.rs
@@ -87,7 +87,10 @@ impl Backend {
         let transformation = viewport.projection();
 
         let mut layers = Layer::generate(primitives, viewport);
-        layers.push(Layer::overlay(overlay_text, viewport));
+
+        if !overlay_text.is_empty() {
+            layers.push(Layer::overlay(overlay_text, viewport));
+        }
 
         self.prepare(
             device,


### PR DESCRIPTION
The `render` method would return when an empty layer is encountered without explicitly dropping the `RenderPass` (necessary because we use `ManuallyDrop`), which would then leak memory and freeze `wgpu` until the surface was recreated.