### PR TITLE
Add a way to set the winit window theme

### DIFF
--- a/core/src/window.rs
+++ b/core/src/window.rs
@@ -1,6 +1,7 @@
 //! Build window-based GUI applications.
 pub mod icon;
 
+mod window_theme;
 mod event;
 mod level;
 mod mode;
@@ -9,6 +10,7 @@ mod user_attention;
 
 pub use event::Event;
 pub use icon::Icon;
+pub use window_theme::WindowTheme;
 pub use level::Level;
 pub use mode::Mode;
 pub use redraw_request::RedrawRequest;

--- a/core/src/window/window_theme.rs
+++ b/core/src/window/window_theme.rs
@@ -1,0 +1,21 @@
+/// Sets a specific theme for the window.
+///
+/// If `None` is provided, the window will use the system theme.
+///
+/// The default is `None`.
+///
+/// ## Platform-specific
+///
+/// - **macOS:** This is an app-wide setting.
+/// - **Wayland:** This control only CSD. You can also use `WINIT_WAYLAND_CSD_THEME` env variable to set the theme.
+///   Possible values for env variable are: "dark" and light".
+/// - **x11:** Build window with `_GTK_THEME_VARIANT` hint set to `dark` or `light`.
+/// - **iOS / Android / Web / x11 / Orbital:** Ignored.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WindowTheme {
+    /// Use the light variant.
+    Light,
+
+    /// Use the dark variant.
+    Dark,
+}

--- a/examples/styling/src/main.rs
+++ b/examples/styling/src/main.rs
@@ -4,13 +4,21 @@ use iced::widget::{
     row, scrollable, slider, text, text_input, toggler, vertical_rule,
     vertical_space,
 };
-use iced::{Alignment, Color, Element, Length, Sandbox, Settings};
+use iced::{Alignment, Application, Color, Command, Element, executor, Length, Settings, window};
+use iced::window::WindowTheme;
 
 pub fn main() -> iced::Result {
-    Styling::run(Settings::default())
+    Styling::run(Settings {
+        window: window::Settings{
+            window_theme:Some(WindowTheme::Dark),
+            ..Default::default()
+        },
+        ..Default::default()
+    })
 }
 
