### PR TITLE
Add Nord, Dracula, Solarized and Gruvbox themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `default` and `shift_step` methods for `slider` widgets. [#2100](https://github.com/iced-rs/iced/pull/2100)
 - `Custom` variant to `command::Action`. [#2146](https://github.com/iced-rs/iced/pull/2146)
 - Mouse movement events for `MouseArea`. [#2147](https://github.com/iced-rs/iced/pull/2147)
+- Dracula, Nord, Solarized, and Gruvbox variants for `Theme`. [#2170](https://github.com/iced-rs/iced/pull/2170)
 
 ### Changed
 - Enable WebGPU backend in `wgpu` by default instead of WebGL. [#2068](https://github.com/iced-rs/iced/pull/2068)
@@ -127,6 +128,7 @@ Many thanks to...
 - @Tahinli
 - @tarkah
 - @tzemanovic
+- @varbhat
 - @william-shere
 
 ## [0.10.0] - 2023-07-28

--- a/core/src/color.rs
+++ b/core/src/color.rs
@@ -179,23 +179,18 @@ impl From<[f32; 4]> for Color {
 #[macro_export]
 macro_rules! color {
     ($r:expr, $g:expr, $b:expr) => {
-        $crate::Color::from_rgb8($r, $g, $b)
+        color!($r, $g, $b, 1.0)
     };
     ($r:expr, $g:expr, $b:expr, $a:expr) => {
-        $crate::Color::from_rgba8($r, $g, $b, $a)
+        $crate::Color {
+            r: $r as f32 / 255.0,
+            g: $g as f32 / 255.0,
+            b: $b as f32 / 255.0,
+            a: $a,
+        }
     };
     ($hex:expr) => {{
-        let hex = $hex as u32;
-        let r = (hex & 0xff0000) >> 16;
-        let g = (hex & 0xff00) >> 8;
-        let b = (hex & 0xff);
-
-        $crate::Color {
-            r: r as f32 / 255.0,
-            g: g as f32 / 255.0,
-            b: b as f32 / 255.0,
-            a: 1.0,
-        }
+        color!($hex, 1.0)
     }};
     ($hex:expr, $a:expr) => {{
         let hex = $hex as u32;
@@ -203,7 +198,7 @@ macro_rules! color {
         let g = (hex & 0xff00) >> 8;
         let b = (hex & 0xff);
 
-        $crate::Color::from_rgba8(r as u8, g as u8, b as u8, $a)
+        color!(r, g, b, $a)
     }};
 }
 

--- a/core/src/color.rs
+++ b/core/src/color.rs
@@ -190,7 +190,12 @@ macro_rules! color {
         let g = (hex & 0xff00) >> 8;
         let b = (hex & 0xff);
 
-        $crate::Color::from_rgb8(r as u8, g as u8, b as u8)
+        $crate::Color {
+            r: r as f32 / 255.0,
+            g: g as f32 / 255.0,
+            b: b as f32 / 255.0,
+            a: 1.0,
+        }
     }};
     ($hex:expr, $a:expr) => {{
         let hex = $hex as u32;

--- a/examples/styling/src/main.rs
+++ b/examples/styling/src/main.rs
@@ -1,10 +1,9 @@
-use iced::theme::{self, Theme};
 use iced::widget::{
-    button, checkbox, column, container, horizontal_rule, progress_bar, radio,
-    row, scrollable, slider, text, text_input, toggler, vertical_rule,
-    vertical_space,
+    button, checkbox, column, container, horizontal_rule, pick_list,
+    progress_bar, row, scrollable, slider, text, text_input, toggler,
+    vertical_rule, vertical_space,
 };
-use iced::{Alignment, Color, Element, Length, Sandbox, Settings};
+use iced::{Alignment, Element, Length, Sandbox, Settings, Theme};
 
 pub fn main() -> iced::Result {
     Styling::run(Settings::default())
@@ -19,22 +18,9 @@ struct Styling {
     toggler_value: bool,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
-enum ThemeType {
-    Light,
-    Dark,
-    Nord,
-    GruvboxLight,
-    GruvboxDark,
-    Dracula,
-    SolarizedLight,
-    SolarizedDark,
-    Custom,
-}
-
 #[derive(Debug, Clone)]
 enum Message {
-    ThemeChanged(ThemeType),
+    ThemeChanged(Theme),
     InputChanged(String),
     ButtonPressed,
     SliderChanged(f32),
@@ -56,26 +42,7 @@ impl Sandbox for Styling {
     fn update(&mut self, message: Message) {
         match message {
             Message::ThemeChanged(theme) => {
-                self.theme = match theme {
-                    ThemeType::Light => Theme::Light,
-                    ThemeType::Dark => Theme::Dark,
-                    ThemeType::Nord => Theme::Nord,
-                    ThemeType::GruvboxLight => Theme::GruvboxLight,
-                    ThemeType::GruvboxDark => Theme::GruvboxDark,
-                    ThemeType::Dracula => Theme::Dracula,
-                    ThemeType::SolarizedLight => Theme::SolarizedLight,
-                    ThemeType::SolarizedDark => Theme::SolarizedDark,
-                    ThemeType::Custom => Theme::custom(
-                        String::from("Custom"),
-                        theme::Palette {
-                            background: Color::from_rgb(1.0, 0.9, 1.0),
-                            text: Color::BLACK,
-                            primary: Color::from_rgb(0.5, 0.5, 0.0),
-                            success: Color::from_rgb(0.0, 1.0, 0.0),
-                            danger: Color::from_rgb(1.0, 0.0, 0.0),
-                        },
-                    ),
-                }
+                self.theme = theme;
             }
             Message::InputChanged(value) => self.input_value = value,
             Message::ButtonPressed => {}
@@ -86,39 +53,16 @@ impl Sandbox for Styling {
     }
 
     fn view(&self) -> Element<Message> {
-        let choose_theme = [
-            ThemeType::Light,
-            ThemeType::Dark,
-            ThemeType::Nord,
-            ThemeType::Dracula,
-            ThemeType::SolarizedLight,
-            ThemeType::SolarizedDark,
-            ThemeType::GruvboxLight,
-            ThemeType::GruvboxDark,
-            ThemeType::Custom,
+        let choose_theme = column![
+            text("Theme:"),
+            pick_list(
+                Theme::ALL,
+                Some(self.theme.clone()),
+                Message::ThemeChanged
+            )
+            .width(Length::Fill),
         ]
-        .iter()
-        .fold(
-            column![text("Choose a theme:")].spacing(10),
-            |column, theme| {
-                column.push(radio(
-                    format!("{theme:?}"),
-                    *theme,
-                    Some(match self.theme {
-                        Theme::Light => ThemeType::Light,
-                        Theme::Dark => ThemeType::Dark,
-                        Theme::Dracula => ThemeType::Dracula,
-                        Theme::Nord => ThemeType::Nord,
-                        Theme::SolarizedLight => ThemeType::SolarizedLight,
-                        Theme::SolarizedDark => ThemeType::SolarizedDark,
-                        Theme::GruvboxLight => ThemeType::GruvboxLight,
-                        Theme::GruvboxDark => ThemeType::GruvboxDark,
-                        Theme::Custom { .. } => ThemeType::Custom,
-                    }),
-                    Message::ThemeChanged,
-                ))
-            },
-        );
+        .spacing(10);
 
         let text_input = text_input("Type something...", &self.input_value)
             .on_input(Message::InputChanged)

--- a/examples/styling/src/main.rs
+++ b/examples/styling/src/main.rs
@@ -23,6 +23,12 @@ struct Styling {
 enum ThemeType {
     Light,
     Dark,
+    Nord,
+    GruvboxLight,
+    GruvboxDark,
+    Dracula,
+    SolarizedLight,
+    SolarizedDark,
     Custom,
 }
 
@@ -53,6 +59,12 @@ impl Sandbox for Styling {
                 self.theme = match theme {
                     ThemeType::Light => Theme::Light,
                     ThemeType::Dark => Theme::Dark,
+                    ThemeType::Nord => Theme::Nord,
+                    ThemeType::GruvboxLight => Theme::GruvboxLight,
+                    ThemeType::GruvboxDark => Theme::GruvboxDark,
+                    ThemeType::Dracula => Theme::Dracula,
+                    ThemeType::SolarizedLight => Theme::SolarizedLight,
+                    ThemeType::SolarizedDark => Theme::SolarizedDark,
                     ThemeType::Custom => Theme::custom(
                         String::from("Custom"),
                         theme::Palette {
@@ -74,24 +86,39 @@ impl Sandbox for Styling {
     }
 
     fn view(&self) -> Element<Message> {
-        let choose_theme =
-            [ThemeType::Light, ThemeType::Dark, ThemeType::Custom]
-                .iter()
-                .fold(
-                    column![text("Choose a theme:")].spacing(10),
-                    |column, theme| {
-                        column.push(radio(
-                            format!("{theme:?}"),
-                            *theme,
-                            Some(match self.theme {
-                                Theme::Light => ThemeType::Light,
-                                Theme::Dark => ThemeType::Dark,
-                                Theme::Custom { .. } => ThemeType::Custom,
-                            }),
-                            Message::ThemeChanged,
-                        ))
-                    },
-                );
+        let choose_theme = [
+            ThemeType::Light,
+            ThemeType::Dark,
+            ThemeType::Nord,
+            ThemeType::Dracula,
+            ThemeType::SolarizedLight,
+            ThemeType::SolarizedDark,
+            ThemeType::GruvboxLight,
+            ThemeType::GruvboxDark,
+            ThemeType::Custom,
+        ]
+        .iter()
+        .fold(
+            column![text("Choose a theme:")].spacing(10),
+            |column, theme| {
+                column.push(radio(
+                    format!("{theme:?}"),
+                    *theme,
+                    Some(match self.theme {
+                        Theme::Light => ThemeType::Light,
+                        Theme::Dark => ThemeType::Dark,
+                        Theme::Dracula => ThemeType::Dracula,
+                        Theme::Nord => ThemeType::Nord,
+                        Theme::SolarizedLight => ThemeType::SolarizedLight,
+                        Theme::SolarizedDark => ThemeType::SolarizedDark,
+                        Theme::GruvboxLight => ThemeType::GruvboxLight,
+                        Theme::GruvboxDark => ThemeType::GruvboxDark,
+                        Theme::Custom { .. } => ThemeType::Custom,
+                    }),
+                    Message::ThemeChanged,
+                ))
+            },
+        );
 
         let text_input = text_input("Type something...", &self.input_value)
             .on_input(Message::InputChanged)

--- a/style/src/theme.rs
+++ b/style/src/theme.rs
@@ -25,6 +25,7 @@ use crate::core::{Background, Border, Color, Shadow, Vector};
 
 use std::fmt;
 use std::rc::Rc;
+use std::sync::Arc;
 
 /// A built-in theme.
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -47,12 +48,21 @@ pub enum Theme {
     /// The built-in gruvbox dark variant.
     GruvboxDark,
     /// A [`Theme`] that uses a [`Custom`] palette.
-    Custom(Box<Custom>),
+    Custom(Arc<Custom>),
 }
 
 impl Theme {
     /// A list with all the defined themes.
-    pub const ALL: &'static [Self] = &[Self::Light, Self::Dark];
+    pub const ALL: &'static [Self] = &[
+        Self::Light,
+        Self::Dark,
+        Self::Dracula,
+        Self::Nord,
+        Self::SolarizedLight,
+        Self::SolarizedDark,
+        Self::GruvboxLight,
+        Self::GruvboxDark,
+    ];
 
     /// Creates a new custom [`Theme`] from the given [`Palette`].
     pub fn custom(name: String, palette: Palette) -> Self {
@@ -66,7 +76,7 @@ impl Theme {
         palette: Palette,
         generate: impl FnOnce(Palette) -> palette::Extended,
     ) -> Self {
-        Self::Custom(Box::new(Custom::with_fn(name, palette, generate)))
+        Self::Custom(Arc::new(Custom::with_fn(name, palette, generate)))
     }
 
     /// Returns the [`Palette`] of the [`Theme`].

--- a/style/src/theme.rs
+++ b/style/src/theme.rs
@@ -35,17 +35,17 @@ pub enum Theme {
     Light,
     /// The built-in dark variant.
     Dark,
-    /// The built-in dracula variant.
+    /// The built-in Dracula variant.
     Dracula,
-    /// The built-in nord variant.
+    /// The built-in Nord variant.
     Nord,
-    /// The built-in solarized light variant.
+    /// The built-in Solarized Light variant.
     SolarizedLight,
-    /// The built-in solarized dark variant.
+    /// The built-in Solarized Dark variant.
     SolarizedDark,
-    /// The built-in gruvbox light variant.
+    /// The built-in Gruvbox Light variant.
     GruvboxLight,
-    /// The built-in gruvbox dark variant.
+    /// The built-in Gruvbox Dark variant.
     GruvboxDark,
     /// A [`Theme`] that uses a [`Custom`] palette.
     Custom(Arc<Custom>),

--- a/style/src/theme.rs
+++ b/style/src/theme.rs
@@ -34,6 +34,18 @@ pub enum Theme {
     Light,
     /// The built-in dark variant.
     Dark,
+    /// The built-in dracula variant.
+    Dracula,
+    /// The built-in nord variant.
+    Nord,
+    /// The built-in solarized light variant.
+    SolarizedLight,
+    /// The built-in solarized dark variant.
+    SolarizedDark,
+    /// The built-in gruvbox light variant.
+    GruvboxLight,
+    /// The built-in gruvbox dark variant.
+    GruvboxDark,
     /// A [`Theme`] that uses a [`Custom`] palette.
     Custom(Box<Custom>),
 }
@@ -62,6 +74,12 @@ impl Theme {
         match self {
             Self::Light => Palette::LIGHT,
             Self::Dark => Palette::DARK,
+            Self::Dracula => Palette::DRACULA,
+            Self::Nord => Palette::NORD,
+            Self::SolarizedLight => Palette::SOLARIZED_LIGHT,
+            Self::SolarizedDark => Palette::SOLARIZED_DARK,
+            Self::GruvboxLight => Palette::GRUVBOX_LIGHT,
+            Self::GruvboxDark => Palette::GRUVBOX_DARK,
             Self::Custom(custom) => custom.palette,
         }
     }
@@ -71,6 +89,12 @@ impl Theme {
         match self {
             Self::Light => &palette::EXTENDED_LIGHT,
             Self::Dark => &palette::EXTENDED_DARK,
+            Self::Dracula => &palette::EXTENDED_DRACULA,
+            Self::Nord => &palette::EXTENDED_NORD,
+            Self::SolarizedLight => &palette::EXTENDED_SOLARIZED_LIGHT,
+            Self::SolarizedDark => &palette::EXTENDED_SOLARIZED_DARK,
+            Self::GruvboxLight => &palette::EXTENDED_GRUVBOX_LIGHT,
+            Self::GruvboxDark => &palette::EXTENDED_GRUVBOX_DARK,
             Self::Custom(custom) => &custom.extended,
         }
     }
@@ -81,6 +105,12 @@ impl fmt::Display for Theme {
         match self {
             Self::Light => write!(f, "Light"),
             Self::Dark => write!(f, "Dark"),
+            Self::Dracula => write!(f, "Dracula"),
+            Self::Nord => write!(f, "Nord"),
+            Self::SolarizedLight => write!(f, "Solarized Light"),
+            Self::SolarizedDark => write!(f, "Solarized Dark"),
+            Self::GruvboxLight => write!(f, "Gruvbox Light"),
+            Self::GruvboxDark => write!(f, "Gruvbox Dark"),
             Self::Custom(custom) => custom.fmt(f),
         }
     }

--- a/style/src/theme/palette.rs
+++ b/style/src/theme/palette.rs
@@ -1,5 +1,5 @@
 //! Define the colors of a theme.
-use iced_core::Color;
+use iced_core::{color, Color};
 
 use once_cell::sync::Lazy;
 use palette::color_difference::Wcag21RelativeContrast;
@@ -67,6 +67,66 @@ impl Palette {
             0x3F as f32 / 255.0,
         ),
     };
+
+    /// The built-in dracula variant of a [`Palette`].
+    /// theme source: https://draculatheme.com
+    pub const DRACULA: Self = Self {
+        background: color!(0x282A36), // BACKGROUND
+        text: color!(0xf8f8f2),       // FOREGROUND
+        primary: color!(0xbd93f9),    // PURPLE
+        success: color!(0x50fa7b),    // GREEN
+        danger: color!(0xff5555),     // RED
+    };
+
+    /// The built-in nord variant of a [`Palette`].
+    /// theme source: https://www.nordtheme.com/docs/colors-and-palettes
+    pub const NORD: Self = Self {
+        background: color!(0x2e3440), // nord0
+        text: color!(0xeceff4),       // nord6
+        primary: color!(0x8fbcbb),    // nord7
+        success: color!(0xa3be8c),    // nord14
+        danger: color!(0xbf616a),     // nord11
+    };
+
+    /// The built-in solarized light variant of a [`Palette`].
+    /// light variant of https://ethanschoonover.com/solarized
+    pub const SOLARIZED_LIGHT: Self = Self {
+        background: color!(0xfdf6e3), // base3
+        text: color!(0x657b83),       // base00
+        primary: color!(0x2aa198),    // cyan
+        success: color!(0x859900),    // green
+        danger: color!(0xdc322f),     // red
+    };
+
+    /// The built-in solarized dark variant of a [`Palette`].
+    /// dark variant of https://ethanschoonover.com/solarized
+    pub const SOLARIZED_DARK: Self = Self {
+        background: color!(0x002b36), // base03
+        text: color!(0x839496),       // base0
+        primary: color!(0x2aa198),    // cyan
+        success: color!(0x859900),    // green
+        danger: color!(0xdc322f),     // red
+    };
+
+    /// The built-in gruvbox light variant of a [`Palette`].
+    /// light variant of https://github.com/morhetz/gruvbox
+    pub const GRUVBOX_LIGHT: Self = Self {
+        background: color!(0xfbf1c7), // light BG_0
+        text: color!(0x282828),       // light FG0_29
+        primary: color!(0x458588),    // light BLUE_4
+        success: color!(0x98971a),    // light GREEN_2
+        danger: color!(0xcc241d),     // light RED_1
+    };
+
+    /// The built-in gruvbox dark variant of a [`Palette`].
+    /// dark variant of https://github.com/morhetz/gruvbox
+    pub const GRUVBOX_DARK: Self = Self {
+        background: color!(0x282828), // dark BG_0
+        text: color!(0xfbf1c7),       // dark FG0_29
+        primary: color!(0x458588),    // dark BLUE_4
+        success: color!(0x98971a),    // dark GREEN_2
+        danger: color!(0xcc241d),     // dark RED_1
+    };
 }
 
 /// An extended set of colors generated from a [`Palette`].
@@ -93,6 +153,30 @@ pub static EXTENDED_LIGHT: Lazy<Extended> =
 /// The built-in dark variant of an [`Extended`] palette.
 pub static EXTENDED_DARK: Lazy<Extended> =
     Lazy::new(|| Extended::generate(Palette::DARK));
+
+/// The built-in dracula variant of an [`Extended`] palette.
+pub static EXTENDED_DRACULA: Lazy<Extended> =
+    Lazy::new(|| Extended::generate(Palette::DRACULA));
+
+/// The built-in nord variant of an [`Extended`] palette.
+pub static EXTENDED_NORD: Lazy<Extended> =
+    Lazy::new(|| Extended::generate(Palette::NORD));
+
+/// The built-in solarized light variant of an [`Extended`] palette.
+pub static EXTENDED_SOLARIZED_LIGHT: Lazy<Extended> =
+    Lazy::new(|| Extended::generate(Palette::SOLARIZED_LIGHT));
+
+/// The built-in solarized dark variant of an [`Extended`] palette.
+pub static EXTENDED_SOLARIZED_DARK: Lazy<Extended> =
+    Lazy::new(|| Extended::generate(Palette::SOLARIZED_DARK));
+
+/// The built-in gruvbox light variant of an [`Extended`] palette.
+pub static EXTENDED_GRUVBOX_LIGHT: Lazy<Extended> =
+    Lazy::new(|| Extended::generate(Palette::GRUVBOX_LIGHT));
+
+/// The built-in gruvbox dark variant of an [`Extended`] palette.
+pub static EXTENDED_GRUVBOX_DARK: Lazy<Extended> =
+    Lazy::new(|| Extended::generate(Palette::GRUVBOX_DARK));
 
 impl Extended {
     /// Generates an [`Extended`] palette from a simple [`Palette`].

--- a/style/src/theme/palette.rs
+++ b/style/src/theme/palette.rs
@@ -1,5 +1,5 @@
 //! Define the colors of a theme.
-use iced_core::{color, Color};
+use crate::core::{color, Color};
 
 use once_cell::sync::Lazy;
 use palette::color_difference::Wcag21RelativeContrast;

--- a/style/src/theme/palette.rs
+++ b/style/src/theme/palette.rs
@@ -68,8 +68,9 @@ impl Palette {
         ),
     };
 
-    /// The built-in dracula variant of a [`Palette`].
-    /// theme source: https://draculatheme.com
+    /// The built-in Dracula variant of a [`Palette`].
+    ///
+    /// Source: https://draculatheme.com
     pub const DRACULA: Self = Self {
         background: color!(0x282A36), // BACKGROUND
         text: color!(0xf8f8f2),       // FOREGROUND
@@ -78,8 +79,9 @@ impl Palette {
         danger: color!(0xff5555),     // RED
     };
 
-    /// The built-in nord variant of a [`Palette`].
-    /// theme source: https://www.nordtheme.com/docs/colors-and-palettes
+    /// The built-in Nord variant of a [`Palette`].
+    ///
+    /// Source: https://www.nordtheme.com/docs/colors-and-palettes
     pub const NORD: Self = Self {
         background: color!(0x2e3440), // nord0
         text: color!(0xeceff4),       // nord6
@@ -88,8 +90,9 @@ impl Palette {
         danger: color!(0xbf616a),     // nord11
     };
 
-    /// The built-in solarized light variant of a [`Palette`].
-    /// light variant of https://ethanschoonover.com/solarized
+    /// The built-in Solarized Light variant of a [`Palette`].
+    ///
+    /// Source: https://ethanschoonover.com/solarized
     pub const SOLARIZED_LIGHT: Self = Self {
         background: color!(0xfdf6e3), // base3
         text: color!(0x657b83),       // base00
@@ -98,8 +101,9 @@ impl Palette {
         danger: color!(0xdc322f),     // red
     };
 
-    /// The built-in solarized dark variant of a [`Palette`].
-    /// dark variant of https://ethanschoonover.com/solarized
+    /// The built-in Solarized Dark variant of a [`Palette`].
+    ///
+    /// Source: https://ethanschoonover.com/solarized
     pub const SOLARIZED_DARK: Self = Self {
         background: color!(0x002b36), // base03
         text: color!(0x839496),       // base0
@@ -108,8 +112,9 @@ impl Palette {
         danger: color!(0xdc322f),     // red
     };
 
-    /// The built-in gruvbox light variant of a [`Palette`].
-    /// light variant of https://github.com/morhetz/gruvbox
+    /// The built-in Gruvbox Light variant of a [`Palette`].
+    ///
+    /// Source: https://github.com/morhetz/gruvbox
     pub const GRUVBOX_LIGHT: Self = Self {
         background: color!(0xfbf1c7), // light BG_0
         text: color!(0x282828),       // light FG0_29
@@ -118,8 +123,9 @@ impl Palette {
         danger: color!(0xcc241d),     // light RED_1
     };
 
-    /// The built-in gruvbox dark variant of a [`Palette`].
-    /// dark variant of https://github.com/morhetz/gruvbox
+    /// The built-in Gruvbox Dark variant of a [`Palette`].
+    ///
+    /// Source: https://github.com/morhetz/gruvbox
     pub const GRUVBOX_DARK: Self = Self {
         background: color!(0x282828), // dark BG_0
         text: color!(0xfbf1c7),       // dark FG0_29
@@ -154,27 +160,27 @@ pub static EXTENDED_LIGHT: Lazy<Extended> =
 pub static EXTENDED_DARK: Lazy<Extended> =
     Lazy::new(|| Extended::generate(Palette::DARK));
 
-/// The built-in dracula variant of an [`Extended`] palette.
+/// The built-in Dracula variant of an [`Extended`] palette.
 pub static EXTENDED_DRACULA: Lazy<Extended> =
     Lazy::new(|| Extended::generate(Palette::DRACULA));
 
-/// The built-in nord variant of an [`Extended`] palette.
+/// The built-in Nord variant of an [`Extended`] palette.
 pub static EXTENDED_NORD: Lazy<Extended> =
     Lazy::new(|| Extended::generate(Palette::NORD));
 
-/// The built-in solarized light variant of an [`Extended`] palette.
+/// The built-in Solarized Light variant of an [`Extended`] palette.
 pub static EXTENDED_SOLARIZED_LIGHT: Lazy<Extended> =
     Lazy::new(|| Extended::generate(Palette::SOLARIZED_LIGHT));
 
-/// The built-in solarized dark variant of an [`Extended`] palette.
+/// The built-in Solarized Dark variant of an [`Extended`] palette.
 pub static EXTENDED_SOLARIZED_DARK: Lazy<Extended> =
     Lazy::new(|| Extended::generate(Palette::SOLARIZED_DARK));
 
-/// The built-in gruvbox light variant of an [`Extended`] palette.
+/// The built-in Gruvbox Light variant of an [`Extended`] palette.
 pub static EXTENDED_GRUVBOX_LIGHT: Lazy<Extended> =
     Lazy::new(|| Extended::generate(Palette::GRUVBOX_LIGHT));
 
-/// The built-in gruvbox dark variant of an [`Extended`] palette.
+/// The built-in Gruvbox Dark variant of an [`Extended`] palette.
 pub static EXTENDED_GRUVBOX_DARK: Lazy<Extended> =
     Lazy::new(|| Extended::generate(Palette::GRUVBOX_DARK));
 


### PR DESCRIPTION
@hecrj , This PR is accordingly to how we discussed in Discord.

This PR does two things:
1. makes color! macro return Color directly instead of invoking another function which does it. This way, we can use color! macro to create constant colors. 
2.  Adds the following palette and themes:
    - Dracula : https://draculatheme.com/
    - Nord: https://www.nordtheme.com/#palettes-modularity
    - Solarized (light and dark): https://ethanschoonover.com/solarized/
    -  Gruvbox (light and dark): https://github.com/morhetz/gruvbox