### PR TITLE
Use the correct GIF for the progress bar example

### DIFF
--- a/examples/progress_bar/README.md
+++ b/examples/progress_bar/README.md
@@ -5,7 +5,7 @@ A simple progress bar that can be filled by using a slider.
 The __[`main`]__ file contains all the code of the example.
 
 <div align="center">
-  <img src="https://iced.rs/examples/pokedex.gif">
+  <img src="https://iced.rs/examples/progress_bar.gif">
 </div>
 
 You can run it with `cargo run`:


### PR DESCRIPTION
The Pokédex GIF does not seem to be relevant for this example. 😅
This little PR fixes the URL to the correct GIF.