### PR TITLE
Disable maximize window button if `Settings::resizable` is `false`

### DIFF
--- a/winit/src/settings.rs
+++ b/winit/src/settings.rs
@@ -130,6 +130,12 @@ impl Window {
             .with_title(title)
             .with_inner_size(winit::dpi::LogicalSize { width, height })
             .with_resizable(self.resizable)
+            .with_enabled_buttons(if self.resizable {
+                winit::window::WindowButtons::all()
+            } else {
+                winit::window::WindowButtons::CLOSE
+                    | winit::window::WindowButtons::MINIMIZE
+            })
             .with_decorations(self.decorations)
             .with_transparent(self.transparent)
             .with_window_icon(self.icon.and_then(conversion::icon))


### PR DESCRIPTION
Fixes #2121.
