### PR TITLE
Added `text_shaping` method to `Tooltip`

### DIFF
--- a/widget/src/tooltip.rs
+++ b/widget/src/tooltip.rs
@@ -64,6 +64,12 @@ where
         self
     }
 
+    /// Sets the [`text::Shaping`] strategy of the [`Tooltip`].
+    pub fn text_shaping(mut self, shaping: text::Shaping) -> Self {
+        self.tooltip = self.tooltip.shaping(shaping);
+        self
+    }
+
     /// Sets the font of the [`Tooltip`].
     ///
     /// [`Font`]: Renderer::Font


### PR DESCRIPTION
The ability to change the `text::Shaping` strategy, introduced in version 0.10, was still missing for `Tooltip`s.
I simply introduced a `text_shaping` method to update this widget to the new capabilities of the library. 