### PR TITLE
Fix majority of unresolved documentation links

### DIFF
--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -1,8 +1,5 @@
 name: Document
-on:
-  push:
-    branches:
-      - master
+on: [push, pull_request]
 jobs:
   all:
     runs-on: ubuntu-20.04
@@ -31,6 +28,7 @@ jobs:
     - name: Write CNAME file
       run: echo 'docs.iced.rs' > ./target/doc/CNAME
     - name: Publish documentation
+      if: github.ref == 'refs/heads/master'
       uses: peaceiris/actions-gh-pages@v3
       with:
         deploy_key: ${{ secrets.DOCS_DEPLOY_KEY }}

--- a/core/src/angle.rs
+++ b/core/src/angle.rs
@@ -55,7 +55,7 @@ impl num_traits::FromPrimitive for Radians {
 }
 
 impl Radians {
-    /// Calculates the line in which the [`Angle`] intercepts the `bounds`.
+    /// Calculates the line in which the angle intercepts the `bounds`.
     pub fn to_distance(&self, bounds: &Rectangle) -> (Point, Point) {
         let angle = self.0 - FRAC_PI_2;
         let r = Vector::new(f32::cos(angle), f32::sin(angle));

--- a/core/src/gradient.rs
+++ b/core/src/gradient.rs
@@ -6,8 +6,6 @@ use std::cmp::Ordering;
 #[derive(Debug, Clone, Copy, PartialEq)]
 /// A fill which transitions colors progressively along a direction, either linearly, radially (TBD),
 /// or conically (TBD).
-///
-/// For a gradient which can be used as a fill on a canvas, see [`iced_graphics::Gradient`].
 pub enum Gradient {
     /// A linear gradient interpolates colors along a direction at a specific angle.
     Linear(Linear),

--- a/core/src/gradient.rs
+++ b/core/src/gradient.rs
@@ -9,7 +9,7 @@ use std::cmp::Ordering;
 ///
 /// For a gradient which can be used as a fill on a canvas, see [`iced_graphics::Gradient`].
 pub enum Gradient {
-    /// A linear gradient interpolates colors along a direction at a specific [`Angle`].
+    /// A linear gradient interpolates colors along a direction at a specific angle.
     Linear(Linear),
 }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -9,6 +9,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/iced-rs/iced/9ab6923e943f784985e9ef9ca28b10278297225d/docs/logo.svg"
 )]
+#![forbid(unsafe_code, rust_2018_idioms)]
 #![deny(
     missing_debug_implementations,
     missing_docs,
@@ -17,9 +18,9 @@
     clippy::from_over_into,
     clippy::needless_borrow,
     clippy::new_without_default,
-    clippy::useless_conversion
+    clippy::useless_conversion,
+    rustdoc::broken_intra_doc_links
 )]
-#![forbid(unsafe_code, rust_2018_idioms)]
 #![allow(clippy::inherent_to_string, clippy::type_complexity)]
 pub mod alignment;
 pub mod clipboard;

--- a/core/src/shell.rs
+++ b/core/src/shell.rs
@@ -35,7 +35,7 @@ impl<'a, Message> Shell<'a, Message> {
         self.messages.push(message);
     }
 
-    /// Requests a new frame to be drawn at the given [`Instant`].
+    /// Requests a new frame to be drawn.
     pub fn request_redraw(&mut self, request: window::RedrawRequest) {
         match self.redraw_request {
             None => {
@@ -48,7 +48,7 @@ impl<'a, Message> Shell<'a, Message> {
         }
     }
 
-    /// Returns the requested [`Instant`] a redraw should happen, if any.
+    /// Returns the request a redraw should happen, if any.
     pub fn redraw_request(&self) -> Option<window::RedrawRequest> {
         self.redraw_request
     }

--- a/core/src/window/icon.rs
+++ b/core/src/window/icon.rs
@@ -49,7 +49,7 @@ impl Icon {
 }
 
 #[derive(Debug, thiserror::Error)]
-/// An error produced when using [`Icon::from_rgba`] with invalid arguments.
+/// An error produced when using [`from_rgba`] with invalid arguments.
 pub enum Error {
     /// Produced when the length of the `rgba` argument isn't divisible by 4, thus `rgba` can't be
     /// safely interpreted as 32bpp RGBA pixels.

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -4,6 +4,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/iced-rs/iced/9ab6923e943f784985e9ef9ca28b10278297225d/docs/logo.svg"
 )]
+#![forbid(unsafe_code, rust_2018_idioms)]
 #![deny(
     missing_debug_implementations,
     missing_docs,
@@ -12,9 +13,9 @@
     clippy::from_over_into,
     clippy::needless_borrow,
     clippy::new_without_default,
-    clippy::useless_conversion
+    clippy::useless_conversion,
+    rustdoc::broken_intra_doc_links
 )]
-#![forbid(unsafe_code, rust_2018_idioms)]
 #![allow(clippy::inherent_to_string, clippy::type_complexity)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 pub use futures;

--- a/futures/src/runtime.rs
+++ b/futures/src/runtime.rs
@@ -9,9 +9,9 @@ use std::marker::PhantomData;
 /// A batteries-included runtime of commands and subscriptions.
 ///
 /// If you have an [`Executor`], a [`Runtime`] can be leveraged to run any
-/// [`Command`] or [`Subscription`] and get notified of the results!
+/// `Command` or [`Subscription`] and get notified of the results!
 ///
