### PR TITLE
Layout consistency

### DIFF
--- a/core/src/element.rs
+++ b/core/src/element.rs
@@ -6,7 +6,7 @@ use crate::renderer;
 use crate::widget;
 use crate::widget::tree::{self, Tree};
 use crate::{
-    Clipboard, Color, Layout, Length, Rectangle, Shell, Vector, Widget,
+    Clipboard, Color, Layout, Length, Rectangle, Shell, Size, Vector, Widget,
 };
 
 use std::any::Any;
@@ -296,12 +296,8 @@ where
         self.widget.diff(tree);
     }
 
-    fn width(&self) -> Length {
-        self.widget.width()
-    }
-
-    fn height(&self) -> Length {
-        self.widget.height()
+    fn size(&self) -> Size<Length> {
+        self.widget.size()
     }
 
     fn layout(
@@ -466,12 +462,8 @@ impl<'a, Message, Renderer> Widget<Message, Renderer>
 where
     Renderer: crate::Renderer,
 {
-    fn width(&self) -> Length {
-        self.element.widget.width()
-    }
-
-    fn height(&self) -> Length {
-        self.element.widget.height()
+    fn size(&self) -> Size<Length> {
+        self.element.widget.size()
     }
 
     fn tag(&self) -> tree::Tag {

--- a/core/src/layout.rs
+++ b/core/src/layout.rs
@@ -71,12 +71,12 @@ pub fn next_to_each_other(
     left: impl FnOnce(&Limits) -> Node,
     right: impl FnOnce(&Limits) -> Node,
 ) -> Node {
-    let mut left_node = left(limits);
+    let left_node = left(limits);
     let left_size = left_node.size();
 
     let right_limits = limits.shrink(Size::new(left_size.width + spacing, 0.0));
 
-    let mut right_node = right(&right_limits);
+    let right_node = right(&right_limits);
     let right_size = right_node.size();
 
     let (left_y, right_y) = if left_size.height > right_size.height {
@@ -85,14 +85,14 @@ pub fn next_to_each_other(
         ((right_size.height - left_size.height) / 2.0, 0.0)
     };
 
-    left_node.move_to(Point::new(0.0, left_y));
-    right_node.move_to(Point::new(left_size.width + spacing, right_y));
-
     Node::with_children(
         Size::new(
             left_size.width + spacing + right_size.width,
             left_size.height.max(right_size.height),
         ),
-        vec![left_node, right_node],
+        vec![
+            left_node.move_to(Point::new(0.0, left_y)),
+            right_node.move_to(Point::new(left_size.width + spacing, right_y)),
+        ],
     )
 }

--- a/core/src/layout/flex.rs
+++ b/core/src/layout/flex.rs
@@ -166,13 +166,10 @@ where
         };
 
         if fill_main_factor != 0 {
-            let max_main = if fill_main_factor == 0 {
-                available.max(0.0)
-            } else {
-                remaining * fill_main_factor as f32 / fill_main_sum as f32
-            };
+            let max_main =
+                remaining * fill_main_factor as f32 / fill_main_sum as f32;
 
-            let min_main = if fill_main_factor == 0 || max_main.is_infinite() {
+            let min_main = if max_main.is_infinite() {
                 0.0
             } else {
                 max_main
@@ -184,9 +181,7 @@ where
                 cross
             };
 
-            let (min_width, min_height) =
-                axis.pack(min_main, axis.cross(limits.min()));
-
+            let (min_width, min_height) = axis.pack(min_main, 0.0);
             let (max_width, max_height) = axis.pack(max_main, max_cross);
 
             let child_limits = Limits::new(

--- a/core/src/layout/flex.rs
+++ b/core/src/layout/flex.rs
@@ -142,6 +142,7 @@ where
             let size = layout.size();
 
             available -= axis.main(size);
+            cross = cross.max(axis.cross(layout.size()));
 
             nodes[i] = layout;
         }

--- a/core/src/layout/flex.rs
+++ b/core/src/layout/flex.rs
@@ -79,7 +79,17 @@ where
     let max_cross = axis.cross(limits.max());
 
     let mut fill_main_sum = 0;
-    let mut cross = 0.0f32;
+    let mut cross = match axis {
+        Axis::Horizontal => match height {
+            Length::Shrink => 0.0,
+            _ => max_cross,
+        },
+        Axis::Vertical => match width {
+            Length::Shrink => 0.0,
+            _ => max_cross,
+        },
+    };
+
     let mut available = axis.main(limits.max()) - total_spacing;
 
     let mut nodes: Vec<Node> = Vec::with_capacity(items.len());
@@ -113,17 +123,6 @@ where
         }
     }
 
-    let intrinsic_cross = match axis {
-        Axis::Horizontal => match height {
-            Length::Shrink => cross,
-            _ => max_cross,
-        },
-        Axis::Vertical => match width {
-            Length::Shrink => cross,
-            _ => max_cross,
-        },
-    };
-
     for (i, (child, tree)) in items.iter().zip(trees.iter_mut()).enumerate() {
         let (fill_main_factor, fill_cross_factor) = {
             let size = child.as_widget().size();
@@ -132,7 +131,7 @@ where
         };
 
         if fill_main_factor == 0 && fill_cross_factor != 0 {
-            let (max_width, max_height) = axis.pack(available, intrinsic_cross);
+            let (max_width, max_height) = axis.pack(available, cross);
 
             let child_limits =
                 Limits::new(Size::ZERO, Size::new(max_width, max_height));
@@ -182,7 +181,7 @@ where
             let max_cross = if fill_cross_factor == 0 {
                 max_cross
             } else {
-                intrinsic_cross
+                cross
             };
 
             let (min_width, min_height) =

--- a/core/src/layout/flex.rs
+++ b/core/src/layout/flex.rs
@@ -239,9 +239,9 @@ where
 
     let (intrinsic_width, intrinsic_height) = axis.pack(main - pad.0, cross);
     let size = limits.resolve(
-        Size::new(intrinsic_width, intrinsic_height),
         width,
         height,
+        Size::new(intrinsic_width, intrinsic_height),
     );
 
     Node::with_children(size.expand(padding), nodes)

--- a/core/src/layout/flex.rs
+++ b/core/src/layout/flex.rs
@@ -86,10 +86,11 @@ where
     nodes.resize(items.len(), Node::default());
 
     for (i, (child, tree)) in items.iter().zip(trees.iter_mut()).enumerate() {
-        let (fill_main_factor, fill_cross_factor) = axis.pack(
-            child.as_widget().width().fill_factor(),
-            child.as_widget().height().fill_factor(),
-        );
+        let (fill_main_factor, fill_cross_factor) = {
+            let size = child.as_widget().size();
+
+            axis.pack(size.width.fill_factor(), size.height.fill_factor())
+        };
 
         if fill_main_factor == 0 {
             if fill_cross_factor == 0 {
@@ -124,10 +125,11 @@ where
     };
 
     for (i, (child, tree)) in items.iter().zip(trees.iter_mut()).enumerate() {
-        let (fill_main_factor, fill_cross_factor) = axis.pack(
-            child.as_widget().width().fill_factor(),
-            child.as_widget().height().fill_factor(),
-        );
+        let (fill_main_factor, fill_cross_factor) = {
+            let size = child.as_widget().size();
+
+            axis.pack(size.width.fill_factor(), size.height.fill_factor())
+        };
 
         if fill_main_factor == 0 && fill_cross_factor != 0 {
             let (max_width, max_height) = axis.pack(available, intrinsic_cross);
@@ -157,10 +159,11 @@ where
     };
 
     for (i, (child, tree)) in items.iter().zip(trees).enumerate() {
-        let (fill_main_factor, fill_cross_factor) = axis.pack(
-            child.as_widget().width().fill_factor(),
-            child.as_widget().height().fill_factor(),
-        );
+        let (fill_main_factor, fill_cross_factor) = {
+            let size = child.as_widget().size();
+
+            axis.pack(size.width.fill_factor(), size.height.fill_factor())
+        };
 
         if fill_main_factor != 0 {
             let max_main = if fill_main_factor == 0 {

--- a/core/src/layout/flex.rs
+++ b/core/src/layout/flex.rs
@@ -123,11 +123,11 @@ where
 
     let max_cross = match axis {
         Axis::Horizontal => match height {
-            Length::Shrink => cross,
+            Length::Shrink if cross > 0.0 => cross,
             _ => max_cross,
         },
         Axis::Vertical => match width {
-            Length::Shrink => cross,
+            Length::Shrink if cross > 0.0 => cross,
             _ => max_cross,
         },
     };
@@ -154,8 +154,7 @@ where
             let (min_width, min_height) =
                 axis.pack(min_main, axis.cross(limits.min()));
 
-            let (max_width, max_height) = axis
-                .pack(max_main, max_cross * fill_cross_factor.max(1) as f32);
+            let (max_width, max_height) = axis.pack(max_main, max_cross);
 
             let child_limits = Limits::new(
                 Size::new(min_width, min_height),

--- a/core/src/layout/flex.rs
+++ b/core/src/layout/flex.rs
@@ -139,10 +139,13 @@ where
         );
 
         if fill_main_factor != 0 || fill_cross_factor != 0 {
-            let max_main =
-                remaining * fill_main_factor as f32 / fill_main_sum as f32;
+            let max_main = if fill_main_factor == 0 {
+                available.max(0.0)
+            } else {
+                remaining * fill_main_factor as f32 / fill_main_sum as f32
+            };
 
-            let min_main = if max_main.is_infinite() {
+            let min_main = if fill_main_factor == 0 || max_main.is_infinite() {
                 0.0
             } else {
                 max_main

--- a/core/src/layout/limits.rs
+++ b/core/src/layout/limits.rs
@@ -1,12 +1,11 @@
 #![allow(clippy::manual_clamp)]
-use crate::{Length, Padding, Size};
+use crate::{Length, Size};
 
 /// A set of size constraints for layouting.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Limits {
     min: Size,
     max: Size,
-    fill: Size,
 }
 
 impl Limits {
@@ -14,16 +13,11 @@ impl Limits {
     pub const NONE: Limits = Limits {
         min: Size::ZERO,
         max: Size::INFINITY,
-        fill: Size::INFINITY,
     };
 
     /// Creates new [`Limits`] with the given minimum and maximum [`Size`].
     pub const fn new(min: Size, max: Size) -> Limits {
-        Limits {
-            min,
-            max,
-            fill: Size::INFINITY,
-        }
+        Limits { min, max }
     }
 
     /// Returns the minimum [`Size`] of the [`Limits`].
@@ -36,26 +30,15 @@ impl Limits {
         self.max
     }
 
-    /// Returns the fill [`Size`] of the [`Limits`].
-    pub fn fill(&self) -> Size {
-        self.fill
-    }
-
     /// Applies a width constraint to the current [`Limits`].
     pub fn width(mut self, width: impl Into<Length>) -> Limits {
         match width.into() {
-            Length::Shrink => {
-                self.fill.width = self.min.width;
-            }
-            Length::Fill | Length::FillPortion(_) => {
-                self.fill.width = self.fill.width.min(self.max.width);
-            }
+            Length::Shrink | Length::Fill | Length::FillPortion(_) => {}
             Length::Fixed(amount) => {
                 let new_width = amount.min(self.max.width).max(self.min.width);
 
                 self.min.width = new_width;
                 self.max.width = new_width;
-                self.fill.width = new_width;
             }
         }
 
@@ -65,19 +48,13 @@ impl Limits {
     /// Applies a height constraint to the current [`Limits`].
     pub fn height(mut self, height: impl Into<Length>) -> Limits {
         match height.into() {
-            Length::Shrink => {
-                self.fill.height = self.min.height;
-            }
-            Length::Fill | Length::FillPortion(_) => {
-                self.fill.height = self.fill.height.min(self.max.height);
-            }
+            Length::Shrink | Length::Fill | Length::FillPortion(_) => {}
             Length::Fixed(amount) => {
                 let new_height =
                     amount.min(self.max.height).max(self.min.height);
 
                 self.min.height = new_height;
                 self.max.height = new_height;
-                self.fill.height = new_height;
             }
         }
 
@@ -112,13 +89,10 @@ impl Limits {
         self
     }
 
-    /// Shrinks the current [`Limits`] to account for the given padding.
-    pub fn pad(&self, padding: Padding) -> Limits {
-        self.shrink(Size::new(padding.horizontal(), padding.vertical()))
-    }
-
     /// Shrinks the current [`Limits`] by the given [`Size`].
-    pub fn shrink(&self, size: Size) -> Limits {
+    pub fn shrink(&self, size: impl Into<Size>) -> Limits {
+        let size = size.into();
+
         let min = Size::new(
             (self.min().width - size.width).max(0.0),
             (self.min().height - size.height).max(0.0),
@@ -129,12 +103,7 @@ impl Limits {
             (self.max().height - size.height).max(0.0),
         );
 
-        let fill = Size::new(
-            (self.fill.width - size.width).max(0.0),
-            (self.fill.height - size.height).max(0.0),
-        );
-
-        Limits { min, max, fill }
+        Limits { min, max }
     }
 
     /// Removes the minimum width constraint for the current [`Limits`].
@@ -142,22 +111,38 @@ impl Limits {
         Limits {
             min: Size::ZERO,
             max: self.max,
-            fill: self.fill,
         }
     }
 
     /// Computes the resulting [`Size`] that fits the [`Limits`] given the
     /// intrinsic size of some content.
-    pub fn resolve(&self, intrinsic_size: Size) -> Size {
-        Size::new(
-            intrinsic_size
-                .width
-                .min(self.max.width)
-                .max(self.fill.width),
-            intrinsic_size
+    pub fn resolve(
+        &self,
+        intrinsic_size: Size,
+        width: impl Into<Length>,
+        height: impl Into<Length>,
+    ) -> Size {
+        let width = match width.into() {
+            Length::Fill | Length::FillPortion(_) => self.max.width,
+            Length::Fixed(amount) => {
+                amount.min(self.max.width).max(self.min.width)
+            }
+            Length::Shrink => {
+                intrinsic_size.width.min(self.max.width).max(self.min.width)
+            }
+        };
+
+        let height = match height.into() {
+            Length::Fill | Length::FillPortion(_) => self.max.height,
+            Length::Fixed(amount) => {
+                amount.min(self.max.height).max(self.min.height)
+            }
+            Length::Shrink => intrinsic_size
                 .height
                 .min(self.max.height)
-                .max(self.fill.height),
-        )
+                .max(self.min.height),
+        };
+
+        Size::new(width, height)
     }
 }

--- a/core/src/layout/limits.rs
+++ b/core/src/layout/limits.rs
@@ -114,13 +114,14 @@ impl Limits {
         }
     }
 
-    /// Computes the resulting [`Size`] that fits the [`Limits`] given the
-    /// intrinsic size of some content.
+    /// Computes the resulting [`Size`] that fits the [`Limits`] given
+    /// some width and height requirements and the intrinsic size of
+    /// some content.
     pub fn resolve(
         &self,
-        intrinsic_size: Size,
         width: impl Into<Length>,
         height: impl Into<Length>,
+        intrinsic_size: Size,
     ) -> Size {
         let width = match width.into() {
             Length::Fill | Length::FillPortion(_) => self.max.width,

--- a/core/src/layout/node.rs
+++ b/core/src/layout/node.rs
@@ -1,4 +1,4 @@
-use crate::{Alignment, Point, Rectangle, Size, Vector};
+use crate::{Alignment, Padding, Point, Rectangle, Size, Vector};
 
 /// The bounds of an element and its children.
 #[derive(Debug, Clone, Default)]
@@ -26,6 +26,14 @@ impl Node {
         }
     }
 
+    /// Creates a new [`Node`] that wraps a single child with some [`Padding`].
+    pub fn container(child: Self, padding: Padding) -> Self {
+        Self::with_children(
+            child.bounds.size().expand(padding),
+            vec![child.move_to(Point::new(padding.left, padding.top))],
+        )
+    }
+
     /// Returns the [`Size`] of the [`Node`].
     pub fn size(&self) -> Size {
         Size::new(self.bounds.width, self.bounds.height)
@@ -43,6 +51,17 @@ impl Node {
 
     /// Aligns the [`Node`] in the given space.
     pub fn align(
+        mut self,
+        horizontal_alignment: Alignment,
+        vertical_alignment: Alignment,
+        space: Size,
+    ) -> Self {
+        self.align_mut(horizontal_alignment, vertical_alignment, space);
+        self
+    }
+
+    /// Mutable reference version of [`align`].
+    pub fn align_mut(
         &mut self,
         horizontal_alignment: Alignment,
         vertical_alignment: Alignment,
@@ -70,7 +89,13 @@ impl Node {
     }
 
     /// Moves the [`Node`] to the given position.
-    pub fn move_to(&mut self, position: Point) {
+    pub fn move_to(mut self, position: Point) -> Self {
+        self.move_to_mut(position);
+        self
+    }
+
+    /// Mutable reference version of [`move_to`].
+    pub fn move_to_mut(&mut self, position: Point) {
         self.bounds.x = position.x;
         self.bounds.y = position.y;
     }

--- a/core/src/layout/node.rs
+++ b/core/src/layout/node.rs
@@ -60,7 +60,7 @@ impl Node {
         self
     }
 
-    /// Mutable reference version of [`align`].
+    /// Mutable reference version of [`Self::align`].
     pub fn align_mut(
         &mut self,
         horizontal_alignment: Alignment,
@@ -94,7 +94,7 @@ impl Node {
         self
     }
 
-    /// Mutable reference version of [`move_to`].
+    /// Mutable reference version of [`Self::move_to`].
     pub fn move_to_mut(&mut self, position: impl Into<Point>) {
         let position = position.into();
 

--- a/core/src/layout/node.rs
+++ b/core/src/layout/node.rs
@@ -89,19 +89,23 @@ impl Node {
     }
 
     /// Moves the [`Node`] to the given position.
-    pub fn move_to(mut self, position: Point) -> Self {
+    pub fn move_to(mut self, position: impl Into<Point>) -> Self {
         self.move_to_mut(position);
         self
     }
 
     /// Mutable reference version of [`move_to`].
-    pub fn move_to_mut(&mut self, position: Point) {
+    pub fn move_to_mut(&mut self, position: impl Into<Point>) {
+        let position = position.into();
+
         self.bounds.x = position.x;
         self.bounds.y = position.y;
     }
 
     /// Translates the [`Node`] by the given translation.
-    pub fn translate(self, translation: Vector) -> Self {
+    pub fn translate(self, translation: impl Into<Vector>) -> Self {
+        let translation = translation.into();
+
         Self {
             bounds: self.bounds + translation,
             ..self

--- a/core/src/length.rs
+++ b/core/src/length.rs
@@ -42,6 +42,18 @@ impl Length {
     pub fn is_fill(&self) -> bool {
         self.fill_factor() != 0
     }
+
+    /// Returns the "fluid" variant of the [`Length`].
+    ///
+    /// Specifically:
+    /// - [`Length::Shrink`] if [`Length::Shrink`] or [`Length::Fixed`].
+    /// - [`Length::Fill`] otherwise.
+    pub fn fluid(&self) -> Length {
+        match self {
+            Length::Fill | Length::FillPortion(_) => Length::Fill,
+            Length::Shrink | Length::Fixed(_) => Length::Shrink,
+        }
+    }
 }
 
 impl From<Pixels> for Length {

--- a/core/src/length.rs
+++ b/core/src/length.rs
@@ -36,6 +36,12 @@ impl Length {
             Length::Fixed(_) => 0,
         }
     }
+
+    /// Returns `true` iff the [`Length`] is either [`Length::Fill`] or
+    // [`Length::FillPortion`].
+    pub fn is_fill(&self) -> bool {
+        self.fill_factor() != 0
+    }
 }
 
 impl From<Pixels> for Length {

--- a/core/src/padding.rs
+++ b/core/src/padding.rs
@@ -154,3 +154,9 @@ impl From<[f32; 4]> for Padding {
         }
     }
 }
+
+impl From<Padding> for Size {
+    fn from(padding: Padding) -> Self {
+        Self::new(padding.horizontal(), padding.vertical())
+    }
+}

--- a/core/src/point.rs
+++ b/core/src/point.rs
@@ -36,20 +36,26 @@ impl<T: Num> Point<T> {
     }
 }
 
-impl From<[f32; 2]> for Point {
-    fn from([x, y]: [f32; 2]) -> Self {
+impl<T> From<[T; 2]> for Point<T>
+where
+    T: Num,
+{
+    fn from([x, y]: [T; 2]) -> Self {
         Point { x, y }
     }
 }
 
-impl From<[u16; 2]> for Point<u16> {
-    fn from([x, y]: [u16; 2]) -> Self {
-        Point::new(x, y)
+impl<T> From<(T, T)> for Point<T>
+where
+    T: Num,
+{
+    fn from((x, y): (T, T)) -> Self {
+        Self { x, y }
     }
 }
 
-impl From<Point> for [f32; 2] {
-    fn from(point: Point) -> [f32; 2] {
+impl<T> From<Point<T>> for [T; 2] {
+    fn from(point: Point<T>) -> [T; 2] {
         [point.x, point.y]
     }
 }

--- a/core/src/size.rs
+++ b/core/src/size.rs
@@ -1,4 +1,4 @@
-use crate::{Padding, Vector};
+use crate::Vector;
 
 /// An amount of space in 2 dimensions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -26,15 +26,7 @@ impl Size {
     /// A [`Size`] with infinite width and height.
     pub const INFINITY: Size = Size::new(f32::INFINITY, f32::INFINITY);
 
-    /// Increments the [`Size`] to account for the given padding.
-    pub fn pad(&self, padding: Padding) -> Self {
-        Size {
-            width: self.width + padding.horizontal(),
-            height: self.height + padding.vertical(),
-        }
-    }
-
-    /// Returns the minimum of each component of this size and another
+    /// Returns the minimum of each component of this size and another.
     pub fn min(self, other: Self) -> Self {
         Size {
             width: self.width.min(other.width),
@@ -42,11 +34,21 @@ impl Size {
         }
     }
 
-    /// Returns the maximum of each component of this size and another
+    /// Returns the maximum of each component of this size and another.
     pub fn max(self, other: Self) -> Self {
         Size {
             width: self.width.max(other.width),
             height: self.height.max(other.height),
+        }
+    }
+
+    /// Expands this [`Size`] by the given amount.
+    pub fn expand(self, other: impl Into<Size>) -> Self {
+        let other = other.into();
+
+        Size {
+            width: self.width + other.width,
+            height: self.height + other.height,
         }
     }
 }

--- a/core/src/widget.rs
+++ b/core/src/widget.rs
@@ -15,7 +15,7 @@ use crate::layout::{self, Layout};
 use crate::mouse;
 use crate::overlay;
 use crate::renderer;
-use crate::{Clipboard, Length, Rectangle, Shell};
+use crate::{Clipboard, Length, Rectangle, Shell, Size};
 
 /// A component that displays information and allows interaction.
 ///
@@ -48,6 +48,14 @@ where
 
     /// Returns the height of the [`Widget`].
     fn height(&self) -> Length;
+
+    /// Returns a [`Size`] hint for laying out the [`Widget`].
+    ///
+    /// This hint may be used by some widget containers to adjust their sizing strategy
+    /// during construction.
+    fn size_hint(&self) -> Size<Length> {
+        Size::new(self.width(), self.height())
+    }
 
     /// Returns the [`layout::Node`] of the [`Widget`].
     ///

--- a/core/src/widget.rs
+++ b/core/src/widget.rs
@@ -43,18 +43,15 @@ pub trait Widget<Message, Renderer>
 where
     Renderer: crate::Renderer,
 {
-    /// Returns the width of the [`Widget`].
-    fn width(&self) -> Length;
-
-    /// Returns the height of the [`Widget`].
-    fn height(&self) -> Length;
+    /// Returns the [`Size`] of the [`Widget`] in lengths.
+    fn size(&self) -> Size<Length>;
 
     /// Returns a [`Size`] hint for laying out the [`Widget`].
     ///
     /// This hint may be used by some widget containers to adjust their sizing strategy
     /// during construction.
     fn size_hint(&self) -> Size<Length> {
-        Size::new(self.width(), self.height())
+        self.size()
     }
 
     /// Returns the [`layout::Node`] of the [`Widget`].

--- a/core/src/widget/text.rs
+++ b/core/src/widget/text.rs
@@ -206,28 +206,27 @@ pub fn layout<Renderer>(
 where
     Renderer: text::Renderer,
 {
-    let limits = limits.width(width).height(height);
-    let bounds = limits.max();
+    layout::sized(limits, width, height, |limits| {
+        let bounds = limits.max();
 
-    let size = size.unwrap_or_else(|| renderer.default_size());
-    let font = font.unwrap_or_else(|| renderer.default_font());
+        let size = size.unwrap_or_else(|| renderer.default_size());
+        let font = font.unwrap_or_else(|| renderer.default_font());
 
-    let State(ref mut paragraph) = state;
+        let State(ref mut paragraph) = state;
 
-    paragraph.update(text::Text {
-        content,
-        bounds,
-        size,
-        line_height,
-        font,
-        horizontal_alignment,
-        vertical_alignment,
-        shaping,
-    });
+        paragraph.update(text::Text {
+            content,
+            bounds,
+            size,
+            line_height,
+            font,
+            horizontal_alignment,
+            vertical_alignment,
+            shaping,
+        });
 
-    let size = limits.resolve(paragraph.min_bounds(), width, height);
-
-    layout::Node::new(size)
+        paragraph.min_bounds()
+    })
 }
 
 /// Draws text using the same logic as the [`Text`] widget.

--- a/core/src/widget/text.rs
+++ b/core/src/widget/text.rs
@@ -5,7 +5,9 @@ use crate::mouse;
 use crate::renderer;
 use crate::text::{self, Paragraph};
 use crate::widget::tree::{self, Tree};
-use crate::{Color, Element, Layout, Length, Pixels, Point, Rectangle, Widget};
+use crate::{
+    Color, Element, Layout, Length, Pixels, Point, Rectangle, Size, Widget,
+};
 
 use std::borrow::Cow;
 
@@ -134,12 +136,11 @@ where
         tree::State::new(State(Renderer::Paragraph::default()))
     }
 
-    fn width(&self) -> Length {
-        self.width
-    }
-
-    fn height(&self) -> Length {
-        self.height
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: self.width,
+            height: self.height,
+        }
     }
 
     fn layout(

--- a/core/src/widget/text.rs
+++ b/core/src/widget/text.rs
@@ -224,7 +224,7 @@ where
         shaping,
     });
 
-    let size = limits.resolve(paragraph.min_bounds());
+    let size = limits.resolve(paragraph.min_bounds(), width, height);
 
     layout::Node::new(size)
 }

--- a/examples/custom_quad/src/main.rs
+++ b/examples/custom_quad/src/main.rs
@@ -26,12 +26,11 @@ mod quad {
     where
         Renderer: renderer::Renderer,
     {
-        fn width(&self) -> Length {
-            Length::Shrink
-        }
-
-        fn height(&self) -> Length {
-            Length::Shrink
+        fn size(&self) -> Size<Length> {
+            Size {
+                width: Length::Shrink,
+                height: Length::Shrink,
+            }
         }
 
         fn layout(

--- a/examples/custom_widget/src/main.rs
+++ b/examples/custom_widget/src/main.rs
@@ -33,12 +33,11 @@ mod circle {
     where
         Renderer: renderer::Renderer,
     {
-        fn width(&self) -> Length {
-            Length::Shrink
-        }
-
-        fn height(&self) -> Length {
-            Length::Shrink
+        fn size(&self) -> Size<Length> {
+            Size {
+                width: Length::Shrink,
+                height: Length::Shrink,
+            }
         }
 
         fn layout(

--- a/examples/download_progress/src/main.rs
+++ b/examples/download_progress/src/main.rs
@@ -73,16 +73,15 @@ impl Application for Example {
     }
 
     fn view(&self) -> Element<Message> {
-        let downloads = Column::with_children(
-            self.downloads.iter().map(Download::view).collect(),
-        )
-        .push(
-            button("Add another download")
-                .on_press(Message::Add)
-                .padding(10),
-        )
-        .spacing(20)
-        .align_items(Alignment::End);
+        let downloads =
+            Column::with_children(self.downloads.iter().map(Download::view))
+                .push(
+                    button("Add another download")
+                        .on_press(Message::Add)
+                        .padding(10),
+                )
+                .spacing(20)
+                .align_items(Alignment::End);
 
         container(downloads)
             .width(Length::Fill)

--- a/examples/events/src/main.rs
+++ b/examples/events/src/main.rs
@@ -82,8 +82,7 @@ impl Application for Events {
             self.last
                 .iter()
                 .map(|event| text(format!("{event:?}")).size(40))
-                .map(Element::from)
-                .collect(),
+                .map(Element::from),
         );
 
         let toggle = checkbox(

--- a/examples/game_of_life/src/main.rs
+++ b/examples/game_of_life/src/main.rs
@@ -146,7 +146,8 @@ impl Application for GameOfLife {
                 .view()
                 .map(move |message| Message::Grid(message, version)),
             controls,
-        ];
+        ]
+        .height(Length::Fill);
 
         container(content)
             .width(Length::Fill)
@@ -178,7 +179,6 @@ fn view_controls<'a>(
         slider(1.0..=1000.0, speed as f32, Message::SpeedChanged),
         text(format!("x{speed}")).size(16),
     ]
-    .width(Length::Fill)
     .align_items(Alignment::Center)
     .spacing(10);
 

--- a/examples/geometry/src/main.rs
+++ b/examples/geometry/src/main.rs
@@ -29,9 +29,9 @@ mod rainbow {
             _renderer: &Renderer,
             limits: &layout::Limits,
         ) -> layout::Node {
-            let size = limits.resolve(Size::ZERO, Length::Fill, Length::Shrink);
+            let width = limits.max().width;
 
-            layout::Node::new(Size::new(size.width, size.width))
+            layout::Node::new(Size::new(width, width))
         }
 
         fn draw(

--- a/examples/geometry/src/main.rs
+++ b/examples/geometry/src/main.rs
@@ -16,12 +16,11 @@ mod rainbow {
     }
 
     impl<Message> Widget<Message, Renderer> for Rainbow {
-        fn width(&self) -> Length {
-            Length::Fill
-        }
-
-        fn height(&self) -> Length {
-            Length::Shrink
+        fn size(&self) -> Size<Length> {
+            Size {
+                width: Length::Fill,
+                height: Length::Shrink,
+            }
         }
 
         fn layout(

--- a/examples/geometry/src/main.rs
+++ b/examples/geometry/src/main.rs
@@ -30,7 +30,7 @@ mod rainbow {
             _renderer: &Renderer,
             limits: &layout::Limits,
         ) -> layout::Node {
-            let size = limits.width(Length::Fill).resolve(Size::ZERO);
+            let size = limits.resolve(Size::ZERO, Length::Fill, Length::Shrink);
 
             layout::Node::new(Size::new(size.width, size.width))
         }

--- a/examples/integration/src/controls.rs
+++ b/examples/integration/src/controls.rs
@@ -81,32 +81,25 @@ impl Program for Controls {
             );
 
         Row::new()
-            .width(Length::Fill)
             .height(Length::Fill)
             .align_items(Alignment::End)
             .push(
-                Column::new()
-                    .width(Length::Fill)
-                    .align_items(Alignment::End)
-                    .push(
-                        Column::new()
-                            .padding(10)
-                            .spacing(10)
-                            .push(
-                                Text::new("Background color")
-                                    .style(Color::WHITE),
-                            )
-                            .push(sliders)
-                            .push(
-                                Text::new(format!("{background_color:?}"))
-                                    .size(14)
-                                    .style(Color::WHITE),
-                            )
-                            .push(
-                                text_input("Placeholder", text)
-                                    .on_input(Message::TextChanged),
-                            ),
-                    ),
+                Column::new().align_items(Alignment::End).push(
+                    Column::new()
+                        .padding(10)
+                        .spacing(10)
+                        .push(Text::new("Background color").style(Color::WHITE))
+                        .push(sliders)
+                        .push(
+                            Text::new(format!("{background_color:?}"))
+                                .size(14)
+                                .style(Color::WHITE),
+                        )
+                        .push(
+                            text_input("Placeholder", text)
+                                .on_input(Message::TextChanged),
+                        ),
+                ),
             )
             .into()
     }

--- a/examples/layout/Cargo.toml
+++ b/examples/layout/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "layout"
+version = "0.1.0"
+authors = ["Héctor Ramón Jiménez <hector0193@gmail.com>"]
+edition = "2021"
+publish = false
+
+[dependencies]
+iced = { path = "../.." }

--- a/examples/layout/Cargo.toml
+++ b/examples/layout/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 publish = false
 
 [dependencies]
-iced = { path = "../.." }
+iced = { path = "../..", features = ["canvas"] }

--- a/examples/layout/src/main.rs
+++ b/examples/layout/src/main.rs
@@ -1,8 +1,8 @@
 use iced::executor;
 use iced::keyboard;
 use iced::widget::{
-    button, checkbox, column, container, horizontal_space, row, text,
-    vertical_rule,
+    button, checkbox, column, container, horizontal_space, pick_list, row,
+    text, vertical_rule,
 };
 use iced::{
     color, Alignment, Application, Color, Command, Element, Font, Length,
@@ -17,13 +17,15 @@ pub fn main() -> iced::Result {
 struct Layout {
     example: Example,
     explain: bool,
+    theme: Theme,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 enum Message {
     Next,
     Previous,
     ExplainToggled(bool),
+    ThemeSelected(Theme),
 }
 
 impl Application for Layout {
@@ -37,6 +39,7 @@ impl Application for Layout {
             Self {
                 example: Example::default(),
                 explain: false,
+                theme: Theme::Light,
             },
             Command::none(),
         )
@@ -57,6 +60,9 @@ impl Application for Layout {
             Message::ExplainToggled(explain) => {
                 self.explain = explain;
             }
+            Message::ThemeSelected(theme) => {
+                self.theme = theme;
+            }
         }
 
         Command::none()
@@ -75,7 +81,13 @@ impl Application for Layout {
             text(self.example.title).size(20).font(Font::MONOSPACE),
             horizontal_space(Length::Fill),
             checkbox("Explain", self.explain, Message::ExplainToggled),
+            pick_list(
+                Theme::ALL,
+                Some(self.theme.clone()),
+                Message::ThemeSelected
+            ),
         ]
+        .spacing(20)
         .align_items(Alignment::Center);
 
         let example = container(if self.explain {
@@ -115,7 +127,7 @@ impl Application for Layout {
     }
 
     fn theme(&self) -> Theme {
-        Theme::Dark
+        self.theme.clone()
     }
 }
 

--- a/examples/layout/src/main.rs
+++ b/examples/layout/src/main.rs
@@ -4,7 +4,7 @@ use iced::mouse;
 use iced::theme;
 use iced::widget::{
     button, canvas, checkbox, column, container, horizontal_space, pick_list,
-    row, scrollable, text, vertical_rule, vertical_space,
+    row, scrollable, text, vertical_rule,
 };
 use iced::{
     color, Alignment, Application, Color, Command, Element, Font, Length,
@@ -284,9 +284,19 @@ fn application<'a>() -> Element<'a, Message> {
     .center_y();
 
     let content = container(
-        scrollable(column!["Content!", vertical_space(2000), "The end"])
-            .width(Length::Fill)
-            .height(Length::Fill),
+        scrollable(
+            column![
+                "Content!",
+                square(400),
+                square(200),
+                square(400),
+                "The end"
+            ]
+            .spacing(40)
+            .align_items(Alignment::Center)
+            .width(Length::Fill),
+        )
+        .height(Length::Fill),
     )
     .padding(10);
 

--- a/examples/layout/src/main.rs
+++ b/examples/layout/src/main.rs
@@ -1,8 +1,11 @@
 use iced::executor;
 use iced::keyboard;
-use iced::widget::{column, container, row, text, vertical_rule};
+use iced::widget::{
+    button, column, container, horizontal_space, row, text, vertical_rule,
+};
 use iced::{
-    Application, Command, Element, Length, Settings, Subscription, Theme,
+    color, Application, Color, Command, Element, Length, Settings,
+    Subscription, Theme,
 };
 
 pub fn main() -> iced::Result {
@@ -61,7 +64,29 @@ impl Application for Layout {
     }
 
     fn view(&self) -> Element<Message> {
-        self.example.view()
+        let example = container(self.example.view()).style(
+            container::Appearance::default().with_border(Color::BLACK, 2.0),
+        );
+
+        let controls = row([
+            (!self.example.is_first()).then_some(
+                button("← Previous")
+                    .padding([5, 10])
+                    .on_press(Message::Previous)
+                    .into(),
+            ),
+            Some(horizontal_space(Length::Fill).into()),
+            (!self.example.is_last()).then_some(
+                button("Next →")
+                    .padding([5, 10])
+                    .on_press(Message::Next)
+                    .into(),
+            ),
+        ]
+        .into_iter()
+        .filter_map(std::convert::identity));
+
+        column![example, controls].spacing(10).padding(20).into()
     }
 }
 
@@ -82,6 +107,14 @@ impl Example {
             view: nested_quotes,
         },
     ];
+
+    fn is_first(self) -> bool {
+        Self::LIST.first() == Some(&self)
+    }
+
+    fn is_last(self) -> bool {
+        Self::LIST.last() == Some(&self)
+    }
 
     fn previous(self) -> Self {
         let Some(index) =
@@ -127,20 +160,26 @@ fn centered<'a>() -> Element<'a, Message> {
 }
 
 fn nested_quotes<'a>() -> Element<'a, Message> {
-    container((1..5).fold(
-        column![text("Original text")].padding(10),
-        |quotes, i| {
+    let quotes =
+        (1..5).fold(column![text("Original text")].padding(10), |quotes, i| {
             column![
-                row![vertical_rule(2), quotes].height(Length::Shrink),
+                container(
+                    row![vertical_rule(2), quotes].height(Length::Shrink)
+                )
+                .style(
+                    container::Appearance::default()
+                        .with_background(color!(0x000000, 0.05))
+                ),
                 text(format!("Reply {i}"))
             ]
             .spacing(10)
             .padding(10)
-        },
-    ))
-    .width(Length::Fill)
-    .height(Length::Fill)
-    .center_x()
-    .center_y()
-    .into()
+        });
+
+    container(quotes)
+        .width(Length::Fill)
+        .height(Length::Fill)
+        .center_x()
+        .center_y()
+        .into()
 }

--- a/examples/layout/src/main.rs
+++ b/examples/layout/src/main.rs
@@ -106,7 +106,7 @@ impl Example {
                 column![text("Original text")].padding(10),
                 |quotes, i| {
                     column![
-                        row![vertical_rule(2), quotes],
+                        row![vertical_rule(2), quotes].height(Length::Shrink),
                         text(format!("Reply {i}"))
                     ]
                     .spacing(10)

--- a/examples/layout/src/main.rs
+++ b/examples/layout/src/main.rs
@@ -84,7 +84,7 @@ impl Application for Layout {
             ),
         ]
         .into_iter()
-        .filter_map(std::convert::identity));
+        .flatten());
 
         column![example, controls].spacing(10).padding(20).into()
     }

--- a/examples/layout/src/main.rs
+++ b/examples/layout/src/main.rs
@@ -1,0 +1,123 @@
+use iced::executor;
+use iced::widget::{column, container, row, text, vertical_rule};
+use iced::{
+    Application, Command, Element, Length, Settings, Subscription, Theme,
+};
+
+pub fn main() -> iced::Result {
+    Layout::run(Settings::default())
+}
+
+#[derive(Debug)]
+struct Layout {
+    previous: Vec<Example>,
+    current: Example,
+    next: Vec<Example>,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Message {
+    Next,
+    Previous,
+}
+
+impl Application for Layout {
+    type Message = Message;
+    type Theme = Theme;
+    type Executor = executor::Default;
+    type Flags = ();
+
+    fn new(_flags: Self::Flags) -> (Self, Command<Message>) {
+        (
+            Self {
+                previous: vec![],
+                current: Example::Centered,
+                next: vec![Example::NestedQuotes],
+            },
+            Command::none(),
+        )
+    }
+
+    fn title(&self) -> String {
+        String::from("Counter - Iced")
+    }
+
+    fn update(&mut self, message: Self::Message) -> Command<Message> {
+        match message {
+            Message::Next => {
+                if !self.next.is_empty() {
+                    let previous = std::mem::replace(
+                        &mut self.current,
+                        self.next.remove(0),
+                    );
+
+                    self.previous.push(previous);
+                }
+            }
+            Message::Previous => {
+                if let Some(previous) = self.previous.pop() {
+                    let next = std::mem::replace(&mut self.current, previous);
+
+                    self.next.insert(0, next);
+                }
+            }
+        }
+
+        Command::none()
+    }
+
+    fn subscription(&self) -> Subscription<Message> {
+        use iced::event::{self, Event};
+        use iced::keyboard;
+
+        event::listen_with(|event, status| match event {
+            Event::Keyboard(keyboard::Event::KeyReleased {
+                key_code, ..
+            }) if status == event::Status::Ignored => match key_code {
+                keyboard::KeyCode::Left => Some(Message::Previous),
+                keyboard::KeyCode::Right => Some(Message::Next),
+                _ => None,
+            },
+            _ => None,
+        })
+    }
+
+    fn view(&self) -> Element<Message> {
+        self.current.view()
+    }
+}
+
+#[derive(Debug)]
+enum Example {
+    Centered,
+    NestedQuotes,
+}
+
+impl Example {
+    fn view(&self) -> Element<Message> {
+        match self {
+            Self::Centered => container(text("I am centered!").size(50))
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .center_x()
+                .center_y()
+                .into(),
+            Self::NestedQuotes => container((1..5).fold(
+                column![text("Original text")].padding(10),
+                |quotes, i| {
+                    column![
+                        row![vertical_rule(2), quotes],
+                        text(format!("Reply {i}"))
+                    ]
+                    .spacing(10)
+                    .padding(10)
+                },
+            ))
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .center_x()
+            .center_y()
+            .into(),
+        }
+    }
+}

--- a/examples/lazy/src/main.rs
+++ b/examples/lazy/src/main.rs
@@ -178,35 +178,23 @@ impl Sandbox for App {
                 }
             });
 
-            column(
-                items
-                    .into_iter()
-                    .map(|item| {
-                        let button = button("Delete")
-                            .on_press(Message::DeleteItem(item.clone()))
-                            .style(theme::Button::Destructive);
+            column(items.into_iter().map(|item| {
+                let button = button("Delete")
+                    .on_press(Message::DeleteItem(item.clone()))
+                    .style(theme::Button::Destructive);
 
-                        row![
-                            text(&item.name)
-                                .style(theme::Text::Color(item.color.into())),
-                            horizontal_space(Length::Fill),
-                            pick_list(
-                                Color::ALL,
-                                Some(item.color),
-                                move |color| {
-                                    Message::ItemColorChanged(
-                                        item.clone(),
-                                        color,
-                                    )
-                                }
-                            ),
-                            button
-                        ]
-                        .spacing(20)
-                        .into()
-                    })
-                    .collect(),
-            )
+                row![
+                    text(&item.name)
+                        .style(theme::Text::Color(item.color.into())),
+                    horizontal_space(Length::Fill),
+                    pick_list(Color::ALL, Some(item.color), move |color| {
+                        Message::ItemColorChanged(item.clone(), color)
+                    }),
+                    button
+                ]
+                .spacing(20)
+                .into()
+            }))
             .spacing(10)
         });
 

--- a/examples/loading_spinners/src/circular.rs
+++ b/examples/loading_spinners/src/circular.rs
@@ -244,12 +244,11 @@ where
         tree::State::new(State::default())
     }
 
-    fn width(&self) -> Length {
-        Length::Fixed(self.size)
-    }
-
-    fn height(&self) -> Length {
-        Length::Fixed(self.size)
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: Length::Fixed(self.size),
+            height: Length::Fixed(self.size),
+        }
     }
 
     fn layout(

--- a/examples/loading_spinners/src/circular.rs
+++ b/examples/loading_spinners/src/circular.rs
@@ -257,10 +257,7 @@ where
         _renderer: &iced::Renderer<Theme>,
         limits: &layout::Limits,
     ) -> layout::Node {
-        let limits = limits.width(self.size).height(self.size);
-        let size = limits.resolve(Size::ZERO, self.size, self.size);
-
-        layout::Node::new(size)
+        layout::atomic(limits, self.size, self.size)
     }
 
     fn on_event(

--- a/examples/loading_spinners/src/circular.rs
+++ b/examples/loading_spinners/src/circular.rs
@@ -259,7 +259,7 @@ where
         limits: &layout::Limits,
     ) -> layout::Node {
         let limits = limits.width(self.size).height(self.size);
-        let size = limits.resolve(Size::ZERO);
+        let size = limits.resolve(Size::ZERO, self.size, self.size);
 
         layout::Node::new(size)
     }

--- a/examples/loading_spinners/src/linear.rs
+++ b/examples/loading_spinners/src/linear.rs
@@ -180,7 +180,7 @@ where
         limits: &layout::Limits,
     ) -> layout::Node {
         let limits = limits.width(self.width).height(self.height);
-        let size = limits.resolve(Size::ZERO);
+        let size = limits.resolve(Size::ZERO, self.width, self.height);
 
         layout::Node::new(size)
     }

--- a/examples/loading_spinners/src/linear.rs
+++ b/examples/loading_spinners/src/linear.rs
@@ -165,12 +165,11 @@ where
         tree::State::new(State::default())
     }
 
-    fn width(&self) -> Length {
-        self.width
-    }
-
-    fn height(&self) -> Length {
-        self.height
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: self.width,
+            height: self.height,
+        }
     }
 
     fn layout(

--- a/examples/loading_spinners/src/linear.rs
+++ b/examples/loading_spinners/src/linear.rs
@@ -178,10 +178,7 @@ where
         _renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
-        let limits = limits.width(self.width).height(self.height);
-        let size = limits.resolve(Size::ZERO, self.width, self.height);
-
-        layout::Node::new(size)
+        layout::atomic(limits, self.width, self.height)
     }
 
     fn on_event(

--- a/examples/loading_spinners/src/main.rs
+++ b/examples/loading_spinners/src/main.rs
@@ -96,15 +96,14 @@ impl Application for LoadingSpinners {
 
         container(
             column.push(
-                row(vec![
-                    text("Cycle duration:").into(),
+                row![
+                    text("Cycle duration:"),
                     slider(1.0..=1000.0, self.cycle_duration * 100.0, |x| {
                         Message::CycleDurationChanged(x / 100.0)
                     })
-                    .width(200.0)
-                    .into(),
-                    text(format!("{:.2}s", self.cycle_duration)).into(),
-                ])
+                    .width(200.0),
+                    text(format!("{:.2}s", self.cycle_duration)),
+                ]
                 .align_items(iced::Alignment::Center)
                 .spacing(20.0),
             ),

--- a/examples/modal/src/main.rs
+++ b/examples/modal/src/main.rs
@@ -420,17 +420,14 @@ mod modal {
                 .width(Length::Fill)
                 .height(Length::Fill);
 
-            let mut child = self
+            let child = self
                 .content
                 .as_widget()
-                .layout(self.tree, renderer, &limits);
+                .layout(self.tree, renderer, &limits)
+                .align(Alignment::Center, Alignment::Center, limits.max());
 
-            child.align(Alignment::Center, Alignment::Center, limits.max());
-
-            let mut node = layout::Node::with_children(self.size, vec![child]);
-            node.move_to(position);
-
-            node
+            layout::Node::with_children(self.size, vec![child])
+                .move_to(position)
         }
 
         fn on_event(

--- a/examples/modal/src/main.rs
+++ b/examples/modal/src/main.rs
@@ -281,12 +281,8 @@ mod modal {
             tree.diff_children(&[&self.base, &self.modal]);
         }
 
-        fn width(&self) -> Length {
-            self.base.as_widget().width()
-        }
-
-        fn height(&self) -> Length {
-            self.base.as_widget().height()
+        fn size(&self) -> Size<Length> {
+            self.base.as_widget().size()
         }
 
         fn layout(

--- a/examples/pane_grid/src/main.rs
+++ b/examples/pane_grid/src/main.rs
@@ -297,7 +297,6 @@ fn view_content<'a>(
         text(format!("{}x{}", size.width, size.height)).size(24),
         controls,
     ]
-    .width(Length::Fill)
     .spacing(10)
     .align_items(Alignment::Center);
 

--- a/examples/pick_list/src/main.rs
+++ b/examples/pick_list/src/main.rs
@@ -1,4 +1,4 @@
-use iced::widget::{column, container, pick_list, scrollable, vertical_space};
+use iced::widget::{column, pick_list, scrollable, vertical_space};
 use iced::{Alignment, Element, Length, Sandbox, Settings};
 
 pub fn main() -> iced::Result {
@@ -48,15 +48,11 @@ impl Sandbox for Example {
             pick_list,
             vertical_space(600),
         ]
+        .width(Length::Fill)
         .align_items(Alignment::Center)
         .spacing(10);
 
-        container(scrollable(content))
-            .width(Length::Fill)
-            .height(Length::Fill)
-            .center_x()
-            .center_y()
-            .into()
+        scrollable(content).into()
     }
 }
 

--- a/examples/pick_list/src/main.rs
+++ b/examples/pick_list/src/main.rs
@@ -48,7 +48,6 @@ impl Sandbox for Example {
             pick_list,
             vertical_space(600),
         ]
-        .width(Length::Fill)
         .align_items(Alignment::Center)
         .spacing(10);
 

--- a/examples/scrollable/src/main.rs
+++ b/examples/scrollable/src/main.rs
@@ -147,35 +147,30 @@ impl Application for ScrollableDemo {
             text("Scroller width:"),
             scroller_width_slider,
         ]
-        .spacing(10)
-        .width(Length::Fill);
+        .spacing(10);
 
-        let scroll_orientation_controls = column(vec![
-            text("Scrollbar direction:").into(),
+        let scroll_orientation_controls = column![
+            text("Scrollbar direction:"),
             radio(
                 "Vertical",
                 Direction::Vertical,
                 Some(self.scrollable_direction),
                 Message::SwitchDirection,
-            )
-            .into(),
+            ),
             radio(
                 "Horizontal",
                 Direction::Horizontal,
                 Some(self.scrollable_direction),
                 Message::SwitchDirection,
-            )
-            .into(),
+            ),
             radio(
                 "Both!",
                 Direction::Multi,
                 Some(self.scrollable_direction),
                 Message::SwitchDirection,
-            )
-            .into(),
-        ])
-        .spacing(10)
-        .width(Length::Fill);
+            ),
+        ]
+        .spacing(10);
 
         let scroll_alignment_controls = column(vec![
             text("Scrollable alignment:").into(),
@@ -194,16 +189,14 @@ impl Application for ScrollableDemo {
             )
             .into(),
         ])
-        .spacing(10)
-        .width(Length::Fill);
+        .spacing(10);
 
         let scroll_controls = row![
             scroll_slider_controls,
             scroll_orientation_controls,
             scroll_alignment_controls
         ]
-        .spacing(20)
-        .width(Length::Fill);
+        .spacing(20);
 
         let scroll_to_end_button = || {
             button("Scroll to end")
@@ -229,7 +222,6 @@ impl Application for ScrollableDemo {
                         text("End!"),
                         scroll_to_beginning_button(),
                     ]
-                    .width(Length::Fill)
                     .align_items(Alignment::Center)
                     .padding([40, 0, 40, 0])
                     .spacing(40),
@@ -341,7 +333,6 @@ impl Application for ScrollableDemo {
 
         let content: Element<Message> =
             column![scroll_controls, scrollable_content, progress_bars]
-                .width(Length::Fill)
                 .height(Length::Fill)
                 .align_items(Alignment::Center)
                 .spacing(10)

--- a/examples/scrollable/src/main.rs
+++ b/examples/scrollable/src/main.rs
@@ -172,23 +172,21 @@ impl Application for ScrollableDemo {
         ]
         .spacing(10);
 
-        let scroll_alignment_controls = column(vec![
-            text("Scrollable alignment:").into(),
+        let scroll_alignment_controls = column![
+            text("Scrollable alignment:"),
             radio(
                 "Start",
                 scrollable::Alignment::Start,
                 Some(self.alignment),
                 Message::AlignmentChanged,
-            )
-            .into(),
+            ),
             radio(
                 "End",
                 scrollable::Alignment::End,
                 Some(self.alignment),
                 Message::AlignmentChanged,
             )
-            .into(),
-        ])
+        ]
         .spacing(10);
 
         let scroll_controls = row![
@@ -226,6 +224,7 @@ impl Application for ScrollableDemo {
                     .padding([40, 0, 40, 0])
                     .spacing(40),
                 )
+                .width(Length::Fill)
                 .height(Length::Fill)
                 .direction(scrollable::Direction::Vertical(
                     Properties::new()
@@ -251,6 +250,7 @@ impl Application for ScrollableDemo {
                     .padding([0, 40, 0, 40])
                     .spacing(40),
                 )
+                .width(Length::Fill)
                 .height(Length::Fill)
                 .direction(scrollable::Direction::Horizontal(
                     Properties::new()
@@ -293,6 +293,7 @@ impl Application for ScrollableDemo {
                     .padding([0, 40, 0, 40])
                     .spacing(40),
                 )
+                .width(Length::Fill)
                 .height(Length::Fill)
                 .direction({
                     let properties = Properties::new()
@@ -333,19 +334,11 @@ impl Application for ScrollableDemo {
 
         let content: Element<Message> =
             column![scroll_controls, scrollable_content, progress_bars]
-                .height(Length::Fill)
                 .align_items(Alignment::Center)
                 .spacing(10)
                 .into();
 
-        Element::from(
-            container(content)
-                .width(Length::Fill)
-                .height(Length::Fill)
-                .padding(40)
-                .center_x()
-                .center_y(),
-        )
+        Element::from(container(content).padding(40).center_x().center_y())
     }
 
     fn theme(&self) -> Self::Theme {

--- a/examples/scrollable/src/main.rs
+++ b/examples/scrollable/src/main.rs
@@ -338,7 +338,7 @@ impl Application for ScrollableDemo {
                 .spacing(10)
                 .into();
 
-        Element::from(container(content).padding(40).center_x().center_y())
+        container(content).padding(20).center_x().center_y().into()
     }
 
     fn theme(&self) -> Self::Theme {

--- a/examples/sierpinski_triangle/src/main.rs
+++ b/examples/sierpinski_triangle/src/main.rs
@@ -79,12 +79,10 @@ impl Application for SierpinskiEmulator {
             row![
                 text(format!("Iteration: {:?}", self.graph.iteration)),
                 slider(0..=10000, self.graph.iteration, Message::IterationSet)
-                    .width(Length::Fill)
             ]
             .padding(10)
             .spacing(20),
         ]
-        .width(Length::Fill)
         .align_items(iced::Alignment::Center)
         .into()
     }

--- a/examples/styling/src/main.rs
+++ b/examples/styling/src/main.rs
@@ -104,10 +104,11 @@ impl Sandbox for Styling {
 
         let progress_bar = progress_bar(0.0..=100.0, self.slider_value);
 
-        let scrollable = scrollable(
-            column!["Scroll me!", vertical_space(800), "You did it!"]
-                .width(Length::Fill),
-        )
+        let scrollable = scrollable(column![
+            "Scroll me!",
+            vertical_space(800),
+            "You did it!"
+        ])
         .width(Length::Fill)
         .height(100);
 

--- a/examples/styling/src/main.rs
+++ b/examples/styling/src/main.rs
@@ -53,13 +53,16 @@ impl Sandbox for Styling {
                 self.theme = match theme {
                     ThemeType::Light => Theme::Light,
                     ThemeType::Dark => Theme::Dark,
-                    ThemeType::Custom => Theme::custom(theme::Palette {
-                        background: Color::from_rgb(1.0, 0.9, 1.0),
-                        text: Color::BLACK,
-                        primary: Color::from_rgb(0.5, 0.5, 0.0),
-                        success: Color::from_rgb(0.0, 1.0, 0.0),
-                        danger: Color::from_rgb(1.0, 0.0, 0.0),
-                    }),
+                    ThemeType::Custom => Theme::custom(
+                        String::from("Custom"),
+                        theme::Palette {
+                            background: Color::from_rgb(1.0, 0.9, 1.0),
+                            text: Color::BLACK,
+                            primary: Color::from_rgb(0.5, 0.5, 0.0),
+                            success: Color::from_rgb(0.0, 1.0, 0.0),
+                            danger: Color::from_rgb(1.0, 0.0, 0.0),
+                        },
+                    ),
                 }
             }
             Message::InputChanged(value) => self.input_value = value,

--- a/examples/svg/src/main.rs
+++ b/examples/svg/src/main.rs
@@ -63,7 +63,6 @@ impl Sandbox for Tiger {
                 container(apply_color_filter).width(Length::Fill).center_x()
             ]
             .spacing(20)
-            .width(Length::Fill)
             .height(Length::Fill),
         )
         .width(Length::Fill)

--- a/examples/toast/src/main.rs
+++ b/examples/toast/src/main.rs
@@ -313,12 +313,8 @@ mod toast {
     }
 
     impl<'a, Message> Widget<Message, Renderer> for Manager<'a, Message> {
-        fn width(&self) -> Length {
-            self.content.as_widget().width()
-        }
-
-        fn height(&self) -> Length {
-            self.content.as_widget().height()
+        fn size(&self) -> Size<Length> {
+            self.content.as_widget().size()
         }
 
         fn layout(

--- a/examples/toast/src/main.rs
+++ b/examples/toast/src/main.rs
@@ -106,9 +106,7 @@ impl Application for App {
 
     fn view<'a>(&'a self) -> Element<'a, Message> {
         let subtitle = |title, content: Element<'a, Message>| {
-            column![text(title).size(14), content]
-                .width(Length::Fill)
-                .spacing(5)
+            column![text(title).size(14), content].spacing(5)
         };
 
         let mut add_toast = button("Add Toast");
@@ -153,14 +151,11 @@ impl Application for App {
                             Message::Timeout
                         )
                         .step(1.0)
-                        .width(Length::Fill)
                     ]
                     .spacing(5)
                     .into()
                 ),
-                column![add_toast]
-                    .width(Length::Fill)
-                    .align_items(Alignment::End)
+                column![add_toast].align_items(Alignment::End)
             ]
             .spacing(10)
             .max_width(200),
@@ -513,14 +508,14 @@ mod toast {
             position: Point,
             _translation: Vector,
         ) -> layout::Node {
-            let limits = layout::Limits::new(Size::ZERO, bounds)
-                .width(Length::Fill)
-                .height(Length::Fill);
+            let limits = layout::Limits::new(Size::ZERO, bounds);
 
             layout::flex::resolve(
                 layout::flex::Axis::Vertical,
                 renderer,
                 &limits,
+                Length::Fill,
+                Length::Fill,
                 10.into(),
                 10.0,
                 Alignment::End,

--- a/examples/todos/src/main.rs
+++ b/examples/todos/src/main.rs
@@ -254,13 +254,7 @@ impl Application for Todos {
                     .spacing(20)
                     .max_width(800);
 
-                scrollable(
-                    container(content)
-                        .width(Length::Fill)
-                        .padding(40)
-                        .center_x(),
-                )
-                .into()
+                scrollable(container(content).padding(40).center_x()).into()
             }
         }
     }
@@ -472,7 +466,6 @@ fn empty_message(message: &str) -> Element<'_, Message> {
             .horizontal_alignment(alignment::Horizontal::Center)
             .style(Color::from([0.7, 0.7, 0.7])),
     )
-    .width(Length::Fill)
     .height(200)
     .center_y()
     .into()

--- a/examples/tour/src/main.rs
+++ b/examples/tour/src/main.rs
@@ -509,7 +509,6 @@ impl<'a> Step {
                         )
                     })
                     .map(Element::from)
-                    .collect()
             )
             .spacing(10)
         ]

--- a/examples/tour/src/main.rs
+++ b/examples/tour/src/main.rs
@@ -692,11 +692,7 @@ fn ferris<'a>(
 }
 
 fn button<'a, Message: Clone>(label: &str) -> Button<'a, Message> {
-    iced::widget::button(
-        text(label).horizontal_alignment(alignment::Horizontal::Center),
-    )
-    .padding(12)
-    .width(100)
+    iced::widget::button(text(label)).padding([12, 24])
 }
 
 fn color_slider<'a>(

--- a/examples/websocket/src/main.rs
+++ b/examples/websocket/src/main.rs
@@ -3,7 +3,7 @@ mod echo;
 use iced::alignment::{self, Alignment};
 use iced::executor;
 use iced::widget::{
-    button, column, container, row, scrollable, text, text_input, Column,
+    button, column, container, row, scrollable, text, text_input,
 };
 use iced::{
     Application, Color, Command, Element, Length, Settings, Subscription, Theme,
@@ -108,13 +108,8 @@ impl Application for WebSocket {
             .into()
         } else {
             scrollable(
-                Column::with_children(
-                    self.messages
-                        .iter()
-                        .cloned()
-                        .map(text)
-                        .map(Element::from)
-                        .collect(),
+                column(
+                    self.messages.iter().cloned().map(text).map(Element::from),
                 )
                 .spacing(10),
             )

--- a/examples/websocket/src/main.rs
+++ b/examples/websocket/src/main.rs
@@ -116,7 +116,6 @@ impl Application for WebSocket {
                         .map(Element::from)
                         .collect(),
                 )
-                .width(Length::Fill)
                 .spacing(10),
             )
             .id(MESSAGE_LOG.clone())
@@ -149,7 +148,6 @@ impl Application for WebSocket {
         };
 
         column![message_log, new_message_input]
-            .width(Length::Fill)
             .height(Length::Fill)
             .padding(20)
             .spacing(10)

--- a/examples/websocket/src/main.rs
+++ b/examples/websocket/src/main.rs
@@ -125,7 +125,7 @@ impl Application for WebSocket {
 
             let mut button = button(
                 text("Send")
-                    .height(Length::Fill)
+                    .height(40)
                     .vertical_alignment(alignment::Vertical::Center),
             )
             .padding([0, 20]);

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,4 +1,5 @@
 //! Listen and react to time.
 pub use iced_core::time::{Duration, Instant};
 
+#[allow(unused_imports)]
 pub use iced_futures::backend::default::time::*;

--- a/style/src/container.rs
+++ b/style/src/container.rs
@@ -1,5 +1,5 @@
 //! Change the appearance of a container.
-use iced_core::{Background, BorderRadius, Color};
+use crate::core::{Background, BorderRadius, Color, Pixels};
 
 /// The appearance of a container.
 #[derive(Debug, Clone, Copy)]
@@ -14,6 +14,30 @@ pub struct Appearance {
     pub border_width: f32,
     /// The border [`Color`] of the container.
     pub border_color: Color,
+}
+
+impl Appearance {
+    /// Derives a new [`Appearance`] with a border of the given [`Color`] and
+    /// `width`.
+    pub fn with_border(
+        self,
+        color: impl Into<Color>,
+        width: impl Into<Pixels>,
+    ) -> Self {
+        Self {
+            border_color: color.into(),
+            border_width: width.into().0,
+            ..self
+        }
+    }
+
+    /// Derives a new [`Appearance`] with the given [`Background`].
+    pub fn with_background(self, background: impl Into<Background>) -> Self {
+        Self {
+            background: Some(background.into()),
+            ..self
+        }
+    }
 }
 
 impl std::default::Default for Appearance {

--- a/style/src/theme.rs
+++ b/style/src/theme.rs
@@ -383,6 +383,12 @@ pub enum Container {
     Custom(Box<dyn container::StyleSheet<Style = Theme>>),
 }
 
+impl From<container::Appearance> for Container {
+    fn from(appearance: container::Appearance) -> Self {
+        Self::Custom(Box::new(move |_: &_| appearance))
+    }
+}
+
 impl<T: Fn(&Theme) -> container::Appearance + 'static> From<T> for Container {
     fn from(f: T) -> Self {
         Self::Custom(Box::new(f))

--- a/style/src/theme.rs
+++ b/style/src/theme.rs
@@ -23,6 +23,7 @@ use crate::toggler;
 
 use iced_core::{Background, Color, Vector};
 
+use std::fmt;
 use std::rc::Rc;
 
 /// A built-in theme.
@@ -38,18 +39,22 @@ pub enum Theme {
 }
 
 impl Theme {
+    /// A list with all the defined themes.
+    pub const ALL: &'static [Self] = &[Self::Light, Self::Dark];
+
     /// Creates a new custom [`Theme`] from the given [`Palette`].
-    pub fn custom(palette: Palette) -> Self {
-        Self::custom_with_fn(palette, palette::Extended::generate)
+    pub fn custom(name: String, palette: Palette) -> Self {
+        Self::custom_with_fn(name, palette, palette::Extended::generate)
     }
 
     /// Creates a new custom [`Theme`] from the given [`Palette`], with
     /// a custom generator of a [`palette::Extended`].
     pub fn custom_with_fn(
+        name: String,
         palette: Palette,
         generate: impl FnOnce(Palette) -> palette::Extended,
     ) -> Self {
-        Self::Custom(Box::new(Custom::with_fn(palette, generate)))
+        Self::Custom(Box::new(Custom::with_fn(name, palette, generate)))
     }
 
     /// Returns the [`Palette`] of the [`Theme`].
@@ -71,29 +76,48 @@ impl Theme {
     }
 }
 
+impl fmt::Display for Theme {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Light => write!(f, "Light"),
+            Self::Dark => write!(f, "Dark"),
+            Self::Custom(custom) => custom.fmt(f),
+        }
+    }
+}
+
 /// A [`Theme`] with a customized [`Palette`].
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Custom {
+    name: String,
     palette: Palette,
     extended: palette::Extended,
 }
 
 impl Custom {
     /// Creates a [`Custom`] theme from the given [`Palette`].
-    pub fn new(palette: Palette) -> Self {
-        Self::with_fn(palette, palette::Extended::generate)
+    pub fn new(name: String, palette: Palette) -> Self {
+        Self::with_fn(name, palette, palette::Extended::generate)
     }
 
     /// Creates a [`Custom`] theme from the given [`Palette`] with
     /// a custom generator of a [`palette::Extended`].
     pub fn with_fn(
+        name: String,
         palette: Palette,
         generate: impl FnOnce(Palette) -> palette::Extended,
     ) -> Self {
         Self {
+            name,
             palette,
             extended: generate(palette),
         }
+    }
+}
+
+impl fmt::Display for Custom {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.name)
     }
 }
 

--- a/style/src/theme/palette.rs
+++ b/style/src/theme/palette.rs
@@ -82,6 +82,8 @@ pub struct Extended {
     pub success: Success,
     /// The set of danger colors.
     pub danger: Danger,
+    /// Whether the palette is dark or not.
+    pub is_dark: bool,
 }
 
 /// The built-in light variant of an [`Extended`] palette.
@@ -113,6 +115,7 @@ impl Extended {
                 palette.background,
                 palette.text,
             ),
+            is_dark: is_dark(palette.background),
         }
     }
 }

--- a/widget/src/button.rs
+++ b/widget/src/button.rs
@@ -11,7 +11,7 @@ use crate::core::widget::tree::{self, Tree};
 use crate::core::widget::Operation;
 use crate::core::{
     Background, Clipboard, Color, Element, Layout, Length, Padding, Point,
-    Rectangle, Shell, Vector, Widget,
+    Rectangle, Shell, Size, Vector, Widget,
 };
 
 pub use iced_style::button::{Appearance, StyleSheet};
@@ -149,12 +149,11 @@ where
         tree.diff_children(std::slice::from_ref(&self.content));
     }
 
-    fn width(&self) -> Length {
-        self.width
-    }
-
-    fn height(&self) -> Length {
-        self.height
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: self.width,
+            height: self.height,
+        }
     }
 
     fn layout(

--- a/widget/src/button.rs
+++ b/widget/src/button.rs
@@ -71,11 +71,14 @@ where
 {
     /// Creates a new [`Button`] with the given content.
     pub fn new(content: impl Into<Element<'a, Message, Renderer>>) -> Self {
+        let content = content.into();
+        let size = content.as_widget().size_hint();
+
         Button {
-            content: content.into(),
+            content,
             on_press: None,
-            width: Length::Shrink,
-            height: Length::Shrink,
+            width: size.width.fluid(),
+            height: size.height.fluid(),
             padding: Padding::new(5.0),
             style: <Renderer::Theme as StyleSheet>::Style::default(),
         }

--- a/widget/src/button.rs
+++ b/widget/src/button.rs
@@ -10,8 +10,8 @@ use crate::core::touch;
 use crate::core::widget::tree::{self, Tree};
 use crate::core::widget::Operation;
 use crate::core::{
-    Background, Clipboard, Color, Element, Layout, Length, Padding, Point,
-    Rectangle, Shell, Size, Vector, Widget,
+    Background, Clipboard, Color, Element, Layout, Length, Padding, Rectangle,
+    Shell, Size, Vector, Widget,
 };
 
 pub use iced_style::button::{Appearance, StyleSheet};
@@ -430,20 +430,7 @@ pub fn layout(
     padding: Padding,
     layout_content: impl FnOnce(&layout::Limits) -> layout::Node,
 ) -> layout::Node {
-    let limits = limits.width(width).height(height);
-
-    let content = layout_content(&limits.shrink(padding));
-    let padding = padding.fit(content.size(), limits.max());
-
-    let size = limits
-        .shrink(padding)
-        .resolve(content.size(), width, height)
-        .expand(padding);
-
-    layout::Node::with_children(
-        size,
-        vec![content.move_to(Point::new(padding.left, padding.top))],
-    )
+    layout::padded(limits, width, height, padding, layout_content)
 }
 
 /// Returns the [`mouse::Interaction`] of a [`Button`].

--- a/widget/src/button.rs
+++ b/widget/src/button.rs
@@ -433,13 +433,18 @@ pub fn layout(
 ) -> layout::Node {
     let limits = limits.width(width).height(height);
 
-    let mut content = layout_content(&limits.pad(padding));
+    let content = layout_content(&limits.shrink(padding));
     let padding = padding.fit(content.size(), limits.max());
-    let size = limits.pad(padding).resolve(content.size()).pad(padding);
 
-    content.move_to(Point::new(padding.left, padding.top));
+    let size = limits
+        .shrink(padding)
+        .resolve(content.size(), width, height)
+        .expand(padding);
 
-    layout::Node::with_children(size, vec![content])
+    layout::Node::with_children(
+        size,
+        vec![content.move_to(Point::new(padding.left, padding.top))],
+    )
 }
 
 /// Returns the [`mouse::Interaction`] of a [`Button`].

--- a/widget/src/canvas.rs
+++ b/widget/src/canvas.rs
@@ -133,8 +133,7 @@ where
         _renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
-        let limits = limits.width(self.width).height(self.height);
-        let size = limits.resolve(Size::ZERO);
+        let size = limits.resolve(Size::ZERO, self.width, self.height);
 
         layout::Node::new(size)
     }

--- a/widget/src/canvas.rs
+++ b/widget/src/canvas.rs
@@ -133,9 +133,7 @@ where
         _renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
-        let size = limits.resolve(Size::ZERO, self.width, self.height);
-
-        layout::Node::new(size)
+        layout::atomic(limits, self.width, self.height)
     }
 
     fn on_event(

--- a/widget/src/canvas.rs
+++ b/widget/src/canvas.rs
@@ -14,8 +14,9 @@ use crate::core::layout::{self, Layout};
 use crate::core::mouse;
 use crate::core::renderer;
 use crate::core::widget::tree::{self, Tree};
-use crate::core::{Clipboard, Element, Shell, Widget};
-use crate::core::{Length, Rectangle, Size, Vector};
+use crate::core::{
+    Clipboard, Element, Length, Rectangle, Shell, Size, Vector, Widget,
+};
 use crate::graphics::geometry;
 
 use std::marker::PhantomData;
@@ -119,12 +120,11 @@ where
         tree::State::new(P::State::default())
     }
 
-    fn width(&self) -> Length {
-        self.width
-    }
-
-    fn height(&self) -> Length {
-        self.height
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: self.width,
+            height: self.height,
+        }
     }
 
     fn layout(

--- a/widget/src/checkbox.rs
+++ b/widget/src/checkbox.rs
@@ -174,12 +174,11 @@ where
         tree::State::new(widget::text::State::<Renderer::Paragraph>::default())
     }
 
-    fn width(&self) -> Length {
-        self.width
-    }
-
-    fn height(&self) -> Length {
-        Length::Shrink
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: self.width,
+            height: Length::Shrink,
+        }
     }
 
     fn layout(

--- a/widget/src/column.rs
+++ b/widget/src/column.rs
@@ -7,7 +7,7 @@ use crate::core::renderer;
 use crate::core::widget::{Operation, Tree};
 use crate::core::{
     Alignment, Clipboard, Element, Layout, Length, Padding, Pixels, Rectangle,
-    Shell, Widget,
+    Shell, Size, Widget,
 };
 
 /// A container that distributes its contents vertically.
@@ -129,12 +129,11 @@ where
         tree.diff_children(&self.children);
     }
 
-    fn width(&self) -> Length {
-        self.width
-    }
-
-    fn height(&self) -> Length {
-        self.height
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: self.width,
+            height: self.height,
+        }
     }
 
     fn layout(

--- a/widget/src/column.rs
+++ b/widget/src/column.rs
@@ -35,7 +35,7 @@ impl<'a, Message, Renderer> Column<'a, Message, Renderer> {
         Column {
             spacing: 0.0,
             padding: Padding::ZERO,
-            width: Length::Shrink,
+            width: Length::Fill,
             height: Length::Shrink,
             max_width: f32::INFINITY,
             align_items: Alignment::Start,
@@ -126,15 +126,14 @@ where
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
-        let limits = limits
-            .max_width(self.max_width)
-            .width(self.width)
-            .height(self.height);
+        let limits = limits.max_width(self.max_width);
 
         layout::flex::resolve(
             layout::flex::Axis::Vertical,
             renderer,
             &limits,
+            self.width,
+            self.height,
             self.padding,
             self.spacing,
             self.align_items,

--- a/widget/src/column.rs
+++ b/widget/src/column.rs
@@ -41,9 +41,9 @@ where
 
     /// Creates a [`Column`] with the given elements.
     pub fn with_children(
-        children: impl Iterator<Item = Element<'a, Message, Renderer>>,
+        children: impl IntoIterator<Item = Element<'a, Message, Renderer>>,
     ) -> Self {
-        children.fold(Self::new(), |column, element| column.push(element))
+        children.into_iter().fold(Self::new(), Self::push)
     }
 
     /// Sets the vertical spacing _between_ elements.

--- a/widget/src/column.rs
+++ b/widget/src/column.rs
@@ -35,7 +35,7 @@ impl<'a, Message, Renderer> Column<'a, Message, Renderer> {
         Column {
             spacing: 0.0,
             padding: Padding::ZERO,
-            width: Length::Fill,
+            width: Length::Shrink,
             height: Length::Shrink,
             max_width: f32::INFINITY,
             align_items: Alignment::Start,

--- a/widget/src/combo_box.rs
+++ b/widget/src/combo_box.rs
@@ -8,7 +8,9 @@ use crate::core::renderer;
 use crate::core::text;
 use crate::core::time::Instant;
 use crate::core::widget::{self, Widget};
-use crate::core::{Clipboard, Element, Length, Padding, Rectangle, Shell};
+use crate::core::{
+    Clipboard, Element, Length, Padding, Rectangle, Shell, Size,
+};
 use crate::overlay::menu;
 use crate::text::LineHeight;
 use crate::{container, scrollable, text_input, TextInput};
@@ -297,12 +299,8 @@ where
         + scrollable::StyleSheet
         + menu::StyleSheet,
 {
-    fn width(&self) -> Length {
-        Widget::<TextInputEvent, Renderer>::width(&self.text_input)
-    }
-
-    fn height(&self) -> Length {
-        Widget::<TextInputEvent, Renderer>::height(&self.text_input)
+    fn size(&self) -> Size<Length> {
+        Widget::<TextInputEvent, Renderer>::size(&self.text_input)
     }
 
     fn layout(

--- a/widget/src/container.rs
+++ b/widget/src/container.rs
@@ -52,16 +52,8 @@ where
         Container {
             id: None,
             padding: Padding::ZERO,
-            width: if size.width.is_fill() {
-                Length::Fill
-            } else {
-                Length::Shrink
-            },
-            height: if size.height.is_fill() {
-                Length::Fill
-            } else {
-                Length::Shrink
-            },
+            width: size.width.fluid(),
+            height: size.height.fluid(),
             max_width: f32::INFINITY,
             max_height: f32::INFINITY,
             horizontal_alignment: alignment::Horizontal::Left,

--- a/widget/src/container.rs
+++ b/widget/src/container.rs
@@ -46,11 +46,22 @@ where
     where
         T: Into<Element<'a, Message, Renderer>>,
     {
+        let content = content.into();
+        let size = content.as_widget().size_hint();
+
         Container {
             id: None,
             padding: Padding::ZERO,
-            width: Length::Shrink,
-            height: Length::Shrink,
+            width: if size.width.is_fill() {
+                Length::Fill
+            } else {
+                Length::Shrink
+            },
+            height: if size.height.is_fill() {
+                Length::Fill
+            } else {
+                Length::Shrink
+            },
             max_width: f32::INFINITY,
             max_height: f32::INFINITY,
             horizontal_alignment: alignment::Horizontal::Left,

--- a/widget/src/container.rs
+++ b/widget/src/container.rs
@@ -67,7 +67,7 @@ where
             horizontal_alignment: alignment::Horizontal::Left,
             vertical_alignment: alignment::Vertical::Top,
             style: Default::default(),
-            content: content.into(),
+            content,
         }
     }
 

--- a/widget/src/container.rs
+++ b/widget/src/container.rs
@@ -163,12 +163,11 @@ where
         self.content.as_widget().diff(tree);
     }
 
-    fn width(&self) -> Length {
-        self.width
-    }
-
-    fn height(&self) -> Length {
-        self.height
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: self.width,
+            height: self.height,
+        }
     }
 
     fn layout(

--- a/widget/src/container.rs
+++ b/widget/src/container.rs
@@ -321,27 +321,19 @@ pub fn layout(
     vertical_alignment: alignment::Vertical,
     layout_content: impl FnOnce(&layout::Limits) -> layout::Node,
 ) -> layout::Node {
-    let limits = limits
-        .width(width)
-        .height(height)
-        .max_width(max_width)
-        .max_height(max_height);
-
-    let content = layout_content(&limits.shrink(padding).loose());
-    let padding = padding.fit(content.size(), limits.max());
-    let size = limits
-        .shrink(padding)
-        .resolve(content.size(), width, height);
-
-    layout::Node::with_children(
-        size.expand(padding),
-        vec![content
-            .move_to(Point::new(padding.left, padding.top))
-            .align(
+    layout::positioned(
+        &limits.max_width(max_width).max_height(max_height),
+        width,
+        height,
+        padding,
+        |limits| layout_content(&limits.loose()),
+        |content, size| {
+            content.align(
                 Alignment::from(horizontal_alignment),
                 Alignment::from(vertical_alignment),
                 size,
-            )],
+            )
+        },
     )
 }
 

--- a/widget/src/container.rs
+++ b/widget/src/container.rs
@@ -312,24 +312,27 @@ pub fn layout(
     layout_content: impl FnOnce(&layout::Limits) -> layout::Node,
 ) -> layout::Node {
     let limits = limits
-        .loose()
-        .max_width(max_width)
-        .max_height(max_height)
         .width(width)
-        .height(height);
+        .height(height)
+        .max_width(max_width)
+        .max_height(max_height);
 
-    let mut content = layout_content(&limits.pad(padding).loose());
+    let content = layout_content(&limits.shrink(padding).loose());
     let padding = padding.fit(content.size(), limits.max());
-    let size = limits.pad(padding).resolve(content.size());
+    let size = limits
+        .shrink(padding)
+        .resolve(content.size(), width, height);
 
-    content.move_to(Point::new(padding.left, padding.top));
-    content.align(
-        Alignment::from(horizontal_alignment),
-        Alignment::from(vertical_alignment),
-        size,
-    );
-
-    layout::Node::with_children(size.pad(padding), vec![content])
+    layout::Node::with_children(
+        size.expand(padding),
+        vec![content
+            .move_to(Point::new(padding.left, padding.top))
+            .align(
+                Alignment::from(horizontal_alignment),
+                Alignment::from(vertical_alignment),
+                size,
+            )],
+    )
 }
 
 /// Draws the background of a [`Container`] given its [`Appearance`] and its `bounds`.

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -271,7 +271,7 @@ pub fn pick_list<'a, Message, Renderer, T>(
     on_selected: impl Fn(T) -> Message + 'a,
 ) -> PickList<'a, T, Message, Renderer>
 where
-    T: ToString + Eq + 'static,
+    T: ToString + PartialEq + 'static,
     [T]: ToOwned<Owned = Vec<T>>,
     Renderer: core::text::Renderer,
     Renderer::Theme: pick_list::StyleSheet

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -80,6 +80,7 @@ pub fn keyed_column<'a, Key, Message, Renderer>(
 ) -> keyed::Column<'a, Key, Message, Renderer>
 where
     Key: Copy + PartialEq,
+    Renderer: core::Renderer,
 {
     keyed::Column::with_children(children)
 }

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -34,7 +34,7 @@ macro_rules! column {
         $crate::Column::new()
     );
     ($($x:expr),+ $(,)?) => (
-        $crate::Column::with_children([$($crate::core::Element::from($x)),+].into_iter())
+        $crate::Column::with_children([$($crate::core::Element::from($x)),+])
     );
 }
 
@@ -47,7 +47,7 @@ macro_rules! row {
         $crate::Row::new()
     );
     ($($x:expr),+ $(,)?) => (
-        $crate::Row::with_children([$($crate::core::Element::from($x)),+].into_iter())
+        $crate::Row::with_children([$($crate::core::Element::from($x)),+])
     );
 }
 
@@ -66,7 +66,7 @@ where
 
 /// Creates a new [`Column`] with the given children.
 pub fn column<'a, Message, Renderer>(
-    children: impl Iterator<Item = Element<'a, Message, Renderer>>,
+    children: impl IntoIterator<Item = Element<'a, Message, Renderer>>,
 ) -> Column<'a, Message, Renderer>
 where
     Renderer: core::Renderer,
@@ -89,7 +89,7 @@ where
 ///
 /// [`Row`]: crate::Row
 pub fn row<'a, Message, Renderer>(
-    children: impl Iterator<Item = Element<'a, Message, Renderer>>,
+    children: impl IntoIterator<Item = Element<'a, Message, Renderer>>,
 ) -> Row<'a, Message, Renderer>
 where
     Renderer: core::Renderer,

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -34,7 +34,7 @@ macro_rules! column {
         $crate::Column::new()
     );
     ($($x:expr),+ $(,)?) => (
-        $crate::Column::with_children(vec![$($crate::core::Element::from($x)),+])
+        $crate::Column::with_children([$($crate::core::Element::from($x)),+].into_iter())
     );
 }
 
@@ -47,7 +47,7 @@ macro_rules! row {
         $crate::Row::new()
     );
     ($($x:expr),+ $(,)?) => (
-        $crate::Row::with_children(vec![$($crate::core::Element::from($x)),+])
+        $crate::Row::with_children([$($crate::core::Element::from($x)),+].into_iter())
     );
 }
 
@@ -65,9 +65,12 @@ where
 }
 
 /// Creates a new [`Column`] with the given children.
-pub fn column<Message, Renderer>(
-    children: Vec<Element<'_, Message, Renderer>>,
-) -> Column<'_, Message, Renderer> {
+pub fn column<'a, Message, Renderer>(
+    children: impl Iterator<Item = Element<'a, Message, Renderer>>,
+) -> Column<'a, Message, Renderer>
+where
+    Renderer: core::Renderer,
+{
     Column::with_children(children)
 }
 
@@ -84,9 +87,12 @@ where
 /// Creates a new [`Row`] with the given children.
 ///
 /// [`Row`]: crate::Row
-pub fn row<Message, Renderer>(
-    children: Vec<Element<'_, Message, Renderer>>,
-) -> Row<'_, Message, Renderer> {
+pub fn row<'a, Message, Renderer>(
+    children: impl Iterator<Item = Element<'a, Message, Renderer>>,
+) -> Row<'a, Message, Renderer>
+where
+    Renderer: core::Renderer,
+{
     Row::with_children(children)
 }
 

--- a/widget/src/image.rs
+++ b/widget/src/image.rs
@@ -99,7 +99,7 @@ where
     };
 
     // The size to be available to the widget prior to `Shrink`ing
-    let raw_size = limits.resolve(image_size, width, height);
+    let raw_size = limits.resolve(width, height, image_size);
 
     // The uncropped size of the image when fit to the bounds above
     let full_size = content_fit.fit(image_size, raw_size);

--- a/widget/src/image.rs
+++ b/widget/src/image.rs
@@ -99,7 +99,7 @@ where
     };
 
     // The size to be available to the widget prior to `Shrink`ing
-    let raw_size = limits.width(width).height(height).resolve(image_size);
+    let raw_size = limits.resolve(image_size, width, height);
 
     // The uncropped size of the image when fit to the bounds above
     let full_size = content_fit.fit(image_size, raw_size);

--- a/widget/src/image.rs
+++ b/widget/src/image.rs
@@ -164,12 +164,11 @@ where
     Renderer: image::Renderer<Handle = Handle>,
     Handle: Clone + Hash,
 {
-    fn width(&self) -> Length {
-        self.width
-    }
-
-    fn height(&self) -> Length {
-        self.height
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: self.width,
+            height: self.height,
+        }
     }
 
     fn layout(

--- a/widget/src/image/viewer.rs
+++ b/widget/src/image/viewer.rs
@@ -113,9 +113,9 @@ where
         let Size { width, height } = renderer.dimensions(&self.handle);
 
         let mut size = limits.resolve(
-            Size::new(width as f32, height as f32),
             self.width,
             self.height,
+            Size::new(width as f32, height as f32),
         );
 
         let expansion_size = if height > width {

--- a/widget/src/image/viewer.rs
+++ b/widget/src/image/viewer.rs
@@ -113,10 +113,11 @@ where
     ) -> layout::Node {
         let Size { width, height } = renderer.dimensions(&self.handle);
 
-        let mut size = limits
-            .width(self.width)
-            .height(self.height)
-            .resolve(Size::new(width as f32, height as f32));
+        let mut size = limits.resolve(
+            Size::new(width as f32, height as f32),
+            self.width,
+            self.height,
+        );
 
         let expansion_size = if height > width {
             self.width

--- a/widget/src/image/viewer.rs
+++ b/widget/src/image/viewer.rs
@@ -97,12 +97,11 @@ where
         tree::State::new(State::new())
     }
 
-    fn width(&self) -> Length {
-        self.width
-    }
-
-    fn height(&self) -> Length {
-        self.height
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: self.width,
+            height: self.height,
+        }
     }
 
     fn layout(

--- a/widget/src/keyed/column.rs
+++ b/widget/src/keyed/column.rs
@@ -8,7 +8,7 @@ use crate::core::widget::tree::{self, Tree};
 use crate::core::widget::Operation;
 use crate::core::{
     Alignment, Clipboard, Element, Layout, Length, Padding, Pixels, Rectangle,
-    Shell, Widget,
+    Shell, Size, Widget,
 };
 
 /// A container that distributes its contents vertically.
@@ -173,12 +173,11 @@ where
         }
     }
 
-    fn width(&self) -> Length {
-        self.width
-    }
-
-    fn height(&self) -> Length {
-        self.height
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: self.width,
+            height: self.height,
+        }
     }
 
     fn layout(

--- a/widget/src/keyed/column.rs
+++ b/widget/src/keyed/column.rs
@@ -196,6 +196,8 @@ where
             layout::flex::Axis::Vertical,
             renderer,
             &limits,
+            self.width,
+            self.height,
             self.padding,
             self.spacing,
             self.align_items,

--- a/widget/src/keyed/column.rs
+++ b/widget/src/keyed/column.rs
@@ -30,26 +30,10 @@ where
 impl<'a, Key, Message, Renderer> Column<'a, Key, Message, Renderer>
 where
     Key: Copy + PartialEq,
+    Renderer: crate::core::Renderer,
 {
     /// Creates an empty [`Column`].
     pub fn new() -> Self {
-        Self::with_children(Vec::new())
-    }
-
-    /// Creates a [`Column`] with the given elements.
-    pub fn with_children(
-        children: impl IntoIterator<Item = (Key, Element<'a, Message, Renderer>)>,
-    ) -> Self {
-        let (keys, children) = children.into_iter().fold(
-            (Vec::new(), Vec::new()),
-            |(mut keys, mut children), (key, child)| {
-                keys.push(key);
-                children.push(child);
-
-                (keys, children)
-            },
-        );
-
         Column {
             spacing: 0.0,
             padding: Padding::ZERO,
@@ -57,9 +41,18 @@ where
             height: Length::Shrink,
             max_width: f32::INFINITY,
             align_items: Alignment::Start,
-            keys,
-            children,
+            keys: Vec::new(),
+            children: Vec::new(),
         }
+    }
+
+    /// Creates a [`Column`] with the given elements.
+    pub fn with_children(
+        children: impl IntoIterator<Item = (Key, Element<'a, Message, Renderer>)>,
+    ) -> Self {
+        children
+            .into_iter()
+            .fold(Self::new(), |column, (key, child)| column.push(key, child))
     }
 
     /// Sets the vertical spacing _between_ elements.
@@ -108,8 +101,19 @@ where
         key: Key,
         child: impl Into<Element<'a, Message, Renderer>>,
     ) -> Self {
+        let child = child.into();
+        let size = child.as_widget().size_hint();
+
+        if size.width.is_fill() {
+            self.width = Length::Fill;
+        }
+
+        if size.height.is_fill() {
+            self.height = Length::Fill;
+        }
+
         self.keys.push(key);
-        self.children.push(child.into());
+        self.children.push(child);
         self
     }
 }
@@ -117,6 +121,7 @@ where
 impl<'a, Key, Message, Renderer> Default for Column<'a, Key, Message, Renderer>
 where
     Key: Copy + PartialEq,
+    Renderer: crate::core::Renderer,
 {
     fn default() -> Self {
         Self::new()

--- a/widget/src/lazy.rs
+++ b/widget/src/lazy.rs
@@ -150,6 +150,13 @@ where
         self.with_element(|element| element.as_widget().height())
     }
 
+    fn size_hint(&self) -> Size<Length> {
+        Size {
+            width: Length::Shrink,
+            height: Length::Shrink,
+        }
+    }
+
     fn layout(
         &self,
         tree: &mut Tree,

--- a/widget/src/lazy.rs
+++ b/widget/src/lazy.rs
@@ -142,12 +142,8 @@ where
         }
     }
 
-    fn width(&self) -> Length {
-        self.with_element(|element| element.as_widget().width())
-    }
-
-    fn height(&self) -> Length {
-        self.with_element(|element| element.as_widget().height())
+    fn size(&self) -> Size<Length> {
+        self.with_element(|element| element.as_widget().size())
     }
 
     fn size_hint(&self) -> Size<Length> {

--- a/widget/src/lazy/component.rs
+++ b/widget/src/lazy/component.rs
@@ -252,6 +252,13 @@ where
         self.with_element(|element| element.as_widget().height())
     }
 
+    fn size_hint(&self) -> Size<Length> {
+        Size {
+            width: Length::Shrink,
+            height: Length::Shrink,
+        }
+    }
+
     fn layout(
         &self,
         tree: &mut Tree,

--- a/widget/src/lazy/component.rs
+++ b/widget/src/lazy/component.rs
@@ -244,12 +244,8 @@ where
         self.rebuild_element_if_necessary();
     }
 
-    fn width(&self) -> Length {
-        self.with_element(|element| element.as_widget().width())
-    }
-
-    fn height(&self) -> Length {
-        self.with_element(|element| element.as_widget().height())
+    fn size(&self) -> Size<Length> {
+        self.with_element(|element| element.as_widget().size())
     }
 
     fn size_hint(&self) -> Size<Length> {

--- a/widget/src/lazy/responsive.rs
+++ b/widget/src/lazy/responsive.rs
@@ -135,12 +135,11 @@ where
         })
     }
 
-    fn width(&self) -> Length {
-        Length::Fill
-    }
-
-    fn height(&self) -> Length {
-        Length::Fill
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: Length::Fill,
+            height: Length::Fill,
+        }
     }
 
     fn layout(

--- a/widget/src/mouse_area.rs
+++ b/widget/src/mouse_area.rs
@@ -8,7 +8,7 @@ use crate::core::renderer;
 use crate::core::touch;
 use crate::core::widget::{tree, Operation, Tree};
 use crate::core::{
-    Clipboard, Element, Layout, Length, Rectangle, Shell, Widget,
+    Clipboard, Element, Layout, Length, Rectangle, Shell, Size, Widget,
 };
 
 /// Emit messages on mouse events.
@@ -110,12 +110,8 @@ where
         tree.diff_children(std::slice::from_ref(&self.content));
     }
 
-    fn width(&self) -> Length {
-        self.content.as_widget().width()
-    }
-
-    fn height(&self) -> Length {
-        self.content.as_widget().height()
+    fn size(&self) -> Size<Length> {
+        self.content.as_widget().size()
     }
 
     fn layout(

--- a/widget/src/overlay/menu.rs
+++ b/widget/src/overlay/menu.rs
@@ -254,15 +254,14 @@ where
         )
         .width(self.width);
 
-        let mut node = self.container.layout(self.state, renderer, &limits);
+        let node = self.container.layout(self.state, renderer, &limits);
+        let size = node.size();
 
         node.move_to(if space_below > space_above {
             position + Vector::new(0.0, self.target_height)
         } else {
-            position - Vector::new(0.0, node.size().height)
-        });
-
-        node
+            position - Vector::new(0.0, size.height)
+        })
     }
 
     fn on_event(
@@ -359,7 +358,6 @@ where
     ) -> layout::Node {
         use std::f32;
 
-        let limits = limits.width(Length::Fill).height(Length::Shrink);
         let text_size =
             self.text_size.unwrap_or_else(|| renderer.default_size());
 
@@ -372,7 +370,7 @@ where
                     * self.options.len() as f32,
             );
 
-            limits.resolve(intrinsic)
+            limits.resolve(intrinsic, Length::Fill, Length::Shrink)
         };
 
         layout::Node::new(size)

--- a/widget/src/overlay/menu.rs
+++ b/widget/src/overlay/menu.rs
@@ -342,12 +342,11 @@ where
     Renderer: text::Renderer,
     Renderer::Theme: StyleSheet,
 {
-    fn width(&self) -> Length {
-        Length::Fill
-    }
-
-    fn height(&self) -> Length {
-        Length::Shrink
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: Length::Fill,
+            height: Length::Shrink,
+        }
     }
 
     fn layout(

--- a/widget/src/overlay/menu.rs
+++ b/widget/src/overlay/menu.rs
@@ -369,7 +369,7 @@ where
                     * self.options.len() as f32,
             );
 
-            limits.resolve(intrinsic, Length::Fill, Length::Shrink)
+            limits.resolve(Length::Fill, Length::Shrink, intrinsic)
         };
 
         layout::Node::new(size)

--- a/widget/src/pane_grid.rs
+++ b/widget/src/pane_grid.rs
@@ -490,8 +490,7 @@ pub fn layout<Renderer, T>(
         &layout::Limits,
     ) -> layout::Node,
 ) -> layout::Node {
-    let limits = limits.width(width).height(height);
-    let size = limits.resolve(Size::ZERO);
+    let size = limits.resolve(Size::ZERO, width, height);
 
     let regions = node.pane_regions(spacing, size);
     let children = contents
@@ -500,16 +499,14 @@ pub fn layout<Renderer, T>(
             let region = regions.get(&pane)?;
             let size = Size::new(region.width, region.height);
 
-            let mut node = layout_content(
+            let node = layout_content(
                 content,
                 tree,
                 renderer,
                 &layout::Limits::new(size, size),
             );
 
-            node.move_to(Point::new(region.x, region.y));
-
-            Some(node)
+            Some(node.move_to(Point::new(region.x, region.y)))
         })
         .collect();
 

--- a/widget/src/pane_grid.rs
+++ b/widget/src/pane_grid.rs
@@ -265,12 +265,11 @@ where
         }
     }
 
-    fn width(&self) -> Length {
-        self.width
-    }
-
-    fn height(&self) -> Length {
-        self.height
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: self.width,
+            height: self.height,
+        }
     }
 
     fn layout(

--- a/widget/src/pane_grid.rs
+++ b/widget/src/pane_grid.rs
@@ -489,7 +489,7 @@ pub fn layout<Renderer, T>(
         &layout::Limits,
     ) -> layout::Node,
 ) -> layout::Node {
-    let size = limits.resolve(Size::ZERO, width, height);
+    let size = limits.resolve(width, height, Size::ZERO);
 
     let regions = node.pane_regions(spacing, size);
     let children = contents

--- a/widget/src/pane_grid/content.rs
+++ b/widget/src/pane_grid/content.rs
@@ -165,7 +165,7 @@ where
 
             let title_bar_size = title_bar_layout.size();
 
-            let mut body_layout = self.body.as_widget().layout(
+            let body_layout = self.body.as_widget().layout(
                 &mut tree.children[0],
                 renderer,
                 &layout::Limits::new(
@@ -177,11 +177,12 @@ where
                 ),
             );
 
-            body_layout.move_to(Point::new(0.0, title_bar_size.height));
-
             layout::Node::with_children(
                 max_size,
-                vec![title_bar_layout, body_layout],
+                vec![
+                    title_bar_layout,
+                    body_layout.move_to(Point::new(0.0, title_bar_size.height)),
+                ],
             )
         } else {
             self.body.as_widget().layout(

--- a/widget/src/pane_grid/title_bar.rs
+++ b/widget/src/pane_grid/title_bar.rs
@@ -217,7 +217,7 @@ where
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
-        let limits = limits.pad(self.padding);
+        let limits = limits.shrink(self.padding);
         let max_size = limits.max();
 
         let title_layout = self.content.as_widget().layout(
@@ -228,8 +228,8 @@ where
 
         let title_size = title_layout.size();
 
-        let mut node = if let Some(controls) = &self.controls {
-            let mut controls_layout = controls.as_widget().layout(
+        let node = if let Some(controls) = &self.controls {
+            let controls_layout = controls.as_widget().layout(
                 &mut tree.children[1],
                 renderer,
                 &layout::Limits::new(Size::ZERO, max_size),
@@ -240,11 +240,13 @@ where
 
             let height = title_size.height.max(controls_size.height);
 
-            controls_layout.move_to(Point::new(space_before_controls, 0.0));
-
             layout::Node::with_children(
                 Size::new(max_size.width, height),
-                vec![title_layout, controls_layout],
+                vec![
+                    title_layout,
+                    controls_layout
+                        .move_to(Point::new(space_before_controls, 0.0)),
+                ],
             )
         } else {
             layout::Node::with_children(
@@ -253,9 +255,7 @@ where
             )
         };
 
-        node.move_to(Point::new(self.padding.left, self.padding.top));
-
-        layout::Node::with_children(node.size().pad(self.padding), vec![node])
+        layout::Node::container(node, self.padding)
     }
 
     pub(crate) fn operate(

--- a/widget/src/pick_list.rs
+++ b/widget/src/pick_list.rs
@@ -392,7 +392,6 @@ where
 {
     use std::f32;
 
-    let limits = limits.width(width).height(Length::Shrink);
     let font = font.unwrap_or_else(|| renderer.default_font());
     let text_size = text_size.unwrap_or_else(|| renderer.default_size());
 
@@ -451,8 +450,10 @@ where
         );
 
         limits
+            .width(width)
+            .height(Length::Shrink)
             .shrink(padding)
-            .resolve(intrinsic, width, Length::Shrink)
+            .resolve(width, Length::Shrink, intrinsic)
             .expand(padding)
     };
 

--- a/widget/src/pick_list.rs
+++ b/widget/src/pick_list.rs
@@ -164,12 +164,11 @@ where
         tree::State::new(State::<Renderer::Paragraph>::new())
     }
 
-    fn width(&self) -> Length {
-        self.width
-    }
-
-    fn height(&self) -> Length {
-        Length::Shrink
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: self.width,
+            height: Length::Shrink,
+        }
     }
 
     fn layout(

--- a/widget/src/pick_list.rs
+++ b/widget/src/pick_list.rs
@@ -451,7 +451,6 @@ where
 
         limits
             .width(width)
-            .height(Length::Shrink)
             .shrink(padding)
             .resolve(width, Length::Shrink, intrinsic)
             .expand(padding)

--- a/widget/src/pick_list.rs
+++ b/widget/src/pick_list.rs
@@ -45,7 +45,7 @@ where
 
 impl<'a, T: 'a, Message, Renderer> PickList<'a, T, Message, Renderer>
 where
-    T: ToString + Eq,
+    T: ToString + PartialEq,
     [T]: ToOwned<Owned = Vec<T>>,
     Renderer: text::Renderer,
     Renderer::Theme: StyleSheet
@@ -145,7 +145,7 @@ where
 impl<'a, T: 'a, Message, Renderer> Widget<Message, Renderer>
     for PickList<'a, T, Message, Renderer>
 where
-    T: Clone + ToString + Eq + 'static,
+    T: Clone + ToString + PartialEq + 'static,
     [T]: ToOwned<Owned = Vec<T>>,
     Message: 'a,
     Renderer: text::Renderer + 'a,
@@ -281,7 +281,7 @@ where
 impl<'a, T: 'a, Message, Renderer> From<PickList<'a, T, Message, Renderer>>
     for Element<'a, Message, Renderer>
 where
-    T: Clone + ToString + Eq + 'static,
+    T: Clone + ToString + PartialEq + 'static,
     [T]: ToOwned<Owned = Vec<T>>,
     Message: 'a,
     Renderer: text::Renderer + 'a,

--- a/widget/src/pick_list.rs
+++ b/widget/src/pick_list.rs
@@ -393,7 +393,7 @@ where
 {
     use std::f32;
 
-    let limits = limits.width(width).height(Length::Shrink).pad(padding);
+    let limits = limits.width(width).height(Length::Shrink);
     let font = font.unwrap_or_else(|| renderer.default_font());
     let text_size = text_size.unwrap_or_else(|| renderer.default_size());
 
@@ -451,7 +451,10 @@ where
             f32::from(text_line_height.to_absolute(text_size)),
         );
 
-        limits.resolve(intrinsic).pad(padding)
+        limits
+            .shrink(padding)
+            .resolve(intrinsic, width, Length::Shrink)
+            .expand(padding)
     };
 
     layout::Node::new(size)

--- a/widget/src/progress_bar.rs
+++ b/widget/src/progress_bar.rs
@@ -99,11 +99,11 @@ where
         _renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
-        let limits = limits
-            .width(self.width)
-            .height(self.height.unwrap_or(Length::Fixed(Self::DEFAULT_HEIGHT)));
-
-        let size = limits.resolve(Size::ZERO);
+        let size = limits.resolve(
+            Size::ZERO,
+            self.width,
+            self.height.unwrap_or(Length::Fixed(Self::DEFAULT_HEIGHT)),
+        );
 
         layout::Node::new(size)
     }

--- a/widget/src/progress_bar.rs
+++ b/widget/src/progress_bar.rs
@@ -85,12 +85,11 @@ where
     Renderer: crate::core::Renderer,
     Renderer::Theme: StyleSheet,
 {
-    fn width(&self) -> Length {
-        self.width
-    }
-
-    fn height(&self) -> Length {
-        self.height.unwrap_or(Length::Fixed(Self::DEFAULT_HEIGHT))
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: self.width,
+            height: self.height.unwrap_or(Length::Fixed(Self::DEFAULT_HEIGHT)),
+        }
     }
 
     fn layout(

--- a/widget/src/progress_bar.rs
+++ b/widget/src/progress_bar.rs
@@ -98,13 +98,11 @@ where
         _renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
-        let size = limits.resolve(
-            Size::ZERO,
+        layout::atomic(
+            limits,
             self.width,
             self.height.unwrap_or(Length::Fixed(Self::DEFAULT_HEIGHT)),
-        );
-
-        layout::Node::new(size)
+        )
     }
 
     fn draw(

--- a/widget/src/qr_code.rs
+++ b/widget/src/qr_code.rs
@@ -50,12 +50,11 @@ impl<'a> QRCode<'a> {
 }
 
 impl<'a, Message, Theme> Widget<Message, Renderer<Theme>> for QRCode<'a> {
-    fn width(&self) -> Length {
-        Length::Shrink
-    }
-
-    fn height(&self) -> Length {
-        Length::Shrink
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: Length::Shrink,
+            height: Length::Shrink,
+        }
     }
 
     fn layout(

--- a/widget/src/radio.rs
+++ b/widget/src/radio.rs
@@ -201,12 +201,11 @@ where
         tree::State::new(widget::text::State::<Renderer::Paragraph>::default())
     }
 
-    fn width(&self) -> Length {
-        self.width
-    }
-
-    fn height(&self) -> Length {
-        Length::Shrink
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: self.width,
+            height: Length::Shrink,
+        }
     }
 
     fn layout(

--- a/widget/src/row.rs
+++ b/widget/src/row.rs
@@ -21,24 +21,29 @@ pub struct Row<'a, Message, Renderer = crate::Renderer> {
     children: Vec<Element<'a, Message, Renderer>>,
 }
 
-impl<'a, Message, Renderer> Row<'a, Message, Renderer> {
+impl<'a, Message, Renderer> Row<'a, Message, Renderer>
+where
+    Renderer: crate::core::Renderer,
+{
     /// Creates an empty [`Row`].
     pub fn new() -> Self {
-        Self::with_children(Vec::new())
-    }
-
-    /// Creates a [`Row`] with the given elements.
-    pub fn with_children(
-        children: Vec<Element<'a, Message, Renderer>>,
-    ) -> Self {
         Row {
             spacing: 0.0,
             padding: Padding::ZERO,
             width: Length::Shrink,
             height: Length::Shrink,
             align_items: Alignment::Start,
-            children,
+            children: Vec::new(),
         }
+    }
+
+    /// Creates a [`Row`] with the given elements.
+    pub fn with_children(
+        children: impl Iterator<Item = Element<'a, Message, Renderer>>,
+    ) -> Self {
+        children
+            .into_iter()
+            .fold(Self::new(), |column, element| column.push(element))
     }
 
     /// Sets the horizontal spacing _between_ elements.
@@ -80,12 +85,26 @@ impl<'a, Message, Renderer> Row<'a, Message, Renderer> {
         mut self,
         child: impl Into<Element<'a, Message, Renderer>>,
     ) -> Self {
-        self.children.push(child.into());
+        let child = child.into();
+        let size = child.as_widget().size_hint();
+
+        if size.width.is_fill() {
+            self.width = Length::Fill;
+        }
+
+        if size.height.is_fill() {
+            self.height = Length::Fill;
+        }
+
+        self.children.push(child);
         self
     }
 }
 
-impl<'a, Message, Renderer> Default for Row<'a, Message, Renderer> {
+impl<'a, Message, Renderer> Default for Row<'a, Message, Renderer>
+where
+    Renderer: crate::core::Renderer,
+{
     fn default() -> Self {
         Self::new()
     }

--- a/widget/src/row.rs
+++ b/widget/src/row.rs
@@ -34,7 +34,7 @@ impl<'a, Message, Renderer> Row<'a, Message, Renderer> {
         Row {
             spacing: 0.0,
             padding: Padding::ZERO,
-            width: Length::Shrink,
+            width: Length::Fill,
             height: Length::Shrink,
             align_items: Alignment::Start,
             children,
@@ -118,12 +118,12 @@ where
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
-        let limits = limits.width(self.width).height(self.height);
-
         layout::flex::resolve(
             layout::flex::Axis::Horizontal,
             renderer,
             &limits,
+            self.width,
+            self.height,
             self.padding,
             self.spacing,
             self.align_items,

--- a/widget/src/row.rs
+++ b/widget/src/row.rs
@@ -34,7 +34,7 @@ impl<'a, Message, Renderer> Row<'a, Message, Renderer> {
         Row {
             spacing: 0.0,
             padding: Padding::ZERO,
-            width: Length::Fill,
+            width: Length::Shrink,
             height: Length::Shrink,
             align_items: Alignment::Start,
             children,

--- a/widget/src/row.rs
+++ b/widget/src/row.rs
@@ -39,11 +39,9 @@ where
 
     /// Creates a [`Row`] with the given elements.
     pub fn with_children(
-        children: impl Iterator<Item = Element<'a, Message, Renderer>>,
+        children: impl IntoIterator<Item = Element<'a, Message, Renderer>>,
     ) -> Self {
-        children
-            .into_iter()
-            .fold(Self::new(), |column, element| column.push(element))
+        children.into_iter().fold(Self::new(), Self::push)
     }
 
     /// Sets the horizontal spacing _between_ elements.

--- a/widget/src/row.rs
+++ b/widget/src/row.rs
@@ -7,7 +7,7 @@ use crate::core::renderer;
 use crate::core::widget::{Operation, Tree};
 use crate::core::{
     Alignment, Clipboard, Element, Length, Padding, Pixels, Rectangle, Shell,
-    Widget,
+    Size, Widget,
 };
 
 /// A container that distributes its contents horizontally.
@@ -123,12 +123,11 @@ where
         tree.diff_children(&self.children);
     }
 
-    fn width(&self) -> Length {
-        self.width
-    }
-
-    fn height(&self) -> Length {
-        self.height
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: self.width,
+            height: self.height,
+        }
     }
 
     fn layout(

--- a/widget/src/row.rs
+++ b/widget/src/row.rs
@@ -121,7 +121,7 @@ where
         layout::flex::resolve(
             layout::flex::Axis::Horizontal,
             renderer,
-            &limits,
+            limits,
             self.width,
             self.height,
             self.padding,

--- a/widget/src/rule.rs
+++ b/widget/src/rule.rs
@@ -62,12 +62,11 @@ where
     Renderer: crate::core::Renderer,
     Renderer::Theme: StyleSheet,
 {
-    fn width(&self) -> Length {
-        self.width
-    }
-
-    fn height(&self) -> Length {
-        self.height
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: self.width,
+            height: self.height,
+        }
     }
 
     fn layout(

--- a/widget/src/rule.rs
+++ b/widget/src/rule.rs
@@ -75,7 +75,7 @@ where
         _renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
-        layout::Node::new(limits.resolve(Size::ZERO, self.width, self.height))
+        layout::atomic(limits, self.width, self.height)
     }
 
     fn draw(

--- a/widget/src/rule.rs
+++ b/widget/src/rule.rs
@@ -76,9 +76,7 @@ where
         _renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
-        let limits = limits.width(self.width).height(self.height);
-
-        layout::Node::new(limits.resolve(Size::ZERO))
+        layout::Node::new(limits.resolve(Size::ZERO, self.width, self.height))
     }
 
     fn draw(

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -489,7 +489,7 @@ pub fn layout<Renderer>(
     );
 
     let content = layout_content(renderer, &child_limits);
-    let size = limits.resolve(content.size());
+    let size = limits.resolve(content.size(), width, height);
 
     layout::Node::with_children(size, vec![content])
 }

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -220,12 +220,11 @@ where
         tree.diff_children(std::slice::from_ref(&self.content));
     }
 
-    fn width(&self) -> Length {
-        self.width
-    }
-
-    fn height(&self) -> Length {
-        self.height
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: self.width,
+            height: self.height,
+        }
     }
 
     fn layout(

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -469,28 +469,25 @@ pub fn layout<Renderer>(
     direction: &Direction,
     layout_content: impl FnOnce(&Renderer, &layout::Limits) -> layout::Node,
 ) -> layout::Node {
-    let limits = limits.width(width).height(height);
+    layout::contained(limits, width, height, |limits| {
+        let child_limits = layout::Limits::new(
+            Size::new(limits.min().width, limits.min().height),
+            Size::new(
+                if direction.horizontal().is_some() {
+                    f32::INFINITY
+                } else {
+                    limits.max().width
+                },
+                if direction.vertical().is_some() {
+                    f32::MAX
+                } else {
+                    limits.max().height
+                },
+            ),
+        );
 
-    let child_limits = layout::Limits::new(
-        Size::new(limits.min().width, limits.min().height),
-        Size::new(
-            if direction.horizontal().is_some() {
-                f32::INFINITY
-            } else {
-                limits.max().width
-            },
-            if direction.vertical().is_some() {
-                f32::MAX
-            } else {
-                limits.max().height
-            },
-        ),
-    );
-
-    let content = layout_content(renderer, &child_limits);
-    let size = limits.resolve(content.size(), width, height);
-
-    layout::Node::with_children(size, vec![content])
+        layout_content(renderer, &child_limits)
+    })
 }
 
 /// Processes an [`Event`] and updates the [`State`] of a [`Scrollable`]

--- a/widget/src/shader.rs
+++ b/widget/src/shader.rs
@@ -85,7 +85,7 @@ where
         limits: &layout::Limits,
     ) -> layout::Node {
         let limits = limits.width(self.width).height(self.height);
-        let size = limits.resolve(Size::ZERO);
+        let size = limits.resolve(Size::ZERO, self.width, self.height);
 
         layout::Node::new(size)
     }

--- a/widget/src/shader.rs
+++ b/widget/src/shader.rs
@@ -70,12 +70,11 @@ where
         tree::State::new(P::State::default())
     }
 
-    fn width(&self) -> Length {
-        self.width
-    }
-
-    fn height(&self) -> Length {
-        self.height
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: self.width,
+            height: self.height,
+        }
     }
 
     fn layout(

--- a/widget/src/shader.rs
+++ b/widget/src/shader.rs
@@ -83,10 +83,7 @@ where
         _renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
-        let limits = limits.width(self.width).height(self.height);
-        let size = limits.resolve(Size::ZERO, self.width, self.height);
-
-        layout::Node::new(size)
+        layout::atomic(limits, self.width, self.height)
     }
 
     fn on_event(

--- a/widget/src/slider.rs
+++ b/widget/src/slider.rs
@@ -172,9 +172,7 @@ where
         _renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
-        let size = limits.resolve(Size::ZERO, self.width, self.height);
-
-        layout::Node::new(size)
+        layout::atomic(limits, self.width, self.height)
     }
 
     fn on_event(

--- a/widget/src/slider.rs
+++ b/widget/src/slider.rs
@@ -159,12 +159,11 @@ where
         tree::State::new(State::new())
     }
 
-    fn width(&self) -> Length {
-        self.width
-    }
-
-    fn height(&self) -> Length {
-        Length::Shrink
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: self.width,
+            height: Length::Shrink,
+        }
     }
 
     fn layout(

--- a/widget/src/slider.rs
+++ b/widget/src/slider.rs
@@ -173,8 +173,7 @@ where
         _renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
-        let limits = limits.width(self.width).height(self.height);
-        let size = limits.resolve(Size::ZERO);
+        let size = limits.resolve(Size::ZERO, self.width, self.height);
 
         layout::Node::new(size)
     }

--- a/widget/src/space.rs
+++ b/widget/src/space.rs
@@ -58,7 +58,7 @@ where
         _renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
-        layout::Node::new(limits.resolve(Size::ZERO, self.width, self.height))
+        layout::atomic(limits, self.width, self.height)
     }
 
     fn draw(

--- a/widget/src/space.rs
+++ b/widget/src/space.rs
@@ -59,9 +59,7 @@ where
         _renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
-        let limits = limits.width(self.width).height(self.height);
-
-        layout::Node::new(limits.resolve(Size::ZERO))
+        layout::Node::new(limits.resolve(Size::ZERO, self.width, self.height))
     }
 
     fn draw(

--- a/widget/src/space.rs
+++ b/widget/src/space.rs
@@ -45,12 +45,11 @@ impl<Message, Renderer> Widget<Message, Renderer> for Space
 where
     Renderer: core::Renderer,
 {
-    fn width(&self) -> Length {
-        self.width
-    }
-
-    fn height(&self) -> Length {
-        self.height
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: self.width,
+            height: self.height,
+        }
     }
 
     fn layout(

--- a/widget/src/svg.rs
+++ b/widget/src/svg.rs
@@ -114,7 +114,7 @@ where
         let image_size = Size::new(width as f32, height as f32);
 
         // The size to be available to the widget prior to `Shrink`ing
-        let raw_size = limits.resolve(image_size, self.width, self.height);
+        let raw_size = limits.resolve(self.width, self.height, image_size);
 
         // The uncropped size of the image when fit to the bounds above
         let full_size = self.content_fit.fit(image_size, raw_size);

--- a/widget/src/svg.rs
+++ b/widget/src/svg.rs
@@ -115,10 +115,7 @@ where
         let image_size = Size::new(width as f32, height as f32);
 
         // The size to be available to the widget prior to `Shrink`ing
-        let raw_size = limits
-            .width(self.width)
-            .height(self.height)
-            .resolve(image_size);
+        let raw_size = limits.resolve(image_size, self.width, self.height);
 
         // The uncropped size of the image when fit to the bounds above
         let full_size = self.content_fit.fit(image_size, raw_size);

--- a/widget/src/svg.rs
+++ b/widget/src/svg.rs
@@ -96,12 +96,11 @@ where
     Renderer: svg::Renderer,
     Renderer::Theme: iced_style::svg::StyleSheet,
 {
-    fn width(&self) -> Length {
-        self.width
-    }
-
-    fn height(&self) -> Length {
-        self.height
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: self.width,
+            height: self.height,
+        }
     }
 
     fn layout(

--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -350,7 +350,7 @@ where
         }
 
         internal.editor.update(
-            limits.pad(self.padding).max(),
+            limits.shrink(self.padding).max(),
             self.font.unwrap_or_else(|| renderer.default_font()),
             self.text_size.unwrap_or_else(|| renderer.default_size()),
             self.line_height,

--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -9,7 +9,7 @@ use crate::core::text::highlighter::{self, Highlighter};
 use crate::core::text::{self, LineHeight};
 use crate::core::widget::{self, Widget};
 use crate::core::{
-    Clipboard, Color, Element, Length, Padding, Pixels, Rectangle, Shell,
+    Clipboard, Color, Element, Length, Padding, Pixels, Rectangle, Shell, Size,
     Vector,
 };
 
@@ -316,12 +316,11 @@ where
         })
     }
 
-    fn width(&self) -> Length {
-        self.width
-    }
-
-    fn height(&self) -> Length {
-        self.height
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: self.width,
+            height: self.height,
+        }
     }
 
     fn layout(

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -506,14 +506,11 @@ where
 {
     let font = font.unwrap_or_else(|| renderer.default_font());
     let text_size = size.unwrap_or_else(|| renderer.default_size());
-
     let padding = padding.fit(Size::ZERO, limits.max());
-    let limits = limits
-        .width(width)
-        .pad(padding)
-        .height(line_height.to_absolute(text_size));
+    let height = line_height.to_absolute(text_size);
 
-    let text_bounds = limits.resolve(Size::ZERO);
+    let limits = limits.width(width).shrink(padding).height(height);
+    let text_bounds = limits.resolve(Size::ZERO, width, height);
 
     let placeholder_text = Text {
         font,
@@ -552,41 +549,41 @@ where
 
         let icon_width = state.icon.min_width();
 
-        let mut text_node = layout::Node::new(
-            text_bounds - Size::new(icon_width + icon.spacing, 0.0),
-        );
-
-        let mut icon_node =
-            layout::Node::new(Size::new(icon_width, text_bounds.height));
-
-        match icon.side {
-            Side::Left => {
-                text_node.move_to(Point::new(
+        let (text_position, icon_position) = match icon.side {
+            Side::Left => (
+                Point::new(
                     padding.left + icon_width + icon.spacing,
                     padding.top,
-                ));
-
-                icon_node.move_to(Point::new(padding.left, padding.top));
-            }
-            Side::Right => {
-                text_node.move_to(Point::new(padding.left, padding.top));
-
-                icon_node.move_to(Point::new(
+                ),
+                Point::new(padding.left, padding.top),
+            ),
+            Side::Right => (
+                Point::new(padding.left, padding.top),
+                Point::new(
                     padding.left + text_bounds.width - icon_width,
                     padding.top,
-                ));
-            }
+                ),
+            ),
         };
 
+        let text_node = layout::Node::new(
+            text_bounds - Size::new(icon_width + icon.spacing, 0.0),
+        )
+        .move_to(text_position);
+
+        let icon_node =
+            layout::Node::new(Size::new(icon_width, text_bounds.height))
+                .move_to(icon_position);
+
         layout::Node::with_children(
-            text_bounds.pad(padding),
+            text_bounds.expand(padding),
             vec![text_node, icon_node],
         )
     } else {
-        let mut text = layout::Node::new(text_bounds);
-        text.move_to(Point::new(padding.left, padding.top));
+        let text = layout::Node::new(text_bounds)
+            .move_to(Point::new(padding.left, padding.top));
 
-        layout::Node::with_children(text_bounds.pad(padding), vec![text])
+        layout::Node::with_children(text_bounds.expand(padding), vec![text])
     }
 }
 

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -508,8 +508,8 @@ where
     let padding = padding.fit(Size::ZERO, limits.max());
     let height = line_height.to_absolute(text_size);
 
-    let limits = limits.width(width).shrink(padding).height(height);
-    let text_bounds = limits.resolve(Size::ZERO, width, height);
+    let limits = limits.width(width).shrink(padding);
+    let text_bounds = limits.resolve(width, height, Size::ZERO);
 
     let placeholder_text = Text {
         font,

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -283,12 +283,11 @@ where
         }
     }
 
-    fn width(&self) -> Length {
-        self.width
-    }
-
-    fn height(&self) -> Length {
-        Length::Shrink
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: self.width,
+            height: Length::Shrink,
+        }
     }
 
     fn layout(

--- a/widget/src/toggler.rs
+++ b/widget/src/toggler.rs
@@ -168,12 +168,11 @@ where
         tree::State::new(widget::text::State::<Renderer::Paragraph>::default())
     }
 
-    fn width(&self) -> Length {
-        self.width
-    }
-
-    fn height(&self) -> Length {
-        Length::Shrink
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: self.width,
+            height: Length::Shrink,
+        }
     }
 
     fn layout(

--- a/widget/src/tooltip.rs
+++ b/widget/src/tooltip.rs
@@ -353,7 +353,7 @@ where
                     .then(|| viewport.size())
                     .unwrap_or(Size::INFINITY),
             )
-            .pad(Padding::new(self.padding)),
+            .shrink(Padding::new(self.padding)),
         );
 
         let text_bounds = text_layout.bounds();

--- a/widget/src/tooltip.rs
+++ b/widget/src/tooltip.rs
@@ -131,12 +131,8 @@ where
         widget::tree::Tag::of::<State>()
     }
 
-    fn width(&self) -> Length {
-        self.content.as_widget().width()
-    }
-
-    fn height(&self) -> Length {
-        self.content.as_widget().height()
+    fn size(&self) -> Size<Length> {
+        self.content.as_widget().size()
     }
 
     fn layout(

--- a/widget/src/vertical_slider.rs
+++ b/widget/src/vertical_slider.rs
@@ -170,8 +170,7 @@ where
         _renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
-        let limits = limits.width(self.width).height(self.height);
-        let size = limits.resolve(Size::ZERO);
+        let size = limits.resolve(Size::ZERO, self.width, self.height);
 
         layout::Node::new(size)
     }

--- a/widget/src/vertical_slider.rs
+++ b/widget/src/vertical_slider.rs
@@ -156,12 +156,11 @@ where
         tree::State::new(State::new())
     }
 
-    fn width(&self) -> Length {
-        Length::Shrink
-    }
-
-    fn height(&self) -> Length {
-        self.height
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: Length::Shrink,
+            height: self.height,
+        }
     }
 
     fn layout(

--- a/widget/src/vertical_slider.rs
+++ b/widget/src/vertical_slider.rs
@@ -169,9 +169,7 @@ where
         _renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
-        let size = limits.resolve(Size::ZERO, self.width, self.height);
-
-        layout::Node::new(size)
+        layout::atomic(limits, self.width, self.height)
     }
 
     fn on_event(


### PR DESCRIPTION
This PR improves the intuitiveness of our layout engine by solving a bunch of inconsistencies related to our sizing strategies.

# Shrunken fills

Until now, it was considered an invalid layout to have a container with `Length::Shrink` containing some widget with `Length::Fill` in a specific dimension. Specifically, this use case would cause the `Fill` item to steal all the available space independently of the position of the parent in the widget tree (see #2186). In practice, this could cause widgets to fully disappear unexpectedly in completely unrelated places of the application unless `Fill` was explicitly set everywhere.

The changes here modify our `flex` layout logic so that `Shrink` actually takes priority over `Fill`. As a result, a container with a `Shrink` strategy containing some widget with a `Fill` strategy will simply collapse its contents. Effectively, this makes invalid layouts local and avoids them from leaking through multiple levels of the widget tree.

Furthermore, a `Shrink` parent with a `Fill` children in its cross axis will only collapse if the parent does not have any `Shrink` children. If some children are `Shrink`, then the `Fill` children will fill as much space as the widest child. This behavior can be leveraged to satisfy a bunch of use cases that previously were impossible to model without using custom widgets.

For instance, this layout

![image](https://github.com/iced-rs/iced/assets/518289/62770b65-524a-472c-b430-473bfba90b5f)

can now be achieved with `row` and `vertical_rule`:

```rust
row![vertical_rule(2), "Original text"].height(Length::Shrink)
```

While a `vertical_rule` uses a `Fill` strategy for its `height` and the parent `row` is set to `Shrink`, the layout works as expected because the `text` has a `Shrink` height.

# Adaptive containers

But wait! What happens with containers that by default `Shrink` but only have `Fill` children? Do we have to manually set `Fill` everywhere now for its contents to not disappear? No! Containers now adapt their sizing strategy based on their children.

The `width` and `height` methods of the `Widget` trait are now consolidated into a single `size` method that returns a `Size<Length>`. A new `size_hint` method also exists, which by default returns `size`, and it is leveraged by containers to guess the proper sizing strategy during construction.

In practice, this means that if we want a container to `Shrink` when some of its children are `Fill`, we need to opt in on this behavior explicitly. It also means that we do not need to explicitly set `Fill` everywhere in order for layouts to work as expected.

# A `layout` example

I have also created a new example: `layout`, which is meant to showcase a bunch of common, useful layouts that can be easily achieved with the built-in widgets:

![image](https://github.com/iced-rs/iced/assets/518289/55480d4c-c8e9-4c76-8ef7-a49ff720e098)


# Other (useful) minor changes

- The `fill` field in `layout::Limits` has been removed, simplifying its meaning considerably.
- The `column` and `row` functions now take an `IntoIterator` instead of a `Vec`.
- The `layout` module now has a bunch of new helpers with common layout strategies; useful for custom widgets.
- `container::Appearance` can be directly used as the `style` of a `Container`.

Fixes #2186.