### PR TITLE
Add mouse move events to MouseArea

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Texture filtering options for `Image`. [#1894](https://github.com/iced-rs/iced/pull/1894)
 - `default` and `shift_step` methods for `slider` widgets. [#2100](https://github.com/iced-rs/iced/pull/2100)
 - `Custom` variant to `command::Action`. [#2146](https://github.com/iced-rs/iced/pull/2146)
+- Mouse movement events for `MouseArea`. [#2147](https://github.com/iced-rs/iced/pull/2147)
 
 ### Changed
 - Enable WebGPU backend in `wgpu` by default instead of WebGL. [#2068](https://github.com/iced-rs/iced/pull/2068)

--- a/widget/src/mouse_area.rs
+++ b/widget/src/mouse_area.rs
@@ -288,7 +288,7 @@ fn update<Message: Clone, Theme, Renderer>(
     | Event::Touch(touch::Event::FingerMoved { id: _, position }) = event
     {
         let state: &mut State = tree.state.downcast_mut();
-        handle_mouse_move(widget, state, shell, *position, layout.bounds())
+        handle_mouse_move(widget, state, shell, *position, layout.bounds());
     }
 
     if !cursor.is_over(layout.bounds()) {
@@ -376,15 +376,15 @@ fn handle_mouse_move<Message: Clone, Theme, Renderer>(
         widget.on_mouse_exit.as_mut(),
     ) {
         (Some(enter_msg), _, _) if mouse_in_area && !state.mouse_in_area => {
-            shell.publish(enter_msg.clone())
+            shell.publish(enter_msg.clone());
         }
         (_, Some(build_move_msg), _)
             if mouse_in_area && state.mouse_in_area =>
         {
-            shell.publish(build_move_msg(position))
+            shell.publish(build_move_msg(position));
         }
         (_, _, Some(exit_msg)) if !mouse_in_area && state.mouse_in_area => {
-            shell.publish(exit_msg.clone())
+            shell.publish(exit_msg.clone());
         }
         _ => {}
     }


### PR DESCRIPTION
Adds `on_mouse_enter`, `on_mouse_move`, `on_mouse_exit` callbacks to `MouseArea`.

([Since those where found to be missing](https://discord.com/channels/628993209984614400/1021828532189528094/1177226871126106194))