### PR TITLE
Fix overlay group event handling

### DIFF
--- a/core/src/layout.rs
+++ b/core/src/layout.rs
@@ -54,7 +54,9 @@ impl<'a> Layout<'a> {
     }
 
     /// Returns an iterator over the [`Layout`] of the children of a [`Node`].
-    pub fn children(self) -> impl Iterator<Item = Layout<'a>> {
+    pub fn children(
+        self,
+    ) -> impl DoubleEndedIterator<Item = Layout<'a>> + ExactSizeIterator {
         self.node.children().iter().map(move |node| {
             Layout::with_offset(
                 Vector::new(self.position.x, self.position.y),

--- a/core/src/overlay/group.rs
+++ b/core/src/overlay/group.rs
@@ -86,20 +86,23 @@ where
         clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, Message>,
     ) -> event::Status {
-        self.children
-            .iter_mut()
-            .zip(layout.children())
-            .map(|(child, layout)| {
-                child.on_event(
-                    event.clone(),
-                    layout,
-                    cursor,
-                    renderer,
-                    clipboard,
-                    shell,
-                )
-            })
-            .fold(event::Status::Ignored, event::Status::merge)
+        self.children.iter_mut().zip(layout.children()).rev().fold(
+            event::Status::Ignored,
+            |current, (child, layout)| {
+                if matches!(current, event::Status::Captured) {
+                    event::Status::Captured
+                } else {
+                    child.on_event(
+                        event.clone(),
+                        layout,
+                        cursor,
+                        renderer,
+                        clipboard,
+                        shell,
+                    )
+                }
+            },
+        )
     }
 
     fn draw(


### PR DESCRIPTION
Currently the overlay group runs ` on_event` for all its children without checking if one of them already handled the event. 

This PR simply fixes that by checking the result of each ` on_event` call before making the next. I am not sure if this is intentional or not, but since `nested.rs` seems to care about checking the returned status for overlays I thought it should be the same here.

https://github.com/iced-rs/iced/blob/cb8b70bec3e8bbf809e7d8ffc559adb712f45e14/runtime/src/overlay/nested.rs#L210)

The children are iterated in reverse drawing order so that overlays in the front get the first chance to handle the event.