### PR TITLE
`Stream` support for `Command`

### DIFF
--- a/runtime/src/command.rs
+++ b/runtime/src/command.rs
@@ -4,8 +4,10 @@ mod action;
 pub use action::Action;
 
 use crate::core::widget;
+use crate::futures::futures;
 use crate::futures::MaybeSend;
 
+use futures::Stream;
 use std::fmt;
 use std::future::Future;
 
@@ -43,9 +45,19 @@ impl<T> Command<T> {
         future: impl Future<Output = A> + 'static + MaybeSend,
         f: impl FnOnce(A) -> T + 'static + MaybeSend,
     ) -> Command<T> {
-        use iced_futures::futures::FutureExt;
+        use futures::FutureExt;
 
         Command::single(Action::Future(Box::pin(future.map(f))))
+    }
+
+    /// Creates a [`Command`] that runs the given stream to completion.
+    pub fn run<A>(
+        stream: impl Stream<Item = A> + 'static + MaybeSend,
+        f: impl Fn(A) -> T + 'static + MaybeSend,
+    ) -> Command<T> {
+        use futures::StreamExt;
+
+        Command::single(Action::Stream(Box::pin(stream.map(f))))
     }
 
     /// Creates a [`Command`] that performs the actions of all the given

--- a/runtime/src/command/action.rs
+++ b/runtime/src/command/action.rs
@@ -18,6 +18,11 @@ pub enum Action<T> {
     /// [`Future`]: iced_futures::BoxFuture
     Future(iced_futures::BoxFuture<T>),
 
+    /// Run a [`Stream`] to completion.
+    ///
+    /// [`Stream`]: iced_futures::BoxStream
+    Stream(iced_futures::BoxStream<T>),
+
     /// Run a clipboard action.
     Clipboard(clipboard::Action<T>),
 
@@ -52,10 +57,11 @@ impl<T> Action<T> {
         A: 'static,
         T: 'static,
     {
-        use iced_futures::futures::FutureExt;
+        use iced_futures::futures::{FutureExt, StreamExt};
 
         match self {
             Self::Future(future) => Action::Future(Box::pin(future.map(f))),
+            Self::Stream(stream) => Action::Stream(Box::pin(stream.map(f))),
             Self::Clipboard(action) => Action::Clipboard(action.map(f)),
             Self::Window(window) => Action::Window(window.map(f)),
             Self::System(system) => Action::System(system.map(f)),
@@ -74,6 +80,7 @@ impl<T> fmt::Debug for Action<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Future(_) => write!(f, "Action::Future"),
+            Self::Stream(_) => write!(f, "Action::Stream"),
             Self::Clipboard(action) => {
                 write!(f, "Action::Clipboard({action:?})")
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,7 +190,6 @@ pub use crate::core::{
     color, Alignment, Background, BorderRadius, Color, ContentFit, Degrees,
     Gradient, Length, Padding, Pixels, Point, Radians, Rectangle, Size, Vector,
 };
-pub use crate::runtime::Command;
 
 pub mod clipboard {
     //! Access the clipboard.
@@ -237,6 +236,11 @@ pub mod mouse {
     pub use crate::core::mouse::{
         Button, Cursor, Event, Interaction, ScrollDelta,
     };
+}
+
+pub mod command {
+    //! Run asynchronous actions.
+    pub use crate::runtime::command::{channel, Command};
 }
 
 pub mod subscription {
@@ -287,6 +291,7 @@ pub mod widget {
 }
 
 pub use application::Application;
+pub use command::Command;
 pub use error::Error;
 pub use event::Event;
 pub use executor::Executor;

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -736,6 +736,9 @@ pub fn run_command<A, C, E>(
             command::Action::Future(future) => {
                 runtime.spawn(future);
             }
+            command::Action::Stream(stream) => {
+                runtime.run(stream);
+            }
             command::Action::Clipboard(action) => match action {
                 clipboard::Action::Read(tag) => {
                     let message = tag(clipboard.read());


### PR DESCRIPTION
This PR implements support for running a `Stream` to completion with the new `Command::run` constructor.

Additionally, it introduces a `command::channel` helper that can be used analogously to `subscription::channel`.

These changes should simplify use cases where running a background worker with some initial configuration or impure state is necessary.