### PR TITLE
Add Length::FillPercentage

### DIFF
--- a/core/src/layout/limits.rs
+++ b/core/src/layout/limits.rs
@@ -50,6 +50,10 @@ impl Limits {
             Length::Fill | Length::FillPortion(_) => {
                 self.fill.width = self.fill.width.min(self.max.width);
             }
+            Length::FillPercentage(percentage) => {
+                let amount = self.max.width * percentage;
+                self.fill.width = amount.min(self.max.width).max(self.min.width);
+            }
             Length::Fixed(amount) => {
                 let new_width = amount.min(self.max.width).max(self.min.width);
 
@@ -70,6 +74,10 @@ impl Limits {
             }
             Length::Fill | Length::FillPortion(_) => {
                 self.fill.height = self.fill.height.min(self.max.height);
+            }
+            Length::FillPercentage(percentage) => {
+                let amount = self.max.height * percentage;
+                self.fill.height = amount.min(self.max.height).max(self.min.height);
             }
             Length::Fixed(amount) => {
                 let new_height =

--- a/core/src/length.rs
+++ b/core/src/length.rs
@@ -15,6 +15,9 @@ pub enum Length {
     /// `Length::Fill` is equivalent to `Length::FillPortion(1)`.
     FillPortion(u16),
 
+    /// Fill a percentage of the remaining space (0.0..=1.0)
+    FillPercentage(f32),
+
     /// Fill the least amount of space
     Shrink,
 
@@ -32,6 +35,7 @@ impl Length {
         match self {
             Length::Fill => 1,
             Length::FillPortion(factor) => *factor,
+            Length::FillPercentage(_) => 0,
             Length::Shrink => 0,
             Length::Fixed(_) => 0,
         }


### PR DESCRIPTION
Add `Length::FillPercentage(f32)` fill strategy that calculates the space to use with `percentage * max`, this is useful if you want to use a specific percentage of the available space. Any feedback is appreciated, for an example I am not sure if the percentage should be in the range 0.0..=1.0 like it is now or should it be in 0.0..=100.0 or if it should use `fill` instead of `max` for the calculation.