### PR TITLE
Fix some `clippy::pedantic` lints

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,7 +8,8 @@ clippy --workspace --no-deps -- \
   -D clippy::match-wildcard-for-single-variants \
   -D clippy::redundant-closure-for-method-calls \
   -D clippy::filter_map_next \
-  -D clippy::manual_let_else
+  -D clippy::manual_let_else \
+  -D clippy::unused_async
 """
 
 nitpick = """

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
 [alias]
-lint = "clippy --workspace --no-deps -- -D warnings -D clippy::semicolon_if_nothing_returned"
+lint = "clippy --workspace --no-deps -- -D warnings -D clippy::semicolon_if_nothing_returned -D clippy::trivially-copy-pass-by-ref"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+lint = "clippy --workspace --no-deps -- -D warnings -D clippy::semicolon_if_nothing_returned"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,7 +6,7 @@ clippy --workspace --no-deps -- \
   -D clippy::trivially-copy-pass-by-ref \
   -D clippy::default_trait_access \
   -D clippy::match-wildcard-for-single-variants \
-  -D clippy::redundant-closure-for-method-calls
+  -D clippy::redundant-closure-for-method-calls \
 """
 
 nitpick = """
@@ -30,5 +30,10 @@ clippy --workspace --no-deps -- \
   -A clippy::if_not_else \
   -A clippy::redundant_else \
   -A clippy::used_underscore_binding \
-  -A clippy::cast_possible_wrap
+  -A clippy::cast_possible_wrap \
+  -A clippy::unnecessary_wraps \
+  -A clippy::struct-excessive-bools \
+  -A clippy::float-cmp \
+  -A clippy::single_match_else \
+  -A clippy::unreadable_literal
 """

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,7 +5,8 @@ clippy --workspace --no-deps -- \
   -D clippy::semicolon_if_nothing_returned \
   -D clippy::trivially-copy-pass-by-ref \
   -D clippy::default_trait_access \
-  -D clippy::match-wildcard-for-single-variants
+  -D clippy::match-wildcard-for-single-variants \
+  -D clippy::redundant-closure-for-method-calls
 """
 
 nitpick = """
@@ -28,5 +29,6 @@ clippy --workspace --no-deps -- \
   -A clippy::module_name_repetitions \
   -A clippy::if_not_else \
   -A clippy::redundant_else \
-  -A clippy::used_underscore_binding
+  -A clippy::used_underscore_binding \
+  -A clippy::cast_possible_wrap
 """

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,7 +7,8 @@ clippy --workspace --no-deps -- \
   -D clippy::default_trait_access \
   -D clippy::match-wildcard-for-single-variants \
   -D clippy::redundant-closure-for-method-calls \
-  -D clippy::filter_map_next
+  -D clippy::filter_map_next \
+  -D clippy::manual_let_else
 """
 
 nitpick = """
@@ -38,5 +39,8 @@ clippy --workspace --no-deps -- \
   -A clippy::single_match_else \
   -A clippy::unreadable_literal \
   -A clippy::explicit_deref_methods \
-  -A clippy::map_unwrap_or
+  -A clippy::map_unwrap_or \
+  -A clippy::unnested_or_patterns \
+  -A clippy::similar_names \
+  -A clippy::unused_self
 """

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
 [alias]
-lint = "clippy --workspace --no-deps -- -D warnings -D clippy::semicolon_if_nothing_returned -D clippy::trivially-copy-pass-by-ref"
+lint = "clippy --workspace --no-deps -- -D warnings -D clippy::semicolon_if_nothing_returned -D clippy::trivially-copy-pass-by-ref -D clippy::default_trait_access"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,32 @@
 [alias]
-lint = "clippy --workspace --no-deps -- -D warnings -D clippy::semicolon_if_nothing_returned -D clippy::trivially-copy-pass-by-ref -D clippy::default_trait_access"
+lint = """
+clippy --workspace --no-deps -- \
+  -D warnings \
+  -D clippy::semicolon_if_nothing_returned \
+  -D clippy::trivially-copy-pass-by-ref \
+  -D clippy::default_trait_access \
+  -D clippy::match-wildcard-for-single-variants
+"""
+
+nitpick = """
+clippy --workspace --no-deps -- \
+  -D warnings \
+  -D clippy::pedantic \
+  -A clippy::must_use_candidate \
+  -A clippy::return_self_not_must_use \
+  -A clippy::needless_pass_by_value \
+  -A clippy::cast_precision_loss \
+  -A clippy::cast_sign_loss \
+  -A clippy::cast_possible_truncation \
+  -A clippy::match_same_arms \
+  -A clippy::missing-errors-doc \
+  -A clippy::missing-panics-doc \
+  -A clippy::cast_lossless \
+  -A clippy::doc_markdown \
+  -A clippy::items_after_statements \
+  -A clippy::too_many_lines \
+  -A clippy::module_name_repetitions \
+  -A clippy::if_not_else \
+  -A clippy::redundant_else \
+  -A clippy::used_underscore_binding
+"""

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,6 +7,7 @@ clippy --workspace --no-deps -- \
   -D clippy::default_trait_access \
   -D clippy::match-wildcard-for-single-variants \
   -D clippy::redundant-closure-for-method-calls \
+  -D clippy::filter_map_next
 """
 
 nitpick = """
@@ -35,5 +36,7 @@ clippy --workspace --no-deps -- \
   -A clippy::struct-excessive-bools \
   -A clippy::float-cmp \
   -A clippy::single_match_else \
-  -A clippy::unreadable_literal
+  -A clippy::unreadable_literal \
+  -A clippy::explicit_deref_methods \
+  -A clippy::map_unwrap_or
 """

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,4 +9,4 @@ jobs:
         components: clippy
     - uses: actions/checkout@master
     - name: Check lints
