### PR TITLE
Fix `Command<T>::perform` to return a `Command<T>`

### DIFF
--- a/examples/screenshot/src/main.rs
+++ b/examples/screenshot/src/main.rs
@@ -298,10 +298,7 @@ fn numeric_input(
 ) -> Element<'_, Option<u32>> {
     text_input(
         placeholder,
-        &value
-            .as_ref()
-            .map(ToString::to_string)
-            .unwrap_or_else(String::new),
+        &value.as_ref().map(ToString::to_string).unwrap_or_default(),
     )
     .on_input(move |text| {
         if text.is_empty() {

--- a/runtime/src/command.rs
+++ b/runtime/src/command.rs
@@ -40,9 +40,9 @@ impl<T> Command<T> {
 
     /// Creates a [`Command`] that performs the action of the given future.
     pub fn perform<A>(
-        future: impl Future<Output = T> + 'static + MaybeSend,
-        f: impl FnOnce(T) -> A + 'static + MaybeSend,
-    ) -> Command<A> {
+        future: impl Future<Output = A> + 'static + MaybeSend,
+        f: impl FnOnce(A) -> T + 'static + MaybeSend,
+    ) -> Command<T> {
         use iced_futures::futures::FutureExt;
 
         Command::single(Action::Future(Box::pin(future.map(f))))


### PR DESCRIPTION
This seems like clearly the correct thing to do here. If the type bound on `Command` isn't specified, it makes no difference, since the generic is inferred in a way that works with either definition. But this is important if `Command<T>` is aliased with a concrete type.