### PR TITLE
Fix theme palette name being ambiguous

### DIFF
--- a/examples/styling/src/main.rs
+++ b/examples/styling/src/main.rs
@@ -53,13 +53,15 @@ impl Sandbox for Styling {
                 self.theme = match theme {
                     ThemeType::Light => Theme::Light,
                     ThemeType::Dark => Theme::Dark,
-                    ThemeType::Custom => Theme::custom(theme::Palette {
-                        background: Color::from_rgb(1.0, 0.9, 1.0),
-                        text: Color::BLACK,
-                        primary: Color::from_rgb(0.5, 0.5, 0.0),
-                        success: Color::from_rgb(0.0, 1.0, 0.0),
-                        danger: Color::from_rgb(1.0, 0.0, 0.0),
-                    }),
+                    ThemeType::Custom => {
+                        Theme::custom(theme::palette::Palette {
+                            background: Color::from_rgb(1.0, 0.9, 1.0),
+                            text: Color::BLACK,
+                            primary: Color::from_rgb(0.5, 0.5, 0.0),
+                            success: Color::from_rgb(0.0, 1.0, 0.0),
+                            danger: Color::from_rgb(1.0, 0.0, 0.0),
+                        })
+                    }
                 }
             }
             Message::InputChanged(value) => self.input_value = value,

--- a/style/src/theme.rs
+++ b/style/src/theme.rs
@@ -1,8 +1,6 @@
 //! Use the built-in theme and styles.
 pub mod palette;
 
-pub use palette::Palette;
-
 use crate::application;
 use crate::button;
 use crate::checkbox;
@@ -38,24 +36,24 @@ pub enum Theme {
 
 impl Theme {
     /// Creates a new custom [`Theme`] from the given [`Palette`].
-    pub fn custom(palette: Palette) -> Self {
+    pub fn custom(palette: palette::Palette) -> Self {
         Self::custom_with_fn(palette, palette::Extended::generate)
     }
 
     /// Creates a new custom [`Theme`] from the given [`Palette`], with
     /// a custom generator of a [`palette::Extended`].
     pub fn custom_with_fn(
-        palette: Palette,
-        generate: impl FnOnce(Palette) -> palette::Extended,
+        palette: palette::Palette,
+        generate: impl FnOnce(palette::Palette) -> palette::Extended,
     ) -> Self {
         Self::Custom(Box::new(Custom::with_fn(palette, generate)))
     }
 
     /// Returns the [`Palette`] of the [`Theme`].
-    pub fn palette(&self) -> Palette {
+    pub fn palette(&self) -> palette::Palette {
         match self {
-            Self::Light => Palette::LIGHT,
-            Self::Dark => Palette::DARK,
+            Self::Light => palette::Palette::LIGHT,
+            Self::Dark => palette::Palette::DARK,
             Self::Custom(custom) => custom.palette,
         }
     }
@@ -73,21 +71,21 @@ impl Theme {
 /// A [`Theme`] with a customized [`Palette`].
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Custom {
-    palette: Palette,
+    palette: palette::Palette,
     extended: palette::Extended,
 }
 
 impl Custom {
     /// Creates a [`Custom`] theme from the given [`Palette`].
-    pub fn new(palette: Palette) -> Self {
+    pub fn new(palette: palette::Palette) -> Self {
         Self::with_fn(palette, palette::Extended::generate)
     }
 
     /// Creates a [`Custom`] theme from the given [`Palette`] with
     /// a custom generator of a [`palette::Extended`].
     pub fn with_fn(
-        palette: Palette,
-        generate: impl FnOnce(Palette) -> palette::Extended,
+        palette: palette::Palette,
+        generate: impl FnOnce(palette::Palette) -> palette::Extended,
     ) -> Self {
         Self {
             palette,


### PR DESCRIPTION
I had issues running the examples because the `theme.rs` had the palette module import being flagged as "ambiguous" by the compiler.

> error[E0659]: `palette` is ambiguous
> --> style/src/theme.rs:4:9
> |
> 4 | pub use palette::Palette;
> |         ^^^^^^^ ambiguous name
> |
> = note: ambiguous because of multiple potential import sources
> = note: `palette` could refer to a crate passed with `--extern`
> = help: use `::palette` to refer to this crate unambiguously
> note: `palette` could also refer to the module defined here
> --> style/src/theme.rs:2:1
> |
> 2 | pub mod palette;
> | ^^^^^^^^^^^^^^^^
> = help: use `self::palette` to refer to this module unambiguously

the `styling` example was also relying on the import structure so had to update that as well.