-/// [`Command`]: crate::Command
+/// [`Subscription`]: crate::Subscription
 #[derive(Debug)]
 pub struct Runtime<Executor, Sender, Message> {
     executor: Executor,
@@ -75,6 +75,7 @@ where
     /// [`Tracker::update`] to learn more about this!
     ///
     /// [`Tracker::update`]: subscription::Tracker::update
+    /// [`Subscription`]: crate::Subscription
     pub fn track(
         &mut self,
         recipes: impl IntoIterator<

--- a/futures/src/subscription.rs
+++ b/futures/src/subscription.rs
@@ -19,16 +19,14 @@ pub type EventStream = BoxStream<(Event, event::Status)>;
 
 /// A request to listen to external events.
 ///
-/// Besides performing async actions on demand with [`Command`], most
+/// Besides performing async actions on demand with `Command`, most
 /// applications also need to listen to external events passively.
 ///
-/// A [`Subscription`] is normally provided to some runtime, like a [`Command`],
+/// A [`Subscription`] is normally provided to some runtime, like a `Command`,
 /// and it will generate events as long as the user keeps requesting it.
 ///
 /// For instance, you can use a [`Subscription`] to listen to a WebSocket
 /// connection, keyboard presses, mouse events, time ticks, etc.
-///
-/// [`Command`]: crate::Command
 #[must_use = "`Subscription` must be returned to runtime to take effect"]
 pub struct Subscription<Message> {
     recipes: Vec<Box<dyn Recipe<Output = Message>>>,

--- a/futures/src/subscription/tracker.rs
+++ b/futures/src/subscription/tracker.rs
@@ -14,6 +14,8 @@ use std::hash::Hasher as _;
 /// If you have an application that continuously returns a [`Subscription`],
 /// you can use a [`Tracker`] to keep track of the different recipes and keep
 /// its executions alive.
+///
+/// [`Subscription`]: crate::Subscription
 #[derive(Debug, Default)]
 pub struct Tracker {
     subscriptions: HashMap<u64, Execution>,
@@ -51,6 +53,7 @@ impl Tracker {
     /// the [`Tracker`] changes.
     ///
     /// [`Recipe`]: crate::subscription::Recipe
+    /// [`Subscription`]: crate::Subscription
     pub fn update<Message, Receiver>(
         &mut self,
         recipes: impl Iterator<Item = Box<dyn Recipe<Output = Message>>>,

--- a/graphics/src/compositor.rs
+++ b/graphics/src/compositor.rs
@@ -63,7 +63,7 @@ pub trait Compositor: Sized {
     /// Screenshots the current [`Renderer`] primitives to an offscreen texture, and returns the bytes of
     /// the texture ordered as `RGBA` in the sRGB color space.
     ///
-    /// [`Renderer`]: Self::Renderer;
+    /// [`Renderer`]: Self::Renderer
     fn screenshot<T: AsRef<str>>(
         &mut self,
         renderer: &mut Self::Renderer,

--- a/graphics/src/geometry.rs
+++ b/graphics/src/geometry.rs
@@ -14,11 +14,11 @@ pub use text::Text;
 
 pub use crate::gradient::{self, Gradient};
 
-/// A renderer capable of drawing some [`Geometry`].
+/// A renderer capable of drawing some [`Self::Geometry`].
 pub trait Renderer: crate::core::Renderer {
     /// The kind of geometry this renderer can draw.
     type Geometry;
 
-    /// Draws the given layers of [`Geometry`].
+    /// Draws the given layers of [`Self::Geometry`].
     fn draw(&mut self, layers: Vec<Self::Geometry>);
 }

--- a/graphics/src/geometry/fill.rs
+++ b/graphics/src/geometry/fill.rs
@@ -1,4 +1,6 @@
-//! Fill [crate::widget::canvas::Geometry] with a certain style.
+//! Fill [`Geometry`] with a certain style.
+//!
+//! [`Geometry`]: super::Renderer::Geometry
 pub use crate::geometry::Style;
 
 use crate::core::Color;

--- a/graphics/src/geometry/stroke.rs
+++ b/graphics/src/geometry/stroke.rs
@@ -1,4 +1,6 @@
-//! Create lines from a [crate::widget::canvas::Path] and assigns them various attributes/styles.
+//! Create lines from a [`Path`] and assigns them various attributes/styles.
+//!
+//! [`Path`]: super::Path
 pub use crate::geometry::Style;
 
 use iced_core::Color;

--- a/graphics/src/gradient.rs
+++ b/graphics/src/gradient.rs
@@ -1,4 +1,4 @@
-//! A gradient that can be used as a [`Fill`] for some geometry.
+//! A gradient that can be used as a fill for some geometry.
 //!
 //! For a gradient that you can use as a background variant for a widget, see [`Gradient`].
 //!
@@ -53,7 +53,7 @@ pub struct Linear {
 }
 
 impl Linear {
-    /// Creates a new [`Builder`].
+    /// Creates a new [`Linear`] builder.
     pub fn new(start: Point, end: Point) -> Self {
         Self {
             start,

--- a/graphics/src/gradient.rs
+++ b/graphics/src/gradient.rs
@@ -1,8 +1,6 @@
 //! A gradient that can be used as a fill for some geometry.
 //!
 //! For a gradient that you can use as a background variant for a widget, see [`Gradient`].
-//!
-//! [`Gradient`]: crate::core::Gradient;
 use crate::color;
 use crate::core::gradient::ColorStop;
 use crate::core::{self, Color, Point, Rectangle};
@@ -36,10 +34,7 @@ impl Gradient {
     }
 }
 
-/// A linear gradient that can be used in the style of [`Fill`] or [`Stroke`].
-///
-/// [`Fill`]: crate::geometry::Fill;
-/// [`Stroke`]: crate::geometry::Stroke;
+/// A linear gradient.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Linear {
     /// The absolute starting position of the gradient.

--- a/graphics/src/lib.rs
+++ b/graphics/src/lib.rs
@@ -7,6 +7,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/iced-rs/iced/9ab6923e943f784985e9ef9ca28b10278297225d/docs/logo.svg"
 )]
+#![forbid(rust_2018_idioms)]
 #![deny(
     missing_debug_implementations,
     missing_docs,
@@ -16,9 +17,9 @@
     clippy::from_over_into,
     clippy::needless_borrow,
     clippy::new_without_default,
-    clippy::useless_conversion
+    clippy::useless_conversion,
+    rustdoc::broken_intra_doc_links
 )]
-#![forbid(rust_2018_idioms)]
 #![allow(clippy::inherent_to_string, clippy::type_complexity)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 mod antialiasing;

--- a/graphics/src/mesh.rs
+++ b/graphics/src/mesh.rs
@@ -41,7 +41,7 @@ impl Damage for Mesh {
     }
 }
 
-/// A set of [`Vertex2D`] and indices representing a list of triangles.
+/// A set of vertices and indices representing a list of triangles.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Indexed<T> {
     /// The vertices of the mesh

--- a/renderer/src/geometry.rs
+++ b/renderer/src/geometry.rs
@@ -96,13 +96,11 @@ impl Frame {
     /// resulting glyphs will not be rotated or scaled properly.
     ///
     /// Additionally, all text will be rendered on top of all the layers of
-    /// a [`Canvas`]. Therefore, it is currently only meant to be used for
+    /// a `Canvas`. Therefore, it is currently only meant to be used for
     /// overlays, which is the most common use case.
     ///
     /// Support for vectorial text is planned, and should address all these
     /// limitations.
-    ///
-    /// [`Canvas`]: crate::widget::Canvas
     pub fn fill_text(&mut self, text: impl Into<Text>) {
         delegate!(self, frame, frame.fill_text(text));
     }

--- a/renderer/src/lib.rs
+++ b/renderer/src/lib.rs
@@ -1,3 +1,16 @@
+#![forbid(rust_2018_idioms)]
+#![deny(
+    unsafe_code,
+    unused_results,
+    clippy::extra_unused_lifetimes,
+    clippy::from_over_into,
+    clippy::needless_borrow,
+    clippy::new_without_default,
+    clippy::useless_conversion,
+    rustdoc::broken_intra_doc_links
+)]
+#![allow(clippy::inherent_to_string, clippy::type_complexity)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 pub mod compositor;
 
 #[cfg(feature = "geometry")]

--- a/renderer/src/settings.rs
+++ b/renderer/src/settings.rs
@@ -1,9 +1,7 @@
 use crate::core::Font;
 use crate::graphics::Antialiasing;
 
-/// The settings of a [`Backend`].
-///
-/// [`Backend`]: crate::Backend
+/// The settings of a Backend.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Settings {
     /// The default [`Font`] to use.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -2,32 +2,9 @@
 //!
 //! ![The native path of the Iced ecosystem](https://github.com/iced-rs/iced/raw/improvement/update-ecosystem-and-roadmap/docs/graphs/native.png)
 //!
-//! `iced_native` takes [`iced_core`] and builds a native runtime on top of it,
-//! featuring:
-//!
-//! - A custom layout engine, greatly inspired by [`druid`]
-//! - Event handling for all the built-in widgets
-//! - A renderer-agnostic API
-//!
-//! To achieve this, it introduces a couple of reusable interfaces:
-//!
-//! - A [`Widget`] trait, which is used to implement new widgets: from layout
-//!   requirements to event and drawing logic.
-//! - A bunch of `Renderer` traits, meant to keep the crate renderer-agnostic.
-//!
-//! # Usage
-//! The strategy to use this crate depends on your particular use case. If you
-//! want to:
-//! - Implement a custom shell or integrate it in your own system, check out the
-//! [`UserInterface`] type.
-//! - Build a new renderer, see the [renderer] module.
-//! - Build a custom widget, start at the [`Widget`] trait.
+//! `iced_runtime` takes [`iced_core`] and builds a native runtime on top of it.
 //!
 //! [`iced_core`]: https://github.com/iced-rs/iced/tree/0.10/core
-//! [`iced_winit`]: https://github.com/iced-rs/iced/tree/0.10/winit
-//! [`druid`]: https://github.com/xi-editor/druid
-//! [`raw-window-handle`]: https://github.com/rust-windowing/raw-window-handle
-//! [renderer]: crate::renderer
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/iced-rs/iced/9ab6923e943f784985e9ef9ca28b10278297225d/docs/logo.svg"
 )]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -8,6 +8,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/iced-rs/iced/9ab6923e943f784985e9ef9ca28b10278297225d/docs/logo.svg"
 )]
