### PR TITLE
Make TextInput widget hold horizontal scrolling position

### DIFF
--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -563,19 +563,23 @@ where
                 None
             };
 
-            state.is_focused = if click_position.is_some() {
-                state.is_focused.take().or_else(|| {
-                    let now = Instant::now();
+            if click_position.is_some() {
+                if !state.is_focused() {
+                    state.cursor.move_to(0);
 
-                    Some(Focus {
-                        updated_at: now,
-                        now,
-                        is_window_focused: true,
-                        horizontal_scroll_offset: RefCell::default(),
-                    })
-                })
+                    state.is_focused = {
+                        let now = Instant::now();
+
+                        Some(Focus {
+                            updated_at: now,
+                            now,
+                            is_window_focused: true,
+                            horizontal_scroll_offset: RefCell::default(),
+                        })
+                    };
+                }
             } else {
-                None
+                state.is_focused = None;
             };
 
             if let Some(cursor_position) = click_position {


### PR DESCRIPTION
This PR adds stateful horizontal scrolling offset for TextInput widget state.

Fixes #1285

The horizontal scrolling value is saved in `Focus` property of TextInput's `State`, so it's reset as soon as the widget loses focus.

It is updated on each `draw` call and is clamped to ensure that:
1. the cursor always stays visible;
2. there is no empty space to the right of the text, unless there is not enough text to fill entire width;
3. there is a bit of space between the cursor in its rightmost position and the clip boundary of the text (original behavior).

This way, even if the underlying value changes or the cursor is moved through any means, the widget will scroll to accommodate the change.

Mouse selection now also works as expected: the view won't move while the user selects text in the middle, and will scroll left or right if the mouse cursor is dragged to the left/right edge or beyond. Clicking on an unfocused widget now always puts the text cursor under the mouse cursor, regardless of where the (invisible while unfocused) text cursor was before that.