### PR TITLE
fix: Total and Used Ram in Example and Add Videos for Examples

### DIFF
--- a/examples/arc/README.md
+++ b/examples/arc/README.md
@@ -12,3 +12,7 @@ cargo run --package arc
 ```
 
 [`main`]: src/main.rs
+
+
+https://github.com/Tahinli/iced/assets/96421894/c784a1b4-895e-41bd-a535-ad08faf01c36
+

--- a/examples/checkbox/README.md
+++ b/examples/checkbox/README.md
@@ -10,3 +10,7 @@ cargo run --package checkbox
 ```
 
 [`main`]: src/main.rs
+
+
+https://github.com/Tahinli/iced/assets/96421894/6c4a3e2b-f792-48a3-9204-89759e084c15
+

--- a/examples/component/README.md
+++ b/examples/component/README.md
@@ -1,0 +1,4 @@
+
+
+https://github.com/Tahinli/iced/assets/96421894/a7ebbd06-83b8-4c87-bf3d-4e6d7cdde545
+

--- a/examples/custom_quad/README.md
+++ b/examples/custom_quad/README.md
@@ -1,0 +1,4 @@
+
+
+https://github.com/Tahinli/iced/assets/96421894/5bfbe5bf-6588-4fd1-9409-0c3226436640
+

--- a/examples/editor/README.md
+++ b/examples/editor/README.md
@@ -1,0 +1,4 @@
+
+
+https://github.com/Tahinli/iced/assets/96421894/50363051-2b5c-4b55-8755-e0ec75d33820
+

--- a/examples/events/README.md
+++ b/examples/events/README.md
@@ -10,3 +10,7 @@ cargo run --package events
 ```
 
 [`main`]: src/main.rs
+
+
+https://github.com/Tahinli/iced/assets/96421894/30022387-73e1-4b83-9272-46f9a8c9edd8
+

--- a/examples/exit/README.md
+++ b/examples/exit/README.md
@@ -10,3 +10,7 @@ cargo run --package exit
 ```
 
 [`main`]: src/main.rs
+
+
+https://github.com/Tahinli/iced/assets/96421894/4fa92685-98f4-4e2d-b4e3-602dcf4a57b8
+

--- a/examples/gradient/README.md
+++ b/examples/gradient/README.md
@@ -1,0 +1,4 @@
+
+
+https://github.com/Tahinli/iced/assets/96421894/ae89bd0c-ce58-4668-a4d3-c4ad4b491584
+

--- a/examples/lazy/README.md
+++ b/examples/lazy/README.md
@@ -1,0 +1,4 @@
+
+
+https://github.com/Tahinli/iced/assets/96421894/bcec3246-635d-4b6d-bd3d-60a7bc27c77b
+

--- a/examples/loading_spinners/README.md
+++ b/examples/loading_spinners/README.md
@@ -6,3 +6,7 @@ You can run it with `cargo run`:
 ```
 cargo run --package loading_spinners
 ```
+
+
+https://github.com/Tahinli/iced/assets/96421894/479c251b-94f0-4310-b249-14bb41d6bdfb
+

--- a/examples/modal/README.md
+++ b/examples/modal/README.md
@@ -1,0 +1,4 @@
+
+
+https://github.com/Tahinli/iced/assets/96421894/64086f4a-a9e0-4a38-b3ff-1aa49a7246e7
+

--- a/examples/multitouch/README.md
+++ b/examples/multitouch/README.md
@@ -1,0 +1,4 @@
+
+
+https://github.com/Tahinli/iced/assets/96421894/5856d93a-1a8d-4362-89b9-2ec426683bfa
+

--- a/examples/progress_bar/README.md
+++ b/examples/progress_bar/README.md
@@ -4,13 +4,13 @@ A simple progress bar that can be filled by using a slider.
 
 The __[`main`]__ file contains all the code of the example.
 