+#![forbid(unsafe_code, rust_2018_idioms)]
 #![deny(
     missing_debug_implementations,
     missing_docs,
@@ -16,9 +17,9 @@
     clippy::from_over_into,
     clippy::needless_borrow,
     clippy::new_without_default,
-    clippy::useless_conversion
+    clippy::useless_conversion,
+    rustdoc::broken_intra_doc_links
 )]
-#![forbid(unsafe_code, rust_2018_idioms)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 pub mod clipboard;
 pub mod command;

--- a/runtime/src/overlay/nested.rs
+++ b/runtime/src/overlay/nested.rs
@@ -6,7 +6,7 @@ use crate::core::renderer;
 use crate::core::widget;
 use crate::core::{Clipboard, Event, Layout, Point, Rectangle, Shell, Size};
 
-/// An [`Overlay`] container that displays nested overlays
+/// An overlay container that displays nested overlays
 #[allow(missing_debug_implementations)]
 pub struct Nested<'a, Message, Renderer> {
     overlay: overlay::Element<'a, Message, Renderer>,
@@ -27,6 +27,8 @@ where
     }
 
     /// Returns the layout [`Node`] of the [`Nested`] overlay.
+    ///
+    /// [`Node`]: layout::Node
     pub fn layout(
         &mut self,
         renderer: &Renderer,

--- a/runtime/src/program/state.rs
+++ b/runtime/src/program/state.rs
@@ -175,7 +175,7 @@ where
         (uncaptured_events, command)
     }
 
-    /// Applies [`widget::Operation`]s to the [`State`]
+    /// Applies [`Operation`]s to the [`State`]
     pub fn operate(
         &mut self,
         renderer: &mut P::Renderer,

--- a/runtime/src/user_interface.rs
+++ b/runtime/src/user_interface.rs
@@ -356,7 +356,7 @@ where
     /// It returns the current [`mouse::Interaction`]. You should update the
     /// icon of the mouse cursor accordingly in your system.
     ///
-    /// [`Renderer`]: crate::Renderer
+    /// [`Renderer`]: crate::core::Renderer
     ///
     /// # Example
     /// We can finally draw our [counter](index.html#usage) by
@@ -619,7 +619,7 @@ pub enum State {
     /// The [`UserInterface`] is up-to-date and can be reused without
     /// rebuilding.
     Updated {
-        /// The [`Instant`] when a redraw should be performed.
+        /// The [`window::RedrawRequest`] when a redraw should be performed.
         redraw_request: Option<window::RedrawRequest>,
     },
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,11 +258,11 @@ pub mod system {
 pub mod overlay {
     //! Display interactive elements on top of other widgets.
 
-    /// A generic [`Overlay`].
+    /// A generic overlay.
     ///
-    /// This is an alias of an `iced_native` element with a default `Renderer`.
+    /// This is an alias of an [`overlay::Element`] with a default `Renderer`.
     ///
-    /// [`Overlay`]: iced_native::Overlay
+    /// [`overlay::Element`]: crate::core::overlay::Element
     pub type Element<'a, Message, Renderer = crate::Renderer> =
         crate::core::overlay::Element<'a, Message, Renderer>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,6 +151,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/iced-rs/iced/9ab6923e943f784985e9ef9ca28b10278297225d/docs/logo.svg"
 )]
+#![forbid(rust_2018_idioms, unsafe_code)]
 #![deny(
     missing_debug_implementations,
     missing_docs,
@@ -159,9 +160,9 @@
     clippy::from_over_into,
     clippy::needless_borrow,
     clippy::new_without_default,
-    clippy::useless_conversion
+    clippy::useless_conversion,
+    rustdoc::broken_intra_doc_links
 )]
-#![forbid(rust_2018_idioms, unsafe_code)]
 #![allow(clippy::inherent_to_string, clippy::type_complexity)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 use iced_widget::graphics;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -23,7 +23,7 @@ pub struct Settings<Flags> {
 
     /// The default [`Font`] to be used.
     ///
-    /// By default, it uses [`Font::SansSerif`].
+    /// By default, it uses [`Family::SansSerif`](crate::font::Family::SansSerif).
     pub default_font: Font,
 
     /// The text size that will be used by default.

--- a/src/window/icon.rs
+++ b/src/window/icon.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 
 /// Creates an icon from an image file.
 ///
-/// This will return an error in case the file is missing at run-time. You may prefer [`Self::from_file_data`] instead.
+/// This will return an error in case the file is missing at run-time. You may prefer [`from_file_data`] instead.
 #[cfg(feature = "image")]
 pub fn from_file<P: AsRef<Path>>(icon_path: P) -> Result<Icon, Error> {
     let icon = image::io::Reader::open(icon_path)?.decode()?.to_rgba8();

--- a/style/src/lib.rs
+++ b/style/src/lib.rs
@@ -7,16 +7,18 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/iced-rs/iced/9ab6923e943f784985e9ef9ca28b10278297225d/docs/logo.svg"
 )]
