### PR TITLE
fix: Check cursor in bounds when scrolling image::Viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `BorderRadius` not exposed in root crate. [#1972](https://github.com/iced-rs/iced/pull/1972)
 - Outdated `ROADMAP`. [#1958](https://github.com/iced-rs/iced/pull/1958)
 - `iced_wgpu` freezing on empty layers. [#1996](https://github.com/iced-rs/iced/pull/1996)
+- `image::Viewer` reacting to any scroll event. [#1998](https://github.com/iced-rs/iced/pull/1998)
 
 Many thanks to...
 
@@ -99,6 +100,7 @@ Many thanks to...
 - @JonathanLindsey
 - @kr105
 - @marienz
+- @malramsay64
 - @nicksenger
 - @nicoburns
 - @Redhawk18

--- a/widget/src/image/viewer.rs
+++ b/widget/src/image/viewer.rs
@@ -154,7 +154,8 @@ where
 
         match event {
             Event::Mouse(mouse::Event::WheelScrolled { delta }) => {
-                let Some(cursor_position) = cursor.position() else {
+                // Ensure the cursor is within the bounds of the widget
+                let Some(cursor_position) = cursor.position_over(bounds) else {
                     return event::Status::Ignored;
                 };
 

--- a/widget/src/image/viewer.rs
+++ b/widget/src/image/viewer.rs
@@ -154,7 +154,6 @@ where
 
         match event {
             Event::Mouse(mouse::Event::WheelScrolled { delta }) => {
-                // Ensure the cursor is within the bounds of the widget
                 let Some(cursor_position) = cursor.position_over(bounds) else {
                     return event::Status::Ignored;
                 };


### PR DESCRIPTION
Ensure that the cursor is within the bounds of the image::Viewer when
performing the scrolling.

Fixes #1997
