### PR TITLE
Chore: Apply clippy docs keyword quoting

### DIFF
--- a/core/src/color.rs
+++ b/core/src/color.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "palette")]
 use palette::rgb::{Srgb, Srgba};
 
-/// A color in the sRGB color space.
+/// A color in the `sRGB` color space.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub struct Color {
     /// Red component, 0.0 - 1.0

--- a/core/src/window/icon.rs
+++ b/core/src/window/icon.rs
@@ -3,7 +3,7 @@ use crate::Size;
 
 use std::mem;
 
-/// Builds an  [`Icon`] from its RGBA pixels in the sRGB color space.
+/// Builds an  [`Icon`] from its RGBA pixels in the `sRGB` color space.
 pub fn from_rgba(
     rgba: Vec<u8>,
     width: u32,

--- a/futures/src/subscription.rs
+++ b/futures/src/subscription.rs
@@ -25,7 +25,7 @@ pub type EventStream = BoxStream<(Event, event::Status)>;
 /// A [`Subscription`] is normally provided to some runtime, like a `Command`,
 /// and it will generate events as long as the user keeps requesting it.
 ///
-/// For instance, you can use a [`Subscription`] to listen to a WebSocket
+/// For instance, you can use a [`Subscription`] to listen to a `WebSocket`
 /// connection, keyboard presses, mouse events, time ticks, etc.
 #[must_use = "`Subscription` must be returned to runtime to take effect"]
 pub struct Subscription<Message> {
@@ -355,7 +355,7 @@ where
 /// }
 /// ```
 ///
-/// Check out the [`websocket`] example, which showcases this pattern to maintain a WebSocket
+/// Check out the [`websocket`] example, which showcases this pattern to maintain a `WebSocket`
 /// connection open.
 ///
 /// [`websocket`]: https://github.com/iced-rs/iced/tree/0.10/examples/websocket

--- a/graphics/src/compositor.rs
+++ b/graphics/src/compositor.rs
@@ -61,7 +61,7 @@ pub trait Compositor: Sized {
     ) -> Result<(), SurfaceError>;
 
     /// Screenshots the current [`Renderer`] primitives to an offscreen texture, and returns the bytes of
-    /// the texture ordered as `RGBA` in the sRGB color space.
+    /// the texture ordered as `RGBA` in the `sRGB` color space.
     ///
     /// [`Renderer`]: Self::Renderer
     fn screenshot<T: AsRef<str>>(

--- a/runtime/src/window/screenshot.rs
+++ b/runtime/src/window/screenshot.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 /// Data of a screenshot, captured with `window::screenshot()`.
 ///
-/// The `bytes` of this screenshot will always be ordered as `RGBA` in the sRGB color space.
+/// The `bytes` of this screenshot will always be ordered as `RGBA` in the `sRGB` color space.
 #[derive(Clone)]
 pub struct Screenshot {
     /// The bytes of the [`Screenshot`].

--- a/style/src/rule.rs
+++ b/style/src/rule.rs
@@ -47,7 +47,7 @@ impl FillMode {
     ///
     /// # Returns
     ///
-    /// * (starting_offset, length)
+    /// * (`starting_offset`, `length`)
     pub fn fill(&self, space: f32) -> (f32, f32) {
         match *self {
             FillMode::Full => (0.0, space),


### PR DESCRIPTION
Add quotes a number of doc strings like `sRGB`