-      run: cargo clippy --workspace --all-features --all-targets --no-deps -- -D warnings
+      run: cargo lint

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,5 @@ target/
 pkg/
 **/*.rs.bk
 Cargo.lock
-.cargo/
 dist/
 traces/

--- a/core/src/element.rs
+++ b/core/src/element.rs
@@ -293,7 +293,7 @@ where
     }
 
     fn diff(&self, tree: &mut Tree) {
-        self.widget.diff(tree)
+        self.widget.diff(tree);
     }
 
     fn width(&self) -> Length {
@@ -418,7 +418,7 @@ where
         viewport: &Rectangle,
     ) {
         self.widget
-            .draw(tree, renderer, theme, style, layout, cursor, viewport)
+            .draw(tree, renderer, theme, style, layout, cursor, viewport);
     }
 
     fn mouse_interaction(
@@ -508,7 +508,7 @@ where
     ) {
         self.element
             .widget
-            .operate(state, layout, renderer, operation)
+            .operate(state, layout, renderer, operation);
     }
 
     fn on_event(

--- a/core/src/gradient.rs
+++ b/core/src/gradient.rs
@@ -95,7 +95,7 @@ impl Linear {
         stops: impl IntoIterator<Item = ColorStop>,
     ) -> Self {
         for stop in stops {
-            self = self.add_stop(stop.offset, stop.color)
+            self = self.add_stop(stop.offset, stop.color);
         }
 
         self

--- a/core/src/hasher.rs
+++ b/core/src/hasher.rs
@@ -4,7 +4,7 @@ pub struct Hasher(twox_hash::XxHash64);
 
 impl core::hash::Hasher for Hasher {
     fn write(&mut self, bytes: &[u8]) {
-        self.0.write(bytes)
+        self.0.write(bytes);
     }
 
     fn finish(&self) -> u64 {

--- a/core/src/mouse/click.rs
+++ b/core/src/mouse/click.rs
@@ -24,7 +24,7 @@ pub enum Kind {
 }
 
 impl Kind {
-    fn next(&self) -> Kind {
+    fn next(self) -> Kind {
         match self {
             Kind::Single => Kind::Double,
             Kind::Double => Kind::Triple,

--- a/core/src/overlay/element.rs
+++ b/core/src/overlay/element.rs
@@ -98,7 +98,7 @@ where
         layout: Layout<'_>,
         cursor: mouse::Cursor,
     ) {
-        self.overlay.draw(renderer, theme, style, layout, cursor)
+        self.overlay.draw(renderer, theme, style, layout, cursor);
     }
 
     /// Applies a [`widget::Operation`] to the [`Element`].
@@ -205,7 +205,7 @@ where
                 state: &mut dyn widget::operation::TextInput,
                 id: Option<&widget::Id>,
             ) {
-                self.operation.text_input(state, id)
+                self.operation.text_input(state, id);
             }
 
             fn custom(&mut self, state: &mut dyn Any, id: Option<&widget::Id>) {
@@ -262,7 +262,7 @@ where
         layout: Layout<'_>,
         cursor: mouse::Cursor,
     ) {
-        self.content.draw(renderer, theme, style, layout, cursor)
+        self.content.draw(renderer, theme, style, layout, cursor);
     }
 
     fn is_over(

--- a/core/src/overlay/group.rs
+++ b/core/src/overlay/group.rs
@@ -143,7 +143,7 @@ where
                 |(child, layout)| {
                     child.operate(layout, renderer, operation);
                 },
-            )
+            );
         });
     }
 

--- a/core/src/shell.rs
+++ b/core/src/shell.rs
@@ -71,7 +71,7 @@ impl<'a, Message> Shell<'a, Message> {
         if self.is_layout_invalid {
             self.is_layout_invalid = false;
 
-            f()
+            f();
         }
     }
 

--- a/core/src/widget/operation/focusable.rs
+++ b/core/src/widget/operation/focusable.rs
@@ -49,7 +49,7 @@ pub fn focus<T>(target: Id) -> impl Operation<T> {
             _bounds: Rectangle,
             operate_on_children: &mut dyn FnMut(&mut dyn Operation<T>),
         ) {
-            operate_on_children(self)
+            operate_on_children(self);
         }
     }
 
@@ -85,7 +85,7 @@ where
             _bounds: Rectangle,
             operate_on_children: &mut dyn FnMut(&mut dyn Operation<T>),
         ) {
-            operate_on_children(self)
+            operate_on_children(self);
         }
 
         fn finish(&self) -> Outcome<T> {
@@ -132,7 +132,7 @@ pub fn focus_previous<T>() -> impl Operation<T> {
             _bounds: Rectangle,
             operate_on_children: &mut dyn FnMut(&mut dyn Operation<T>),
         ) {
-            operate_on_children(self)
+            operate_on_children(self);
         }
     }
 
@@ -166,7 +166,7 @@ pub fn focus_next<T>() -> impl Operation<T> {
             _bounds: Rectangle,
             operate_on_children: &mut dyn FnMut(&mut dyn Operation<T>),
         ) {
-            operate_on_children(self)
+            operate_on_children(self);
         }
     }
 
@@ -193,7 +193,7 @@ pub fn find_focused() -> impl Operation<Id> {
             _bounds: Rectangle,
             operate_on_children: &mut dyn FnMut(&mut dyn Operation<Id>),
         ) {
-            operate_on_children(self)
+            operate_on_children(self);
         }
 
         fn finish(&self) -> Outcome<Id> {

--- a/core/src/widget/operation/scrollable.rs
+++ b/core/src/widget/operation/scrollable.rs
@@ -26,7 +26,7 @@ pub fn snap_to<T>(target: Id, offset: RelativeOffset) -> impl Operation<T> {
             _bounds: Rectangle,
             operate_on_children: &mut dyn FnMut(&mut dyn Operation<T>),
         ) {
-            operate_on_children(self)
+            operate_on_children(self);
         }
 
         fn scrollable(
@@ -60,7 +60,7 @@ pub fn scroll_to<T>(target: Id, offset: AbsoluteOffset) -> impl Operation<T> {
             _bounds: Rectangle,
             operate_on_children: &mut dyn FnMut(&mut dyn Operation<T>),
         ) {
-            operate_on_children(self)
+            operate_on_children(self);
         }
 
         fn scrollable(

--- a/core/src/widget/operation/text_input.rs
+++ b/core/src/widget/operation/text_input.rs
@@ -38,7 +38,7 @@ pub fn move_cursor_to_front<T>(target: Id) -> impl Operation<T> {
             _bounds: Rectangle,
             operate_on_children: &mut dyn FnMut(&mut dyn Operation<T>),
         ) {
-            operate_on_children(self)
+            operate_on_children(self);
         }
     }
 
@@ -68,7 +68,7 @@ pub fn move_cursor_to_end<T>(target: Id) -> impl Operation<T> {
             _bounds: Rectangle,
             operate_on_children: &mut dyn FnMut(&mut dyn Operation<T>),
         ) {
-            operate_on_children(self)
+            operate_on_children(self);
         }
     }
 
@@ -99,7 +99,7 @@ pub fn move_cursor_to<T>(target: Id, position: usize) -> impl Operation<T> {
             _bounds: Rectangle,
             operate_on_children: &mut dyn FnMut(&mut dyn Operation<T>),
         ) {
-            operate_on_children(self)
+            operate_on_children(self);
         }
     }
 
@@ -128,7 +128,7 @@ pub fn select_all<T>(target: Id) -> impl Operation<T> {
             _bounds: Rectangle,
             operate_on_children: &mut dyn FnMut(&mut dyn Operation<T>),
         ) {
-            operate_on_children(self)
+            operate_on_children(self);
         }
     }
 

--- a/core/src/widget/tree.rs
+++ b/core/src/widget/tree.rs
@@ -61,7 +61,7 @@ impl Tree {
         Renderer: crate::Renderer,
     {
         if self.tag == new.borrow().tag() {
-            new.borrow().diff(self)
+            new.borrow().diff(self);
         } else {
             *self = Self::new(new);
         }
@@ -78,7 +78,7 @@ impl Tree {
             new_children,
             |tree, widget| tree.diff(widget.borrow()),
             |widget| Self::new(widget.borrow()),
-        )
+        );
     }
 
     /// Reconciliates the children of the tree with the provided list of widgets using custom

--- a/examples/arc/src/main.rs
+++ b/examples/arc/src/main.rs
@@ -37,7 +37,7 @@ impl Application for Arc {
         (
             Arc {
                 start: Instant::now(),
-                cache: Default::default(),
+                cache: Cache::default(),
             },
             Command::none(),
         )

--- a/examples/bezier_tool/src/main.rs
+++ b/examples/bezier_tool/src/main.rs
@@ -100,12 +100,9 @@ mod bezier {
             bounds: Rectangle,
             cursor: mouse::Cursor,
         ) -> (event::Status, Option<Curve>) {
-            let cursor_position =
-                if let Some(position) = cursor.position_in(bounds) {
-                    position
-                } else {
-                    return (event::Status::Ignored, None);
-                };
+            let Some(cursor_position) = cursor.position_in(bounds) else {
+                return (event::Status::Ignored, None);
+            };
 
             match event {
                 Event::Mouse(mouse_event) => {

--- a/examples/bezier_tool/src/main.rs
+++ b/examples/bezier_tool/src/main.rs
@@ -81,7 +81,7 @@ mod bezier {
         }
 
         pub fn request_redraw(&mut self) {
-            self.cache.clear()
+            self.cache.clear();
         }
     }
 

--- a/examples/clock/src/main.rs
+++ b/examples/clock/src/main.rs
@@ -35,7 +35,7 @@ impl Application for Clock {
             Clock {
                 now: time::OffsetDateTime::now_local()
                     .unwrap_or_else(|_| time::OffsetDateTime::now_utc()),
-                clock: Default::default(),
+                clock: Cache::default(),
             },
             Command::none(),
         )

--- a/examples/clock/src/main.rs
+++ b/examples/clock/src/main.rs
@@ -141,7 +141,7 @@ impl<Message> canvas::Program<Message, Renderer> for Clock {
             frame.with_save(|frame| {
                 frame.rotate(hand_rotation(self.now.second(), 60));
                 frame.stroke(&long_hand, thin_stroke());
-            })
+            });
         });
 
         vec![clock]

--- a/examples/download_progress/src/main.rs
+++ b/examples/download_progress/src/main.rs
@@ -123,7 +123,7 @@ impl Download {
             | State::Errored { .. } => {
                 self.state = State::Downloading { progress: 0.0 };
             }
-            _ => {}
+            State::Downloading{ .. } => {}
         }
     }
 

--- a/examples/download_progress/src/main.rs
+++ b/examples/download_progress/src/main.rs
@@ -123,7 +123,7 @@ impl Download {
             | State::Errored { .. } => {
                 self.state = State::Downloading { progress: 0.0 };
             }
-            State::Downloading{ .. } => {}
+            State::Downloading { .. } => {}
         }
     }
 

--- a/examples/game_of_life/src/main.rs
+++ b/examples/game_of_life/src/main.rs
@@ -406,12 +406,9 @@ mod grid {
                 *interaction = Interaction::None;
             }
 
-            let cursor_position =
-                if let Some(position) = cursor.position_in(bounds) {
-                    position
-                } else {
-                    return (event::Status::Ignored, None);
-                };
+            let Some(cursor_position) = cursor.position_in(bounds) else {
+                return (event::Status::Ignored, None);
+            };
 
             let cell = Cell::at(self.project(cursor_position, bounds.size()));
             let is_populated = self.state.contains(&cell);

--- a/examples/game_of_life/src/main.rs
+++ b/examples/game_of_life/src/main.rs
@@ -472,7 +472,7 @@ mod grid {
                                             * (1.0 / self.scaling),
                                 ))
                             }
-                            _ => None,
+                            Interaction::None => None,
                         };
 
                         let event_status = match interaction {
@@ -676,7 +676,7 @@ mod grid {
                 Interaction::None if cursor.is_over(bounds) => {
                     mouse::Interaction::Crosshair
                 }
-                _ => mouse::Interaction::default(),
+                Interaction::None => mouse::Interaction::default(),
             }
         }
     }

--- a/examples/integration/src/controls.rs
+++ b/examples/integration/src/controls.rs
@@ -19,7 +19,7 @@ impl Controls {
     pub fn new() -> Controls {
         Controls {
             background_color: Color::BLACK,
-            text: Default::default(),
+            text: String::default(),
         }
     }
 

--- a/examples/integration/src/main.rs
+++ b/examples/integration/src/main.rs
@@ -256,7 +256,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                         {
                             // We clear the frame
-                            let mut render_pass = scene.clear(
+                            let mut render_pass = Scene::clear(
                                 &view,
                                 &mut encoder,
                                 program.background_color(),

--- a/examples/integration/src/scene.rs
+++ b/examples/integration/src/scene.rs
@@ -16,7 +16,6 @@ impl Scene {
     }
 
     pub fn clear<'a>(
-        &self,
         target: &'a wgpu::TextureView,
         encoder: &'a mut wgpu::CommandEncoder,
         background_color: Color,

--- a/examples/lazy/src/main.rs
+++ b/examples/lazy/src/main.rs
@@ -27,7 +27,7 @@ impl Default for App {
                 .into_iter()
                 .map(From::from)
                 .collect(),
-            input: Default::default(),
+            input: String::default(),
             order: Order::Ascending,
         }
     }
@@ -107,7 +107,7 @@ impl From<&str> for Item {
     fn from(s: &str) -> Self {
         Self {
             name: s.to_owned(),
-            color: Default::default(),
+            color: Color::default(),
         }
     }
 }

--- a/examples/modal/src/main.rs
+++ b/examples/modal/src/main.rs
@@ -228,7 +228,9 @@ mod modal {
     use iced::alignment::Alignment;
     use iced::event;
     use iced::mouse;
-    use iced::{Color, Element, Event, Length, Point, Rectangle, Size};
+    use iced::{
+        BorderRadius, Color, Element, Event, Length, Point, Rectangle, Size,
+    };
 
     /// A widget that centers a modal element over some base element
     pub struct Modal<'a, Message, Renderer> {
@@ -474,7 +476,7 @@ mod modal {
             renderer.fill_quad(
                 renderer::Quad {
                     bounds: layout.bounds(),
-                    border_radius: Default::default(),
+                    border_radius: BorderRadius::default(),
                     border_width: 0.0,
                     border_color: Color::TRANSPARENT,
                 },

--- a/examples/pane_grid/src/main.rs
+++ b/examples/pane_grid/src/main.rs
@@ -61,11 +61,8 @@ impl Application for Example {
     fn update(&mut self, message: Message) -> Command<Message> {
         match message {
             Message::Split(axis, pane) => {
-                let result = self.panes.split(
-                    axis,
-                    &pane,
-                    Pane::new(self.panes_created),
-                );
+                let result =
+                    self.panes.split(axis, pane, Pane::new(self.panes_created));
 
                 if let Some((pane, _)) = result {
                     self.focus = Some(pane);
@@ -77,7 +74,7 @@ impl Application for Example {
                 if let Some(pane) = self.focus {
                     let result = self.panes.split(
                         axis,
-                        &pane,
+                        pane,
                         Pane::new(self.panes_created),
                     );
 
@@ -90,8 +87,7 @@ impl Application for Example {
             }
             Message::FocusAdjacent(direction) => {
                 if let Some(pane) = self.focus {
-                    if let Some(adjacent) =
-                        self.panes.adjacent(&pane, direction)
+                    if let Some(adjacent) = self.panes.adjacent(pane, direction)
                     {
                         self.focus = Some(adjacent);
                     }
@@ -101,37 +97,34 @@ impl Application for Example {
                 self.focus = Some(pane);
             }
             Message::Resized(pane_grid::ResizeEvent { split, ratio }) => {
-                self.panes.resize(&split, ratio);
+                self.panes.resize(split, ratio);
             }
             Message::Dragged(pane_grid::DragEvent::Dropped {
                 pane,
                 target,
             }) => {
-                self.panes.drop(&pane, target);
+                self.panes.drop(pane, target);
             }
             Message::Dragged(_) => {}
             Message::TogglePin(pane) => {
-                if let Some(Pane { is_pinned, .. }) = self.panes.get_mut(&pane)
-                {
+                if let Some(Pane { is_pinned, .. }) = self.panes.get_mut(pane) {
                     *is_pinned = !*is_pinned;
                 }
             }
-            Message::Maximize(pane) => self.panes.maximize(&pane),
+            Message::Maximize(pane) => self.panes.maximize(pane),
             Message::Restore => {
                 self.panes.restore();
             }
             Message::Close(pane) => {
-                if let Some((_, sibling)) = self.panes.close(&pane) {
+                if let Some((_, sibling)) = self.panes.close(pane) {
                     self.focus = Some(sibling);
                 }
             }
             Message::CloseFocused => {
                 if let Some(pane) = self.focus {
-                    if let Some(Pane { is_pinned, .. }) = self.panes.get(&pane)
-                    {
+                    if let Some(Pane { is_pinned, .. }) = self.panes.get(pane) {
                         if !is_pinned {
-                            if let Some((_, sibling)) = self.panes.close(&pane)
-                            {
+                            if let Some((_, sibling)) = self.panes.close(pane) {
                                 self.focus = Some(sibling);
                             }
                         }

--- a/examples/screenshot/Cargo.toml
+++ b/examples/screenshot/Cargo.toml
@@ -7,7 +7,11 @@ publish = false
 
 [dependencies]
 iced.workspace = true
-iced.features = ["debug", "image", "advanced"]
+iced.features = ["debug", "image", "advanced", "tokio"]
 
-image = { workspace = true, features = ["png"]}
+image.workspace = true
+image.features = ["png"]
+
+tokio.workspace = true
+
 tracing-subscriber = "0.3"

--- a/examples/screenshot/src/main.rs
+++ b/examples/screenshot/src/main.rs
@@ -273,15 +273,20 @@ impl Application for Example {
 
 async fn save_to_png(screenshot: Screenshot) -> Result<String, PngError> {
     let path = "screenshot.png".to_string();
-    img::save_buffer(
-        &path,
-        &screenshot.bytes,
-        screenshot.size.width,
-        screenshot.size.height,
-        ColorType::Rgba8,
-    )
-    .map(|_| path)
-    .map_err(|err| PngError(format!("{err:?}")))
+
+    tokio::task::spawn_blocking(move || {
+        img::save_buffer(
+            &path,
+            &screenshot.bytes,
+            screenshot.size.width,
+            screenshot.size.height,
+            ColorType::Rgba8,
+        )
+        .map(|_| path)
+        .map_err(|err| PngError(format!("{err:?}")))
+    })
+    .await
+    .expect("Blocking task to finish")
 }
 
 #[derive(Clone, Debug)]

--- a/examples/scrollable/src/main.rs
+++ b/examples/scrollable/src/main.rs
@@ -391,12 +391,12 @@ impl scrollable::StyleSheet for ScrollbarCustomStyle {
                     .background,
                 border_radius: 2.0.into(),
                 border_width: 0.0,
-                border_color: Default::default(),
+                border_color: Color::default(),
                 scroller: Scroller {
                     color: Color::from_rgb8(250, 85, 134),
                     border_radius: 2.0.into(),
                     border_width: 0.0,
-                    border_color: Default::default(),
+                    border_color: Color::default(),
                 },
             }
         } else {

--- a/examples/sierpinski_triangle/src/main.rs
+++ b/examples/sierpinski_triangle/src/main.rs
@@ -108,10 +108,7 @@ impl canvas::Program<Message> for SierpinskiGraph {
         bounds: Rectangle,
         cursor: mouse::Cursor,
     ) -> (event::Status, Option<Message>) {
-        let cursor_position = if let Some(position) = cursor.position_in(bounds)
-        {
-            position
-        } else {
+        let Some(cursor_position) = cursor.position_in(bounds) else {
             return (event::Status::Ignored, None);
         };
 

--- a/examples/solar_system/src/main.rs
+++ b/examples/solar_system/src/main.rs
@@ -117,8 +117,8 @@ impl State {
         let (width, height) = window::Settings::default().size;
 
         State {
-            space_cache: Default::default(),
-            system_cache: Default::default(),
+            space_cache: canvas::Cache::default(),
+            system_cache: canvas::Cache::default(),
             start: now,
             now,
             stars: Self::generate_stars(width, height),

--- a/examples/toast/src/main.rs
+++ b/examples/toast/src/main.rs
@@ -639,7 +639,7 @@ mod toast {
                         child
                             .as_widget()
                             .operate(state, layout, renderer, operation);
-                    })
+                    });
             });
         }
 

--- a/examples/todos/src/main.rs
+++ b/examples/todos/src/main.rs
@@ -443,7 +443,7 @@ pub enum Filter {
 }
 
 impl Filter {
-    fn matches(&self, task: &Task) -> bool {
+    fn matches(self, task: &Task) -> bool {
         match self {
             Filter::All => true,
             Filter::Active => !task.completed,

--- a/examples/tooltip/src/main.rs
+++ b/examples/tooltip/src/main.rs
@@ -40,7 +40,7 @@ impl Sandbox for Example {
                     Position::Right => Position::FollowCursor,
                 };
 
-                self.position = position
+                self.position = position;
             }
         }
     }

--- a/examples/tour/src/main.rs
+++ b/examples/tour/src/main.rs
@@ -285,7 +285,7 @@ impl<'a> Step {
                     is_showing_icon, ..
                 } = self
                 {
-                    *is_showing_icon = toggle
+                    *is_showing_icon = toggle;
                 }
             }
         };

--- a/examples/websocket/src/echo/server.rs
+++ b/examples/websocket/src/echo/server.rs
@@ -47,10 +47,7 @@ async fn user_connected(ws: WebSocket) {
     });
 
     while let Some(result) = user_ws_rx.next().await {
-        let msg = match result {
-            Ok(msg) => msg,
-            Err(_) => break,
-        };
+        let Ok(msg) = result else { break };
 
         let _ = tx.send(msg).await;
     }

--- a/graphics/src/geometry/path/builder.rs
+++ b/graphics/src/geometry/path/builder.rs
@@ -174,7 +174,7 @@ impl Builder {
     /// the starting point.
     #[inline]
     pub fn close(&mut self) {
-        self.raw.close()
+        self.raw.close();
     }
 
     /// Builds the [`Path`] of this [`Builder`].

--- a/graphics/src/gradient.rs
+++ b/graphics/src/gradient.rs
@@ -88,7 +88,7 @@ impl Linear {
         stops: impl IntoIterator<Item = ColorStop>,
     ) -> Self {
         for stop in stops {
-            self = self.add_stop(stop.offset, stop.color)
+            self = self.add_stop(stop.offset, stop.color);
         }
 
         self

--- a/graphics/src/image.rs
+++ b/graphics/src/image.rs
@@ -79,7 +79,7 @@ impl Operation {
         use image::imageops;
 
         if self.contains(Self::FLIP_DIAGONALLY) {
-            imageops::flip_vertical_in_place(&mut image)
+            imageops::flip_vertical_in_place(&mut image);
         }
 
         if self.contains(Self::ROTATE_180) {

--- a/graphics/src/renderer.rs
+++ b/graphics/src/renderer.rs
@@ -237,7 +237,7 @@ where
     }
 
     fn draw(&mut self, handle: image::Handle, bounds: Rectangle) {
-        self.primitives.push(Primitive::Image { handle, bounds })
+        self.primitives.push(Primitive::Image { handle, bounds });
     }
 }
 
@@ -259,6 +259,6 @@ where
             handle,
             color,
             bounds,
-        })
+        });
     }
 }

--- a/renderer/src/geometry/cache.rs
+++ b/renderer/src/geometry/cache.rs
@@ -35,7 +35,7 @@ impl Cache {
     /// Creates a new empty [`Cache`].
     pub fn new() -> Self {
         Cache {
-            state: Default::default(),
+            state: RefCell::default(),
         }
     }
 

--- a/renderer/src/lib.rs
+++ b/renderer/src/lib.rs
@@ -257,7 +257,7 @@ impl<T> crate::graphics::geometry::Renderer for Renderer<T> {
                         crate::Geometry::TinySkia(primitive) => {
                             renderer.draw_primitive(primitive);
                         }
-                        _ => unreachable!(),
+                        crate::Geometry::Wgpu(_) => unreachable!(),
                     }
                 }
             }
@@ -268,7 +268,7 @@ impl<T> crate::graphics::geometry::Renderer for Renderer<T> {
                         crate::Geometry::Wgpu(primitive) => {
                             renderer.draw_primitive(primitive);
                         }
-                        _ => unreachable!(),
+                        crate::Geometry::TinySkia(_) => unreachable!(),
                     }
                 }
             }

--- a/renderer/src/lib.rs
+++ b/renderer/src/lib.rs
@@ -60,7 +60,7 @@ impl<T> Renderer<T> {
     pub fn draw_mesh(&mut self, mesh: Mesh) {
         match self {
             Self::TinySkia(_) => {
-                log::warn!("Unsupported mesh primitive: {mesh:?}")
+                log::warn!("Unsupported mesh primitive: {mesh:?}");
             }
             #[cfg(feature = "wgpu")]
             Self::Wgpu(renderer) => {
@@ -241,7 +241,7 @@ impl<T> crate::core::svg::Renderer for Renderer<T> {
         color: Option<crate::core::Color>,
         bounds: Rectangle,
     ) {
-        delegate!(self, renderer, renderer.draw(handle, color, bounds))
+        delegate!(self, renderer, renderer.draw(handle, color, bounds));
     }
 }
 

--- a/runtime/src/overlay/nested.rs
+++ b/runtime/src/overlay/nested.rs
@@ -164,7 +164,7 @@ where
             }
         }
 
-        recurse(&mut self.overlay, layout, renderer, operation)
+        recurse(&mut self.overlay, layout, renderer, operation);
     }
 
     /// Processes a runtime [`Event`].

--- a/runtime/src/program/state.rs
+++ b/runtime/src/program/state.rs
@@ -200,7 +200,7 @@ where
                 match operation.finish() {
                     operation::Outcome::None => {}
                     operation::Outcome::Some(message) => {
-                        self.queued_messages.push(message)
+                        self.queued_messages.push(message);
                     }
                     operation::Outcome::Chain(next) => {
                         current_operation = Some(next);

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -77,9 +77,9 @@ where
     fn default() -> Self {
         Self {
             id: None,
-            window: Default::default(),
+            window: window::Settings::default(),
             flags: Default::default(),
-            default_font: Default::default(),
+            default_font: Font::default(),
             default_text_size: Pixels(16.0),
             antialiasing: false,
             exit_on_close_request: true,

--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -52,7 +52,7 @@ impl Default for Settings {
             transparent: false,
             level: Level::default(),
             icon: None,
-            platform_specific: Default::default(),
+            platform_specific: PlatformSpecific::default(),
         }
     }
 }

--- a/style/src/theme.rs
+++ b/style/src/theme.rs
@@ -393,7 +393,7 @@ impl container::StyleSheet for Theme {
 
     fn appearance(&self, style: &Self::Style) -> container::Appearance {
         match style {
-            Container::Transparent => Default::default(),
+            Container::Transparent => container::Appearance::default(),
             Container::Box => {
                 let palette = self.extended_palette();
 
@@ -904,7 +904,7 @@ impl svg::StyleSheet for Theme {
 
     fn appearance(&self, style: &Self::Style) -> svg::Appearance {
         match style {
-            Svg::Default => Default::default(),
+            Svg::Default => svg::Appearance::default(),
             Svg::Custom(custom) => custom.appearance(self),
         }
     }
@@ -1053,7 +1053,7 @@ impl text::StyleSheet for Theme {
 
     fn appearance(&self, style: Self::Style) -> text::Appearance {
         match style {
-            Text::Default => Default::default(),
+            Text::Default => text::Appearance::default(),
             Text::Color(c) => text::Appearance { color: Some(c) },
         }
     }

--- a/tiny_skia/src/geometry.rs
+++ b/tiny_skia/src/geometry.rs
@@ -180,7 +180,7 @@ fn convert_path(path: &Path) -> Option<tiny_skia::Path> {
     use iced_graphics::geometry::path::lyon_path;
 
     let mut builder = tiny_skia::PathBuilder::new();
-    let mut last_point = Default::default();
+    let mut last_point = lyon_path::math::Point::default();
 
     for event in path.raw() {
         match event {

--- a/tiny_skia/src/vector.rs
+++ b/tiny_skia/src/vector.rs
@@ -172,9 +172,9 @@ impl Cache {
                 for pixel in
                     bytemuck::cast_slice_mut::<u8, u32>(image.data_mut())
                 {
-                    *pixel = *pixel & 0xFF00FF00
-                        | ((0x000000FF & *pixel) << 16)
-                        | ((0x00FF0000 & *pixel) >> 16);
+                    *pixel = *pixel & 0xFF00_FF00
+                        | ((0x0000_00FF & *pixel) << 16)
+                        | ((0x00FF_0000 & *pixel) >> 16);
                 }
             }
 

--- a/wgpu/src/buffer.rs
+++ b/wgpu/src/buffer.rs
@@ -87,7 +87,7 @@ impl<T: bytemuck::Pod> Buffer<T> {
 
     /// Clears any temporary data (i.e. offsets) from the buffer.
     pub fn clear(&mut self) {
-        self.offsets.clear()
+        self.offsets.clear();
     }
 
     /// Returns the offset at `index`, if it exists.

--- a/wgpu/src/color.rs
+++ b/wgpu/src/color.rs
@@ -12,7 +12,7 @@ pub fn convert(
 
     let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
         label: Some("iced_wgpu.offscreen.sampler"),
-        ..Default::default()
+        ..wgpu::SamplerDescriptor::default()
     });
 
     //sampler in 0
@@ -102,10 +102,10 @@ pub fn convert(
             primitive: wgpu::PrimitiveState {
                 topology: wgpu::PrimitiveTopology::TriangleList,
                 front_face: wgpu::FrontFace::Cw,
-                ..Default::default()
+                ..wgpu::PrimitiveState::default()
             },
             depth_stencil: None,
-            multisample: Default::default(),
+            multisample: wgpu::MultisampleState::default(),
             multiview: None,
         });
 

--- a/wgpu/src/geometry.rs
+++ b/wgpu/src/geometry.rs
@@ -480,7 +480,7 @@ impl Frame {
                                 },
                                 size: self.size,
                             }),
-                        ))
+                        ));
                     }
                 }
                 Buffer::Gradient(buffer) => {
@@ -493,7 +493,7 @@ impl Frame {
                                 },
                                 size: self.size,
                             }),
-                        ))
+                        ));
                     }
                 }
             }

--- a/wgpu/src/image/atlas.rs
+++ b/wgpu/src/image/atlas.rs
@@ -237,7 +237,7 @@ impl Atlas {
                         }));
                     }
                 }
-                _ => {}
+                Layer::Full => {}
             }
         }
 

--- a/wgpu/src/image/atlas.rs
+++ b/wgpu/src/image/atlas.rs
@@ -104,7 +104,7 @@ impl Atlas {
 
             padded_data[offset..offset + 4 * width as usize].copy_from_slice(
                 &data[row * 4 * width as usize..(row + 1) * 4 * width as usize],
-            )
+            );
         }
 
         match &entry {

--- a/wgpu/src/layer.rs
+++ b/wgpu/src/layer.rs
@@ -202,7 +202,7 @@ impl<'a> Layer<'a> {
                         translation,
                         primitive,
                         current_layer,
-                    )
+                    );
                 }
             }
             Primitive::Clip { bounds, content } => {

--- a/wgpu/src/text.rs
+++ b/wgpu/src/text.rs
@@ -64,7 +64,7 @@ impl Pipeline {
             self.renderers.push(glyphon::TextRenderer::new(
                 &mut self.atlas,
                 device,
-                Default::default(),
+                wgpu::MultisampleState::default(),
                 None,
             ));
         }

--- a/wgpu/src/triangle.rs
+++ b/wgpu/src/triangle.rs
@@ -329,12 +329,12 @@ impl Pipeline {
 
 fn fragment_target(
     texture_format: wgpu::TextureFormat,
-) -> Option<wgpu::ColorTargetState> {
-    Some(wgpu::ColorTargetState {
+) -> wgpu::ColorTargetState {
+    wgpu::ColorTargetState {
         format: texture_format,
         blend: Some(wgpu::BlendState::ALPHA_BLENDING),
         write_mask: wgpu::ColorWrites::ALL,
-    })
+    }
 }
 
 fn primitive_state() -> wgpu::PrimitiveState {
@@ -521,7 +521,7 @@ mod solid {
                         fragment: Some(wgpu::FragmentState {
                             module: &shader,
                             entry_point: "solid_fs_main",
-                            targets: &[triangle::fragment_target(format)],
+                            targets: &[Some(triangle::fragment_target(format))],
                         }),
                         primitive: triangle::primitive_state(),
                         depth_stencil: None,
@@ -698,7 +698,7 @@ mod gradient {
                     fragment: Some(wgpu::FragmentState {
                         module: &shader,
                         entry_point: "gradient_fs_main",
-                        targets: &[triangle::fragment_target(format)],
+                        targets: &[Some(triangle::fragment_target(format))],
                     }),
                     primitive: triangle::primitive_state(),
                     depth_stencil: None,

--- a/widget/src/button.rs
+++ b/widget/src/button.rs
@@ -146,7 +146,7 @@ where
     }
 
     fn diff(&self, tree: &mut Tree) {
-        tree.diff_children(std::slice::from_ref(&self.content))
+        tree.diff_children(std::slice::from_ref(&self.content));
     }
 
     fn width(&self) -> Length {

--- a/widget/src/column.rs
+++ b/widget/src/column.rs
@@ -159,7 +159,7 @@ where
                     child
                         .as_widget()
                         .operate(state, layout, renderer, operation);
-                })
+                });
         });
     }
 

--- a/widget/src/image.rs
+++ b/widget/src/image.rs
@@ -141,14 +141,14 @@ pub fn draw<Renderer, Handle>(
             ..bounds
         };
 
-        renderer.draw(handle.clone(), drawing_bounds + offset)
+        renderer.draw(handle.clone(), drawing_bounds + offset);
     };
 
     if adjusted_fit.width > bounds.width || adjusted_fit.height > bounds.height
     {
         renderer.with_layer(bounds, render);
     } else {
-        render(renderer)
+        render(renderer);
     }
 }
 
@@ -191,7 +191,7 @@ where
         _cursor: mouse::Cursor,
         _viewport: &Rectangle,
     ) {
-        draw(renderer, layout, &self.handle, self.content_fit)
+        draw(renderer, layout, &self.handle, self.content_fit);
     }
 }
 

--- a/widget/src/image/viewer.rs
+++ b/widget/src/image/viewer.rs
@@ -334,7 +334,7 @@ where
                         y: bounds.y,
                         ..Rectangle::with_size(image_size)
                     },
-                )
+                );
             });
         });
     }

--- a/widget/src/keyed/column.rs
+++ b/widget/src/keyed/column.rs
@@ -220,7 +220,7 @@ where
                     child
                         .as_widget()
                         .operate(state, layout, renderer, operation);
-                })
+                });
         });
     }
 

--- a/widget/src/lazy.rs
+++ b/widget/src/lazy.rs
@@ -135,7 +135,7 @@ where
 
             (*self.element.borrow_mut()) = Some(current.element.clone());
             self.with_element(|element| {
-                tree.diff_children(std::slice::from_ref(&element.as_widget()))
+                tree.diff_children(std::slice::from_ref(&element.as_widget()));
             });
         } else {
             (*self.element.borrow_mut()) = Some(current.element.clone());
@@ -243,8 +243,8 @@ where
                 layout,
                 cursor,
                 viewport,
-            )
-        })
+            );
+        });
     }
 
     fn overlay<'b>(

--- a/widget/src/lazy/component.rs
+++ b/widget/src/lazy/component.rs
@@ -511,7 +511,7 @@ impl<'a, 'b, Message, Renderer, Event, S> Drop
     for Overlay<'a, 'b, Message, Renderer, Event, S>
 {
     fn drop(&mut self) {
-        if let Some(heads) = self.0.take().map(|inner| inner.into_heads()) {
+        if let Some(heads) = self.0.take().map(Inner::into_heads) {
             *heads.instance.tree.borrow_mut().borrow_mut() = Some(heads.tree);
         }
     }

--- a/widget/src/lazy/responsive.rs
+++ b/widget/src/lazy/responsive.rs
@@ -240,9 +240,9 @@ where
             |tree, renderer, layout, element| {
                 element.as_widget().draw(
                     tree, renderer, theme, style, layout, cursor, viewport,
-                )
+                );
             },
-        )
+        );
     }
 
     fn mouse_interaction(

--- a/widget/src/pane_grid.rs
+++ b/widget/src/pane_grid.rs
@@ -606,11 +606,10 @@ pub fn update<'a, Message, T: Draggable>(
                         } else {
                             let dropped_region = contents
                                 .zip(layout.children())
-                                .filter_map(|(target, layout)| {
+                                .find_map(|(target, layout)| {
                                     layout_region(layout, cursor_position)
                                         .map(|region| (target, region))
-                                })
-                                .next();
+                                });
 
                             match dropped_region {
                                 Some(((target, _), region))
@@ -1151,21 +1150,19 @@ pub struct ResizeEvent {
  * Helpers
  */
 fn hovered_split<'a>(
