### PR TITLE
use general Renderer type in integration example

### DIFF
--- a/examples/integration/src/controls.rs
+++ b/examples/integration/src/controls.rs
@@ -1,4 +1,4 @@
-use iced_wgpu::Renderer;
+use iced_renderer::Renderer;
 use iced_widget::{slider, text_input, Column, Row, Text};
 use iced_winit::core::{Alignment, Color, Element, Length};
 use iced_winit::runtime::{Command, Program};


### PR DESCRIPTION
This allows applications that are based off the integration example to use the generic `iced_renderer::Renderer` type in the rest of their codebase and to work with third party libraries.

I couldn't compile the example with the `plotters-iced` lib without this change. See #2061 for more details.
