### PR TITLE
Add font loader for Sandbox, Program and Application.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Custom Font loader for SandBox, Program and Application Via Settings.
+
 ## [0.10.0] - 2023-07-28
 ### Added
 - Text shaping, font fallback, and `iced_wgpu` overhaul. [#1697](https://github.com/iced-rs/iced/pull/1697)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Custom Font loader for SandBox, Program and Application Via Settings.
 
+
+Many thanks to...
+
+- @genusistimelord
+
 ## [0.10.0] - 2023-07-28
 ### Added
 - Text shaping, font fallback, and `iced_wgpu` overhaul. [#1697](https://github.com/iced-rs/iced/pull/1697)

--- a/src/application.rs
+++ b/src/application.rs
@@ -205,11 +205,13 @@ pub trait Application: Sized {
             ..crate::renderer::Settings::default()
         };
 
+        let custom_fonts = settings.custom_fonts.clone();
+
         Ok(crate::shell::application::run::<
             Instance<Self>,
             Self::Executor,
             crate::renderer::Compositor<Self::Theme>,
-        >(settings.into(), renderer_settings)?)
+        >(settings.into(), renderer_settings, custom_fonts)?)
     }
 }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,4 +1,6 @@
 //! Configure your application.
+use std::borrow::Cow;
+
 use crate::window;
 use crate::Font;
 
@@ -49,6 +51,13 @@ pub struct Settings<Flags> {
     ///
     /// [`Application`]: crate::Application
     pub exit_on_close_request: bool,
+
+    /// Custom fonts to be loaded when iced initiates.
+    /// uses the Bytes of loaded fonts.
+    /// This will be slower than using commands to batch load.
+    ///
+    /// By default, it is `Vec::new()`.
+    pub custom_fonts: Vec<Cow<'static, [u8]>>,
 }
 
 impl<Flags> Settings<Flags> {
@@ -66,7 +75,24 @@ impl<Flags> Settings<Flags> {
             default_text_size: default_settings.default_text_size,
             antialiasing: default_settings.antialiasing,
             exit_on_close_request: default_settings.exit_on_close_request,
+            custom_fonts: default_settings.custom_fonts,
         }
+    }
+
+    /// Adds Font bytes to the custom_fonts Vec to be loaded on
+    /// [`Application`] initiation.
+    ///
+    /// [`Application`]: crate::Application
+    pub fn add_custom_fonts(
+        mut self,
+        fonts: impl IntoIterator<Item = impl Into<Cow<'static, [u8]>>>,
+    ) -> Self {
+        let mut fonts = fonts
+            .into_iter()
+            .map(|f| f.into())
+            .collect::<Vec<Cow<'static, [u8]>>>();
+        self.custom_fonts.append(&mut fonts);
+        self
     }
 }
 
@@ -83,6 +109,7 @@ where
             default_text_size: 16.0,
             antialiasing: false,
             exit_on_close_request: true,
+            custom_fonts: Vec::new(),
         }
     }
 }


### PR DESCRIPTION
This will add a Sync based font loader that will load all custom fonts placed inside the settings under custom_fonts. 

#Example
```rust
fn main() -> iced::Result {
    let mut settings = Settings::default();
    settings = settings.add_custom_fonts([iced_aw::graphics::icons::ICON_FONT_BYTES]);
    CardExample::run(settings)
}
```