### PR TITLE
Enable WebGPU backend in `wgpu` by default instead of WebGL

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,8 @@ jobs:
 
   web:
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: --cfg=web_sys_unstable_apis
     steps:
     - uses: hecrj/setup-rust-action@v1
       with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,8 @@ palette = ["iced_core/palette"]
 system = ["iced_winit/system"]
 # Enables broken "sRGB linear" blending to reproduce color management of the Web
 web-colors = ["iced_renderer/web-colors"]
+# Enables the WebGL backend, replacing WebGPU
+webgl = ["iced_renderer/webgl"]
 # Enables the advanced module
 advanced = []
 

--- a/renderer/Cargo.toml
+++ b/renderer/Cargo.toml
@@ -17,6 +17,7 @@ svg = ["iced_tiny_skia/svg", "iced_wgpu?/svg"]
 geometry = ["iced_graphics/geometry", "iced_tiny_skia/geometry", "iced_wgpu?/geometry"]
 tracing = ["iced_wgpu?/tracing"]
 web-colors = ["iced_wgpu?/web-colors"]
+webgl = ["iced_wgpu?/webgl"]
 
 [dependencies]
 raw-window-handle = "0.5"

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -12,6 +12,7 @@ geometry = ["iced_graphics/geometry", "lyon"]
 image = ["iced_graphics/image"]
 svg = ["resvg"]
 web-colors = ["iced_graphics/web-colors"]
+webgl = ["wgpu/webgl"]
 
 [dependencies]
 wgpu = "0.17"
@@ -23,9 +24,6 @@ bitflags = "1.2"
 once_cell = "1.0"
 rustc-hash = "1.1"
 log = "0.4"
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-wgpu = { version = "0.17", features = ["webgl"] }
 
 [dependencies.twox-hash]
 version = "1.6"


### PR DESCRIPTION
Instead, we expose a new `webgl` feature.

As discussed on Discourse: https://discourse.iced.rs/t/allowing-users-to-compile-wgpu-without-the-webgl-flag-in-wasm-builds/59/2