### PR TITLE
Fix `ComboBox` widget panic on wasm

### DIFF
--- a/widget/src/combo_box.rs
+++ b/widget/src/combo_box.rs
@@ -6,6 +6,7 @@ use crate::core::mouse;
 use crate::core::overlay;
 use crate::core::renderer;
 use crate::core::text;
+use crate::core::time::Instant;
 use crate::core::widget::{self, Widget};
 use crate::core::{Clipboard, Element, Length, Padding, Rectangle, Shell};
 use crate::overlay::menu;
@@ -14,7 +15,6 @@ use crate::{container, scrollable, text_input, TextInput};
 
 use std::cell::RefCell;
 use std::fmt::Display;
-use std::time::Instant;
 
 /// A widget for searching and selecting a single value from a list of options.
 ///


### PR DESCRIPTION
The `ComboBox` widget always uses `std::time::Instant` which panics on Wasm.

-> switch to `crate::core::time::Instant`
