### PR TITLE
Softbuffer update 0.2 -> 0.3

### DIFF
--- a/examples/system_information_tiny_skia/Cargo.toml
+++ b/examples/system_information_tiny_skia/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "system_information"
+version = "0.1.0"
+authors = ["Richard <richardsoncusto@gmail.com>"]
+edition = "2021"
+publish = false
+
+[dependencies]
+iced = { path = "../..", default-features=false, features = ["system"] }
+bytesize = { version = "1.1.0" }

--- a/examples/system_information_tiny_skia/Cargo.toml
+++ b/examples/system_information_tiny_skia/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "system_information"
+name = "system_information_tiny_skia"
 version = "0.1.0"
 authors = ["Richard <richardsoncusto@gmail.com>"]
 edition = "2021"

--- a/examples/system_information_tiny_skia/src/main.rs
+++ b/examples/system_information_tiny_skia/src/main.rs
@@ -1,0 +1,159 @@
+use iced::widget::{button, column, container, text};
+use iced::{
+    executor, system, Application, Command, Element, Length, Settings, Theme,
+};
+
+use bytesize::ByteSize;
+
+pub fn main() -> iced::Result {
+    Example::run(Settings::default())
+}
+
+#[allow(clippy::large_enum_variant)]
+enum Example {
+    Loading,
+    Loaded { information: system::Information },
+}
+
+#[derive(Clone, Debug)]
+#[allow(clippy::large_enum_variant)]
+enum Message {
+    InformationReceived(system::Information),
+    Refresh,
+}
+
+impl Application for Example {
+    type Message = Message;
+    type Theme = Theme;
+    type Executor = executor::Default;
+    type Flags = ();
+
+    fn new(_flags: ()) -> (Self, Command<Message>) {
+        (
+            Self::Loading,
+            system::fetch_information(Message::InformationReceived),
+        )
+    }
+
+    fn title(&self) -> String {
+        String::from("System Information - Iced")
+    }
+
+    fn update(&mut self, message: Message) -> Command<Message> {
+        match message {
+            Message::Refresh => {
+                *self = Self::Loading;
+
+                return system::fetch_information(Message::InformationReceived);
+            }
+            Message::InformationReceived(information) => {
+                *self = Self::Loaded { information };
+            }
+        }
+
+        Command::none()
+    }
+
+    fn view(&self) -> Element<Message> {
+        let content: Element<_> = match self {
+            Example::Loading => text("Loading...").size(40).into(),
+            Example::Loaded { information } => {
+                let system_name = text(format!(
+                    "System name: {}",
+                    information
+                        .system_name
+                        .as_ref()
+                        .unwrap_or(&"unknown".to_string())
+                ));
+
+                let system_kernel = text(format!(
+                    "System kernel: {}",
+                    information
+                        .system_kernel
+                        .as_ref()
+                        .unwrap_or(&"unknown".to_string())
+                ));
+
+                let system_version = text(format!(
+                    "System version: {}",
+                    information
+                        .system_version
+                        .as_ref()
+                        .unwrap_or(&"unknown".to_string())
+                ));
+
+                let system_short_version = text(format!(
+                    "System short version: {}",
+                    information
+                        .system_short_version
+                        .as_ref()
+                        .unwrap_or(&"unknown".to_string())
+                ));
+
+                let cpu_brand =
+                    text(format!("Processor brand: {}", information.cpu_brand));
+
+                let cpu_cores = text(format!(
+                    "Processor cores: {}",
+                    information
+                        .cpu_cores
+                        .map_or("unknown".to_string(), |cores| cores
+                            .to_string())
+                ));
+
+                let memory_readable =
+                    ByteSize::kb(information.memory_total).to_string();
+
+                let memory_total = text(format!(
+                    "Memory (total): {} kb ({})",
+                    information.memory_total, memory_readable
+                ));
+
+                let memory_text = if let Some(memory_used) =
+                    information.memory_used
+                {
+                    let memory_readable = ByteSize::kb(memory_used).to_string();
+
+                    format!("{memory_used} kb ({memory_readable})")
+                } else {
+                    String::from("None")
+                };
+
+                let memory_used = text(format!("Memory (used): {memory_text}"));
+
+                let graphics_adapter = text(format!(
+                    "Graphics adapter: {}",
+                    information.graphics_adapter
+                ));
+
+                let graphics_backend = text(format!(
+                    "Graphics backend: {}",
+                    information.graphics_backend
+                ));
+
+                column![
+                    system_name.size(30),
+                    system_kernel.size(30),
+                    system_version.size(30),
+                    system_short_version.size(30),
+                    cpu_brand.size(30),
+                    cpu_cores.size(30),
+                    memory_total.size(30),
+                    memory_used.size(30),
+                    graphics_adapter.size(30),
+                    graphics_backend.size(30),
+                    button("Refresh").on_press(Message::Refresh)
+                ]
+                .spacing(10)
+                .into()
+            }
+        };
+
+        container(content)
+            .center_x()
+            .center_y()
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .into()
+    }
+}

--- a/tiny_skia/Cargo.toml
+++ b/tiny_skia/Cargo.toml
@@ -17,7 +17,7 @@ geometry = ["iced_graphics/geometry"]
 
 [dependencies]
 raw-window-handle = "0.5"
-softbuffer = "0.2"
+softbuffer = "0.3"
 tiny-skia = "0.10"
 cosmic-text = "0.9"
 bytemuck = "1"


### PR DESCRIPTION
I saw that iced-tiny-skia still uses softbuffer 0.2. Update to 0.3 is a breaking softbuffer API change. To test this I copied the system_information example, renamed it to system_information_tiny_skia and disabled default features to force to build it with iced-tiny-skia softbuffer CPU rendering.