### PR TITLE
[issue #2002] Ensure that absolute `LineHeight` is always > 0.0

### DIFF
--- a/tiny_skia/src/text.rs
+++ b/tiny_skia/src/text.rs
@@ -54,7 +54,8 @@ impl Pipeline {
         pixels: &mut tiny_skia::PixmapMut<'_>,
         clip_mask: Option<&tiny_skia::Mask>,
     ) {
-        let line_height = f32::from(line_height.to_absolute(Pixels(size)));
+        let line_height = f32::from(line_height.to_absolute(Pixels(size)))
+            .max(f32::MIN_POSITIVE);
 
         let font_system = self.font_system.get_mut();
         let key = Key {
@@ -134,7 +135,8 @@ impl Pipeline {
     ) -> Size {
         let mut measurement_cache = self.cache.borrow_mut();
 
-        let line_height = f32::from(line_height.to_absolute(Pixels(size)));
+        let line_height = f32::from(line_height.to_absolute(Pixels(size)))
+            .max(f32::MIN_POSITIVE);
 
         let (_, entry) = measurement_cache.allocate(
             &mut self.font_system.borrow_mut(),
@@ -164,7 +166,8 @@ impl Pipeline {
     ) -> Option<Hit> {
         let mut measurement_cache = self.cache.borrow_mut();
 
-        let line_height = f32::from(line_height.to_absolute(Pixels(size)));
+        let line_height = f32::from(line_height.to_absolute(Pixels(size)))
+            .max(f32::MIN_POSITIVE);
 
         let (_, entry) = measurement_cache.allocate(
             &mut self.font_system.borrow_mut(),
@@ -405,7 +408,10 @@ impl Cache {
         }
 
         if let hash_map::Entry::Vacant(entry) = self.entries.entry(hash) {
-            let metrics = cosmic_text::Metrics::new(key.size, key.size * 1.2);
+            let metrics = cosmic_text::Metrics::new(
+                key.size,
+                (key.size * 1.2).max(f32::MIN_POSITIVE),
+            );
             let mut buffer = cosmic_text::Buffer::new(font_system, metrics);
 
             buffer.set_size(

--- a/tiny_skia/src/text.rs
+++ b/tiny_skia/src/text.rs
@@ -54,8 +54,7 @@ impl Pipeline {
         pixels: &mut tiny_skia::PixmapMut<'_>,
         clip_mask: Option<&tiny_skia::Mask>,
     ) {
-        let line_height = f32::from(line_height.to_absolute(Pixels(size)))
-            .max(f32::MIN_POSITIVE);
+        let line_height = f32::from(line_height.to_absolute(Pixels(size)));
 
         let font_system = self.font_system.get_mut();
         let key = Key {
@@ -135,8 +134,7 @@ impl Pipeline {
     ) -> Size {
         let mut measurement_cache = self.cache.borrow_mut();
 
-        let line_height = f32::from(line_height.to_absolute(Pixels(size)))
-            .max(f32::MIN_POSITIVE);
+        let line_height = f32::from(line_height.to_absolute(Pixels(size)));
 
         let (_, entry) = measurement_cache.allocate(
             &mut self.font_system.borrow_mut(),
@@ -166,8 +164,7 @@ impl Pipeline {
     ) -> Option<Hit> {
         let mut measurement_cache = self.cache.borrow_mut();
 
-        let line_height = f32::from(line_height.to_absolute(Pixels(size)))
-            .max(f32::MIN_POSITIVE);
+        let line_height = f32::from(line_height.to_absolute(Pixels(size)));
 
         let (_, entry) = measurement_cache.allocate(
             &mut self.font_system.borrow_mut(),
@@ -409,8 +406,8 @@ impl Cache {
 
         if let hash_map::Entry::Vacant(entry) = self.entries.entry(hash) {
             let metrics = cosmic_text::Metrics::new(
-                key.size,
-                (key.size * 1.2).max(f32::MIN_POSITIVE),
+                key.line_height,
+                (key.line_height * 1.2).max(f32::MIN_POSITIVE),
             );
             let mut buffer = cosmic_text::Buffer::new(font_system, metrics);
 

--- a/tiny_skia/src/text.rs
+++ b/tiny_skia/src/text.rs
@@ -406,8 +406,8 @@ impl Cache {
 
         if let hash_map::Entry::Vacant(entry) = self.entries.entry(hash) {
             let metrics = cosmic_text::Metrics::new(
-                key.line_height,
-                (key.line_height * 1.2).max(f32::MIN_POSITIVE),
+                key.size,
+                key.line_height.max(f32::MIN_POSITIVE),
             );
             let mut buffer = cosmic_text::Buffer::new(font_system, metrics);
 

--- a/wgpu/src/text.rs
+++ b/wgpu/src/text.rs
@@ -96,7 +96,8 @@ impl Pipeline {
                             section
                                 .line_height
                                 .to_absolute(Pixels(section.size)),
-                        ),
+                        )
+                        .max(f32::MIN_POSITIVE),
                         font: section.font,
                         bounds: Size {
                             width: section.bounds.width,
@@ -238,7 +239,8 @@ impl Pipeline {
     ) -> Size {
         let mut cache = self.cache.borrow_mut();
 
-        let line_height = f32::from(line_height.to_absolute(Pixels(size)));
+        let line_height = f32::from(line_height.to_absolute(Pixels(size)))
+            .max(f32::MIN_POSITIVE);
 
         let (_, entry) = cache.allocate(
             &mut self.font_system.borrow_mut(),
@@ -269,7 +271,8 @@ impl Pipeline {
     ) -> Option<Hit> {
         let mut cache = self.cache.borrow_mut();
 
-        let line_height = f32::from(line_height.to_absolute(Pixels(size)));
+        let line_height = f32::from(line_height.to_absolute(Pixels(size)))
+            .max(f32::MIN_POSITIVE);
 
         let (_, entry) = cache.allocate(
             &mut self.font_system.borrow_mut(),

--- a/wgpu/src/text.rs
+++ b/wgpu/src/text.rs
@@ -96,8 +96,7 @@ impl Pipeline {
                             section
                                 .line_height
                                 .to_absolute(Pixels(section.size)),
-                        )
-                        .max(f32::MIN_POSITIVE),
+                        ),
                         font: section.font,
                         bounds: Size {
                             width: section.bounds.width,
@@ -239,8 +238,7 @@ impl Pipeline {
     ) -> Size {
         let mut cache = self.cache.borrow_mut();
 
-        let line_height = f32::from(line_height.to_absolute(Pixels(size)))
-            .max(f32::MIN_POSITIVE);
+        let line_height = f32::from(line_height.to_absolute(Pixels(size)));
 
         let (_, entry) = cache.allocate(
             &mut self.font_system.borrow_mut(),
@@ -271,8 +269,7 @@ impl Pipeline {
     ) -> Option<Hit> {
         let mut cache = self.cache.borrow_mut();
 
-        let line_height = f32::from(line_height.to_absolute(Pixels(size)))
-            .max(f32::MIN_POSITIVE);
+        let line_height = f32::from(line_height.to_absolute(Pixels(size)));
 
         let (_, entry) = cache.allocate(
             &mut self.font_system.borrow_mut(),
@@ -417,7 +414,10 @@ impl Cache {
         }
 
         if let hash_map::Entry::Vacant(entry) = self.entries.entry(hash) {
-            let metrics = glyphon::Metrics::new(key.size, key.line_height);
+            let metrics = glyphon::Metrics::new(
+                key.size,
+                key.line_height.max(f32::MIN_POSITIVE),
+            );
             let mut buffer = glyphon::Buffer::new(font_system, metrics);
 
             buffer.set_size(


### PR DESCRIPTION
Fixes #2002.

The gist of the problem is that [LineHeight::to_absolute](https://github.com/iced-rs/iced/blob/c9bd48704dd9679c033dd0b8588e2744a3df44a0/core/src/text.rs#L75-L81) in conjunction with other widgets may inadvertently return `0.0`. This triggers a panic in [cosmic_text's Buffer](https://github.com/pop-os/cosmic-text/blob/37e8f005e6f27ffe29a6e5811071bd112e3fb137/src/buffer.rs#L364-L373) regardless of the renderer.

The original issue has a minimal example. My patch just ensures that absolute LineHeight is > 0.0 to avoid the panic.
