### PR TITLE
Update `wgpu` to `0.17`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Updated `wgpu` to `0.17`. [#2065](https://github.com/iced-rs/iced/pull/2065)
+
+Many thanks to...
+
+- Add your <name> here
 
 ## [0.10.0] - 2023-07-28
 ### Added

--- a/examples/integration/src/main.rs
+++ b/examples/integration/src/main.rs
@@ -82,7 +82,6 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
         futures::futures::executor::block_on(async {
             let adapter = wgpu::util::initialize_adapter_from_env_or_default(
                 &instance,
-                backend,
                 Some(&surface),
             )
             .await

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -25,7 +25,7 @@ rustc-hash = "1.1"
 log = "0.4"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wgpu = { version = "0.16", features = ["webgl"] }
+wgpu = { version = "0.17", features = ["webgl"] }
 
 [dependencies.twox-hash]
 version = "1.6"

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -14,8 +14,8 @@ svg = ["resvg"]
 web-colors = ["iced_graphics/web-colors"]
 
 [dependencies]
-wgpu = "0.16"
-glyphon = "0.3"
+wgpu = "0.17"
+glyphon = { git = "https://github.com/grovesNL/glyphon.git", rev = "20f0f8fa80e0d0df4c63634ce9176fa489546ca9" }
 raw-window-handle = "0.5"
 guillotiere = "0.6"
 futures = "0.3"


### PR DESCRIPTION
We can easily update `wgpu` to `0.17`, since the `master` branch of `glyphon` supports it.

Closes #2053.