### PR TITLE
wgpu: require `Send` on stored pipelines

### DIFF
--- a/wgpu/src/primitive/pipeline.rs
+++ b/wgpu/src/primitive/pipeline.rs
@@ -82,7 +82,7 @@ impl<Theme> Renderer for crate::Renderer<Theme> {
 /// Stores custom, user-provided pipelines.
 #[derive(Default, Debug)]
 pub struct Storage {
-    pipelines: HashMap<TypeId, Box<dyn Any>>,
+    pipelines: HashMap<TypeId, Box<dyn Any + Send>>,
 }
 
 impl Storage {
@@ -92,7 +92,7 @@ impl Storage {
     }
 
     /// Inserts the pipeline `T` in to [`Storage`].
-    pub fn store<T: 'static>(&mut self, pipeline: T) {
+    pub fn store<T: 'static + Send>(&mut self, pipeline: T) {
         let _ = self.pipelines.insert(TypeId::of::<T>(), Box::new(pipeline));
     }
 


### PR DESCRIPTION
hi, thanks for this awesome crate!

I'm using `wgpu::Renderer/Backend` with `Send`, but since `pipeline_storage: pipeline::Storage` was added to `Backend` it is no longer `Send` (#2085). I'd like to restore this by adding the extra bound, it still works with the `examples/custom_shader/src/scene.rs`.