+#![forbid(unsafe_code, rust_2018_idioms)]
 #![deny(
     unused_results,
     clippy::extra_unused_lifetimes,
     clippy::from_over_into,
     clippy::needless_borrow,
     clippy::new_without_default,
-    clippy::useless_conversion
+    clippy::useless_conversion,
+    missing_docs,
+    unused_results,
+    rustdoc::broken_intra_doc_links
 )]
-#![deny(missing_docs, unused_results)]
-#![forbid(unsafe_code, rust_2018_idioms)]
 #![allow(clippy::inherent_to_string, clippy::type_complexity)]
 pub use iced_core as core;
 

--- a/tiny_skia/src/geometry.rs
+++ b/tiny_skia/src/geometry.rs
@@ -303,7 +303,7 @@ pub fn into_fill_rule(rule: fill::Rule) -> tiny_skia::FillRule {
     }
 }
 
-pub fn into_stroke(stroke: &Stroke) -> tiny_skia::Stroke {
+pub fn into_stroke(stroke: &Stroke<'_>) -> tiny_skia::Stroke {
     tiny_skia::Stroke {
         width: stroke.width,
         line_cap: match stroke.line_cap {

--- a/tiny_skia/src/lib.rs
+++ b/tiny_skia/src/lib.rs
@@ -1,3 +1,16 @@
+#![forbid(rust_2018_idioms)]
+#![deny(
+    unsafe_code,
+    unused_results,
+    clippy::extra_unused_lifetimes,
+    clippy::from_over_into,
+    clippy::needless_borrow,
+    clippy::new_without_default,
+    clippy::useless_conversion,
+    rustdoc::broken_intra_doc_links
+)]
+#![allow(clippy::inherent_to_string, clippy::type_complexity)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 pub mod window;
 
 mod backend;

--- a/tiny_skia/src/raster.rs
+++ b/tiny_skia/src/raster.rs
@@ -85,14 +85,14 @@ impl Cache {
                 );
             }
 
-            entry.insert(Some(Entry {
+            let _ = entry.insert(Some(Entry {
                 width: image.width(),
                 height: image.height(),
                 pixels: buffer,
             }));
         }
 
-        self.hits.insert(id);
+        let _ = self.hits.insert(id);
         self.entries.get(&id).unwrap().as_ref().map(|entry| {
             tiny_skia::PixmapRef::from_bytes(
                 bytemuck::cast_slice(&entry.pixels),

--- a/tiny_skia/src/text.rs
+++ b/tiny_skia/src/text.rs
@@ -32,7 +32,7 @@ impl Pipeline {
     }
 
     pub fn load_font(&mut self, bytes: Cow<'static, [u8]>) {
-        self.font_system.get_mut().db_mut().load_font_source(
+        let _ = self.font_system.get_mut().db_mut().load_font_source(
             cosmic_text::fontdb::Source::Binary(Arc::new(bytes.into_owned())),
         );
 
@@ -335,10 +335,10 @@ impl GlyphCache {
                 }
             }
 
-            entry.insert((buffer, image.placement));
+            let _ = entry.insert((buffer, image.placement));
         }
 
-        self.recently_used.insert(key);
+        let _ = self.recently_used.insert(key);
 
         self.entries.get(&key).map(|(buffer, placement)| {
             (bytemuck::cast_slice(buffer.as_slice()), *placement)

--- a/tiny_skia/src/vector.rs
+++ b/tiny_skia/src/vector.rs
@@ -92,10 +92,10 @@ impl Cache {
                 }
             };
 
-            entry.insert(svg);
+            let _ = entry.insert(svg);
         }
 
-        self.tree_hits.insert(id);
+        let _ = self.tree_hits.insert(id);
         self.trees.get(&id).unwrap().as_ref()
     }
 
@@ -178,10 +178,10 @@ impl Cache {
                 }
             }
 
-            self.rasters.insert(key, image);
+            let _ = self.rasters.insert(key, image);
         }
 
-        self.raster_hits.insert(key);
+        let _ = self.raster_hits.insert(key);
         self.rasters.get(&key).map(tiny_skia::Pixmap::as_ref)
     }
 

--- a/tiny_skia/src/window/compositor.rs
+++ b/tiny_skia/src/window/compositor.rs
@@ -39,6 +39,7 @@ impl<Theme> crate::graphics::Compositor for Compositor<Theme> {
         width: u32,
         height: u32,
     ) -> Surface {
+        #[allow(unsafe_code)]
         let window =
             unsafe { softbuffer::GraphicsContext::new(window, window) }
                 .expect("Create softbuffer for window");

--- a/wgpu/src/geometry.rs
+++ b/wgpu/src/geometry.rs
@@ -310,13 +310,11 @@ impl Frame {
     /// resulting glyphs will not be rotated or scaled properly.
     ///
     /// Additionally, all text will be rendered on top of all the layers of
-    /// a [`Canvas`]. Therefore, it is currently only meant to be used for
+    /// a `Canvas`. Therefore, it is currently only meant to be used for
     /// overlays, which is the most common use case.
     ///
     /// Support for vectorial text is planned, and should address all these
     /// limitations.
-    ///
-    /// [`Canvas`]: crate::widget::Canvas
     pub fn fill_text(&mut self, text: impl Into<Text>) {
         let text = text.into();
 

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -20,6 +20,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/iced-rs/iced/9ab6923e943f784985e9ef9ca28b10278297225d/docs/logo.svg"
 )]
+#![forbid(rust_2018_idioms)]
 #![deny(
     missing_debug_implementations,
     missing_docs,
@@ -29,9 +30,9 @@
     clippy::from_over_into,
     clippy::needless_borrow,
     clippy::new_without_default,
-    clippy::useless_conversion
+    clippy::useless_conversion,
+    rustdoc::broken_intra_doc_links
 )]
-#![forbid(rust_2018_idioms)]
 #![allow(clippy::inherent_to_string, clippy::type_complexity)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 pub mod layer;

--- a/widget/src/canvas/event.rs
+++ b/widget/src/canvas/event.rs
@@ -7,7 +7,7 @@ pub use crate::core::event::Status;
 
 /// A [`Canvas`] event.
 ///
-/// [`Canvas`]: crate::widget::Canvas
+/// [`Canvas`]: crate::Canvas
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Event {
     /// A mouse event.

--- a/widget/src/canvas/program.rs
+++ b/widget/src/canvas/program.rs
@@ -8,7 +8,7 @@ use crate::graphics::geometry;
 /// A [`Program`] can mutate internal state and produce messages for an
 /// application.
 ///
-/// [`Canvas`]: crate::widget::Canvas
+/// [`Canvas`]: crate::Canvas
 pub trait Program<Message, Renderer = crate::Renderer>
 where
     Renderer: geometry::Renderer,
@@ -26,7 +26,7 @@ where
     ///
     /// By default, this method does and returns nothing.
     ///
-    /// [`Canvas`]: crate::widget::Canvas
+    /// [`Canvas`]: crate::Canvas
     fn update(
         &self,
         _state: &mut Self::State,
@@ -42,8 +42,9 @@ where
     /// [`Geometry`] can be easily generated with a [`Frame`] or stored in a
     /// [`Cache`].
     ///
-    /// [`Frame`]: crate::widget::canvas::Frame
-    /// [`Cache`]: crate::widget::canvas::Cache
+    /// [`Geometry`]: crate::canvas::Geometry
+    /// [`Frame`]: crate::canvas::Frame
+    /// [`Cache`]: crate::canvas::Cache
     fn draw(
         &self,
         state: &Self::State,
@@ -58,7 +59,7 @@ where
     /// The interaction returned will be in effect even if the cursor position
     /// is out of bounds of the program's [`Canvas`].
     ///
-    /// [`Canvas`]: crate::widget::Canvas
+    /// [`Canvas`]: crate::Canvas
     fn mouse_interaction(
         &self,
         _state: &Self::State,

--- a/widget/src/checkbox.rs
+++ b/widget/src/checkbox.rs
@@ -122,7 +122,7 @@ where
         self
     }
 
-    /// Sets the text [`LineHeight`] of the [`Checkbox`].
+    /// Sets the text [`text::LineHeight`] of the [`Checkbox`].
     pub fn text_line_height(
         mut self,
         line_height: impl Into<text::LineHeight>,
@@ -137,9 +137,9 @@ where
         self
     }
 
-    /// Sets the [`Font`] of the text of the [`Checkbox`].
+    /// Sets the [`Renderer::Font`] of the text of the [`Checkbox`].
     ///
-    /// [`Font`]: crate::text::Renderer::Font
+    /// [`Renderer::Font`]: crate::core::text::Renderer
     pub fn font(mut self, font: impl Into<Renderer::Font>) -> Self {
         self.font = Some(font.into());
         self

--- a/widget/src/combo_box.rs
+++ b/widget/src/combo_box.rs
@@ -20,7 +20,7 @@ use std::time::Instant;
 ///
 /// This widget is composed by a [`TextInput`] that can be filled with the text
 /// to search for corresponding values from the list of options that are displayed
-/// as a [`Menu`].
+/// as a Menu.
 #[allow(missing_debug_implementations)]
 pub struct ComboBox<'a, T, Message, Renderer = crate::Renderer>
 where
@@ -131,14 +131,16 @@ where
         self
     }
 
-    /// Sets the [`Font`] of the [`ComboBox`].
+    /// Sets the [`Renderer::Font`] of the [`ComboBox`].
+    ///
+    /// [`Renderer::Font`]: text::Renderer
     pub fn font(mut self, font: Renderer::Font) -> Self {
         self.text_input = self.text_input.font(font);
         self.font = Some(font);
         self
     }
 
-    /// Sets the [`Icon`] of the [`ComboBox`].
+    /// Sets the [`text_input::Icon`] of the [`ComboBox`].
     pub fn icon(mut self, icon: text_input::Icon<Renderer::Font>) -> Self {
         self.text_input = self.text_input.icon(icon);
         self

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -25,7 +25,7 @@ use std::ops::RangeInclusive;
 
 /// Creates a [`Column`] with the given children.
 ///
-/// [`Column`]: widget::Column
+/// [`Column`]: crate::Column
 #[macro_export]
 macro_rules! column {
     () => (
@@ -38,7 +38,7 @@ macro_rules! column {
 
 /// Creates a [`Row`] with the given children.
 ///
-/// [`Row`]: widget::Row
+/// [`Row`]: crate::Row
 #[macro_export]
 macro_rules! row {
     () => (
@@ -51,7 +51,7 @@ macro_rules! row {
 
 /// Creates a new [`Container`] with the provided content.
 ///
-/// [`Container`]: widget::Container
+/// [`Container`]: crate::Container
 pub fn container<'a, Message, Renderer>(
     content: impl Into<Element<'a, Message, Renderer>>,
 ) -> Container<'a, Message, Renderer>
@@ -64,7 +64,7 @@ where
 
 /// Creates a new [`Column`] with the given children.
 ///
-/// [`Column`]: widget::Column
+/// [`Column`]: crate::Column
 pub fn column<Message, Renderer>(
     children: Vec<Element<'_, Message, Renderer>>,
 ) -> Column<'_, Message, Renderer> {
@@ -73,7 +73,7 @@ pub fn column<Message, Renderer>(
 
 /// Creates a new [`Row`] with the given children.
 ///
-/// [`Row`]: widget::Row
+/// [`Row`]: crate::Row
 pub fn row<Message, Renderer>(
     children: Vec<Element<'_, Message, Renderer>>,
 ) -> Row<'_, Message, Renderer> {
@@ -82,7 +82,7 @@ pub fn row<Message, Renderer>(
 
 /// Creates a new [`Scrollable`] with the provided content.
 ///
-/// [`Scrollable`]: widget::Scrollable
+/// [`Scrollable`]: crate::Scrollable
 pub fn scrollable<'a, Message, Renderer>(
     content: impl Into<Element<'a, Message, Renderer>>,
 ) -> Scrollable<'a, Message, Renderer>
@@ -95,7 +95,7 @@ where
 
 /// Creates a new [`Button`] with the provided content.
 ///
-/// [`Button`]: widget::Button
+/// [`Button`]: crate::Button
 pub fn button<'a, Message, Renderer>(
     content: impl Into<Element<'a, Message, Renderer>>,
 ) -> Button<'a, Message, Renderer>
@@ -109,8 +109,8 @@ where
 
 /// Creates a new [`Tooltip`] with the provided content, tooltip text, and [`tooltip::Position`].
 ///
-/// [`Tooltip`]: widget::Tooltip
-/// [`tooltip::Position`]: widget::tooltip::Position
+/// [`Tooltip`]: crate::Tooltip
+/// [`tooltip::Position`]: crate::tooltip::Position
 pub fn tooltip<'a, Message, Renderer>(
     content: impl Into<Element<'a, Message, Renderer>>,
     tooltip: impl ToString,
@@ -125,7 +125,7 @@ where
 
 /// Creates a new [`Text`] widget with the provided content.
 ///
-/// [`Text`]: widget::Text
+/// [`Text`]: core::widget::Text
 pub fn text<'a, Renderer>(text: impl ToString) -> Text<'a, Renderer>
 where
     Renderer: core::text::Renderer,
@@ -136,7 +136,7 @@ where
 
 /// Creates a new [`Checkbox`].
 ///
-/// [`Checkbox`]: widget::Checkbox
+/// [`Checkbox`]: crate::Checkbox
 pub fn checkbox<'a, Message, Renderer>(
     label: impl Into<String>,
     is_checked: bool,
@@ -151,7 +151,7 @@ where
 
 /// Creates a new [`Radio`].
 ///
-/// [`Radio`]: widget::Radio
+/// [`Radio`]: crate::Radio
 pub fn radio<Message, Renderer, V>(
     label: impl Into<String>,
     value: V,
@@ -169,7 +169,7 @@ where
 
 /// Creates a new [`Toggler`].
 ///
-/// [`Toggler`]: widget::Toggler
+/// [`Toggler`]: crate::Toggler
 pub fn toggler<'a, Message, Renderer>(
     label: impl Into<Option<String>>,
     is_checked: bool,
@@ -184,7 +184,7 @@ where
 
 /// Creates a new [`TextInput`].
 ///
-/// [`TextInput`]: widget::TextInput
+/// [`TextInput`]: crate::TextInput
 pub fn text_input<'a, Message, Renderer>(
     placeholder: &str,
     value: &str,
@@ -199,7 +199,7 @@ where
 
 /// Creates a new [`Slider`].
 ///
-/// [`Slider`]: widget::Slider
+/// [`Slider`]: crate::Slider
 pub fn slider<'a, T, Message, Renderer>(
     range: std::ops::RangeInclusive<T>,
     value: T,
@@ -216,7 +216,7 @@ where
 
 /// Creates a new [`VerticalSlider`].
 ///
-/// [`VerticalSlider`]: widget::VerticalSlider
+/// [`VerticalSlider`]: crate::VerticalSlider
 pub fn vertical_slider<'a, T, Message, Renderer>(
     range: std::ops::RangeInclusive<T>,
     value: T,
@@ -233,7 +233,7 @@ where
 
 /// Creates a new [`PickList`].
 ///
-/// [`PickList`]: widget::PickList
+/// [`PickList`]: crate::PickList
 pub fn pick_list<'a, Message, Renderer, T>(
     options: impl Into<Cow<'a, [T]>>,
     selected: Option<T>,
@@ -255,7 +255,7 @@ where
 
 /// Creates a new [`ComboBox`].
 ///
-/// [`ComboBox`]: widget::ComboBox
+/// [`ComboBox`]: crate::ComboBox
 pub fn combo_box<'a, T, Message, Renderer>(
     state: &'a combo_box::State<T>,
     placeholder: &str,
@@ -272,21 +272,21 @@ where
 
 /// Creates a new horizontal [`Space`] with the given [`Length`].
 ///
-/// [`Space`]: widget::Space
+/// [`Space`]: crate::Space
 pub fn horizontal_space(width: impl Into<Length>) -> Space {
     Space::with_width(width)
 }
 
 /// Creates a new vertical [`Space`] with the given [`Length`].
 ///
-/// [`Space`]: widget::Space
+/// [`Space`]: crate::Space
 pub fn vertical_space(height: impl Into<Length>) -> Space {
     Space::with_height(height)
 }
 
 /// Creates a horizontal [`Rule`] with the given height.
 ///
-/// [`Rule`]: widget::Rule
+/// [`Rule`]: crate::Rule
 pub fn horizontal_rule<Renderer>(height: impl Into<Pixels>) -> Rule<Renderer>
 where
     Renderer: core::Renderer,
@@ -297,7 +297,7 @@ where
 
 /// Creates a vertical [`Rule`] with the given width.
 ///
-/// [`Rule`]: widget::Rule
+/// [`Rule`]: crate::Rule
 pub fn vertical_rule<Renderer>(width: impl Into<Pixels>) -> Rule<Renderer>
 where
     Renderer: core::Renderer,
@@ -312,7 +312,7 @@ where
 ///   * an inclusive range of possible values, and
 ///   * the current value of the [`ProgressBar`].
 ///
-/// [`ProgressBar`]: widget::ProgressBar
+/// [`ProgressBar`]: crate::ProgressBar
 pub fn progress_bar<Renderer>(
     range: RangeInclusive<f32>,
     value: f32,
@@ -326,7 +326,7 @@ where
 
 /// Creates a new [`Image`].
 ///
-/// [`Image`]: widget::Image
+/// [`Image`]: crate::Image
 #[cfg(feature = "image")]
 pub fn image<Handle>(handle: impl Into<Handle>) -> crate::Image<Handle> {
     crate::Image::new(handle.into())
@@ -334,8 +334,8 @@ pub fn image<Handle>(handle: impl Into<Handle>) -> crate::Image<Handle> {
 
 /// Creates a new [`Svg`] widget from the given [`Handle`].
 ///
-/// [`Svg`]: widget::Svg
-/// [`Handle`]: widget::svg::Handle
+/// [`Svg`]: crate::Svg
+/// [`Handle`]: crate::svg::Handle
 #[cfg(feature = "svg")]
 pub fn svg<Renderer>(
     handle: impl Into<core::svg::Handle>,
@@ -348,6 +348,8 @@ where
 }
 
 /// Creates a new [`Canvas`].
+///
+/// [`Canvas`]: crate::Canvas
 #[cfg(feature = "canvas")]
 pub fn canvas<P, Message, Renderer>(
     program: P,

--- a/widget/src/lib.rs
+++ b/widget/src/lib.rs
@@ -2,6 +2,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/iced-rs/iced/9ab6923e943f784985e9ef9ca28b10278297225d/docs/logo.svg"
 )]
+#![forbid(unsafe_code, rust_2018_idioms)]
 #![deny(
     missing_debug_implementations,
     missing_docs,
@@ -10,9 +11,9 @@
     clippy::from_over_into,
     clippy::needless_borrow,
     clippy::new_without_default,
-    clippy::useless_conversion
+    clippy::useless_conversion,
+    rustdoc::broken_intra_doc_links
 )]
-#![forbid(unsafe_code, rust_2018_idioms)]
 #![allow(clippy::inherent_to_string, clippy::type_complexity)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 pub use iced_renderer as renderer;

--- a/widget/src/overlay/menu.rs
+++ b/widget/src/overlay/menu.rs
@@ -89,7 +89,7 @@ where
         self
     }
 
-    /// Sets the text [`LineHeight`] of the [`Menu`].
+    /// Sets the text [`text::LineHeight`] of the [`Menu`].
     pub fn text_line_height(
         mut self,
         line_height: impl Into<text::LineHeight>,

--- a/widget/src/pane_grid/configuration.rs
+++ b/widget/src/pane_grid/configuration.rs
@@ -2,7 +2,7 @@ use crate::pane_grid::Axis;
 
 /// The arrangement of a [`PaneGrid`].
 ///
-/// [`PaneGrid`]: crate::widget::PaneGrid
+/// [`PaneGrid`]: super::PaneGrid
 #[derive(Debug, Clone)]
 pub enum Configuration<T> {
     /// A split of the available space.
@@ -21,6 +21,6 @@ pub enum Configuration<T> {
     },
     /// A [`Pane`].
     ///
-    /// [`Pane`]: crate::widget::pane_grid::Pane
+    /// [`Pane`]: super::Pane
     Pane(T),
 }

--- a/widget/src/pane_grid/content.rs
+++ b/widget/src/pane_grid/content.rs
@@ -10,7 +10,7 @@ use crate::pane_grid::{Draggable, TitleBar};
 
 /// The content of a [`Pane`].
 ///
-/// [`Pane`]: crate::widget::pane_grid::Pane
+/// [`Pane`]: super::Pane
 #[allow(missing_debug_implementations)]
 pub struct Content<'a, Message, Renderer = crate::Renderer>
 where
@@ -87,7 +87,7 @@ where
 
     /// Draws the [`Content`] with the provided [`Renderer`] and [`Layout`].
     ///
-    /// [`Renderer`]: crate::Renderer
+    /// [`Renderer`]: crate::core::Renderer
     pub fn draw(
         &self,
         tree: &Tree,

--- a/widget/src/pane_grid/node.rs
+++ b/widget/src/pane_grid/node.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeMap;
 
 /// A layout node of a [`PaneGrid`].
 ///
-/// [`PaneGrid`]: crate::widget::PaneGrid
+/// [`PaneGrid`]: super::PaneGrid
 #[derive(Debug, Clone)]
 pub enum Node {
     /// The region of this [`Node`] is split into two.

--- a/widget/src/pane_grid/pane.rs
+++ b/widget/src/pane_grid/pane.rs
@@ -1,5 +1,5 @@
 /// A rectangular region in a [`PaneGrid`] used to display widgets.
 ///
-/// [`PaneGrid`]: crate::widget::PaneGrid
+/// [`PaneGrid`]: super::PaneGrid
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Pane(pub(super) usize);

--- a/widget/src/pane_grid/split.rs
+++ b/widget/src/pane_grid/split.rs
@@ -1,5 +1,5 @@
 /// A divider that splits a region in a [`PaneGrid`] into two different panes.
 ///
-/// [`PaneGrid`]: crate::widget::PaneGrid
+/// [`PaneGrid`]: super::PaneGrid
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Split(pub(super) usize);

--- a/widget/src/pane_grid/state.rs
+++ b/widget/src/pane_grid/state.rs
@@ -1,6 +1,6 @@
 //! The state of a [`PaneGrid`].
 //!
-//! [`PaneGrid`]: crate::widget::PaneGrid
+//! [`PaneGrid`]: super::PaneGrid
 use crate::core::{Point, Size};
 use crate::pane_grid::{
     Axis, Configuration, Direction, Edge, Node, Pane, Region, Split, Target,
@@ -18,23 +18,23 @@ use std::collections::HashMap;
 /// provided to the view function of [`PaneGrid::new`] for displaying each
 /// [`Pane`].
 ///
-/// [`PaneGrid`]: crate::widget::PaneGrid
-/// [`PaneGrid::new`]: crate::widget::PaneGrid::new
+/// [`PaneGrid`]: super::PaneGrid
+/// [`PaneGrid::new`]: super::PaneGrid::new
 #[derive(Debug, Clone)]
 pub struct State<T> {
     /// The panes of the [`PaneGrid`].
     ///
-    /// [`PaneGrid`]: crate::widget::PaneGrid
+    /// [`PaneGrid`]: super::PaneGrid
     pub panes: HashMap<Pane, T>,
 
     /// The internal state of the [`PaneGrid`].
     ///
-    /// [`PaneGrid`]: crate::widget::PaneGrid
+    /// [`PaneGrid`]: super::PaneGrid
     pub internal: Internal,
 
     /// The maximized [`Pane`] of the [`PaneGrid`].
     ///
-    /// [`PaneGrid`]: crate::widget::PaneGrid
+    /// [`PaneGrid`]: super::PaneGrid
     pub(super) maximized: Option<Pane>,
 }
 
@@ -236,6 +236,8 @@ impl<T> State<T> {
     }
 
     /// Move [`Pane`] to an [`Edge`] of the [`PaneGrid`].
+    ///
+    /// [`PaneGrid`]: super::PaneGrid
     pub fn move_to_edge(&mut self, pane: &Pane, edge: Edge) {
         match edge {
             Edge::Top => {
@@ -269,8 +271,8 @@ impl<T> State<T> {
     /// If you want to swap panes on drag and drop in your [`PaneGrid`], you
     /// will need to call this method when handling a [`DragEvent`].
     ///
-    /// [`PaneGrid`]: crate::widget::PaneGrid
-    /// [`DragEvent`]: crate::widget::pane_grid::DragEvent
+    /// [`PaneGrid`]: super::PaneGrid
+    /// [`DragEvent`]: super::DragEvent
     pub fn swap(&mut self, a: &Pane, b: &Pane) {
         self.internal.layout.update(&|node| match node {
             Node::Split { .. } => {}
@@ -292,8 +294,8 @@ impl<T> State<T> {
     /// If you want to enable resize interactions in your [`PaneGrid`], you will
     /// need to call this method when handling a [`ResizeEvent`].
     ///
-    /// [`PaneGrid`]: crate::widget::PaneGrid
-    /// [`ResizeEvent`]: crate::widget::pane_grid::ResizeEvent
+    /// [`PaneGrid`]: super::PaneGrid
+    /// [`ResizeEvent`]: super::ResizeEvent
     pub fn resize(&mut self, split: &Split, ratio: f32) {
         let _ = self.internal.layout.resize(split, ratio);
     }
@@ -315,7 +317,7 @@ impl<T> State<T> {
     /// Maximize the given [`Pane`]. Only this pane will be rendered by the
     /// [`PaneGrid`] until [`Self::restore()`] is called.
     ///
-    /// [`PaneGrid`]: crate::widget::PaneGrid
+    /// [`PaneGrid`]: super::PaneGrid
     pub fn maximize(&mut self, pane: &Pane) {
         self.maximized = Some(*pane);
     }
@@ -323,14 +325,14 @@ impl<T> State<T> {
     /// Restore the currently maximized [`Pane`] to it's normal size. All panes
     /// will be rendered by the [`PaneGrid`].
     ///
-    /// [`PaneGrid`]: crate::widget::PaneGrid
+    /// [`PaneGrid`]: super::PaneGrid
     pub fn restore(&mut self) {
         let _ = self.maximized.take();
     }
 
     /// Returns the maximized [`Pane`] of the [`PaneGrid`].
     ///
-    /// [`PaneGrid`]: crate::widget::PaneGrid
+    /// [`PaneGrid`]: super::PaneGrid
     pub fn maximized(&self) -> Option<Pane> {
         self.maximized
     }
@@ -338,7 +340,7 @@ impl<T> State<T> {
 
 /// The internal state of a [`PaneGrid`].
 ///
-/// [`PaneGrid`]: crate::widget::PaneGrid
+/// [`PaneGrid`]: super::PaneGrid
 #[derive(Debug, Clone)]
 pub struct Internal {
     layout: Node,
@@ -349,7 +351,7 @@ impl Internal {
     /// Initializes the [`Internal`] state of a [`PaneGrid`] from a
     /// [`Configuration`].
     ///
-    /// [`PaneGrid`]: crate::widget::PaneGrid
+    /// [`PaneGrid`]: super::PaneGrid
     pub fn from_configuration<T>(
         panes: &mut HashMap<Pane, T>,
         content: Configuration<T>,
@@ -394,16 +396,16 @@ impl Internal {
 
 /// The current action of a [`PaneGrid`].
 ///
-/// [`PaneGrid`]: crate::widget::PaneGrid
+/// [`PaneGrid`]: super::PaneGrid
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Action {
     /// The [`PaneGrid`] is idle.
     ///
-    /// [`PaneGrid`]: crate::widget::PaneGrid
+    /// [`PaneGrid`]: super::PaneGrid
     Idle,
     /// A [`Pane`] in the [`PaneGrid`] is being dragged.
     ///
-    /// [`PaneGrid`]: crate::widget::PaneGrid
+    /// [`PaneGrid`]: super::PaneGrid
     Dragging {
         /// The [`Pane`] being dragged.
         pane: Pane,
@@ -412,7 +414,7 @@ pub enum Action {
     },
     /// A [`Split`] in the [`PaneGrid`] is being dragged.
     ///
-    /// [`PaneGrid`]: crate::widget::PaneGrid
+    /// [`PaneGrid`]: super::PaneGrid
     Resizing {
         /// The [`Split`] being dragged.
         split: Split,

--- a/widget/src/pane_grid/title_bar.rs
+++ b/widget/src/pane_grid/title_bar.rs
@@ -11,7 +11,7 @@ use crate::core::{
 
 /// The title bar of a [`Pane`].
 ///
-/// [`Pane`]: crate::widget::pane_grid::Pane
+/// [`Pane`]: super::Pane
 #[allow(missing_debug_implementations)]
 pub struct TitleBar<'a, Message, Renderer = crate::Renderer>
 where
@@ -75,7 +75,7 @@ where
     /// [`TitleBar`] is hovered.
     ///
     /// [`controls`]: Self::controls
-    /// [`Pane`]: crate::widget::pane_grid::Pane
+    /// [`Pane`]: super::Pane
     pub fn always_show_controls(mut self) -> Self {
         self.always_show_controls = true;
         self
@@ -114,7 +114,7 @@ where
 
     /// Draws the [`TitleBar`] with the provided [`Renderer`] and [`Layout`].
     ///
-    /// [`Renderer`]: crate::Renderer
+    /// [`Renderer`]: crate::core::Renderer
     pub fn draw(
         &self,
         tree: &Tree,

--- a/widget/src/pick_list.rs
+++ b/widget/src/pick_list.rs
@@ -105,7 +105,7 @@ where
         self
     }
 
-    /// Sets the text [`LineHeight`] of the [`PickList`].
+    /// Sets the text [`text::LineHeight`] of the [`PickList`].
     pub fn text_line_height(
         mut self,
         line_height: impl Into<text::LineHeight>,

--- a/widget/src/radio.rs
+++ b/widget/src/radio.rs
@@ -156,7 +156,7 @@ where
         self
     }
 
-    /// Sets the text [`LineHeight`] of the [`Radio`] button.
+    /// Sets the text [`text::LineHeight`] of the [`Radio`] button.
     pub fn text_line_height(
         mut self,
         line_height: impl Into<text::LineHeight>,

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -182,7 +182,7 @@ where
         self
     }
 
-    /// Sets the [`LineHeight`] of the [`TextInput`].
+    /// Sets the [`text::LineHeight`] of the [`TextInput`].
     pub fn line_height(
         mut self,
         line_height: impl Into<text::LineHeight>,

--- a/widget/src/text_input/value.rs
+++ b/widget/src/text_input/value.rs
@@ -2,7 +2,7 @@ use unicode_segmentation::UnicodeSegmentation;
 
 /// The value of a [`TextInput`].
 ///
-/// [`TextInput`]: crate::widget::TextInput
+/// [`TextInput`]: super::TextInput
 // TODO: Reduce allocations, cache results (?)
 #[derive(Debug, Clone)]
 pub struct Value {

--- a/widget/src/toggler.rs
+++ b/widget/src/toggler.rs
@@ -109,7 +109,7 @@ where
         self
     }
 
-    /// Sets the text [`LineHeight`] of the [`Toggler`].
+    /// Sets the text [`text::LineHeight`] of the [`Toggler`].
     pub fn text_line_height(
         mut self,
         line_height: impl Into<text::LineHeight>,
@@ -136,9 +136,9 @@ where
         self
     }
 
-    /// Sets the [`Font`] of the text of the [`Toggler`]
+    /// Sets the [`Renderer::Font`] of the text of the [`Toggler`]
     ///
-    /// [`Font`]: crate::text::Renderer::Font
+    /// [`Renderer::Font`]: crate::core::text::Renderer
     pub fn font(mut self, font: impl Into<Renderer::Font>) -> Self {
         self.font = Some(font.into());
         self

--- a/winit/src/application/state.rs
+++ b/winit/src/application/state.rs
@@ -184,9 +184,7 @@ where
     /// window.
     ///
     /// Normally an [`Application`] should be synchronized with its [`State`]
-    /// and window after calling [`Application::update`].
-    ///
-    /// [`Application::update`]: crate::Program::update
+    /// and window after calling [`crate::application::update`].
     pub fn synchronize(&mut self, application: &A, window: &Window) {
         // Update window title
         let new_title = application.title();

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -521,7 +521,7 @@ pub fn user_attention(
     }
 }
 
-/// Converts some [`Icon`] into it's `winit` counterpart.
+/// Converts some [`window::Icon`] into it's `winit` counterpart.
 ///
 /// Returns `None` if there is an error during the conversion.
 pub fn icon(icon: window::Icon) -> Option<winit::window::Icon> {

--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -17,6 +17,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/iced-rs/iced/9ab6923e943f784985e9ef9ca28b10278297225d/docs/logo.svg"
 )]
+#![forbid(rust_2018_idioms)]
 #![deny(
     missing_debug_implementations,
     missing_docs,
@@ -26,9 +27,9 @@
     clippy::needless_borrow,
     clippy::new_without_default,
     clippy::useless_conversion,
-    unsafe_code
+    unsafe_code,
+    rustdoc::broken_intra_doc_links
 )]
-#![forbid(rust_2018_idioms)]
 #![allow(clippy::inherent_to_string, clippy::type_complexity)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 pub use iced_graphics as graphics;


### PR DESCRIPTION
I noticed that links either don't work at all (see `LineHeight` [here](https://docs.rs/iced/latest/iced/widget/radio/struct.Radio.html#method.text_line_height)) or point to invalid URLs (see link to `PaneGrid` [here](https://docs.rs/iced/latest/iced/widget/pane_grid/struct.Pane.html)). Most could be fixed by pointing to the actual location of an entity however a few are unresolvable because sub-crates cannot link to entities that are not dependencies.