### PR TITLE
Allow fetching the raw window handle of a window by it's `iced::window::Id`.

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -19,4 +19,5 @@ iced_core.workspace = true
 iced_futures.workspace = true
 iced_futures.features = ["thread-pool"]
 
+raw-window-handle.workspace = true
 thiserror.workspace = true

--- a/runtime/src/window.rs
+++ b/runtime/src/window.rs
@@ -15,6 +15,8 @@ use crate::core::{Point, Size};
 use crate::futures::event;
 use crate::futures::Subscription;
 
+use raw_window_handle::RawWindowHandle;
+
 /// Subscribes to the frames of the window of the running application.
 ///
 /// The resulting [`Subscription`] will produce items at a rate equal to the
@@ -163,6 +165,17 @@ pub fn fetch_id<Message>(
     f: impl FnOnce(u64) -> Message + 'static,
 ) -> Command<Message> {
     Command::single(command::Action::Window(Action::FetchId(id, Box::new(f))))
+}
+
+/// Fetches the raw window handle for the specified window.
+pub fn fetch_handle<Message>(
+    id: Id,
+    f: impl FnOnce(RawWindowHandle) -> Message + 'static,
+) -> Command<Message> {
+    Command::single(command::Action::Window(Action::FetchHandle(
+        id,
+        Box::new(f),
+    )))
 }
 
 /// Changes the [`Icon`] of the window.

--- a/runtime/src/window/action.rs
+++ b/runtime/src/window/action.rs
@@ -3,6 +3,8 @@ use crate::core::{Point, Size};
 use crate::futures::MaybeSend;
 use crate::window::Screenshot;
 
+use raw_window_handle::RawWindowHandle;
+
 use std::fmt;
 
 /// An operation to be performed on some window.
@@ -81,6 +83,8 @@ pub enum Action<T> {
     ChangeLevel(Id, Level),
     /// Fetch the raw identifier unique to the window.
     FetchId(Id, Box<dyn FnOnce(u64) -> T + 'static>),
+    /// Fetch the raw window handle.
+    FetchHandle(Id, Box<dyn FnOnce(RawWindowHandle) -> T + 'static>),
     /// Change the window [`Icon`].
     ///
     /// On Windows and X11, this is typically the small icon in the top-left
@@ -140,6 +144,9 @@ impl<T> Action<T> {
             Self::FetchId(id, o) => {
                 Action::FetchId(id, Box::new(move |s| f(o(s))))
             }
+            Self::FetchHandle(id, o) => {
+                Action::FetchHandle(id, Box::new(move |s| f(o(s))))
+            }
             Self::ChangeIcon(id, icon) => Action::ChangeIcon(id, icon),
             Self::Screenshot(id, tag) => Action::Screenshot(
                 id,
@@ -194,6 +201,9 @@ impl<T> fmt::Debug for Action<T> {
                 write!(f, "Action::ChangeLevel({id:?}, {level:?})")
             }
             Self::FetchId(id, _) => write!(f, "Action::FetchId({id:?})"),
+            Self::FetchHandle(id, _) => {
+                write!(f, "Action::FetchHandle({id:?})")
+            }
             Self::ChangeIcon(id, _icon) => {
                 write!(f, "Action::ChangeIcon({id:?})")
             }

--- a/winit/Cargo.toml
+++ b/winit/Cargo.toml
@@ -31,6 +31,7 @@ thiserror.workspace = true
 tracing.workspace = true
 window_clipboard.workspace = true
 winit.workspace = true
+raw-window-handle.workspace = true
 
 sysinfo.workspace = true
 sysinfo.optional = true

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -25,6 +25,8 @@ use futures::channel::mpsc;
 
 use std::mem::ManuallyDrop;
 
+use raw_window_handle::HasRawWindowHandle;
+
 /// An interactive, native cross-platform application.
 ///
 /// This trait is the main entrypoint of Iced. Once implemented, you can run
@@ -807,6 +809,9 @@ pub fn run_command<A, C, E>(
                         .send_event(tag(window.id().into()))
                         .expect("Send message to event loop");
                 }
+                window::Action::FetchHandle(_id, tag) => proxy
+                    .send_event(tag(window.raw_window_handle()))
+                    .expect("Send message to event loop"),
                 window::Action::Screenshot(_id, tag) => {
                     let bytes = compositor.screenshot(
                         renderer,

--- a/winit/src/multi_window.rs
+++ b/winit/src/multi_window.rs
@@ -26,6 +26,8 @@ use std::collections::HashMap;
 use std::mem::ManuallyDrop;
 use std::time::Instant;
 
+use raw_window_handle::HasRawWindowHandle;
+
 /// An interactive, native, cross-platform, multi-windowed application.
 ///
 /// This trait is the main entrypoint of multi-window Iced. Once implemented, you can run
@@ -1036,6 +1038,13 @@ fn run_command<A, C, E>(
                     if let Some(window) = window_manager.get_mut(id) {
                         proxy
                             .send_event(tag(window.raw.id().into()))
+                            .expect("Event loop doesn't exist.");
+                    }
+                }
+                window::Action::FetchHandle(id, tag) => {
+                    if let Some(window) = window_manager.get_mut(id) {
+                        proxy
+                            .send_event(tag(window.raw.raw_window_handle()))
                             .expect("Event loop doesn't exist.");
                     }
                 }


### PR DESCRIPTION
This is useful for specific platform code that the user may want to integrate with iced.