-    splits: impl Iterator<Item = (&'a Split, &'a (Axis, Rectangle, f32))>,
+    mut splits: impl Iterator<Item = (&'a Split, &'a (Axis, Rectangle, f32))>,
     spacing: f32,
     cursor_position: Point,
 ) -> Option<(Split, Axis, Rectangle)> {
-    splits
-        .filter_map(|(split, (axis, region, ratio))| {
-            let bounds = axis.split_line_bounds(*region, *ratio, spacing);
+    splits.find_map(|(split, (axis, region, ratio))| {
+        let bounds = axis.split_line_bounds(*region, *ratio, spacing);
 
-            if bounds.contains(cursor_position) {
-                Some((*split, *axis, bounds))
-            } else {
-                None
-            }
-        })
-        .next()
+        if bounds.contains(cursor_position) {
+            Some((*split, *axis, bounds))
+        } else {
+            None
+        }
+    })
 }
 
 /// The visible contents of the [`PaneGrid`]

--- a/widget/src/pane_grid.rs
+++ b/widget/src/pane_grid.rs
@@ -308,7 +308,7 @@ where
                 .zip(layout.children())
                 .for_each(|(((_pane, content), state), layout)| {
                     content.operate(state, layout, renderer, operation);
-                })
+                });
         });
     }
 
