### PR TITLE
Add access to bounds/content bounds from a scrollable viewport.

### DIFF
--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -1137,16 +1137,6 @@ impl Viewport {
         }
     }
 
-    /// Returns the bounds of the current [`Viewport`].
-    pub fn bounds(&self) -> Rectangle {
-        self.bounds
-    }
-
-    /// Returns the content bounds of the current [`Viewport`].
-    pub fn content_bounds(&self) -> Rectangle {
-        self.content_bounds
-    }
-
     /// Returns the [`RelativeOffset`] of the current [`Viewport`].
     pub fn relative_offset(&self) -> RelativeOffset {
         let AbsoluteOffset { x, y } = self.absolute_offset();
@@ -1155,6 +1145,16 @@ impl Viewport {
         let y = y / (self.content_bounds.height - self.bounds.height);
 
         RelativeOffset { x, y }
+    }
+
+    /// Returns the bounds of the current [`Viewport`].
+    pub fn bounds(&self) -> Rectangle {
+        self.bounds
+    }
+
+    /// Returns the content bounds of the current [`Viewport`].
+    pub fn content_bounds(&self) -> Rectangle {
+        self.content_bounds
     }
 }
 

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -1137,6 +1137,16 @@ impl Viewport {
         }
     }
 
+    /// Returns the bounds of the current [`Viewport`].
+    pub fn bounds(&self) -> Rectangle {
+        self.bounds
+    }
+
+    /// Returns the content bounds of the current [`Viewport`].
+    pub fn content_bounds(&self) -> Rectangle {
+        self.content_bounds
+    }
+
     /// Returns the [`RelativeOffset`] of the current [`Viewport`].
     pub fn relative_offset(&self) -> RelativeOffset {
         let AbsoluteOffset { x, y } = self.absolute_offset();


### PR DESCRIPTION
Added access to the bounds and content bounds of a scrollable's viewport. This is necessary to perform some scrollable optimizations such as virtual lists without creating your own widget, and piggybacking on the scrollable.

Added 2 methods for accessing the corresponding bounds from `Viewport`.