-#[derive(Default)]
+
+#[derive(Debug)]
 struct Styling {
     theme: Theme,
     input_value: String,
@@ -19,6 +27,17 @@ struct Styling {
     toggler_value: bool,
 }
 
+impl Default for Styling {
+    fn default() -> Self {
+       Self{
+           theme: Theme::Dark,
+           input_value: "".to_string(),
+           slider_value: 0.0,
+           checkbox_value: false,
+           toggler_value: false,
+       }
+    }
+}
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 enum ThemeType {
     Light,
@@ -36,30 +55,43 @@ enum Message {
     TogglerToggled(bool),
 }
 
-impl Sandbox for Styling {
+impl Application for Styling {
+    type Executor = executor::Default;
     type Message = Message;
+    type Theme = Theme;
+    type Flags = ();
 
-    fn new() -> Self {
-        Styling::default()
+    fn new(_flags: Self::Flags) -> (Self, Command<Self::Message>) {
+        (Styling::default(),Command::none())
     }
+
 
     fn title(&self) -> String {
         String::from("Styling - Iced")
     }
 
-    fn update(&mut self, message: Message) {
+    fn update(&mut self, message: Message) ->Command<Self::Message>{
         match message {
             Message::ThemeChanged(theme) => {
-                self.theme = match theme {
-                    ThemeType::Light => Theme::Light,
-                    ThemeType::Dark => Theme::Dark,
-                    ThemeType::Custom => Theme::custom(theme::Palette {
-                        background: Color::from_rgb(1.0, 0.9, 1.0),
-                        text: Color::BLACK,
-                        primary: Color::from_rgb(0.5, 0.5, 0.0),
-                        success: Color::from_rgb(0.0, 1.0, 0.0),
-                        danger: Color::from_rgb(1.0, 0.0, 0.0),
-                    }),
+               return  match theme {
+                    ThemeType::Light => {
+                        self.theme =Theme::Light;
+                        window::change_window_theme(Some(WindowTheme::Light))
+                    }
+                    ThemeType::Dark => {
+                        self.theme =Theme::Dark;
+                        window::change_window_theme(Some(WindowTheme::Dark))
+                    }
+                    ThemeType::Custom => {
+                        self.theme = Theme::custom(theme::Palette {
+                            background: Color::from_rgb(1.0, 0.9, 1.0),
+                            text: Color::BLACK,
+                            primary: Color::from_rgb(0.5, 0.5, 0.0),
+                            success: Color::from_rgb(0.0, 1.0, 0.0),
+                            danger: Color::from_rgb(1.0, 0.0, 0.0),
+                        });
+                        window::change_window_theme(Some(WindowTheme::Dark))
+                    }
                 }
             }
             Message::InputChanged(value) => self.input_value = value,
@@ -67,7 +99,9 @@ impl Sandbox for Styling {
             Message::SliderChanged(value) => self.slider_value = value,
             Message::CheckboxToggled(value) => self.checkbox_value = value,
             Message::TogglerToggled(value) => self.toggler_value = value,
-        }
+        };
+        Command::none()
+
     }
 
     fn view(&self) -> Element<Message> {

--- a/examples/styling/src/main.rs
+++ b/examples/styling/src/main.rs
@@ -8,13 +8,7 @@ use iced::{Alignment, Application, Color, Command, Element, executor, Length, Se
 use iced::window::WindowTheme;
 
 pub fn main() -> iced::Result {
-    Styling::run(Settings {
-        window: window::Settings{
-            window_theme:Some(WindowTheme::Dark),
-            ..Default::default()
-        },
-        ..Default::default()
-    })
+    Styling::run(Settings::default())
 }
 
 
@@ -62,7 +56,19 @@ impl Application for Styling {
     type Flags = ();
 
     fn new(_flags: Self::Flags) -> (Self, Command<Self::Message>) {
-        (Styling::default(),Command::none())
+        let styling=Styling::default();
+        let window_theme=match styling.theme {
+            Theme::Light => {
+                Some(WindowTheme::Light)
+            }
+            Theme::Dark => {
+                Some(WindowTheme::Dark)
+            }
+            Theme::Custom(_) => {
+                Some(WindowTheme::Dark)
+            }
+        };
+        (styling, window::change_window_theme(window_theme))
     }
 
 

--- a/runtime/src/window.rs
+++ b/runtime/src/window.rs
@@ -8,7 +8,7 @@ pub use screenshot::Screenshot;
 
 use crate::command::{self, Command};
 use crate::core::time::Instant;
-use crate::core::window::{Event, Icon, Level, Mode, UserAttention};
+use crate::core::window::{Event, Icon, Level, Mode, UserAttention,WindowTheme};
 use crate::core::Size;
 use crate::futures::subscription::{self, Subscription};
 
@@ -84,6 +84,10 @@ pub fn toggle_maximize<Message>() -> Command<Message> {
 /// Toggles the window decorations.
 pub fn toggle_decorations<Message>() -> Command<Message> {
     Command::single(command::Action::Window(Action::ToggleDecorations))
+}
+/// Change the window decorations theme.
+pub fn change_window_theme<Message>(window_theme:Option<WindowTheme>) -> Command<Message> {
+    Command::single(command::Action::Window(Action::ChangeWindowTheme(window_theme)))
 }
 
 /// Request user attention to the window, this has no effect if the application

--- a/runtime/src/window/action.rs
+++ b/runtime/src/window/action.rs
@@ -1,4 +1,4 @@
-use crate::core::window::{Icon, Level, Mode, UserAttention};
+use crate::core::window::{Icon, Level, Mode, UserAttention,WindowTheme};
 use crate::core::Size;
 use crate::futures::MaybeSend;
 use crate::window::Screenshot;
@@ -44,6 +44,21 @@ pub enum Action<T> {
     /// - **X11:** Not implemented.
     /// - **Web:** Unsupported.
     ToggleDecorations,
+
+    /// Sets a specific theme for the window.
+    ///
+    /// If `None` is provided, the window will use the system theme.
+    ///
+    /// The default is `None`.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **macOS:** This is an app-wide setting.
+    /// - **Wayland:** This control only CSD. You can also use `WINIT_WAYLAND_CSD_THEME` env variable to set the theme.
+    ///   Possible values for env variable are: "dark" and light".
+    /// - **x11:** Build window with `_GTK_THEME_VARIANT` hint set to `dark` or `light`.
+    /// - **iOS / Android / Web / x11 / Orbital:** Ignored.
+    ChangeWindowTheme(Option<WindowTheme>),
     /// Request user attention to the window, this has no effect if the application
     /// is already focused. How requesting for user attention manifests is platform dependent,
     /// see [`UserAttention`] for details.
@@ -113,6 +128,7 @@ impl<T> Action<T> {
             Self::FetchMode(o) => Action::FetchMode(Box::new(move |s| f(o(s)))),
             Self::ToggleMaximize => Action::ToggleMaximize,
             Self::ToggleDecorations => Action::ToggleDecorations,
+            Self::ChangeWindowTheme(window_theme) => Action::ChangeWindowTheme(window_theme),
             Self::RequestUserAttention(attention_type) => {
                 Action::RequestUserAttention(attention_type)
             }
@@ -149,6 +165,7 @@ impl<T> fmt::Debug for Action<T> {
             Self::FetchMode(_) => write!(f, "Action::FetchMode"),
             Self::ToggleMaximize => write!(f, "Action::ToggleMaximize"),
             Self::ToggleDecorations => write!(f, "Action::ToggleDecorations"),
+            Self::ChangeWindowTheme(_) => write!(f, "Action::ChangeWindowTheme"),
             Self::RequestUserAttention(_) => {
                 write!(f, "Action::RequestUserAttention")
             }

--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -1,4 +1,4 @@
-use crate::window::{Icon, Level, Position};
+use crate::window::{Icon, Level, Position,WindowTheme};
 
 pub use iced_winit::settings::PlatformSpecific;
 
@@ -25,7 +25,20 @@ pub struct Settings {
 
     /// Whether the window should have a border, a title bar, etc. or not.
     pub decorations: bool,
-
+    /// Sets a specific theme for the window.
+    ///
+    /// If `None` is provided, the window will use the system theme.
+    ///
+    /// The default is `None`.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **macOS:** This is an app-wide setting.
+    /// - **Wayland:** This control only CSD. You can also use `WINIT_WAYLAND_CSD_THEME` env variable to set the theme.
+    ///   Possible values for env variable are: "dark" and light".
+    /// - **x11:** Build window with `_GTK_THEME_VARIANT` hint set to `dark` or `light`.
+    /// - **iOS / Android / Web / x11 / Orbital:** Ignored.
+    pub window_theme: Option<WindowTheme>,
     /// Whether the window should be transparent.
     pub transparent: bool,
 
@@ -49,6 +62,7 @@ impl Default for Settings {
             visible: true,
             resizable: true,
             decorations: true,
+            window_theme: None,
             transparent: false,
             level: Level::default(),
             icon: None,
@@ -67,6 +81,7 @@ impl From<Settings> for iced_winit::settings::Window {
             visible: settings.visible,
             resizable: settings.resizable,
             decorations: settings.decorations,
+            window_theme: settings.window_theme,
             transparent: settings.transparent,
             level: settings.level,
             icon: settings.icon.map(Icon::into),

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -12,6 +12,7 @@ use crate::core::renderer;
 use crate::core::time::Instant;
 use crate::core::widget::operation;
 use crate::core::window;
+use crate::core::window::WindowTheme;
 use crate::core::{Event, Size};
 use crate::futures::futures;
 use crate::futures::{Executor, Runtime, Subscription};
@@ -802,6 +803,19 @@ pub fn run_command<A, C, E>(
                 }
                 window::Action::ToggleDecorations => {
                     window.set_decorations(!window.is_decorated());
+                }
+                window::Action::ChangeWindowTheme(window_theme) => {
+                    let theme=match window_theme {
+                        Some(theme)=> match theme {
+                            WindowTheme::Light=>Some(winit::window::Theme::Light),
+                            WindowTheme::Dark=>Some(winit::window::Theme::Dark)
+                        },
+                        None=>None
+                    };
+                    window.set_theme(theme);
+                    //Window theme changes do not take effect immediately and require window changes
+                    window.set_decorations(false);
+                    window.set_decorations(true);
                 }
                 window::Action::RequestUserAttention(user_attention) => {
                     window.request_user_attention(


### PR DESCRIPTION
The following text is generated by automatic translation.
Add a way to set the winit window theme, and then update the styling example to make the window theme follow the iced theme.

![image](https://github.com/iced-rs/iced/assets/50483832/adebb4d5-ecf9-4b3c-9218-1760f16976ef)
![image](https://github.com/iced-rs/iced/assets/50483832/0fb55683-3017-40e5-86a5-2e966ea895f3)
I only tested it on Windows 10, but this calls the winit function directly.
related links:[winit pull](https://github.com/rust-windowing/winit/pull/2553) or [docs](https://docs.rs/winit/0.28.6/winit/window/struct.Window.html#method.set_theme)
There are a few areas that could be improved:

1.Setting window themes via winit functions does not take effect immediately on Windows 10.I solved this problem by reenabling window decorations. Looking at the source code for winit is beyond my ability .Users should rarely change the theme, I think it is acceptable.
```
window.set_theme(theme);
window.set_decorations(false);
window.set_decorations(true);
```
2.The window theme needs to be set manually by the developer, which may cause inconsistencies with the iced theme.
Maybe it should be set by application::StyleSheet?
Actually, I'm not familiar with rust and contribution codes.Please tell me what's wrong.