### PR TITLE
`Transform` primitive

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -12,6 +12,7 @@ keywords.workspace = true
 
 [dependencies]
 bitflags.workspace = true
+glam.workspace = true
 log.workspace = true
 num-traits.workspace = true
 smol_str.workspace = true

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -49,6 +49,7 @@ mod rectangle;
 mod shadow;
 mod shell;
 mod size;
+mod transformation;
 mod vector;
 
 pub use alignment::Alignment;
@@ -75,6 +76,7 @@ pub use shadow::Shadow;
 pub use shell::Shell;
 pub use size::Size;
 pub use text::Text;
+pub use transformation::Transformation;
 pub use vector::Vector;
 pub use widget::Widget;
 

--- a/core/src/mouse/interaction.rs
+++ b/core/src/mouse/interaction.rs
@@ -13,4 +13,5 @@ pub enum Interaction {
     ResizingHorizontally,
     ResizingVertically,
     NotAllowed,
+    ZoomIn,
 }

--- a/core/src/pixels.rs
+++ b/core/src/pixels.rs
@@ -26,3 +26,11 @@ impl From<Pixels> for f32 {
         pixels.0
     }
 }
+
+impl std::ops::Mul<f32> for Pixels {
+    type Output = Pixels;
+
+    fn mul(self, rhs: f32) -> Self {
+        Pixels(self.0 * rhs)
+    }
+}

--- a/core/src/renderer.rs
+++ b/core/src/renderer.rs
@@ -5,7 +5,9 @@ mod null;
 #[cfg(debug_assertions)]
 pub use null::Null;
 
