### PR TITLE
feat: somewhere to place extra actions by platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `style` attribute for `Font`. [#2041](https://github.com/iced-rs/iced/pull/2041)
 - Texture filtering options for `Image`. [#1894](https://github.com/iced-rs/iced/pull/1894)
 - `default` and `shift_step` methods for `slider` widgets. [#2100](https://github.com/iced-rs/iced/pull/2100)
+- `Custom` variant to `command::Action`. [#2146](https://github.com/iced-rs/iced/pull/2146)
 
 ### Changed
 - Enable WebGPU backend in `wgpu` by default instead of WebGL. [#2068](https://github.com/iced-rs/iced/pull/2068)
@@ -101,6 +102,7 @@ Many thanks to...
 - @casperstorm
 - @cfrenette
 - @Davidster
+- @Decodetalkers
 - @derezzedex
 - @dtzxporter
 - @GyulyVGC

--- a/runtime/src/command/action.rs
+++ b/runtime/src/command/action.rs
@@ -45,8 +45,8 @@ pub enum Action<T> {
         tagger: Box<dyn Fn(Result<(), font::Error>) -> T>,
     },
 
-    /// Pass PlatformSpecific action, for some special platform
-    PlatformSpecific(Box<dyn Any>)
+    /// A custom action supported by a specific runtime.
+    Custom(Box<dyn Any>),
 }
 
 impl<T> Action<T> {
@@ -76,7 +76,7 @@ impl<T> Action<T> {
                 bytes,
                 tagger: Box::new(move |result| f(tagger(result))),
             },
-            Self::PlatformSpecific(special) => Action::PlatformSpecific(special)
+            Self::Custom(custom) => Action::Custom(custom),
         }
     }
 }
@@ -95,7 +95,7 @@ impl<T> fmt::Debug for Action<T> {
             Self::System(action) => write!(f, "Action::System({action:?})"),
             Self::Widget(_action) => write!(f, "Action::Widget"),
             Self::LoadFont { .. } => write!(f, "Action::LoadFont"),
-            Self::PlatformSpecific(_) => write!(f, "Action::PlatformSpecific")
+            Self::Custom(_) => write!(f, "Action::Custom"),
         }
     }
 }

--- a/runtime/src/command/action.rs
+++ b/runtime/src/command/action.rs
@@ -5,6 +5,7 @@ use crate::system;
 use crate::window;
 
 use iced_futures::MaybeSend;
+use std::any::Any;
 
 use std::borrow::Cow;
 use std::fmt;
@@ -43,6 +44,9 @@ pub enum Action<T> {
         /// The message to produce when the font has been loaded.
         tagger: Box<dyn Fn(Result<(), font::Error>) -> T>,
     },
+
+    /// Pass PlatformSpecific action, for some special platform
+    PlatformSpecific(Box<dyn Any>)
 }
 
 impl<T> Action<T> {
@@ -72,6 +76,7 @@ impl<T> Action<T> {
                 bytes,
                 tagger: Box::new(move |result| f(tagger(result))),
             },
+            Self::PlatformSpecific(special) => Action::PlatformSpecific(special)
         }
     }
 }
@@ -90,6 +95,7 @@ impl<T> fmt::Debug for Action<T> {
             Self::System(action) => write!(f, "Action::System({action:?})"),
             Self::Widget(_action) => write!(f, "Action::Widget"),
             Self::LoadFont { .. } => write!(f, "Action::LoadFont"),
+            Self::PlatformSpecific(_) => write!(f, "Action::PlatformSpecific")
         }
     }
 }

--- a/runtime/src/command/action.rs
+++ b/runtime/src/command/action.rs
@@ -1,12 +1,11 @@
 use crate::clipboard;
 use crate::core::widget;
 use crate::font;
+use crate::futures::MaybeSend;
 use crate::system;
 use crate::window;
 
-use iced_futures::MaybeSend;
 use std::any::Any;
-
 use std::borrow::Cow;
 use std::fmt;
 

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -861,6 +861,7 @@ pub fn run_command<A, C, E>(
                     .send_event(tagger(Ok(())))
                     .expect("Send message to event loop");
             }
+            command::Action::PlatformSpecific(_) => unimplemented!(),
         }
     }
 }

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -861,7 +861,9 @@ pub fn run_command<A, C, E>(
                     .send_event(tagger(Ok(())))
                     .expect("Send message to event loop");
             }
-            command::Action::PlatformSpecific(_) => unimplemented!(),
+            command::Action::Custom(_) => {
+                log::warn!("Unsupported custom action in `iced_winit` shell");
+            }
         }
     }
 }

--- a/winit/src/multi_window.rs
+++ b/winit/src/multi_window.rs
@@ -1127,6 +1127,9 @@ fn run_command<A, C, E>(
                     .send_event(tagger(Ok(())))
                     .expect("Send message to event loop");
             }
+            command::Action::Custom(_) => {
+                log::warn!("Unsupported custom action in `iced_winit` shell");
+            }
         }
     }
 }


### PR DESCRIPTION
I have view iced-sckt forked iced, and add the extra actions. and there do are some extra actions, like set margin for layer-shell, set lock for ext-session-shell. I think add an any will be of help maybe

I do not know if it is right..

The core team is busy and does not have time to mentor nor babysit new contributors. If a member of the core team thinks that reviewing and understanding your work will take more time and effort than writing it from scratch by themselves, your contribution will be dismissed. It is your responsibility to communicate and figure out how to reduce the likelihood of this!

Read the contributing guidelines for more details: https://github.com/iced-rs/iced/blob/master/CONTRIBUTING.md
