### PR TITLE
Migrate twox-hash -> xxhash-rust. Switch to Xxh3 for better performance.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,7 +150,7 @@ thiserror = "1.0"
 tiny-skia = "0.10"
 tokio = "1.0"
 tracing = "0.1"
-twox-hash = { version = "1.0", default-features = false }
+xxhash-rust = { version = "0.8.7", default-features = false, features = ["xxh3"] }
 unicode-segmentation = "1.0"
 wasm-bindgen-futures = "0.4"
 wasm-timer = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,7 +150,7 @@ thiserror = "1.0"
 tiny-skia = "0.10"
 tokio = "1.0"
 tracing = "0.1"
-xxhash-rust = { version = "0.8", default-features = false, features = ["xxh3"] }
+xxhash-rust = { version = "0.8", features = ["xxh3"] }
 unicode-segmentation = "1.0"
 wasm-bindgen-futures = "0.4"
 wasm-timer = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,7 +150,7 @@ thiserror = "1.0"
 tiny-skia = "0.10"
 tokio = "1.0"
 tracing = "0.1"
-xxhash-rust = { version = "0.8.7", default-features = false, features = ["xxh3"] }
+xxhash-rust = { version = "0.8", default-features = false, features = ["xxh3"] }
 unicode-segmentation = "1.0"
 wasm-bindgen-futures = "0.4"
 wasm-timer = "0.2"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,7 +14,7 @@ keywords.workspace = true
 bitflags.workspace = true
 log.workspace = true
 thiserror.workspace = true
-twox-hash.workspace = true
+xxhash-rust.workspace = true
 num-traits.workspace = true
 
 palette.workspace = true

--- a/core/src/hasher.rs
+++ b/core/src/hasher.rs
@@ -1,6 +1,7 @@
 /// The hasher used to compare layouts.
-#[derive(Debug, Default)]
-pub struct Hasher(twox_hash::XxHash64);
+#[allow(missing_debug_implementations)] // Doesn't really make sense to have debug on the hasher state anyways.
+#[derive(Default)]
+pub struct Hasher(xxhash_rust::xxh3::Xxh3);
 
 impl core::hash::Hasher for Hasher {
     fn write(&mut self, bytes: &[u8]) {

--- a/graphics/Cargo.toml
+++ b/graphics/Cargo.toml
@@ -33,8 +33,8 @@ once_cell.workspace = true
 raw-window-handle.workspace = true
 rustc-hash.workspace = true
 thiserror.workspace = true
-twox-hash.workspace = true
 unicode-segmentation.workspace = true
+xxhash-rust.workspace = true
 
 image.workspace = true
 image.optional = true
@@ -44,7 +44,3 @@ kamadak-exif.optional = true
 
 lyon_path.workspace = true
 lyon_path.optional = true
-
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-twox-hash.workspace = true
-twox-hash.features = ["std"]

--- a/graphics/src/text/cache.rs
+++ b/graphics/src/text/cache.rs
@@ -16,11 +16,7 @@ pub struct Cache {
     hasher: HashBuilder,
 }
 
-#[cfg(not(target_arch = "wasm32"))]
-type HashBuilder = twox_hash::RandomXxHashBuilder64;
-
-#[cfg(target_arch = "wasm32")]
-type HashBuilder = std::hash::BuildHasherDefault<twox_hash::XxHash64>;
+type HashBuilder = xxhash_rust::xxh3::Xxh3Builder;
 
 impl Cache {
     /// Creates a new empty [`Cache`].

--- a/tiny_skia/Cargo.toml
+++ b/tiny_skia/Cargo.toml
@@ -26,11 +26,7 @@ raw-window-handle.workspace = true
 rustc-hash.workspace = true
 softbuffer.workspace = true
 tiny-skia.workspace = true
-twox-hash.workspace = true
+xxhash-rust.workspace = true
 
 resvg.workspace = true
 resvg.optional = true
-
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-twox-hash.workspace = true
-twox-hash.features = ["std"]


### PR DESCRIPTION
xxhash-rust is more maintained, built against `::core`, so no workaround for wasm is necessary. Switch to Xxh3 for better performance, which shows when loading/hashing image buffers.