### PR TITLE
Add doc to direct developers to enable features for iced::time::every

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `size_hint` not being called from `element::Explain`. [#2225](https://github.com/iced-rs/iced/pull/2225)
 - Slow touch scrolling for `TextEditor` widget. [#2140](https://github.com/iced-rs/iced/pull/2140)
 - `Subscription::map` using unreliable function pointer hash to identify mappers. [#2237](https://github.com/iced-rs/iced/pull/2237)
+- Missing feature flag docs for `time::every`. [#2188](https://github.com/iced-rs/iced/pull/2188)
 
 Many thanks to...
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,6 +159,7 @@
     rustdoc::broken_intra_doc_links
 )]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 use iced_widget::graphics;
 use iced_widget::renderer;
 use iced_widget::style;

--- a/src/time.rs
+++ b/src/time.rs
@@ -2,4 +2,13 @@
 pub use iced_core::time::{Duration, Instant};
 
 #[allow(unused_imports)]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(any(
+        feature = "tokio",
+        feature = "async-std",
+        feature = "smol",
+        target_arch = "wasm32"
+    )))
+)]
 pub use iced_futures::backend::default::time::*;


### PR DESCRIPTION
Online document of Iced has the function iced::time::every. However, this function cannot be called when using thread-pool backend.

This PR adds doc to explicitly direct developers to enable appropriate features. This does not change any compiled code.
