### PR TITLE
Added a Frame::scale_nonuniform method 

### DIFF
--- a/examples/game_of_life/src/main.rs
+++ b/examples/game_of_life/src/main.rs
@@ -550,7 +550,7 @@ mod grid {
                     frame.translate(center);
                     frame.scale(self.scaling);
                     frame.translate(self.translation);
-                    frame.scale(Cell::SIZE as f32);
+                    frame.scale(Cell::SIZE);
 
                     let region = self.visible_region(frame.size());
 
@@ -576,7 +576,7 @@ mod grid {
                         frame.translate(center);
                         frame.scale(self.scaling);
                         frame.translate(self.translation);
-                        frame.scale(Cell::SIZE as f32);
+                        frame.scale(Cell::SIZE);
 
                         frame.fill_rectangle(
                             Point::new(cell.j as f32, cell.i as f32),
@@ -630,7 +630,7 @@ mod grid {
                         frame.translate(center);
                         frame.scale(self.scaling);
                         frame.translate(self.translation);
-                        frame.scale(Cell::SIZE as f32);
+                        frame.scale(Cell::SIZE);
 
                         let region = self.visible_region(frame.size());
                         let rows = region.rows();
@@ -834,7 +834,7 @@ mod grid {
     }
 
     impl Cell {
-        const SIZE: usize = 20;
+        const SIZE: u16 = 20;
 
         fn at(position: Point) -> Cell {
             let i = (position.y / Cell::SIZE as f32).ceil() as isize;

--- a/renderer/src/geometry.rs
+++ b/renderer/src/geometry.rs
@@ -168,10 +168,16 @@ impl Frame {
         delegate!(self, frame, frame.rotate(angle));
     }
 
-    /// Applies a scaling to the current transform of the [`Frame`].
+    /// Applies a uniform scaling to the current transform of the [`Frame`].
     #[inline]
     pub fn scale(&mut self, scale: f32) {
         delegate!(self, frame, frame.scale(scale));
+    }
+
+    /// Applies a non-uniform scaling to the current transform of the [`Frame`].
+    #[inline]
+    pub fn scale_nonuniform(&mut self, scale: Vector) {
+        delegate!(self, frame, frame.scale_nonuniform(scale));
     }
 
     pub fn into_geometry(self) -> Geometry {

--- a/renderer/src/geometry.rs
+++ b/renderer/src/geometry.rs
@@ -170,13 +170,13 @@ impl Frame {
 
     /// Applies a uniform scaling to the current transform of the [`Frame`].
     #[inline]
-    pub fn scale(&mut self, scale: f32) {
+    pub fn scale(&mut self, scale: impl Into<f32>) {
         delegate!(self, frame, frame.scale(scale));
     }
 
     /// Applies a non-uniform scaling to the current transform of the [`Frame`].
     #[inline]
-    pub fn scale_nonuniform(&mut self, scale: Vector) {
+    pub fn scale_nonuniform(&mut self, scale: impl Into<Vector>) {
         delegate!(self, frame, frame.scale_nonuniform(scale));
     }
 

--- a/tiny_skia/src/geometry.rs
+++ b/tiny_skia/src/geometry.rs
@@ -154,11 +154,15 @@ impl Frame {
             .pre_concat(tiny_skia::Transform::from_rotate(angle.to_degrees()));
     }
 
-    pub fn scale(&mut self, scale: f32) {
+    pub fn scale(&mut self, scale: impl Into<f32>) {
+        let scale = scale.into();
+
         self.scale_nonuniform(Vector { x: scale, y: scale });
     }
 
-    pub fn scale_nonuniform(&mut self, scale: Vector) {
+    pub fn scale_nonuniform(&mut self, scale: impl Into<Vector>) {
+        let scale = scale.into();
+
         self.transform = self.transform.pre_scale(scale.x, scale.y);
     }
 

--- a/tiny_skia/src/geometry.rs
+++ b/tiny_skia/src/geometry.rs
@@ -158,6 +158,10 @@ impl Frame {
         self.transform = self.transform.pre_scale(scale, scale);
     }
 
+    pub fn scale_nonuniform(&mut self, scale: Vector) {
+        self.transform = self.transform.pre_scale(scale.x, scale.y);
+    }
+
     pub fn into_primitive(self) -> Primitive {
         Primitive::Clip {
             bounds: Rectangle::new(Point::ORIGIN, self.size),

--- a/tiny_skia/src/geometry.rs
+++ b/tiny_skia/src/geometry.rs
@@ -155,7 +155,7 @@ impl Frame {
     }
 
     pub fn scale(&mut self, scale: f32) {
-        self.transform = self.transform.pre_scale(scale, scale);
+        self.scale_nonuniform(Vector { x: scale, y: scale });
     }
 
     pub fn scale_nonuniform(&mut self, scale: Vector) {

--- a/wgpu/src/geometry.rs
+++ b/wgpu/src/geometry.rs
@@ -446,13 +446,17 @@ impl Frame {
 
     /// Applies a uniform scaling to the current transform of the [`Frame`].
     #[inline]
-    pub fn scale(&mut self, scale: f32) {
+    pub fn scale(&mut self, scale: impl Into<f32>) {
+        let scale = scale.into();
+
         self.scale_nonuniform(Vector { x: scale, y: scale });
     }
 
     /// Applies a non-uniform scaling to the current transform of the [`Frame`].
     #[inline]
-    pub fn scale_nonuniform(&mut self, scale: Vector) {
+    pub fn scale_nonuniform(&mut self, scale: impl Into<Vector>) {
+        let scale = scale.into();
+
         self.transforms.current.raw =
             self.transforms.current.raw.pre_scale(scale.x, scale.y);
         self.transforms.current.is_identity = false;

--- a/wgpu/src/geometry.rs
+++ b/wgpu/src/geometry.rs
@@ -444,11 +444,19 @@ impl Frame {
         self.transforms.current.is_identity = false;
     }
 
-    /// Applies a scaling to the current transform of the [`Frame`].
+    /// Applies a uniform scaling to the current transform of the [`Frame`].
     #[inline]
     pub fn scale(&mut self, scale: f32) {
         self.transforms.current.raw =
             self.transforms.current.raw.pre_scale(scale, scale);
+        self.transforms.current.is_identity = false;
+    }
+
+    /// Applies a non-uniform scaling to the current transform of the [`Frame`].
+    #[inline]
+    pub fn scale_nonuniform(&mut self, scale: Vector) {
+        self.transforms.current.raw =
+            self.transforms.current.raw.pre_scale(scale.x, scale.y);
         self.transforms.current.is_identity = false;
     }
 

--- a/wgpu/src/geometry.rs
+++ b/wgpu/src/geometry.rs
@@ -447,9 +447,7 @@ impl Frame {
     /// Applies a uniform scaling to the current transform of the [`Frame`].
     #[inline]
     pub fn scale(&mut self, scale: f32) {
-        self.transforms.current.raw =
-            self.transforms.current.raw.pre_scale(scale, scale);
-        self.transforms.current.is_identity = false;
+        self.scale_nonuniform(Vector { x: scale, y: scale });
     }
 
     /// Applies a non-uniform scaling to the current transform of the [`Frame`].

--- a/widget/src/qr_code.rs
+++ b/widget/src/qr_code.rs
@@ -86,7 +86,7 @@ impl<'a, Message, Theme> Widget<Message, Renderer<Theme>> for QRCode<'a> {
         let geometry =
             self.state.cache.draw(renderer, bounds.size(), |frame| {
                 // Scale units to cell size
-                frame.scale(f32::from(self.cell_size));
+                frame.scale(self.cell_size);
 
                 // Draw background
                 frame.fill_rectangle(


### PR DESCRIPTION
I see no reason why not to make `Frame::scale` take a `Vector` rather than a single `f32` to allow non-same xy scaling.

I have tried to update all references I could find in the code-base but may need to rely on the CI to see if I missed any.