### PR TITLE
fix: RTL text often invisible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Invisible text in RTL languages. [#2016](https://github.com/iced-rs/iced/pull/2016)
 
+Many thanks to...
+
+- @nicksenger
+
 ## [0.10.0] - 2023-07-28
 ### Added
 - Text shaping, font fallback, and `iced_wgpu` overhaul. [#1697](https://github.com/iced-rs/iced/pull/1697)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Invisible text in RTL languages. [#2016](https://github.com/iced-rs/iced/pull/2016)
 
 ## [0.10.0] - 2023-07-28
 ### Added

--- a/wgpu/src/text.rs
+++ b/wgpu/src/text.rs
@@ -425,6 +425,12 @@ impl Cache {
             );
 
             let bounds = measure(&buffer);
+            buffer.set_size(
+                font_system,
+                bounds.width.ceil(),
+                bounds.height.ceil(),
+            );
+
             let _ = entry.insert(Entry { buffer, bounds });
 
             for bounds in [


### PR DESCRIPTION
**Problem**

Sometime text in RTL languages,  when the `Text` widget's width is set to shrink, is only displayed partially or not at all. In this [minimal repro case](https://gist.github.com/nicksenger/b1ea78efe184b7a65d119a75171c28dd), there should be two lines of text, but only the one with a fixed width shows up.

The problem appears to be that glyphon is passed the max width for the text, and returns a buffer which corresponds to the provided width, however the width of the layout node used to render the text is based on the width of the text itself rather than this maximum. For LTR languages this is fine because the text is left-aligned in the buffer. For RTL languages, when the max-width is larger than the width of the actual text, the buffer returned from glyphon will extend outside the bounds of the layout node, so it is hidden or shows up only partially.

https://github.com/iced-rs/iced/assets/16542714/c5ad3aff-7255-41c3-8a0a-f5e8782bddb2

**Solution**

The solution I found is to resize the buffer based on the measured text dimensions. This fixes (subjectively) the provided repro example. There is some runtime cost, but it seems like it should be acceptable since this operation is cached.

**Considerations**

As far as I can tell this doesn't change behavior for LTR text. For RTL text however, it does change the behavior when the specified width is greater than that required to render the text. RTL text will no longer automatically be shifted to the right side of the layout bounds if the specified bound width is greater than that required to display the text, so it is up to the Iced user to decide whether a particular section of text should be right aligned with its container or not (regardless of whether it flows LTR or RTL).

I think this is a reasonable trade to have text show up in cases where it currently doesn't, but maybe there is a way to get both? I didn't see it.