### PR TITLE
[Fix] `PaneGrid` click interaction on the top edge

### DIFF
--- a/widget/src/pane_grid/state.rs
+++ b/widget/src/pane_grid/state.rs
@@ -403,6 +403,15 @@ pub enum Action {
     ///
     /// [`PaneGrid`]: super::PaneGrid
     Idle,
+    /// A [`Pane`] in the [`PaneGrid`] is being clicked.
+    ///
+    /// [`PaneGrid`]: super::PaneGrid
+    Clicking {
+        /// The [`Pane`] being clicked.
+        pane: Pane,
+        /// The starting [`Point`] of the click interaction.
+        origin: Point,
+    },
     /// A [`Pane`] in the [`PaneGrid`] is being dragged.
     ///
     /// [`PaneGrid`]: super::PaneGrid
@@ -428,6 +437,14 @@ impl Action {
     pub fn picked_pane(&self) -> Option<(Pane, Point)> {
         match *self {
             Action::Dragging { pane, origin, .. } => Some((pane, origin)),
+            _ => None,
+        }
+    }
+
+    /// Returns the current [`Pane`] that is being clicked, if any.
+    pub fn clicked_pane(&self) -> Option<(Pane, Point)> {
+        match *self {
+            Action::Clicking { pane, origin, .. } => Some((pane, origin)),
             _ => None,
         }
     }


### PR DESCRIPTION
## Issue

Clicking on the top edge of a `PaneGrid` expands the clicked pane and pushes all other panes on the top row to below. 

This occurs because clicking a pane directly leads to a `Dragging` action, that, once button is released, will `drop` the `pane` on the top `edge`.

![issuee](https://github.com/iced-rs/iced/assets/51237625/b0d62e9a-5f77-4aff-8dd5-4b3f6187f99d)

## Solution

This PR adds a new `action`, `Clicking`, which will only jump to `Dragging` if cursor moves a given deadband distance from the original click position. I have defined this deadband distance as `10` pixels, but let me know if it is too short/wide.

## Result

![fixx](https://github.com/iced-rs/iced/assets/51237625/598be347-7023-44ee-8ba5-b64c9dcfa507)