-<div align="center">
-  <img src="https://iced.rs/examples/pokedex.gif">
-</div>
-
 You can run it with `cargo run`:
 ```
 cargo run --package progress_bar
 ```
 
 [`main`]: src/main.rs
+
+
+https://github.com/Tahinli/iced/assets/96421894/62317048-9f67-4c1a-a6d6-8ce2a3aca6e4
+

--- a/examples/screenshot/README.md
+++ b/examples/screenshot/README.md
@@ -1,0 +1,4 @@
+
+
+https://github.com/Tahinli/iced/assets/96421894/7e07d385-f470-4a64-b791-5fbffcd6b587
+

--- a/examples/sierpinski_triangle/README.md
+++ b/examples/sierpinski_triangle/README.md
@@ -12,3 +12,7 @@ You can run with cargo:
 ```
 cargo run --package sierpinski_triangle
 ```
+
+
+https://github.com/Tahinli/iced/assets/96421894/e4422aeb-0db0-40ac-b4c1-22243aa5bcb7
+

--- a/examples/svg/README.md
+++ b/examples/svg/README.md
@@ -15,3 +15,7 @@ cargo run --package svg
 
 [`main`]: src/main.rs
 [Ghostscript Tiger]: https://commons.wikimedia.org/wiki/File:Ghostscript_Tiger.svg
+
+
+https://github.com/Tahinli/iced/assets/96421894/66001c76-4ede-4995-8ac6-b06a66232985
+

--- a/examples/system_information/README.md
+++ b/examples/system_information/README.md
@@ -1,0 +1,4 @@
+
+
+https://github.com/Tahinli/iced/assets/96421894/1f2a7196-181f-4c6e-a54c-5304bdfb985f
+

--- a/examples/system_information/src/main.rs
+++ b/examples/system_information/src/main.rs
@@ -102,19 +102,19 @@ impl Application for Example {
                 ));
 
                 let memory_readable =
-                    ByteSize::kb(information.memory_total).to_string();
+                    ByteSize::b(information.memory_total).to_string();
 
                 let memory_total = text(format!(
-                    "Memory (total): {} kb ({memory_readable})",
+                    "Memory (total): {} b ({memory_readable})",
                     information.memory_total,
                 ));
 
                 let memory_text = if let Some(memory_used) =
                     information.memory_used
                 {
-                    let memory_readable = ByteSize::kb(memory_used).to_string();
+                    let memory_readable = ByteSize::b(memory_used).to_string();
 
-                    format!("{memory_used} kb ({memory_readable})")
+                    format!("{memory_used} b ({memory_readable})")
                 } else {
                     String::from("None")
                 };

--- a/examples/toast/README.md
+++ b/examples/toast/README.md
@@ -1,0 +1,4 @@
+
+
+https://github.com/Tahinli/iced/assets/96421894/1c30718e-efbc-42a2-a94e-438620431ac1
+

--- a/examples/tooltip/README.md
+++ b/examples/tooltip/README.md
@@ -12,3 +12,7 @@ cargo run --package tooltip
 ```
 
 [`main`]: src/main.rs
+
+
+https://github.com/Tahinli/iced/assets/96421894/585afc9f-7269-4147-8bfa-153c3a7456a2
+

--- a/examples/visible_bounds/README.md
+++ b/examples/visible_bounds/README.md
@@ -1,0 +1,4 @@
+
+
+https://github.com/Tahinli/iced/assets/96421894/0d88dca0-46ec-456f-a36e-56664e94028d
+

--- a/examples/websocket/README.md
+++ b/examples/websocket/README.md
@@ -15,3 +15,7 @@ cargo run --package websocket
 [`main`]: src/main.rs
 [`echo`]: src/echo.rs
 [`echo::server`]: src/echo/server.rs
+
+
+https://github.com/Tahinli/iced/assets/96421894/c8c88008-659d-4fab-962f-cd77e8647fb2
+


### PR DESCRIPTION
Total and used ram was showing like TB and GB level in system information example, but the actual values are GB and MB.
I added videos about examples that don't have visual showcase.
