### PR TITLE
wgpu: set `layers` to `Layer::Full`

### DIFF
--- a/wgpu/src/image/atlas.rs
+++ b/wgpu/src/image/atlas.rs
@@ -55,7 +55,7 @@ impl Atlas {
         Atlas {
             texture,
             texture_view,
-            layers: vec![Layer::Empty],
+            layers: vec![Layer::Full],
         }
     }
 


### PR DESCRIPTION
Hi, updating `iced` to `v0.10` and I noticed that `glow` was removed. Using `wgpu` I'm experiencing issues with svg/images rendering: I see a black box instead of the image.
The solution that I found is to replace `Layer::Empty` with `Layer::Full`. It seems working, but I'm not sure if this can cause any other issues.