-use crate::{Background, Border, Color, Rectangle, Shadow, Size, Vector};
+use crate::{
+    Background, Border, Color, Rectangle, Shadow, Size, Transformation, Vector,
+};
 
 /// A component that can be used by widgets to draw themselves on a screen.
 pub trait Renderer: Sized {
@@ -14,12 +16,24 @@ pub trait Renderer: Sized {
     /// The layer will clip its contents to the provided `bounds`.
     fn with_layer(&mut self, bounds: Rectangle, f: impl FnOnce(&mut Self));
 
-    /// Applies a `translation` to the primitives recorded in the given closure.
+    /// Applies a [`Transformation`] to the primitives recorded in the given closure.
+    fn with_transformation(
+        &mut self,
+        transformation: Transformation,
+        f: impl FnOnce(&mut Self),
+    );
+
+    /// Applies a translation to the primitives recorded in the given closure.
     fn with_translation(
         &mut self,
         translation: Vector,
         f: impl FnOnce(&mut Self),
-    );
+    ) {
+        self.with_transformation(
+            Transformation::translate(translation.x, translation.y),
+            f,
+        );
+    }
 
     /// Fills a [`Quad`] with the provided [`Background`].
     fn fill_quad(&mut self, quad: Quad, background: impl Into<Background>);

--- a/core/src/renderer/null.rs
+++ b/core/src/renderer/null.rs
@@ -1,7 +1,9 @@
 use crate::alignment;
 use crate::renderer::{self, Renderer};
 use crate::text::{self, Text};
-use crate::{Background, Color, Font, Pixels, Point, Rectangle, Size, Vector};
+use crate::{
+    Background, Color, Font, Pixels, Point, Rectangle, Size, Transformation,
+};
 
 use std::borrow::Cow;
 
@@ -21,9 +23,9 @@ impl Null {
 impl Renderer for Null {
     fn with_layer(&mut self, _bounds: Rectangle, _f: impl FnOnce(&mut Self)) {}
 
-    fn with_translation(
+    fn with_transformation(
         &mut self,
-        _translation: Vector,
+        _transformation: Transformation,
         _f: impl FnOnce(&mut Self),
     ) {
     }

--- a/core/src/transformation.rs
+++ b/core/src/transformation.rs
@@ -1,4 +1,4 @@
-use crate::core::{Point, Rectangle, Size, Vector};
+use crate::{Point, Rectangle, Size, Vector};
 
 use glam::{Mat4, Vec3, Vec4};
 use std::ops::Mul;
@@ -31,19 +31,14 @@ impl Transformation {
         Transformation(Mat4::from_scale(Vec3::new(scaling, scaling, 1.0)))
     }
 
-    /// The scale factor of the [`Transformation`].
+    /// Returns the scale factor of the [`Transformation`].
     pub fn scale_factor(&self) -> f32 {
         self.0.x_axis.x
     }
 
-    /// The translation on the X axis.
-    pub fn translation_x(&self) -> f32 {
-        self.0.w_axis.x
-    }
-
-    /// The translation on the Y axis.
-    pub fn translation_y(&self) -> f32 {
-        self.0.w_axis.y
+    /// Returns the translation of the [`Transformation`].
+    pub fn translation(&self) -> Vector {
+        Vector::new(self.0.w_axis.x, self.0.w_axis.y)
     }
 }
 

--- a/examples/bezier_tool/Cargo.toml
+++ b/examples/bezier_tool/Cargo.toml
@@ -7,4 +7,4 @@ publish = false
 
 [dependencies]
 iced.workspace = true
-iced.features = ["canvas"]
+iced.features = ["canvas", "debug"]

--- a/examples/loupe/Cargo.toml
+++ b/examples/loupe/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "loupe"
+version = "0.1.0"
+authors = ["Héctor Ramón Jiménez <hector0193@gmail.com>"]
+edition = "2021"
+publish = false
+
+[dependencies]
+iced.workspace = true
+iced.features = ["advanced", "debug"]

--- a/examples/loupe/src/main.rs
+++ b/examples/loupe/src/main.rs
@@ -1,0 +1,185 @@
+use iced::widget::{button, column, container, text};
+use iced::{Alignment, Element, Length, Sandbox, Settings};
+
+use loupe::loupe;
+
+pub fn main() -> iced::Result {
+    Counter::run(Settings::default())
+}
+
+struct Counter {
+    value: i32,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Message {
+    IncrementPressed,
+    DecrementPressed,
+}
+
+impl Sandbox for Counter {
+    type Message = Message;
+
+    fn new() -> Self {
+        Self { value: 0 }
+    }
+
+    fn title(&self) -> String {
+        String::from("Counter - Iced")
+    }
+
+    fn update(&mut self, message: Message) {
+        match message {
+            Message::IncrementPressed => {
+                self.value += 1;
+            }
+            Message::DecrementPressed => {
+                self.value -= 1;
+            }
+        }
+    }
+
+    fn view(&self) -> Element<Message> {
+        container(loupe(
+            3.0,
+            column![
+                button("Increment").on_press(Message::IncrementPressed),
+                text(self.value).size(50),
+                button("Decrement").on_press(Message::DecrementPressed)
+            ]
+            .padding(20)
+            .align_items(Alignment::Center),
+        ))
+        .width(Length::Fill)
+        .height(Length::Fill)
+        .center_x()
+        .center_y()
+        .into()
+    }
+}
+
+mod loupe {
+    use iced::advanced::layout::{self, Layout};
+    use iced::advanced::renderer;
+    use iced::advanced::widget::{self, Widget};
+    use iced::advanced::Renderer as _;
+    use iced::mouse;
+    use iced::{
+        Color, Element, Length, Rectangle, Renderer, Size, Theme,
+        Transformation,
+    };
+
+    pub fn loupe<'a, Message>(
+        zoom: f32,
+        content: impl Into<Element<'a, Message>>,
+    ) -> Loupe<'a, Message>
+    where
+        Message: 'static,
+    {
+        Loupe {
+            zoom,
+            content: content.into().explain(Color::BLACK),
+        }
+    }
+
+    pub struct Loupe<'a, Message> {
+        zoom: f32,
+        content: Element<'a, Message>,
+    }
+
+    impl<'a, Message> Widget<Message, Theme, Renderer> for Loupe<'a, Message> {
+        fn tag(&self) -> widget::tree::Tag {
+            self.content.as_widget().tag()
+        }
+
+        fn state(&self) -> widget::tree::State {
+            self.content.as_widget().state()
+        }
+
+        fn children(&self) -> Vec<widget::Tree> {
+            self.content.as_widget().children()
+        }
+
+        fn diff(&self, tree: &mut widget::Tree) {
+            self.content.as_widget().diff(tree);
+        }
+
+        fn size(&self) -> Size<Length> {
+            self.content.as_widget().size()
+        }
+
+        fn layout(
+            &self,
+            tree: &mut widget::Tree,
+            renderer: &Renderer,
+            limits: &layout::Limits,
+        ) -> layout::Node {
+            self.content.as_widget().layout(tree, renderer, limits)
+        }
+
+        fn draw(
+            &self,
+            tree: &widget::Tree,
+            renderer: &mut Renderer,
+            theme: &Theme,
+            style: &renderer::Style,
+            layout: Layout<'_>,
+            cursor: mouse::Cursor,
+            viewport: &Rectangle,
+        ) {
+            let bounds = layout.bounds();
+
+            if let Some(position) = cursor.position_in(bounds) {
+                renderer.with_layer(bounds, |renderer| {
+                    renderer.with_transformation(
+                        Transformation::translate(
+                            bounds.x + position.x * (1.0 - self.zoom),
+                            bounds.y + position.y * (1.0 - self.zoom),
+                        ) * Transformation::scale(self.zoom)
+                            * Transformation::translate(-bounds.x, -bounds.y),
+                        |renderer| {
+                            self.content.as_widget().draw(
+                                tree,
+                                renderer,
+                                theme,
+                                style,
+                                layout,
+                                mouse::Cursor::Unavailable,
+                                viewport,
+                            );
+                        },
+                    );
+                });
+            } else {
+                self.content.as_widget().draw(
+                    tree, renderer, theme, style, layout, cursor, viewport,
+                );
+            }
+        }
+
+        fn mouse_interaction(
+            &self,
+            _state: &widget::Tree,
+            layout: Layout<'_>,
+            cursor: mouse::Cursor,
+            _viewport: &Rectangle,
+            _renderer: &Renderer,
+        ) -> mouse::Interaction {
+            if cursor.is_over(layout.bounds()) {
+                mouse::Interaction::ZoomIn
+            } else {
+                mouse::Interaction::Idle
+            }
+        }
+    }
+
+    impl<'a, Message> From<Loupe<'a, Message>>
+        for Element<'a, Message, Theme, Renderer>
+    where
+        Message: 'a,
+    {
+        fn from(loupe: Loupe<'a, Message>) -> Self {
+            Self::new(loupe)
+        }
+    }
+}

--- a/graphics/Cargo.toml
+++ b/graphics/Cargo.toml
@@ -26,7 +26,6 @@ iced_futures.workspace = true
 bitflags.workspace = true
 bytemuck.workspace = true
 cosmic-text.workspace = true
-glam.workspace = true
 half.workspace = true
 log.workspace = true
 once_cell.workspace = true

--- a/graphics/src/damage.rs
+++ b/graphics/src/damage.rs
@@ -102,10 +102,10 @@ impl<T: Damage> Damage for Primitive<T> {
                 .fold(Rectangle::with_size(Size::ZERO), |a, b| {
                     Rectangle::union(&a, &b)
                 }),
-            Self::Translate {
-                translation,
+            Self::Transform {
+                transformation,
                 content,
-            } => content.bounds() + *translation,
+            } => content.bounds() * *transformation,
             Self::Cache { content } => content.bounds(),
             Self::Custom(custom) => custom.bounds(),
         }
@@ -144,19 +144,19 @@ fn regions<T: Damage>(a: &Primitive<T>, b: &Primitive<T>) -> Vec<Rectangle> {
             }
         }
         (
-            Primitive::Translate {
-                translation: translation_a,
+            Primitive::Transform {
+                transformation: transformation_a,
                 content: content_a,
             },
-            Primitive::Translate {
-                translation: translation_b,
+            Primitive::Transform {
+                transformation: transformation_b,
                 content: content_b,
             },
         ) => {
-            if translation_a == translation_b {
+            if transformation_a == transformation_b {
                 return regions(content_a, content_b)
                     .into_iter()
-                    .map(|r| r + *translation_a)
+                    .map(|r| r * *transformation_a)
                     .collect();
             }
         }

--- a/graphics/src/lib.rs
+++ b/graphics/src/lib.rs
@@ -19,7 +19,6 @@
 mod antialiasing;
 mod error;
 mod primitive;
-mod transformation;
 mod viewport;
 
 pub mod backend;
@@ -46,7 +45,6 @@ pub use gradient::Gradient;
 pub use mesh::Mesh;
 pub use primitive::Primitive;
 pub use renderer::Renderer;
-pub use transformation::Transformation;
 pub use viewport::Viewport;
 
 pub use iced_core as core;

--- a/graphics/src/primitive.rs
+++ b/graphics/src/primitive.rs
@@ -8,6 +8,7 @@ use crate::core::{
 };
 use crate::text::editor;
 use crate::text::paragraph;
+use crate::Transformation;
 
 use std::sync::Arc;
 
@@ -104,12 +105,12 @@ pub enum Primitive<T> {
         /// The content of the clip
         content: Box<Primitive<T>>,
     },
-    /// A primitive that applies a translation
-    Translate {
-        /// The translation vector
-        translation: Vector,
+    /// A primitive that applies a [`Transformation`]
+    Transform {
+        /// The [`Transformation`]
+        transformation: Transformation,
 
-        /// The primitive to translate
+        /// The primitive to transform
         content: Box<Primitive<T>>,
     },
     /// A cached primitive.
@@ -125,12 +126,12 @@ pub enum Primitive<T> {
 }
 
 impl<T> Primitive<T> {
-    /// Creates a [`Primitive::Group`].
+    /// Groups the current [`Primitive`].
     pub fn group(primitives: Vec<Self>) -> Self {
         Self::Group { primitives }
     }
 
-    /// Creates a [`Primitive::Clip`].
+    /// Clips the current [`Primitive`].
     pub fn clip(self, bounds: Rectangle) -> Self {
         Self::Clip {
             bounds,
@@ -138,10 +139,21 @@ impl<T> Primitive<T> {
         }
     }
 
-    /// Creates a [`Primitive::Translate`].
+    /// Translates the current [`Primitive`].
     pub fn translate(self, translation: Vector) -> Self {
-        Self::Translate {
-            translation,
+        Self::Transform {
+            transformation: Transformation::translate(
+                translation.x,
+                translation.y,
+            ),
+            content: Box::new(self),
+        }
+    }
+
+    /// Transforms the current [`Primitive`].
+    pub fn transform(self, transformation: Transformation) -> Self {
+        Self::Transform {
+            transformation,
             content: Box::new(self),
         }
     }

--- a/graphics/src/primitive.rs
+++ b/graphics/src/primitive.rs
@@ -4,11 +4,11 @@ use crate::core::image;
 use crate::core::svg;
 use crate::core::text;
 use crate::core::{
-    Background, Border, Color, Font, Pixels, Point, Rectangle, Shadow, Vector,
+    Background, Border, Color, Font, Pixels, Point, Rectangle, Shadow,
+    Transformation, Vector,
 };
 use crate::text::editor;
 use crate::text::paragraph;
-use crate::Transformation;
 
 use std::sync::Arc;
 

--- a/graphics/src/renderer.rs
+++ b/graphics/src/renderer.rs
@@ -6,7 +6,7 @@ use crate::core::renderer;
 use crate::core::svg;
 use crate::core::text::Text;
 use crate::core::{
-    Background, Color, Font, Pixels, Point, Rectangle, Size, Vector,
+    Background, Color, Font, Pixels, Point, Rectangle, Size, Transformation,
 };
 use crate::text;
 use crate::Primitive;
@@ -73,20 +73,20 @@ impl<B: Backend> Renderer<B> {
     }
 
     /// Starts recording a translation.
-    pub fn start_translation(&mut self) -> Vec<Primitive<B::Primitive>> {
+    pub fn start_transformation(&mut self) -> Vec<Primitive<B::Primitive>> {
         std::mem::take(&mut self.primitives)
     }
 
     /// Ends the recording of a translation.
-    pub fn end_translation(
+    pub fn end_transformation(
         &mut self,
         primitives: Vec<Primitive<B::Primitive>>,
-        translation: Vector,
+        transformation: Transformation,
     ) {
         let layer = std::mem::replace(&mut self.primitives, primitives);
 
         self.primitives
-            .push(Primitive::group(layer).translate(translation));
+            .push(Primitive::group(layer).transform(transformation));
     }
 }
 
@@ -99,16 +99,16 @@ impl<B: Backend> iced_core::Renderer for Renderer<B> {
         self.end_layer(current, bounds);
     }
 
-    fn with_translation(
+    fn with_transformation(
         &mut self,
-        translation: Vector,
+        transformation: Transformation,
         f: impl FnOnce(&mut Self),
     ) {
-        let current = self.start_translation();
+        let current = self.start_transformation();
 
         f(self);
 
-        self.end_translation(current, translation);
+        self.end_transformation(current, transformation);
     }
 
     fn fill_quad(

--- a/graphics/src/transformation.rs
+++ b/graphics/src/transformation.rs
@@ -26,19 +26,14 @@ impl Transformation {
         Transformation(Mat4::from_translation(Vec3::new(x, y, 0.0)))
     }
 
-    /// Creates a scale transformation.
-    pub fn scale(x: f32, y: f32) -> Transformation {
-        Transformation(Mat4::from_scale(Vec3::new(x, y, 1.0)))
+    /// Creates a uniform scaling transformation.
+    pub fn scale(scaling: f32) -> Transformation {
+        Transformation(Mat4::from_scale(Vec3::new(scaling, scaling, 1.0)))
     }
 
-    /// The scale factor on the X axis.
-    pub fn scale_x(&self) -> f32 {
+    /// The scale factor of the [`Transformation`].
+    pub fn scale_factor(&self) -> f32 {
         self.0.x_axis.x
-    }
-
-    /// The scale factor on the Y axis.
-    pub fn scale_y(&self) -> f32 {
-        self.0.y_axis.y
     }
 
     /// The translation on the X axis.

--- a/graphics/src/viewport.rs
+++ b/graphics/src/viewport.rs
@@ -1,6 +1,4 @@
-use crate::Transformation;
-
-use iced_core::Size;
+use crate::core::{Size, Transformation};
 
 /// A viewing region for displaying computer graphics.
 #[derive(Debug, Clone)]

--- a/renderer/src/geometry.rs
+++ b/renderer/src/geometry.rs
@@ -4,19 +4,8 @@ pub use cache::Cache;
 
 use crate::core::{Point, Rectangle, Size, Vector};
 use crate::graphics::geometry::{Fill, Path, Stroke, Text};
+use crate::graphics::Transformation;
 use crate::Renderer;
-
-pub enum Frame {
-    TinySkia(iced_tiny_skia::geometry::Frame),
-    #[cfg(feature = "wgpu")]
-    Wgpu(iced_wgpu::geometry::Frame),
-}
-
-pub enum Geometry {
-    TinySkia(iced_tiny_skia::Primitive),
-    #[cfg(feature = "wgpu")]
-    Wgpu(iced_wgpu::Primitive),
-}
 
 macro_rules! delegate {
     ($frame:expr, $name:ident, $body:expr) => {
@@ -26,6 +15,32 @@ macro_rules! delegate {
             Self::Wgpu($name) => $body,
         }
     };
+}
+
+pub enum Geometry {
+    TinySkia(iced_tiny_skia::Primitive),
+    #[cfg(feature = "wgpu")]
+    Wgpu(iced_wgpu::Primitive),
+}
+
+impl Geometry {
+    pub fn transform(self, transformation: Transformation) -> Self {
+        match self {
+            Self::TinySkia(primitive) => {
+                Self::TinySkia(primitive.transform(transformation))
+            }
+            #[cfg(feature = "wgpu")]
+            Self::Wgpu(primitive) => {
+                Self::Wgpu(primitive.transform(transformation))
+            }
+        }
+    }
+}
+
+pub enum Frame {
+    TinySkia(iced_tiny_skia::geometry::Frame),
+    #[cfg(feature = "wgpu")]
+    Wgpu(iced_wgpu::geometry::Frame),
 }
 
 impl Frame {

--- a/renderer/src/geometry.rs
+++ b/renderer/src/geometry.rs
@@ -2,9 +2,8 @@ mod cache;
 
 pub use cache::Cache;
 
-use crate::core::{Point, Rectangle, Size, Vector};
+use crate::core::{Point, Rectangle, Size, Transformation, Vector};
 use crate::graphics::geometry::{Fill, Path, Stroke, Text};
-use crate::graphics::Transformation;
 use crate::Renderer;
 
 macro_rules! delegate {

--- a/renderer/src/lib.rs
+++ b/renderer/src/lib.rs
@@ -22,7 +22,9 @@ pub use geometry::Geometry;
 
 use crate::core::renderer;
 use crate::core::text::{self, Text};
-use crate::core::{Background, Color, Font, Pixels, Point, Rectangle, Vector};
+use crate::core::{
+    Background, Color, Font, Pixels, Point, Rectangle, Transformation,
+};
 use crate::graphics::text::Editor;
 use crate::graphics::text::Paragraph;
 use crate::graphics::Mesh;
@@ -97,20 +99,20 @@ impl core::Renderer for Renderer {
         }
     }
 
-    fn with_translation(
+    fn with_transformation(
         &mut self,
-        translation: Vector,
+        transformation: Transformation,
         f: impl FnOnce(&mut Self),
     ) {
         match self {
             Self::TinySkia(renderer) => {
-                let primitives = renderer.start_translation();
+                let primitives = renderer.start_transformation();
 
                 f(self);
 
                 match self {
                     Self::TinySkia(renderer) => {
-                        renderer.end_translation(primitives, translation);
+                        renderer.end_transformation(primitives, transformation);
                     }
                     #[cfg(feature = "wgpu")]
                     _ => unreachable!(),
@@ -118,14 +120,14 @@ impl core::Renderer for Renderer {
             }
             #[cfg(feature = "wgpu")]
             Self::Wgpu(renderer) => {
-                let primitives = renderer.start_translation();
+                let primitives = renderer.start_transformation();
 
                 f(self);
 
                 match self {
                     #[cfg(feature = "wgpu")]
                     Self::Wgpu(renderer) => {
-                        renderer.end_translation(primitives, translation);
+                        renderer.end_transformation(primitives, transformation);
                     }
                     _ => unreachable!(),
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,7 +193,8 @@ pub use crate::core::color;
 pub use crate::core::gradient;
 pub use crate::core::{
     Alignment, Background, Border, Color, ContentFit, Degrees, Gradient,
-    Length, Padding, Pixels, Point, Radians, Rectangle, Shadow, Size, Vector,
+    Length, Padding, Pixels, Point, Radians, Rectangle, Shadow, Size,
+    Transformation, Vector,
 };
 
 pub mod clipboard {

--- a/tiny_skia/src/backend.rs
+++ b/tiny_skia/src/backend.rs
@@ -461,7 +461,7 @@ impl Backend {
                     paragraph,
                     *position * transformation,
                     *color,
-                    scale_factor,
+                    scale_factor * transformation.scale_factor(),
                     pixels,
                     clip_mask,
                 );
@@ -523,7 +523,7 @@ impl Backend {
                     *horizontal_alignment,
                     *vertical_alignment,
                     *shaping,
-                    scale_factor,
+                    scale_factor * transformation.scale_factor(),
                     pixels,
                     clip_mask,
                 );
@@ -770,10 +770,10 @@ fn into_color(color: Color) -> tiny_skia::Color {
 
 fn into_transform(transformation: Transformation) -> tiny_skia::Transform {
     tiny_skia::Transform {
-        sx: transformation.scale_x(),
+        sx: transformation.scale_factor(),
         kx: 0.0,
         ky: 0.0,
-        sy: transformation.scale_y(),
+        sy: transformation.scale_factor(),
         tx: transformation.translation_x(),
         ty: transformation.translation_y(),
     }

--- a/tiny_skia/src/backend.rs
+++ b/tiny_skia/src/backend.rs
@@ -1,9 +1,11 @@
 use tiny_skia::Size;
 
-use crate::core::{Background, Color, Gradient, Rectangle, Vector};
+use crate::core::{
+    Background, Color, Gradient, Rectangle, Transformation, Vector,
+};
 use crate::graphics::backend;
 use crate::graphics::text;
-use crate::graphics::{Transformation, Viewport};
+use crate::graphics::Viewport;
 use crate::primitive::{self, Primitive};
 
 use std::borrow::Cow;
@@ -459,11 +461,12 @@ impl Backend {
 
                 self.text_pipeline.draw_paragraph(
                     paragraph,
-                    *position * transformation,
+                    *position,
                     *color,
-                    scale_factor * transformation.scale_factor(),
+                    scale_factor,
                     pixels,
                     clip_mask,
+                    transformation,
                 );
             }
             Primitive::Editor {
@@ -484,11 +487,12 @@ impl Backend {
 
                 self.text_pipeline.draw_editor(
                     editor,
-                    *position * transformation,
+                    *position,
                     *color,
                     scale_factor,
                     pixels,
                     clip_mask,
+                    transformation,
                 );
             }
             Primitive::Text {
@@ -515,7 +519,7 @@ impl Backend {
 
                 self.text_pipeline.draw_cached(
                     content,
-                    *bounds * transformation,
+                    *bounds,
                     *color,
                     *size,
                     *line_height,
@@ -523,9 +527,10 @@ impl Backend {
                     *horizontal_alignment,
                     *vertical_alignment,
                     *shaping,
-                    scale_factor * transformation.scale_factor(),
+                    scale_factor,
                     pixels,
                     clip_mask,
+                    transformation,
                 );
             }
             Primitive::RawText(text::Raw {
@@ -550,11 +555,12 @@ impl Backend {
 
                 self.text_pipeline.draw_raw(
                     &buffer,
-                    *position * transformation,
+                    *position,
                     *color,
                     scale_factor,
                     pixels,
                     clip_mask,
+                    transformation,
                 );
             }
             #[cfg(feature = "image")]
@@ -769,13 +775,15 @@ fn into_color(color: Color) -> tiny_skia::Color {
 }
 
 fn into_transform(transformation: Transformation) -> tiny_skia::Transform {
+    let translation = transformation.translation();
+
     tiny_skia::Transform {
         sx: transformation.scale_factor(),
         kx: 0.0,
         ky: 0.0,
         sy: transformation.scale_factor(),
-        tx: transformation.translation_x(),
-        ty: transformation.translation_y(),
+        tx: translation.x,
+        ty: translation.y,
     }
 }
 

--- a/tiny_skia/src/geometry.rs
+++ b/tiny_skia/src/geometry.rs
@@ -1,9 +1,9 @@
 use crate::core::text::LineHeight;
-use crate::core::{Pixels, Point, Rectangle, Size, Vector};
+use crate::core::{Pixels, Point, Rectangle, Size, Transformation, Vector};
 use crate::graphics::geometry::fill::{self, Fill};
 use crate::graphics::geometry::stroke::{self, Stroke};
 use crate::graphics::geometry::{Path, Style, Text};
-use crate::graphics::{Gradient, Transformation};
+use crate::graphics::Gradient;
 use crate::primitive::{self, Primitive};
 
 pub struct Frame {

--- a/tiny_skia/src/geometry.rs
+++ b/tiny_skia/src/geometry.rs
@@ -3,7 +3,7 @@ use crate::core::{Pixels, Point, Rectangle, Size, Vector};
 use crate::graphics::geometry::fill::{self, Fill};
 use crate::graphics::geometry::stroke::{self, Stroke};
 use crate::graphics::geometry::{Path, Style, Text};
-use crate::graphics::Gradient;
+use crate::graphics::{Gradient, Transformation};
 use crate::primitive::{self, Primitive};
 
 pub struct Frame {
@@ -181,8 +181,8 @@ impl Frame {
     }
 
     pub fn clip(&mut self, frame: Self, at: Point) {
-        self.primitives.push(Primitive::Translate {
-            translation: Vector::new(at.x, at.y),
+        self.primitives.push(Primitive::Transform {
+            transformation: Transformation::translate(at.x, at.y),
             content: Box::new(frame.into_primitive()),
         });
     }

--- a/wgpu/src/backend.rs
+++ b/wgpu/src/backend.rs
@@ -1,7 +1,7 @@
-use crate::core::{Color, Size};
+use crate::core::{Color, Size, Transformation};
 use crate::graphics::backend;
 use crate::graphics::color;
-use crate::graphics::{Transformation, Viewport};
+use crate::graphics::Viewport;
 use crate::primitive::pipeline;
 use crate::primitive::{self, Primitive};
 use crate::quad;

--- a/wgpu/src/backend.rs
+++ b/wgpu/src/backend.rs
@@ -147,8 +147,8 @@ impl Backend {
             }
 
             if !layer.meshes.is_empty() {
-                let scaled = transformation
-                    * Transformation::scale(scale_factor, scale_factor);
+                let scaled =
+                    transformation * Transformation::scale(scale_factor);
 
                 self.triangle_pipeline.prepare(
                     device,
@@ -161,8 +161,8 @@ impl Backend {
             #[cfg(any(feature = "image", feature = "svg"))]
             {
                 if !layer.images.is_empty() {
-                    let scaled = transformation
-                        * Transformation::scale(scale_factor, scale_factor);
+                    let scaled =
+                        transformation * Transformation::scale(scale_factor);
 
                     self.image_pipeline.prepare(
                         device,

--- a/wgpu/src/geometry.rs
+++ b/wgpu/src/geometry.rs
@@ -1,6 +1,6 @@
 //! Build and draw geometry.
 use crate::core::text::LineHeight;
-use crate::core::{Pixels, Point, Rectangle, Size, Vector};
+use crate::core::{Pixels, Point, Rectangle, Size, Transformation, Vector};
 use crate::graphics::color;
 use crate::graphics::geometry::fill::{self, Fill};
 use crate::graphics::geometry::{
@@ -8,7 +8,6 @@ use crate::graphics::geometry::{
 };
 use crate::graphics::gradient::{self, Gradient};
 use crate::graphics::mesh::{self, Mesh};
-use crate::graphics::Transformation;
 use crate::primitive::{self, Primitive};
 
 use lyon::geom::euclid;

--- a/wgpu/src/geometry.rs
+++ b/wgpu/src/geometry.rs
@@ -8,6 +8,7 @@ use crate::graphics::geometry::{
 };
 use crate::graphics::gradient::{self, Gradient};
 use crate::graphics::mesh::{self, Mesh};
+use crate::graphics::Transformation;
 use crate::primitive::{self, Primitive};
 
 use lyon::geom::euclid;
@@ -435,7 +436,7 @@ impl Frame {
     pub fn clip(&mut self, frame: Frame, at: Point) {
         let size = frame.size();
         let primitives = frame.into_primitives();
-        let translation = Vector::new(at.x, at.y);
+        let transformation = Transformation::translate(at.x, at.y);
 
         let (text, meshes) = primitives
             .into_iter()
@@ -443,12 +444,12 @@ impl Frame {
 
         self.primitives.push(Primitive::Group {
             primitives: vec![
-                Primitive::Translate {
-                    translation,
+                Primitive::Transform {
+                    transformation,
                     content: Box::new(Primitive::Group { primitives: meshes }),
                 },
-                Primitive::Translate {
-                    translation,
+                Primitive::Transform {
+                    transformation,
                     content: Box::new(Primitive::Clip {
                         bounds: Rectangle::with_size(size),
                         content: Box::new(Primitive::Group {

--- a/wgpu/src/image.rs
+++ b/wgpu/src/image.rs
@@ -8,8 +8,7 @@ mod vector;
 
 use atlas::Atlas;
 
-use crate::core::{Rectangle, Size};
-use crate::graphics::Transformation;
+use crate::core::{Rectangle, Size, Transformation};
 use crate::layer;
 use crate::Buffer;
 

--- a/wgpu/src/layer.rs
+++ b/wgpu/src/layer.rs
@@ -12,10 +12,12 @@ pub use text::Text;
 
 use crate::core;
 use crate::core::alignment;
-use crate::core::{Color, Font, Pixels, Point, Rectangle, Size, Vector};
+use crate::core::{
+    Color, Font, Pixels, Point, Rectangle, Size, Transformation, Vector,
+};
 use crate::graphics;
 use crate::graphics::color;
-use crate::graphics::{Transformation, Viewport};
+use crate::graphics::Viewport;
 use crate::primitive::{self, Primitive};
 use crate::quad::{self, Quad};
 
@@ -130,10 +132,10 @@ impl<'a> Layer<'a> {
 
                 layer.text.push(Text::Paragraph {
                     paragraph: paragraph.clone(),
-                    position: *position * transformation,
+                    position: *position,
                     color: *color,
-                    clip_bounds: *clip_bounds * transformation,
-                    scale: transformation.scale_factor(),
+                    clip_bounds: *clip_bounds,
+                    transformation,
                 });
             }
             Primitive::Editor {
@@ -146,10 +148,10 @@ impl<'a> Layer<'a> {
 
                 layer.text.push(Text::Editor {
                     editor: editor.clone(),
-                    position: *position * transformation,
+                    position: *position,
                     color: *color,
-                    clip_bounds: *clip_bounds * transformation,
-                    scale: transformation.scale_factor(),
+                    clip_bounds: *clip_bounds,
+                    transformation,
                 });
             }
             Primitive::Text {
@@ -168,7 +170,7 @@ impl<'a> Layer<'a> {
 
                 layer.text.push(Text::Cached(text::Cached {
                     content,
-                    bounds: *bounds * transformation,
+                    bounds: *bounds + transformation.translation(),
                     size: *size * transformation.scale_factor(),
                     line_height: *line_height,
                     color: *color,

--- a/wgpu/src/layer.rs
+++ b/wgpu/src/layer.rs
@@ -169,7 +169,7 @@ impl<'a> Layer<'a> {
                 layer.text.push(Text::Cached(text::Cached {
                     content,
                     bounds: *bounds * transformation,
-                    size: *size,
+                    size: *size * transformation.scale_y(),
                     line_height: *line_height,
                     color: *color,
                     font: *font,

--- a/wgpu/src/layer.rs
+++ b/wgpu/src/layer.rs
@@ -181,20 +181,13 @@ impl<'a> Layer<'a> {
                     clip_bounds: *clip_bounds * transformation,
                 }));
             }
-            graphics::Primitive::RawText(graphics::text::Raw {
-                buffer,
-                position,
-                color,
-                clip_bounds,
-            }) => {
+            graphics::Primitive::RawText(raw) => {
                 let layer = &mut layers[current_layer];
 
-                layer.text.push(Text::Raw(graphics::text::Raw {
-                    buffer: buffer.clone(),
-                    position: *position * transformation,
-                    color: *color,
-                    clip_bounds: *clip_bounds * transformation,
-                }));
+                layer.text.push(Text::Raw {
+                    raw: raw.clone(),
+                    transformation,
+                });
             }
             Primitive::Quad {
                 bounds,

--- a/wgpu/src/layer.rs
+++ b/wgpu/src/layer.rs
@@ -133,7 +133,7 @@ impl<'a> Layer<'a> {
                     position: *position * transformation,
                     color: *color,
                     clip_bounds: *clip_bounds * transformation,
-                    scale: transformation.scale_y(),
+                    scale: transformation.scale_factor(),
                 });
             }
             Primitive::Editor {
@@ -149,7 +149,7 @@ impl<'a> Layer<'a> {
                     position: *position * transformation,
                     color: *color,
                     clip_bounds: *clip_bounds * transformation,
-                    scale: transformation.scale_y(),
+                    scale: transformation.scale_factor(),
                 });
             }
             Primitive::Text {
@@ -169,7 +169,7 @@ impl<'a> Layer<'a> {
                 layer.text.push(Text::Cached(text::Cached {
                     content,
                     bounds: *bounds * transformation,
-                    size: *size * transformation.scale_y(),
+                    size: *size * transformation.scale_factor(),
                     line_height: *line_height,
                     color: *color,
                     font: *font,

--- a/wgpu/src/layer/mesh.rs
+++ b/wgpu/src/layer/mesh.rs
@@ -1,7 +1,6 @@
 //! A collection of triangle primitives.
-use crate::core::Rectangle;
+use crate::core::{Rectangle, Transformation};
 use crate::graphics::mesh;
-use crate::graphics::Transformation;
 
 /// A mesh of triangles.
 #[derive(Debug, Clone, Copy)]

--- a/wgpu/src/layer/mesh.rs
+++ b/wgpu/src/layer/mesh.rs
@@ -1,14 +1,15 @@
 //! A collection of triangle primitives.
-use crate::core::{Point, Rectangle};
+use crate::core::Rectangle;
 use crate::graphics::mesh;
+use crate::graphics::Transformation;
 
 /// A mesh of triangles.
 #[derive(Debug, Clone, Copy)]
 pub enum Mesh<'a> {
     /// A mesh of triangles with a solid color.
     Solid {
-        /// The origin of the vertices of the [`Mesh`].
-        origin: Point,
+        /// The [`Transformation`] for the vertices of the [`Mesh`].
+        transformation: Transformation,
 
         /// The vertex and index buffers of the [`Mesh`].
         buffers: &'a mesh::Indexed<mesh::SolidVertex2D>,
@@ -18,8 +19,8 @@ pub enum Mesh<'a> {
     },
     /// A mesh of triangles with a gradient color.
     Gradient {
-        /// The origin of the vertices of the [`Mesh`].
-        origin: Point,
+        /// The [`Transformation`] for the vertices of the [`Mesh`].
+        transformation: Transformation,
 
         /// The vertex and index buffers of the [`Mesh`].
         buffers: &'a mesh::Indexed<mesh::GradientVertex2D>,
@@ -31,11 +32,10 @@ pub enum Mesh<'a> {
 
 impl Mesh<'_> {
     /// Returns the origin of the [`Mesh`].
-    pub fn origin(&self) -> Point {
+    pub fn transformation(&self) -> Transformation {
         match self {
-            Self::Solid { origin, .. } | Self::Gradient { origin, .. } => {
-                *origin
-            }
+            Self::Solid { transformation, .. }
+            | Self::Gradient { transformation, .. } => *transformation,
         }
     }
 

--- a/wgpu/src/layer/text.rs
+++ b/wgpu/src/layer/text.rs
@@ -1,6 +1,6 @@
 use crate::core::alignment;
 use crate::core::text;
-use crate::core::{Color, Font, Pixels, Point, Rectangle};
+use crate::core::{Color, Font, Pixels, Point, Rectangle, Transformation};
 use crate::graphics;
 use crate::graphics::text::editor;
 use crate::graphics::text::paragraph;
@@ -15,7 +15,7 @@ pub enum Text<'a> {
         position: Point,
         color: Color,
         clip_bounds: Rectangle,
-        scale: f32,
+        transformation: Transformation,
     },
     /// An editor.
     #[allow(missing_docs)]
@@ -24,7 +24,7 @@ pub enum Text<'a> {
         position: Point,
         color: Color,
         clip_bounds: Rectangle,
-        scale: f32,
+        transformation: Transformation,
     },
     /// Some cached text.
     Cached(Cached<'a>),

--- a/wgpu/src/layer/text.rs
+++ b/wgpu/src/layer/text.rs
@@ -29,7 +29,11 @@ pub enum Text<'a> {
     /// Some cached text.
     Cached(Cached<'a>),
     /// Some raw text.
-    Raw(graphics::text::Raw),
+    #[allow(missing_docs)]
+    Raw {
+        raw: graphics::text::Raw,
+        transformation: Transformation,
+    },
 }
 
 #[derive(Debug, Clone)]

--- a/wgpu/src/layer/text.rs
+++ b/wgpu/src/layer/text.rs
@@ -15,6 +15,7 @@ pub enum Text<'a> {
         position: Point,
         color: Color,
         clip_bounds: Rectangle,
+        scale: f32,
     },
     /// An editor.
     #[allow(missing_docs)]
@@ -23,6 +24,7 @@ pub enum Text<'a> {
         position: Point,
         color: Color,
         clip_bounds: Rectangle,
+        scale: f32,
     },
     /// Some cached text.
     Cached(Cached<'a>),

--- a/wgpu/src/quad.rs
+++ b/wgpu/src/quad.rs
@@ -319,7 +319,7 @@ impl Uniforms {
 impl Default for Uniforms {
     fn default() -> Self {
         Self {
-            transform: *Transformation::identity().as_ref(),
+            transform: *Transformation::IDENTITY.as_ref(),
             scale: 1.0,
             _padding: [0.0; 3],
         }

--- a/wgpu/src/quad.rs
+++ b/wgpu/src/quad.rs
@@ -4,9 +4,9 @@ mod solid;
 use gradient::Gradient;
 use solid::Solid;
 
-use crate::core::{Background, Rectangle};
+use crate::core::{Background, Rectangle, Transformation};
+use crate::graphics;
 use crate::graphics::color;
-use crate::graphics::{self, Transformation};
 
 use bytemuck::{Pod, Zeroable};
 

--- a/wgpu/src/text.rs
+++ b/wgpu/src/text.rs
@@ -109,7 +109,9 @@ impl Pipeline {
 
                     Some(Allocation::Cache(key))
                 }
-                Text::Raw(text) => text.buffer.upgrade().map(Allocation::Raw),
+                Text::Raw { raw, .. } => {
+                    raw.buffer.upgrade().map(Allocation::Raw)
+                }
             })
             .collect();
 
@@ -194,7 +196,10 @@ impl Pipeline {
                             Transformation::IDENTITY,
                         )
                     }
-                    Text::Raw(text) => {
+                    Text::Raw {
+                        raw,
+                        transformation,
+                    } => {
                         let Some(Allocation::Raw(buffer)) = allocation else {
                             return None;
                         };
@@ -204,14 +209,14 @@ impl Pipeline {
                         (
                             buffer.as_ref(),
                             Rectangle::new(
-                                text.position,
+                                raw.position,
                                 Size::new(width, height),
                             ),
                             alignment::Horizontal::Left,
                             alignment::Vertical::Top,
-                            text.color,
-                            text.clip_bounds,
-                            Transformation::IDENTITY,
+                            raw.color,
+                            raw.clip_bounds,
+                            *transformation,
                         )
                     }
                 };

--- a/wgpu/src/text.rs
+++ b/wgpu/src/text.rs
@@ -1,5 +1,5 @@
 use crate::core::alignment;
-use crate::core::{Rectangle, Size};
+use crate::core::{Rectangle, Size, Transformation};
 use crate::graphics::color;
 use crate::graphics::text::cache::{self, Cache};
 use crate::graphics::text::{font_system, to_color, Editor, Paragraph};
@@ -124,13 +124,13 @@ impl Pipeline {
                     vertical_alignment,
                     color,
                     clip_bounds,
-                    scale,
+                    transformation,
                 ) = match section {
                     Text::Paragraph {
                         position,
                         color,
                         clip_bounds,
-                        scale,
+                        transformation,
                         ..
                     } => {
                         use crate::core::text::Paragraph as _;
@@ -147,14 +147,14 @@ impl Pipeline {
                             paragraph.vertical_alignment(),
                             *color,
                             *clip_bounds,
-                            *scale,
+                            *transformation,
                         )
                     }
                     Text::Editor {
                         position,
                         color,
                         clip_bounds,
-                        scale,
+                        transformation,
                         ..
                     } => {
                         use crate::core::text::Editor as _;
@@ -171,7 +171,7 @@ impl Pipeline {
                             alignment::Vertical::Top,
                             *color,
                             *clip_bounds,
-                            *scale,
+                            *transformation,
                         )
                     }
                     Text::Cached(text) => {
@@ -191,7 +191,7 @@ impl Pipeline {
                             text.vertical_alignment,
                             text.color,
                             text.clip_bounds,
-                            1.0,
+                            Transformation::IDENTITY,
                         )
                     }
                     Text::Raw(text) => {
@@ -211,12 +211,12 @@ impl Pipeline {
                             alignment::Vertical::Top,
                             text.color,
                             text.clip_bounds,
-                            1.0,
+                            Transformation::IDENTITY,
                         )
                     }
                 };
 
-                let bounds = bounds * scale_factor;
+                let bounds = bounds * transformation * scale_factor;
 
                 let left = match horizontal_alignment {
                     alignment::Horizontal::Left => bounds.x,
@@ -241,7 +241,7 @@ impl Pipeline {
                     buffer,
                     left,
                     top,
-                    scale: scale * scale_factor,
+                    scale: scale_factor * transformation.scale_factor(),
                     bounds: glyphon::TextBounds {
                         left: clip_bounds.x as i32,
                         top: clip_bounds.y as i32,

--- a/wgpu/src/text.rs
+++ b/wgpu/src/text.rs
@@ -234,8 +234,9 @@ impl Pipeline {
                     alignment::Vertical::Bottom => bounds.y - bounds.height,
                 };
 
-                let clip_bounds =
-                    layer_bounds.intersection(&(clip_bounds * scale_factor))?;
+                let clip_bounds = layer_bounds.intersection(
+                    &(clip_bounds * transformation * scale_factor),
+                )?;
 
                 Some(glyphon::TextArea {
                     buffer,

--- a/wgpu/src/text.rs
+++ b/wgpu/src/text.rs
@@ -124,11 +124,13 @@ impl Pipeline {
                     vertical_alignment,
                     color,
                     clip_bounds,
+                    scale,
                 ) = match section {
                     Text::Paragraph {
                         position,
                         color,
                         clip_bounds,
+                        scale,
                         ..
                     } => {
                         use crate::core::text::Paragraph as _;
@@ -145,12 +147,14 @@ impl Pipeline {
                             paragraph.vertical_alignment(),
                             *color,
                             *clip_bounds,
+                            *scale,
                         )
                     }
                     Text::Editor {
                         position,
                         color,
                         clip_bounds,
+                        scale,
                         ..
                     } => {
                         use crate::core::text::Editor as _;
@@ -167,6 +171,7 @@ impl Pipeline {
                             alignment::Vertical::Top,
                             *color,
                             *clip_bounds,
+                            *scale,
                         )
                     }
                     Text::Cached(text) => {
@@ -186,6 +191,7 @@ impl Pipeline {
                             text.vertical_alignment,
                             text.color,
                             text.clip_bounds,
+                            1.0,
                         )
                     }
                     Text::Raw(text) => {
@@ -205,6 +211,7 @@ impl Pipeline {
                             alignment::Vertical::Top,
                             text.color,
                             text.clip_bounds,
+                            1.0,
                         )
                     }
                 };
@@ -234,7 +241,7 @@ impl Pipeline {
                     buffer,
                     left,
                     top,
-                    scale: scale_factor,
+                    scale: scale * scale_factor,
                     bounds: glyphon::TextBounds {
                         left: clip_bounds.x as i32,
                         top: clip_bounds.y as i32,

--- a/wgpu/src/triangle.rs
+++ b/wgpu/src/triangle.rs
@@ -98,12 +98,10 @@ impl Layer {
         let mut index_offset = 0;
 
         for mesh in meshes {
-            let origin = mesh.origin();
             let indices = mesh.indices();
 
-            let uniforms = Uniforms::new(
-                transformation * Transformation::translate(origin.x, origin.y),
-            );
+            let uniforms =
+                Uniforms::new(transformation * mesh.transformation());
 
             index_offset +=
                 self.index_buffer.write(queue, index_offset, indices);

--- a/wgpu/src/triangle.rs
+++ b/wgpu/src/triangle.rs
@@ -1,8 +1,8 @@
 //! Draw meshes of triangles.
 mod msaa;
 
-use crate::core::Size;
-use crate::graphics::{Antialiasing, Transformation};
+use crate::core::{Size, Transformation};
+use crate::graphics::Antialiasing;
 use crate::layer::mesh::{self, Mesh};
 use crate::Buffer;
 

--- a/widget/src/canvas.rs
+++ b/widget/src/canvas.rs
@@ -7,6 +7,7 @@ pub use event::Event;
 pub use program::Program;
 
 pub use crate::graphics::geometry::*;
+pub use crate::graphics::Transformation;
 pub use crate::renderer::geometry::*;
 
 use crate::core;

--- a/widget/src/canvas.rs
+++ b/widget/src/canvas.rs
@@ -7,7 +7,6 @@ pub use event::Event;
 pub use program::Program;
 
 pub use crate::graphics::geometry::*;
-pub use crate::graphics::Transformation;
 pub use crate::renderer::geometry::*;
 
 use crate::core;
@@ -16,7 +15,7 @@ use crate::core::mouse;
 use crate::core::renderer;
 use crate::core::widget::tree::{self, Tree};
 use crate::core::{
-    Clipboard, Element, Length, Rectangle, Shell, Size, Vector, Widget,
+    Clipboard, Element, Length, Rectangle, Shell, Size, Transformation, Widget,
 };
 use crate::graphics::geometry;
 
@@ -208,8 +207,8 @@ where
 
         let state = tree.state.downcast_ref::<P::State>();
 
-        renderer.with_translation(
-            Vector::new(bounds.x, bounds.y),
+        renderer.with_transformation(
+            Transformation::translate(bounds.x, bounds.y),
             |renderer| {
                 renderer.draw(
                     self.program.draw(state, renderer, theme, bounds, cursor),

--- a/widget/src/image/viewer.rs
+++ b/widget/src/image/viewer.rs
@@ -7,7 +7,7 @@ use crate::core::renderer;
 use crate::core::widget::tree::{self, Tree};
 use crate::core::{
     Clipboard, Element, Layout, Length, Pixels, Point, Rectangle, Shell, Size,
-    Transformation, Vector, Widget,
+    Vector, Widget,
 };
 
 use std::hash::Hash;
@@ -328,21 +328,18 @@ where
         };
 
         renderer.with_layer(bounds, |renderer| {
-            renderer.with_transformation(
-                Transformation::translate(translation.x, translation.y),
-                |renderer| {
-                    image::Renderer::draw(
-                        renderer,
-                        self.handle.clone(),
-                        self.filter_method,
-                        Rectangle {
-                            x: bounds.x,
-                            y: bounds.y,
-                            ..Rectangle::with_size(image_size)
-                        },
-                    );
-                },
-            );
+            renderer.with_translation(translation, |renderer| {
+                image::Renderer::draw(
+                    renderer,
+                    self.handle.clone(),
+                    self.filter_method,
+                    Rectangle {
+                        x: bounds.x,
+                        y: bounds.y,
+                        ..Rectangle::with_size(image_size)
+                    },
+                );
+            });
         });
     }
 }

--- a/widget/src/image/viewer.rs
+++ b/widget/src/image/viewer.rs
@@ -7,7 +7,7 @@ use crate::core::renderer;
 use crate::core::widget::tree::{self, Tree};
 use crate::core::{
     Clipboard, Element, Layout, Length, Pixels, Point, Rectangle, Shell, Size,
-    Vector, Widget,
+    Transformation, Vector, Widget,
 };
 
 use std::hash::Hash;
@@ -328,18 +328,21 @@ where
         };
 
         renderer.with_layer(bounds, |renderer| {
-            renderer.with_translation(translation, |renderer| {
-                image::Renderer::draw(
-                    renderer,
-                    self.handle.clone(),
-                    self.filter_method,
-                    Rectangle {
-                        x: bounds.x,
-                        y: bounds.y,
-                        ..Rectangle::with_size(image_size)
-                    },
-                );
-            });
+            renderer.with_transformation(
+                Transformation::translate(translation.x, translation.y),
+                |renderer| {
+                    image::Renderer::draw(
+                        renderer,
+                        self.handle.clone(),
+                        self.filter_method,
+                        Rectangle {
+                            x: bounds.x,
+                            y: bounds.y,
+                            ..Rectangle::with_size(image_size)
+                        },
+                    );
+                },
+            );
         });
     }
 }

--- a/widget/src/pane_grid.rs
+++ b/widget/src/pane_grid.rs
@@ -43,7 +43,7 @@ use crate::core::widget;
 use crate::core::widget::tree::{self, Tree};
 use crate::core::{
     Clipboard, Element, Layout, Length, Pixels, Point, Rectangle, Shell, Size,
-    Vector, Widget,
+    Transformation, Vector, Widget,
 };
 
 /// A collection of panes distributed using either vertical or horizontal splits
@@ -962,9 +962,11 @@ pub fn draw<Theme, Renderer, T>(
         if let Some(cursor_position) = cursor.position() {
             let bounds = layout.bounds();
 
-            renderer.with_translation(
-                cursor_position
-                    - Point::new(bounds.x + origin.x, bounds.y + origin.y),
+            let translation = cursor_position
+                - Point::new(bounds.x + origin.x, bounds.y + origin.y);
+
+            renderer.with_transformation(
+                Transformation::translate(translation.x, translation.y),
                 |renderer| {
                     renderer.with_layer(bounds, |renderer| {
                         draw_pane(

--- a/widget/src/pane_grid.rs
+++ b/widget/src/pane_grid.rs
@@ -43,7 +43,7 @@ use crate::core::widget;
 use crate::core::widget::tree::{self, Tree};
 use crate::core::{
     Clipboard, Element, Layout, Length, Pixels, Point, Rectangle, Shell, Size,
-    Transformation, Vector, Widget,
+    Vector, Widget,
 };
 
 /// A collection of panes distributed using either vertical or horizontal splits
@@ -965,21 +965,18 @@ pub fn draw<Theme, Renderer, T>(
             let translation = cursor_position
                 - Point::new(bounds.x + origin.x, bounds.y + origin.y);
 
-            renderer.with_transformation(
-                Transformation::translate(translation.x, translation.y),
-                |renderer| {
-                    renderer.with_layer(bounds, |renderer| {
-                        draw_pane(
-                            pane,
-                            renderer,
-                            default_style,
-                            layout,
-                            pane_cursor,
-                            viewport,
-                        );
-                    });
-                },
-            );
+            renderer.with_translation(translation, |renderer| {
+                renderer.with_layer(bounds, |renderer| {
+                    draw_pane(
+                        pane,
+                        renderer,
+                        default_style,
+                        layout,
+                        pane_cursor,
+                        viewport,
+                    );
+                });
+            });
         }
     }
 

--- a/widget/src/qr_code.rs
+++ b/widget/src/qr_code.rs
@@ -5,7 +5,8 @@ use crate::core::mouse;
 use crate::core::renderer::{self, Renderer as _};
 use crate::core::widget::Tree;
 use crate::core::{
-    Color, Element, Layout, Length, Point, Rectangle, Size, Vector, Widget,
+    Color, Element, Layout, Length, Point, Rectangle, Size, Transformation,
+    Vector, Widget,
 };
 use crate::graphics::geometry::Renderer as _;
 use crate::Renderer;
@@ -121,9 +122,12 @@ impl<'a, Message, Theme> Widget<Message, Theme, Renderer> for QRCode<'a> {
 
         let translation = Vector::new(bounds.x, bounds.y);
 
-        renderer.with_translation(translation, |renderer| {
-            renderer.draw(vec![geometry]);
-        });
+        renderer.with_transformation(
+            Transformation::translate(translation.x, translation.y),
+            |renderer| {
+                renderer.draw(vec![geometry]);
+            },
+        );
     }
 }
 

--- a/widget/src/qr_code.rs
+++ b/widget/src/qr_code.rs
@@ -5,8 +5,7 @@ use crate::core::mouse;
 use crate::core::renderer::{self, Renderer as _};
 use crate::core::widget::Tree;
 use crate::core::{
-    Color, Element, Layout, Length, Point, Rectangle, Size, Transformation,
-    Vector, Widget,
+    Color, Element, Layout, Length, Point, Rectangle, Size, Vector, Widget,
 };
 use crate::graphics::geometry::Renderer as _;
 use crate::Renderer;
@@ -120,10 +119,8 @@ impl<'a, Message, Theme> Widget<Message, Theme, Renderer> for QRCode<'a> {
                     });
             });
 
-        let translation = Vector::new(bounds.x, bounds.y);
-
-        renderer.with_transformation(
-            Transformation::translate(translation.x, translation.y),
+        renderer.with_translation(
+            bounds.position() - Point::ORIGIN,
             |renderer| {
                 renderer.draw(vec![geometry]);
             },

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -385,6 +385,7 @@ pub fn mouse_interaction(
         }
         Interaction::ResizingVertically => winit::window::CursorIcon::NsResize,
         Interaction::NotAllowed => winit::window::CursorIcon::NotAllowed,
+        Interaction::ZoomIn => winit::window::CursorIcon::ZoomIn,
     }
 }
 


### PR DESCRIPTION
This PR replaces the `Translate` primitive in `iced_graphics` with a more generic `Transform` primitive that can take any non-skewing affine `Transformation` (i.e. scaling and translation).

Additionally, a `transform` method has been implemented for `Geometry` in `iced_renderer`. This enables efficient translation and scaling of cached geometry with a `canvas::Cache`, since `transform` can be called on the returned cached geometry!

But not only that, this new primitive can be used to effectively scale any part of the UI. This can be very useful for building node-based editors, for instance.

There are still some quirks to iron out here. Mainly, scaling text does not work currently, but that should be fairly easy to fix.