### PR TITLE
Add functions to fetch if a window is maximized or minimized

### DIFF
--- a/core/src/window/event.rs
+++ b/core/src/window/event.rs
@@ -58,7 +58,7 @@ pub enum Event {
     /// for each file separately.
     FileHovered(PathBuf),
 
-    /// A file has beend dropped into the window.
+    /// A file has been dropped into the window.
     ///
     /// When the user drops multiple files at once, this event will be emitted
     /// for each file separately.

--- a/runtime/src/window.rs
+++ b/runtime/src/window.rs
@@ -65,9 +65,31 @@ pub fn fetch_size<Message>(
     Command::single(command::Action::Window(Action::FetchSize(id, Box::new(f))))
 }
 
+/// Fetches if the window is maximized.
+pub fn fetch_maximized<Message>(
+    id: Id,
+    f: impl FnOnce(bool) -> Message + 'static,
+) -> Command<Message> {
+    Command::single(command::Action::Window(Action::FetchMaximized(
+        id,
+        Box::new(f),
+    )))
+}
+
 /// Maximizes the window.
 pub fn maximize<Message>(id: Id, maximized: bool) -> Command<Message> {
     Command::single(command::Action::Window(Action::Maximize(id, maximized)))
+}
+
+/// Fetches if the window is minimized.
+pub fn fetch_minimized<Message>(
+    id: Id,
+    f: impl FnOnce(Option<bool>) -> Message + 'static,
+) -> Command<Message> {
+    Command::single(command::Action::Window(Action::FetchMinimized(
+        id,
+        Box::new(f),
+    )))
 }
 
 /// Minimizes the window.

--- a/runtime/src/window/action.rs
+++ b/runtime/src/window/action.rs
@@ -21,8 +21,19 @@ pub enum Action<T> {
     Resize(Id, Size),
     /// Fetch the current logical dimensions of the window.
     FetchSize(Id, Box<dyn FnOnce(Size) -> T + 'static>),
+    /// Fetch if the current window is maximized or not.
+    ///
+    /// ## Platform-specific
+    /// - **iOS / Android / Web:** Unsupported.
+    FetchMaximized(Id, Box<dyn FnOnce(bool) -> T + 'static>),
     /// Set the window to maximized or back
     Maximize(Id, bool),
+    /// Fetch if the current window is minimized or not.
+    ///
+    /// ## Platform-specific
+    /// - **Wayland:** Always `None`.
+    /// - **iOS / Android / Web:** Unsupported.
+    FetchMinimized(Id, Box<dyn FnOnce(Option<bool>) -> T + 'static>),
     /// Set the window to minimized or back
     Minimize(Id, bool),
     /// Move the window to the given logical coordinates.
@@ -106,7 +117,13 @@ impl<T> Action<T> {
             Self::FetchSize(id, o) => {
                 Action::FetchSize(id, Box::new(move |s| f(o(s))))
             }
+            Self::FetchMaximized(id, o) => {
+                Action::FetchMaximized(id, Box::new(move |s| f(o(s))))
+            }
             Self::Maximize(id, maximized) => Action::Maximize(id, maximized),
+            Self::FetchMinimized(id, o) => {
+                Action::FetchMinimized(id, Box::new(move |s| f(o(s))))
+            }
             Self::Minimize(id, minimized) => Action::Minimize(id, minimized),
             Self::Move(id, position) => Action::Move(id, position),
             Self::ChangeMode(id, mode) => Action::ChangeMode(id, mode),
@@ -144,8 +161,14 @@ impl<T> fmt::Debug for Action<T> {
                 write!(f, "Action::Resize({id:?}, {size:?})")
             }
             Self::FetchSize(id, _) => write!(f, "Action::FetchSize({id:?})"),
+            Self::FetchMaximized(id, _) => {
+                write!(f, "Action::FetchMaximized({id:?})")
+            }
             Self::Maximize(id, maximized) => {
                 write!(f, "Action::Maximize({id:?}, {maximized})")
+            }
+            Self::FetchMinimized(id, _) => {
+                write!(f, "Action::FetchMinimized({id:?})")
             }
             Self::Minimize(id, minimized) => {
                 write!(f, "Action::Minimize({id:?}, {minimized}")

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -742,8 +742,18 @@ pub fn run_command<A, C, E>(
                         )))
                         .expect("Send message to event loop");
                 }
+                window::Action::FetchMaximized(_id, callback) => {
+                    proxy
+                        .send_event(callback(window.is_maximized()))
+                        .expect("Send message to event loop");
+                }
                 window::Action::Maximize(_id, maximized) => {
                     window.set_maximized(maximized);
+                }
+                window::Action::FetchMinimized(_id, callback) => {
+                    proxy
+                        .send_event(callback(window.is_minimized()))
+                        .expect("Send message to event loop");
                 }
                 window::Action::Minimize(_id, minimized) => {
                     window.set_minimized(minimized);

--- a/winit/src/multi_window.rs
+++ b/winit/src/multi_window.rs
@@ -942,9 +942,23 @@ fn run_command<A, C, E>(
                             .expect("Send message to event loop");
                     }
                 }
+                window::Action::FetchMaximized(id, callback) => {
+                    if let Some(window) = window_manager.get_mut(id) {
+                        proxy
+                            .send_event(callback(window.raw.is_maximized()))
+                            .expect("Send message to event loop");
+                    }
+                }
                 window::Action::Maximize(id, maximized) => {
                     if let Some(window) = window_manager.get_mut(id) {
                         window.raw.set_maximized(maximized);
+                    }
+                }
+                window::Action::FetchMinimized(id, callback) => {
+                    if let Some(window) = window_manager.get_mut(id) {
+                        proxy
+                            .send_event(callback(window.raw.is_minimized()))
+                            .expect("Send message to event loop");
                     }
                 }
                 window::Action::Minimize(id, minimized) => {


### PR DESCRIPTION
This pull request is in hopes to solve an issue for another individual who wants to be able to accurately determine if the window was previously maximized. I introduced these functions since you could listen for the `CloseRequested` then query if the window was maximized and save then - rather than creating a custom event listening for when a `Resized` event that makes the window maximized.

If anything needs to be corrected to fit the styling, please let me know and I will fix it.