### PR TITLE
Improve `TextEditor` slow scrolling behavior with touchpads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Incorrect unit in `system::Information`. [#2223](https://github.com/iced-rs/iced/pull/2223)
 - `size_hint` not being called from `element::Map`. [#2224](https://github.com/iced-rs/iced/pull/2224)
 - `size_hint` not being called from `element::Explain`. [#2225](https://github.com/iced-rs/iced/pull/2225)
+- Slow touch scrolling for `TextEditor` widget. [#2140](https://github.com/iced-rs/iced/pull/2140)
 
 Many thanks to...
 
@@ -93,6 +94,7 @@ Many thanks to...
 - @arslee07
 - @AustinMReppert
 - @avsaase
+- @blazra
 - @brianch
 - @bungoboingo
 - @Calastrophe

--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -409,7 +409,9 @@ where
             Update::Scroll(mut lines) => {
                 lines += state.partial_scroll;
                 state.partial_scroll = lines.fract();
-                shell.publish(on_edit(Action::Scroll { lines: lines as i32 }))
+                shell.publish(on_edit(Action::Scroll {
+                    lines: lines as i32,
+                }))
             }
             Update::Unfocus => {
                 state.is_focused = false;

--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -406,12 +406,13 @@ where
 
                 shell.publish(on_edit(action));
             }
-            Update::Scroll(mut lines) => {
-                lines += state.partial_scroll;
+            Update::Scroll(lines) => {
+                let lines = lines + state.partial_scroll;
                 state.partial_scroll = lines.fract();
+
                 shell.publish(on_edit(Action::Scroll {
                     lines: lines as i32,
-                }))
+                }));
             }
             Update::Unfocus => {
                 state.is_focused = false;

--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -289,6 +289,7 @@ struct State<Highlighter: text::Highlighter> {
     is_focused: bool,
     last_click: Option<mouse::Click>,
     drag_click: Option<mouse::click::Kind>,
+    partial_scroll: f32,
     highlighter: RefCell<Highlighter>,
     highlighter_settings: Highlighter::Settings,
     highlighter_format_address: usize,
@@ -310,6 +311,7 @@ where
             is_focused: false,
             last_click: None,
             drag_click: None,
+            partial_scroll: 0.0,
             highlighter: RefCell::new(Highlighter::new(
                 &self.highlighter_settings,
             )),
@@ -403,6 +405,11 @@ where
                 state.drag_click = Some(click.kind());
 
                 shell.publish(on_edit(action));
+            }
+            Update::Scroll(mut lines) => {
+                lines += state.partial_scroll;
+                state.partial_scroll = lines.fract();
+                shell.publish(on_edit(Action::Scroll { lines: lines as i32 }))
             }
             Update::Unfocus => {
                 state.is_focused = false;
@@ -577,6 +584,7 @@ where
 
 enum Update {
     Click(mouse::Click),
+    Scroll(f32),
     Unfocus,
     Release,
     Action(Action),
@@ -630,21 +638,16 @@ impl Update {
                 mouse::Event::WheelScrolled { delta }
                     if cursor.is_over(bounds) =>
                 {
-                    action(Action::Scroll {
-                        lines: match delta {
-                            mouse::ScrollDelta::Lines { y, .. } => {
-                                if y.abs() > 0.0 {
-                                    (y.signum() * -(y.abs() * 4.0).max(1.0))
-                                        as i32
-                                } else {
-                                    0
-                                }
+                    Some(Update::Scroll(match delta {
+                        mouse::ScrollDelta::Lines { y, .. } => {
+                            if y.abs() > 0.0 {
+                                y.signum() * -(y.abs() * 4.0).max(1.0)
+                            } else {
+                                0.0
                             }
-                            mouse::ScrollDelta::Pixels { y, .. } => {
-                                (-y / 4.0) as i32
-                            }
-                        },
-                    })
+                        }
+                        mouse::ScrollDelta::Pixels { y, .. } => -y / 4.0,
+                    }))
                 }
                 _ => None,
             },


### PR DESCRIPTION
If you scroll really slowly, then the text editor does not scroll, because the scrolling events which scroll by less than a single line don't do anything.

I have made a change so that the TextEditor stores the fractional part of the number of lines to scroll and adds it on the next scroll event.
For example, Kate or Konsole seems to behave like this.
