### PR TITLE
fix(examples-styling): fixed checkbox and toggler getting hidden behind scrollbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated `wgpu` to `0.17`. [#2065](https://github.com/iced-rs/iced/pull/2065)
 
+### Fixed
+- Missing `width` attribute in `styling` example. [#2062](https://github.com/iced-rs/iced/pull/2062)
+
 Many thanks to...
 
-- Add your <name> here
+- @akshayr-mecha
 
 ## [0.10.0] - 2023-07-28
 ### Added

--- a/examples/styling/src/main.rs
+++ b/examples/styling/src/main.rs
@@ -108,6 +108,7 @@ impl Sandbox for Styling {
             column!["Scroll me!", vertical_space(800), "You did it!"]
                 .width(Length::Fill),
         )
+        .width(300)    
         .height(100);
 
         let checkbox = checkbox(

--- a/examples/styling/src/main.rs
+++ b/examples/styling/src/main.rs
@@ -108,7 +108,7 @@ impl Sandbox for Styling {
             column!["Scroll me!", vertical_space(800), "You did it!"]
                 .width(Length::Fill),
         )
-        .width(300)    
+        .width(Length::Fill)
         .height(100);
 
         let checkbox = checkbox(


### PR DESCRIPTION
Fix for this issue https://github.com/iced-rs/iced/issues/2056
Column inside scrollable has Length::Fill so it is taking the entire width thus hiding check box and toggler. Added fixed width to scrollable so Lenth::Fill will be relative to fixed width.
