### PR TITLE
Chore: Inline format args for ease of reading

### DIFF
--- a/examples/game_of_life/src/main.rs
+++ b/examples/game_of_life/src/main.rs
@@ -610,8 +610,7 @@ mod grid {
 
                 frame.fill_text(Text {
                     content: format!(
-                        "{} cell{} @ {:?} ({})",
-                        cell_count,
+                        "{cell_count} cell{} @ {:?} ({})",
                         if cell_count == 1 { "" } else { "s" },
                         self.last_tick_duration,
                         self.last_queued_ticks

--- a/examples/screenshot/src/main.rs
+++ b/examples/screenshot/src/main.rs
@@ -184,8 +184,8 @@ impl Application for Example {
                 .align_items(Alignment::Center);
 
         if let Some(crop_error) = &self.crop_error {
-            crop_controls = crop_controls
-                .push(text(format!("Crop error! \n{}", crop_error)));
+            crop_controls =
+                crop_controls.push(text(format!("Crop error! \n{crop_error}")));
         }
 
         let mut controls = column![
@@ -221,9 +221,9 @@ impl Application for Example {
 
         if let Some(png_result) = &self.saved_png_path {
             let msg = match png_result {
-                Ok(path) => format!("Png saved as: {:?}!", path),
+                Ok(path) => format!("Png saved as: {path:?}!"),
                 Err(msg) => {
-                    format!("Png could not be saved due to:\n{:?}", msg)
+                    format!("Png could not be saved due to:\n{msg:?}")
                 }
             };
 
@@ -281,7 +281,7 @@ async fn save_to_png(screenshot: Screenshot) -> Result<String, PngError> {
         ColorType::Rgba8,
     )
     .map(|_| path)
-    .map_err(|err| PngError(format!("{:?}", err)))
+    .map_err(|err| PngError(format!("{err:?}")))
 }
 
 #[derive(Clone, Debug)]

--- a/examples/system_information/src/main.rs
+++ b/examples/system_information/src/main.rs
@@ -105,8 +105,8 @@ impl Application for Example {
                     ByteSize::kb(information.memory_total).to_string();
 
                 let memory_total = text(format!(
-                    "Memory (total): {} kb ({})",
-                    information.memory_total, memory_readable
+                    "Memory (total): {} kb ({memory_readable})",
+                    information.memory_total,
                 ));
 
                 let memory_text = if let Some(memory_used) =

--- a/examples/todos/src/main.rs
+++ b/examples/todos/src/main.rs
@@ -415,8 +415,7 @@ fn view_controls(tasks: &[Task], current_filter: Filter) -> Element<Message> {
 
     row![
         text(format!(
-            "{} {} left",
-            tasks_left,
+            "{tasks_left} {} left",
             if tasks_left == 1 { "task" } else { "tasks" }
         ))
         .width(Length::Fill),

--- a/examples/visible_bounds/src/main.rs
+++ b/examples/visible_bounds/src/main.rs
@@ -94,7 +94,7 @@ impl Application for Example {
             data_row(
                 label,
                 match bounds {
-                    Some(bounds) => format!("{:?}", bounds),
+                    Some(bounds) => format!("{bounds:?}"),
                     None => "not visible".to_string(),
                 },
                 if bounds

--- a/futures/src/subscription/tracker.rs
+++ b/futures/src/subscription/tracker.rs
@@ -147,8 +147,7 @@ impl Tracker {
             .for_each(|listener| {
                 if let Err(error) = listener.try_send((event.clone(), status)) {
                     log::warn!(
-                        "Error sending event to subscription: {:?}",
-                        error
+                        "Error sending event to subscription: {error:?}"
                     );
                 }
             });

--- a/renderer/src/lib.rs
+++ b/renderer/src/lib.rs
@@ -60,7 +60,7 @@ impl<T> Renderer<T> {
     pub fn draw_mesh(&mut self, mesh: Mesh) {
         match self {
             Self::TinySkia(_) => {
-                log::warn!("Unsupported mesh primitive: {:?}", mesh)
+                log::warn!("Unsupported mesh primitive: {mesh:?}")
             }
             #[cfg(feature = "wgpu")]
             Self::Wgpu(renderer) => {

--- a/tiny_skia/src/backend.rs
+++ b/tiny_skia/src/backend.rs
@@ -443,8 +443,7 @@ impl Backend {
             #[cfg(not(feature = "image"))]
             Primitive::Image { .. } => {
                 log::warn!(
-                    "Unsupported primitive in `iced_tiny_skia`: {:?}",
-                    primitive
+                    "Unsupported primitive in `iced_tiny_skia`: {primitive:?}",
                 );
             }
             #[cfg(feature = "svg")]
@@ -473,8 +472,7 @@ impl Backend {
             #[cfg(not(feature = "svg"))]
             Primitive::Svg { .. } => {
                 log::warn!(
-                    "Unsupported primitive in `iced_tiny_skia`: {:?}",
-                    primitive
+                    "Unsupported primitive in `iced_tiny_skia`: {primitive:?}",
                 );
             }
             Primitive::Custom(primitive::Custom::Fill {

--- a/wgpu/src/image/atlas.rs
+++ b/wgpu/src/image/atlas.rs
@@ -86,7 +86,7 @@ impl Atlas {
             entry
         };
 
-        log::info!("Allocated atlas entry: {:?}", entry);
+        log::info!("Allocated atlas entry: {entry:?}");
 
         // It is a webgpu requirement that:
         //   BufferCopyView.layout.bytes_per_row % wgpu::COPY_BYTES_PER_ROW_ALIGNMENT == 0
@@ -139,13 +139,13 @@ impl Atlas {
             }
         }
 
-        log::info!("Current atlas: {:?}", self);
+        log::info!("Current atlas: {self:?}");
 
         Some(entry)
     }
 
     pub fn remove(&mut self, entry: &Entry) {
-        log::info!("Removing atlas entry: {:?}", entry);
+        log::info!("Removing atlas entry: {entry:?}");
 
         match entry {
             Entry::Contiguous(allocation) => {
@@ -258,7 +258,7 @@ impl Atlas {
     }
 
     fn deallocate(&mut self, allocation: &Allocation) {
-        log::info!("Deallocating atlas: {:?}", allocation);
+        log::info!("Deallocating atlas: {allocation:?}");
 
         match allocation {
             Allocation::Full { layer } => {

--- a/wgpu/src/image/vector.rs
+++ b/wgpu/src/image/vector.rs
@@ -152,7 +152,7 @@ impl Cache {
                 let allocation =
                     atlas.upload(device, encoder, width, height, &rgba)?;
 
-                log::debug!("allocating {} {}x{}", id, width, height);
+                log::debug!("allocating {id} {width}x{height}");
 
                 let _ = self.svg_hits.insert(id);
                 let _ = self.rasterized_hits.insert(key);

--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -35,7 +35,7 @@ impl<Theme> Compositor<Theme> {
             ..Default::default()
         });
 
-        log::info!("{:#?}", settings);
+        log::info!("{settings:#?}");
 
         #[cfg(not(target_arch = "wasm32"))]
         if log::max_level() >= log::LevelFilter::Info {
@@ -43,7 +43,7 @@ impl<Theme> Compositor<Theme> {
                 .enumerate_adapters(settings.internal_backend)
                 .map(|adapter| adapter.get_info())
                 .collect();
-            log::info!("Available adapters: {:#?}", available_adapters);
+            log::info!("Available adapters: {available_adapters:#?}");
         }
 
         #[allow(unsafe_code)]
@@ -83,7 +83,7 @@ impl<Theme> Compositor<Theme> {
             })
         })?;
 
-        log::info!("Selected format: {:?}", format);
+        log::info!("Selected format: {format:?}");
 
         #[cfg(target_arch = "wasm32")]
         let limits = [wgpu::Limits::downlevel_webgl2_defaults()

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -157,7 +157,7 @@ where
         )
         .with_visible(false);
 
-    log::debug!("Window builder: {:#?}", builder);
+    log::debug!("Window builder: {builder:#?}");
 
     let window = builder
         .build(&event_loop)
@@ -174,7 +174,7 @@ where
         let body = document.body().unwrap();
 
         let target = target.and_then(|target| {
-            body.query_selector(&format!("#{}", target))
+            body.query_selector(&format!("#{target}"))
                 .ok()
                 .unwrap_or(None)
         });

--- a/winit/src/clipboard.rs
+++ b/winit/src/clipboard.rs
@@ -45,7 +45,7 @@ impl Clipboard {
             State::Connected(clipboard) => match clipboard.write(contents) {
                 Ok(()) => {}
                 Err(error) => {
-                    log::warn!("error writing to clipboard: {}", error)
+                    log::warn!("error writing to clipboard: {error}")
                 }
             },
             State::Unavailable => {}


### PR DESCRIPTION
A minor cleanup to inline all simple cases of format arguments. Makes the format strings just a bit easier to read.