### PR TITLE
Get web examples running again

### DIFF
--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -7,3 +7,7 @@ publish = false
 
 [dependencies]
 iced.workspace = true
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+iced.workspace = true
+iced.features = ["webgl"]

--- a/examples/counter/README.md
+++ b/examples/counter/README.md
@@ -13,4 +13,12 @@ You can run it with `cargo run`:
 cargo run --package counter
 ```
 
+The web version can be run with [`trunk`]:
+
+```
+cd examples/counter
+trunk serve
+```
+
 [`main`]: src/main.rs
+[`trunk`]: https://trunkrs.dev/

--- a/examples/integration/Cargo.toml
+++ b/examples/integration/Cargo.toml
@@ -19,6 +19,5 @@ iced_wgpu.features = ["webgl"]
 
 console_error_panic_hook = "0.1"
 console_log = "1.0"
-log.workspace = true
 wasm-bindgen = "0.2"
 web-sys = { version = "0.3", features = ["Element", "HtmlCanvasElement", "Window", "Document"] }

--- a/examples/integration/Cargo.toml
+++ b/examples/integration/Cargo.toml
@@ -10,6 +10,7 @@ iced_winit.workspace = true
 iced_wgpu.workspace = true
 iced_widget.workspace = true
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tracing-subscriber = "0.3"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/examples/integration/Cargo.toml
+++ b/examples/integration/Cargo.toml
@@ -13,6 +13,9 @@ iced_widget.workspace = true
 tracing-subscriber = "0.3"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+iced_wgpu.workspace = true
+iced_wgpu.features = ["webgl"]
+
 console_error_panic_hook = "0.1"
 console_log = "1.0"
 log.workspace = true

--- a/examples/integration/src/main.rs
+++ b/examples/integration/src/main.rs
@@ -29,7 +29,7 @@ use winit::platform::web::WindowBuilderExtWebSys;
 pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(target_arch = "wasm32")]
     let canvas_element = {
-        console_log::init_with_level(log::Level::Debug)?;
+        console_log::init().expect("Initialize logger");
 
         std::panic::set_hook(Box::new(console_error_panic_hook::hook));
 

--- a/examples/todos/Cargo.toml
+++ b/examples/todos/Cargo.toml
@@ -18,6 +18,9 @@ async-std.workspace = true
 directories-next = "2.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+iced.workspace = true
+iced.features = ["debug", "webgl"]
+
 web-sys = { workspace = true, features = ["Window", "Storage"] }
 wasm-timer.workspace = true
 

--- a/examples/todos/README.md
+++ b/examples/todos/README.md
@@ -14,7 +14,14 @@ You can run the native version with `cargo run`:
 ```
 cargo run --package todos
 ```
-We have not yet implemented a `LocalStorage` version of the auto-save feature. Therefore, it does not work on web _yet_!
+
+The web version can be run with [`trunk`]:
+
+```
+cd examples/todos
+trunk serve
+```
 
 [`main`]: src/main.rs
 [TodoMVC]: http://todomvc.com/
+[`trunk`]: https://trunkrs.dev/

--- a/examples/tour/Cargo.toml
+++ b/examples/tour/Cargo.toml
@@ -18,4 +18,3 @@ iced.features = ["image", "debug", "webgl"]
 
 console_error_panic_hook = "0.1"
 console_log = "1.0"
-log.workspace = true

--- a/examples/tour/Cargo.toml
+++ b/examples/tour/Cargo.toml
@@ -10,3 +10,7 @@ iced.workspace = true
 iced.features = ["image", "debug"]
 
 tracing-subscriber = "0.3"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+iced.workspace = true
+iced.features = ["image", "debug", "webgl"]

--- a/examples/tour/Cargo.toml
+++ b/examples/tour/Cargo.toml
@@ -9,8 +9,13 @@ publish = false
 iced.workspace = true
 iced.features = ["image", "debug"]
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tracing-subscriber = "0.3"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 iced.workspace = true
 iced.features = ["image", "debug", "webgl"]
+
+console_error_panic_hook = "0.1"
+console_log = "1.0"
+log.workspace = true

--- a/examples/tour/src/main.rs
+++ b/examples/tour/src/main.rs
@@ -8,6 +8,13 @@ use iced::widget::{Button, Column, Container, Slider};
 use iced::{Color, Element, Font, Length, Renderer, Sandbox, Settings};
 
 pub fn main() -> iced::Result {
+    #[cfg(target_arch = "wasm32")]
+    {
+        console_log::init_with_level(log::Level::Debug).expect("Initialize logger");
+        std::panic::set_hook(Box::new(console_error_panic_hook::hook));
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
     tracing_subscriber::fmt::init();
 
     Tour::run(Settings::default())

--- a/examples/tour/src/main.rs
+++ b/examples/tour/src/main.rs
@@ -10,7 +10,7 @@ use iced::{Color, Element, Font, Length, Renderer, Sandbox, Settings};
 pub fn main() -> iced::Result {
     #[cfg(target_arch = "wasm32")]
     {
-        console_log::init_with_level(log::Level::Debug).expect("Initialize logger");
+        console_log::init().expect("Initialize logger");
         std::panic::set_hook(Box::new(console_error_panic_hook::hook));
     }
 


### PR DESCRIPTION
Heya!

First things first, thanks for developing this great library!

I recently started experimenting with integrating iced into an existing wgpu application that targets native as well as the web.

Im well aware that web is not the main focus of development, but since there are some examples that have some setup for running on the web, I updated them to build and run again.

The following (web) examples have been updated:
- Counter
- Integration
- Todos
- Tour

With getting the `tour` example running again this should fix #1522 .
The cause for the `RuntimeError: unreachable` as described in the issue #1522 back then is likely not the same as now, since the example changed in the meantime.

Anyways the issue description still fits the current situation "When starting the tours app it crashes on load (only web)".

The reason for the `RuntimeError: unreachable` is the line `tracing_subscriber::fmt::init();` which panics when running on the web.

I added `console_log` for logging and a panic hook to also log panics in the browser console, similar to the integration example, so next time we encounter a `RuntimeError: unreachable` we should get a more descriptive error message.

<br>

I have also updated the `README`s where necessary.

<br>

Note: Text is not rendered on the web because no font is loaded, which is ignored here because it is another already known topic.
