### PR TITLE
fix(#2116): layout method only takes renderer & limits

### DIFF
--- a/examples/custom_widget/src/main.rs
+++ b/examples/custom_widget/src/main.rs
@@ -43,7 +43,6 @@ mod circle {
 
         fn layout(
             &self,
-            _tree: &mut widget::Tree,
             _renderer: &Renderer,
             _limits: &layout::Limits,
         ) -> layout::Node {


### PR DESCRIPTION
Remove `_tree` parameter from `layout` method  in the custom widgets example.