@@ -436,7 +436,7 @@ where
                     tree, renderer, theme, style, layout, cursor, rectangle,
                 );
             },
-        )
+        );
     }
 
     fn overlay<'b>(

--- a/widget/src/pane_grid/node.rs
+++ b/widget/src/pane_grid/node.rs
@@ -95,13 +95,13 @@ impl Node {
         splits
     }
 
-    pub(crate) fn find(&mut self, pane: &Pane) -> Option<&mut Node> {
+    pub(crate) fn find(&mut self, pane: Pane) -> Option<&mut Node> {
         match self {
             Node::Split { a, b, .. } => {
                 a.find(pane).or_else(move || b.find(pane))
             }
             Node::Pane(p) => {
-                if p == pane {
+                if *p == pane {
                     Some(self)
                 } else {
                     None
@@ -139,12 +139,12 @@ impl Node {
         f(self);
     }
 
-    pub(crate) fn resize(&mut self, split: &Split, percentage: f32) -> bool {
+    pub(crate) fn resize(&mut self, split: Split, percentage: f32) -> bool {
         match self {
             Node::Split {
                 id, ratio, a, b, ..
             } => {
-                if id == split {
+                if *id == split {
                     *ratio = percentage;
 
                     true
@@ -158,13 +158,13 @@ impl Node {
         }
     }
 
-    pub(crate) fn remove(&mut self, pane: &Pane) -> Option<Pane> {
+    pub(crate) fn remove(&mut self, pane: Pane) -> Option<Pane> {
         match self {
             Node::Split { a, b, .. } => {
-                if a.pane() == Some(*pane) {
+                if a.pane() == Some(pane) {
                     *self = *b.clone();
                     Some(self.first_pane())
-                } else if b.pane() == Some(*pane) {
+                } else if b.pane() == Some(pane) {
                     *self = *a.clone();
                     Some(self.first_pane())
                 } else {

--- a/widget/src/pane_grid/state.rs
+++ b/widget/src/pane_grid/state.rs
@@ -156,16 +156,16 @@ impl<T> State<T> {
             Region::Center => self.swap(pane, target),
             Region::Edge(edge) => match edge {
                 Edge::Top => {
-                    self.split_and_swap(Axis::Horizontal, target, pane, true)
+                    self.split_and_swap(Axis::Horizontal, target, pane, true);
                 }
                 Edge::Bottom => {
-                    self.split_and_swap(Axis::Horizontal, target, pane, false)
+                    self.split_and_swap(Axis::Horizontal, target, pane, false);
                 }
                 Edge::Left => {
-                    self.split_and_swap(Axis::Vertical, target, pane, true)
+                    self.split_and_swap(Axis::Vertical, target, pane, true);
                 }
                 Edge::Right => {
-                    self.split_and_swap(Axis::Vertical, target, pane, false)
+                    self.split_and_swap(Axis::Vertical, target, pane, false);
                 }
             },
         }
@@ -176,7 +176,7 @@ impl<T> State<T> {
         match target {
             Target::Edge(edge) => self.move_to_edge(pane, edge),
             Target::Pane(target, region) => {
-                self.split_with(&target, pane, region)
+                self.split_with(&target, pane, region);
             }
         }
     }
@@ -241,16 +241,16 @@ impl<T> State<T> {
     pub fn move_to_edge(&mut self, pane: &Pane, edge: Edge) {
         match edge {
             Edge::Top => {
-                self.split_major_node_and_swap(Axis::Horizontal, pane, true)
+                self.split_major_node_and_swap(Axis::Horizontal, pane, true);
             }
             Edge::Bottom => {
-                self.split_major_node_and_swap(Axis::Horizontal, pane, false)
+                self.split_major_node_and_swap(Axis::Horizontal, pane, false);
             }
             Edge::Left => {
-                self.split_major_node_and_swap(Axis::Vertical, pane, true)
+                self.split_major_node_and_swap(Axis::Vertical, pane, true);
             }
             Edge::Right => {
-                self.split_major_node_and_swap(Axis::Vertical, pane, false)
+                self.split_major_node_and_swap(Axis::Vertical, pane, false);
             }
         }
     }

--- a/widget/src/pane_grid/state.rs
+++ b/widget/src/pane_grid/state.rs
@@ -75,14 +75,14 @@ impl<T> State<T> {
     }
 
     /// Returns the internal state of the given [`Pane`], if it exists.
-    pub fn get(&self, pane: &Pane) -> Option<&T> {
-        self.panes.get(pane)
+    pub fn get(&self, pane: Pane) -> Option<&T> {
+        self.panes.get(&pane)
     }
 
     /// Returns the internal state of the given [`Pane`] with mutability, if it
     /// exists.
-    pub fn get_mut(&mut self, pane: &Pane) -> Option<&mut T> {
-        self.panes.get_mut(pane)
+    pub fn get_mut(&mut self, pane: Pane) -> Option<&mut T> {
+        self.panes.get_mut(&pane)
     }
 
     /// Returns an iterator over all the panes of the [`State`], alongside its
@@ -104,13 +104,13 @@ impl<T> State<T> {
 
     /// Returns the adjacent [`Pane`] of another [`Pane`] in the given
     /// direction, if there is one.
-    pub fn adjacent(&self, pane: &Pane, direction: Direction) -> Option<Pane> {
+    pub fn adjacent(&self, pane: Pane, direction: Direction) -> Option<Pane> {
         let regions = self
             .internal
             .layout
             .pane_regions(0.0, Size::new(4096.0, 4096.0));
 
-        let current_region = regions.get(pane)?;
+        let current_region = regions.get(&pane)?;
 
         let target = match direction {
             Direction::Left => {
@@ -142,7 +142,7 @@ impl<T> State<T> {
     pub fn split(
         &mut self,
         axis: Axis,
-        pane: &Pane,
+        pane: Pane,
         state: T,
     ) -> Option<(Pane, Split)> {
         self.split_node(axis, Some(pane), state, false)
@@ -151,7 +151,7 @@ impl<T> State<T> {
     /// Split a target [`Pane`] with a given [`Pane`] on a given [`Region`].
     ///
     /// Panes will be swapped by default for [`Region::Center`].
-    pub fn split_with(&mut self, target: &Pane, pane: &Pane, region: Region) {
+    pub fn split_with(&mut self, target: Pane, pane: Pane, region: Region) {
         match region {
             Region::Center => self.swap(pane, target),
             Region::Edge(edge) => match edge {
@@ -172,11 +172,11 @@ impl<T> State<T> {
     }
 
     /// Drops the given [`Pane`] into the provided [`Target`].
-    pub fn drop(&mut self, pane: &Pane, target: Target) {
+    pub fn drop(&mut self, pane: Pane, target: Target) {
         match target {
             Target::Edge(edge) => self.move_to_edge(pane, edge),
             Target::Pane(target, region) => {
-                self.split_with(&target, pane, region);
+                self.split_with(target, pane, region);
             }
         }
     }
@@ -184,7 +184,7 @@ impl<T> State<T> {
     fn split_node(
         &mut self,
         axis: Axis,
-        pane: Option<&Pane>,
+        pane: Option<Pane>,
         state: T,
         inverse: bool,
     ) -> Option<(Pane, Split)> {
@@ -222,14 +222,14 @@ impl<T> State<T> {
     fn split_and_swap(
         &mut self,
         axis: Axis,
-        target: &Pane,
-        pane: &Pane,
+        target: Pane,
+        pane: Pane,
         swap: bool,
     ) {
         if let Some((state, _)) = self.close(pane) {
             if let Some((new_pane, _)) = self.split(axis, target, state) {
                 if swap {
-                    self.swap(target, &new_pane);
+                    self.swap(target, new_pane);
                 }
             }
         }
@@ -238,7 +238,7 @@ impl<T> State<T> {
     /// Move [`Pane`] to an [`Edge`] of the [`PaneGrid`].
     ///
     /// [`PaneGrid`]: super::PaneGrid
-    pub fn move_to_edge(&mut self, pane: &Pane, edge: Edge) {
+    pub fn move_to_edge(&mut self, pane: Pane, edge: Edge) {
         match edge {
             Edge::Top => {
                 self.split_major_node_and_swap(Axis::Horizontal, pane, true);
@@ -258,7 +258,7 @@ impl<T> State<T> {
     fn split_major_node_and_swap(
         &mut self,
         axis: Axis,
-        pane: &Pane,
+        pane: Pane,
         swap: bool,
     ) {
         if let Some((state, _)) = self.close(pane) {
@@ -273,14 +273,14 @@ impl<T> State<T> {
     ///
     /// [`PaneGrid`]: super::PaneGrid
     /// [`DragEvent`]: super::DragEvent
-    pub fn swap(&mut self, a: &Pane, b: &Pane) {
+    pub fn swap(&mut self, a: Pane, b: Pane) {
         self.internal.layout.update(&|node| match node {
             Node::Split { .. } => {}
             Node::Pane(pane) => {
-                if pane == a {
-                    *node = Node::Pane(*b);
-                } else if pane == b {
-                    *node = Node::Pane(*a);
+                if *pane == a {
+                    *node = Node::Pane(b);
+                } else if *pane == b {
+                    *node = Node::Pane(a);
                 }
             }
         });
@@ -296,19 +296,19 @@ impl<T> State<T> {
     ///
     /// [`PaneGrid`]: super::PaneGrid
     /// [`ResizeEvent`]: super::ResizeEvent
-    pub fn resize(&mut self, split: &Split, ratio: f32) {
+    pub fn resize(&mut self, split: Split, ratio: f32) {
         let _ = self.internal.layout.resize(split, ratio);
     }
 
     /// Closes the given [`Pane`] and returns its internal state and its closest
     /// sibling, if it exists.
-    pub fn close(&mut self, pane: &Pane) -> Option<(T, Pane)> {
-        if self.maximized == Some(*pane) {
+    pub fn close(&mut self, pane: Pane) -> Option<(T, Pane)> {
+        if self.maximized == Some(pane) {
             let _ = self.maximized.take();
         }
 
         if let Some(sibling) = self.internal.layout.remove(pane) {
-            self.panes.remove(pane).map(|state| (state, sibling))
+            self.panes.remove(&pane).map(|state| (state, sibling))
         } else {
             None
         }
@@ -318,8 +318,8 @@ impl<T> State<T> {
     /// [`PaneGrid`] until [`Self::restore()`] is called.
     ///
     /// [`PaneGrid`]: super::PaneGrid
-    pub fn maximize(&mut self, pane: &Pane) {
-        self.maximized = Some(*pane);
+    pub fn maximize(&mut self, pane: Pane) {
+        self.maximized = Some(pane);
     }
 
     /// Restore the currently maximized [`Pane`] to it's normal size. All panes

--- a/widget/src/pane_grid/title_bar.rs
+++ b/widget/src/pane_grid/title_bar.rs
@@ -286,7 +286,7 @@ where
                 controls_layout,
                 renderer,
                 operation,
-            )
+            );
         };
 
         if show_title {
@@ -295,7 +295,7 @@ where
                 title_layout,
                 renderer,
                 operation,
-            )
+            );
         }
     }
 

--- a/widget/src/pick_list.rs
+++ b/widget/src/pick_list.rs
@@ -253,7 +253,7 @@ where
             &self.handle,
             &self.style,
             || tree.state.downcast_ref::<State<Renderer::Paragraph>>(),
-        )
+        );
     }
 
     fn overlay<'b>(

--- a/widget/src/pick_list.rs
+++ b/widget/src/pick_list.rs
@@ -76,7 +76,7 @@ where
             text_line_height: text::LineHeight::default(),
             text_shaping: text::Shaping::Basic,
             font: None,
-            handle: Default::default(),
+            handle: Handle::default(),
             style: Default::default(),
         }
     }

--- a/widget/src/row.rs
+++ b/widget/src/row.rs
@@ -101,7 +101,7 @@ where
     }
 
     fn diff(&self, tree: &mut Tree) {
-        tree.diff_children(&self.children)
+        tree.diff_children(&self.children);
     }
 
     fn width(&self) -> Length {
@@ -148,7 +148,7 @@ where
                     child
                         .as_widget()
                         .operate(state, layout, renderer, operation);
-                })
+                });
         });
     }
 

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -117,7 +117,7 @@ impl Direction {
         match self {
             Self::Horizontal(properties) => Some(properties),
             Self::Both { horizontal, .. } => Some(horizontal),
-            _ => None,
+            Self::Vertical(_) => None,
         }
     }
 
@@ -126,7 +126,7 @@ impl Direction {
         match self {
             Self::Vertical(properties) => Some(properties),
             Self::Both { vertical, .. } => Some(vertical),
-            _ => None,
+            Self::Horizontal(_) => None,
         }
     }
 }

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -46,7 +46,7 @@ where
             id: None,
             width: Length::Shrink,
             height: Length::Shrink,
-            direction: Default::default(),
+            direction: Direction::default(),
             content: content.into(),
             on_scroll: None,
             style: Default::default(),

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -217,7 +217,7 @@ where
     }
 
     fn diff(&self, tree: &mut Tree) {
-        tree.diff_children(std::slice::from_ref(&self.content))
+        tree.diff_children(std::slice::from_ref(&self.content));
     }
 
     fn width(&self) -> Length {
@@ -348,9 +348,9 @@ where
                     layout,
                     cursor,
                     viewport,
-                )
+                );
             },
-        )
+        );
     }
 
     fn mouse_interaction(
@@ -1069,7 +1069,7 @@ impl operation::Scrollable for State {
     }
 
     fn scroll_to(&mut self, offset: AbsoluteOffset) {
-        State::scroll_to(self, offset)
+        State::scroll_to(self, offset);
     }
 }
 
@@ -1203,7 +1203,7 @@ impl State {
                 (self.offset_y.absolute(bounds.height, content_bounds.height)
                     - delta.y)
                     .clamp(0.0, content_bounds.height - bounds.height),
-            )
+            );
         }
 
         if bounds.width < content_bounds.width {

--- a/widget/src/slider.rs
+++ b/widget/src/slider.rs
@@ -223,7 +223,7 @@ where
             &self.range,
             theme,
             &self.style,
-        )
+        );
     }
 
     fn mouse_interaction(

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -250,7 +250,7 @@ where
             self.is_secure,
             self.icon.as_ref(),
             &self.style,
-        )
+        );
     }
 }
 
@@ -375,7 +375,7 @@ where
             self.is_secure,
             self.icon.as_ref(),
             &self.style,
-        )
+        );
     }
 
     fn mouse_interaction(
@@ -622,7 +622,7 @@ where
             font,
             size,
             line_height,
-        )
+        );
     };
 
     match event {
@@ -849,7 +849,7 @@ where
                                 state.cursor.move_left_by_words(value);
                             }
                         } else if modifiers.shift() {
-                            state.cursor.select_left(value)
+                            state.cursor.select_left(value);
                         } else {
                             state.cursor.move_left(value);
                         }
@@ -864,7 +864,7 @@ where
                                 state.cursor.move_right_by_words(value);
                             }
                         } else if modifiers.shift() {
-                            state.cursor.select_right(value)
+                            state.cursor.select_right(value);
                         } else {
                             state.cursor.move_right(value);
                         }
@@ -1220,7 +1220,7 @@ pub fn draw<Renderer>(
 
     if text_width > text_bounds.width {
         renderer.with_layer(text_bounds, |renderer| {
-            renderer.with_translation(Vector::new(-offset, 0.0), render)
+            renderer.with_translation(Vector::new(-offset, 0.0), render);
         });
     } else {
         render(renderer);
@@ -1342,29 +1342,29 @@ impl<P: text::Paragraph> operation::Focusable for State<P> {
     }
 
     fn focus(&mut self) {
-        State::focus(self)
+        State::focus(self);
     }
 
     fn unfocus(&mut self) {
-        State::unfocus(self)
+        State::unfocus(self);
     }
 }
 
 impl<P: text::Paragraph> operation::TextInput for State<P> {
     fn move_cursor_to_front(&mut self) {
-        State::move_cursor_to_front(self)
+        State::move_cursor_to_front(self);
     }
 
     fn move_cursor_to_end(&mut self) {
-        State::move_cursor_to_end(self)
+        State::move_cursor_to_end(self);
     }
 
     fn move_cursor_to(&mut self, position: usize) {
-        State::move_cursor_to(self, position)
+        State::move_cursor_to(self, position);
     }
 
     fn select_all(&mut self) {
-        State::select_all(self)
+        State::select_all(self);
     }
 }
 

--- a/widget/src/text_input/cursor.rs
+++ b/widget/src/text_input/cursor.rs
@@ -65,11 +65,11 @@ impl Cursor {
     }
 
     pub(crate) fn move_right(&mut self, value: &Value) {
-        self.move_right_by_amount(value, 1)
+        self.move_right_by_amount(value, 1);
     }
 
     pub(crate) fn move_right_by_words(&mut self, value: &Value) {
-        self.move_to(value.next_end_of_word(self.right(value)))
+        self.move_to(value.next_end_of_word(self.right(value)));
     }
 
     pub(crate) fn move_right_by_amount(
@@ -79,7 +79,7 @@ impl Cursor {
     ) {
         match self.state(value) {
             State::Index(index) => {
-                self.move_to(index.saturating_add(amount).min(value.len()))
+                self.move_to(index.saturating_add(amount).min(value.len()));
             }
             State::Selection { start, end } => self.move_to(end.max(start)),
         }
@@ -108,10 +108,10 @@ impl Cursor {
     pub(crate) fn select_left(&mut self, value: &Value) {
         match self.state(value) {
             State::Index(index) if index > 0 => {
-                self.select_range(index, index - 1)
+                self.select_range(index, index - 1);
             }
             State::Selection { start, end } if end > 0 => {
-                self.select_range(start, end - 1)
+                self.select_range(start, end - 1);
             }
             _ => {}
         }
@@ -120,10 +120,10 @@ impl Cursor {
     pub(crate) fn select_right(&mut self, value: &Value) {
         match self.state(value) {
             State::Index(index) if index < value.len() => {
-                self.select_range(index, index + 1)
+                self.select_range(index, index + 1);
             }
             State::Selection { start, end } if end < value.len() => {
-                self.select_range(start, end + 1)
+                self.select_range(start, end + 1);
             }
             _ => {}
         }
@@ -132,10 +132,10 @@ impl Cursor {
     pub(crate) fn select_left_by_words(&mut self, value: &Value) {
         match self.state(value) {
             State::Index(index) => {
-                self.select_range(index, value.previous_start_of_word(index))
+                self.select_range(index, value.previous_start_of_word(index));
             }
             State::Selection { start, end } => {
-                self.select_range(start, value.previous_start_of_word(end))
+                self.select_range(start, value.previous_start_of_word(end));
             }
         }
     }
@@ -143,10 +143,10 @@ impl Cursor {
     pub(crate) fn select_right_by_words(&mut self, value: &Value) {
         match self.state(value) {
             State::Index(index) => {
-                self.select_range(index, value.next_end_of_word(index))
+                self.select_range(index, value.next_end_of_word(index));
             }
             State::Selection { start, end } => {
-                self.select_range(start, value.next_end_of_word(end))
+                self.select_range(start, value.next_end_of_word(end));
             }
         }
     }

--- a/widget/src/text_input/cursor.rs
+++ b/widget/src/text_input/cursor.rs
@@ -56,7 +56,7 @@ impl Cursor {
             State::Selection { start, end } => {
                 Some((start.min(end), start.max(end)))
             }
-            _ => None,
+            State::Index(_) => None,
         }
     }
 
@@ -89,7 +89,7 @@ impl Cursor {
         match self.state(value) {
             State::Index(index) if index > 0 => self.move_to(index - 1),
             State::Selection { start, end } => self.move_to(start.min(end)),
-            _ => self.move_to(0),
+            State::Index(_) => self.move_to(0),
         }
     }
 

--- a/widget/src/toggler.rs
+++ b/widget/src/toggler.rs
@@ -286,7 +286,7 @@ where
                 style,
                 label_layout,
                 tree.state.downcast_ref(),
-                Default::default(),
+                crate::text::Appearance::default(),
             );
         }
 

--- a/widget/src/tooltip.rs
+++ b/widget/src/tooltip.rs
@@ -114,7 +114,7 @@ where
     }
 
     fn diff(&self, tree: &mut widget::Tree) {
-        tree.diff_children(&[self.content.as_widget(), &self.tooltip])
+        tree.diff_children(&[self.content.as_widget(), &self.tooltip]);
     }
 
     fn state(&self) -> widget::tree::State {

--- a/widget/src/vertical_slider.rs
+++ b/widget/src/vertical_slider.rs
@@ -220,7 +220,7 @@ where
             &self.range,
             theme,
             &self.style,
-        )
+        );
     }
 
     fn mouse_interaction(

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -762,7 +762,7 @@ pub fn run_command<A, C, E>(
                             size.width,
                             size.height,
                         )))
-                        .expect("Send message to event loop")
+                        .expect("Send message to event loop");
                 }
                 window::Action::Maximize(maximized) => {
                     window.set_maximized(maximized);
@@ -784,7 +784,7 @@ pub fn run_command<A, C, E>(
                     ));
                 }
                 window::Action::ChangeIcon(icon) => {
-                    window.set_window_icon(conversion::icon(icon))
+                    window.set_window_icon(conversion::icon(icon));
                 }
                 window::Action::FetchMode(tag) => {
                     let mode = if window.is_visible().unwrap_or(true) {
@@ -798,7 +798,7 @@ pub fn run_command<A, C, E>(
                         .expect("Send message to event loop");
                 }
                 window::Action::ToggleMaximize => {
-                    window.set_maximized(!window.is_maximized())
+                    window.set_maximized(!window.is_maximized());
                 }
                 window::Action::ToggleDecorations => {
                     window.set_decorations(!window.is_decorated());
@@ -833,7 +833,7 @@ pub fn run_command<A, C, E>(
                             bytes,
                             state.physical_size(),
                         )))
-                        .expect("Send message to event loop.")
+                        .expect("Send message to event loop.");
                 }
             },
             command::Action::System(action) => match action {
@@ -851,7 +851,7 @@ pub fn run_command<A, C, E>(
 
                             proxy
                                 .send_event(message)
-                                .expect("Send message to event loop")
+                                .expect("Send message to event loop");
                         });
                     }
                 }

--- a/winit/src/clipboard.rs
+++ b/winit/src/clipboard.rs
@@ -44,7 +44,7 @@ impl Clipboard {
             State::Connected(clipboard) => match clipboard.write(contents) {
                 Ok(()) => {}
                 Err(error) => {
-                    log::warn!("error writing to clipboard: {error}")
+                    log::warn!("error writing to clipboard: {error}");
                 }
             },
             State::Unavailable => {}
@@ -58,6 +58,6 @@ impl crate::core::Clipboard for Clipboard {
     }
 
     fn write(&mut self, contents: String) {
-        self.write(contents)
+        self.write(contents);
     }
 }

--- a/winit/src/settings.rs
+++ b/winit/src/settings.rs
@@ -235,7 +235,7 @@ impl Default for Window {
             transparent: false,
             level: Level::default(),
             icon: None,
-            platform_specific: Default::default(),
+            platform_specific: PlatformSpecific::default(),
         }
     }
 }

--- a/winit/src/system.rs
+++ b/winit/src/system.rs
@@ -23,7 +23,7 @@ pub(crate) fn information(
 
     let memory_used = sysinfo::get_current_pid()
         .and_then(|pid| system.process(pid).ok_or("Process not found"))
-        .map(|process| process.memory())
+        .map(ProcessExt::memory)
         .ok();
 
     Information {


### PR DESCRIPTION
We enable some pedantic `clippy` lints that are somewhat sane.

This PR also adds a `cargo lint` and `cargo nitpick` command aliases.