### PR TITLE
Added none flag to modifiers.rs

### DIFF
--- a/core/src/keyboard/modifiers.rs
+++ b/core/src/keyboard/modifiers.rs
@@ -4,6 +4,8 @@ bitflags! {
     /// The current state of the keyboard modifiers.
     #[derive(Default)]
     pub struct Modifiers: u32{
+        /// Flag for no modifiers key pressed, to help with pattern matching
+        const NONE = 0b000;
         /// The "shift" key.
         const SHIFT = 0b100;
         // const LSHIFT = 0b010 << 0;


### PR DESCRIPTION
allows pattern matching against no modifiers

```rust
match event {
    Event::Keyboard(iced::keyboard::Event::KeyPressed {
        key_code: iced::keyboard::KeyCode::C,
        modifiers: Modifiers::NONE,
    }) => {
        ...
    }
    Event::Keyboard(iced::keyboard::Event::KeyPressed {
        key_code: iced::keyboard::KeyCode::C,
        modifiers: Modifiers::CTRL,
    }) => {
        ...
    }
    ...
}
```

I haven't read into it much but it seems to me that the bitflags lib has some acknowledged shortcomings, which are addressed in some newer crates, e.g. [flagset](https://github.com/enarx/flagset) 

#1868 may also be convenient to address in a modifiers rework