### PR TITLE
Add `Interaction` overriding to `MouseArea`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,7 @@ Many thanks to...
 - @tarkah
 - @tzemanovic
 - @varbhat
+- @VAWVAW
 - @william-shere
 
 ## [0.10.0] - 2023-07-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fetch_maximized` and `fetch_minimized` commands in `window`. [#2189](https://github.com/iced-rs/iced/pull/2189)
 - `run_with_handle` command in `window`. [#2200](https://github.com/iced-rs/iced/pull/2200)
 - `text_shaping` method for `Tooltip`. [#2172](https://github.com/iced-rs/iced/pull/2172)
+- `interaction` method for `MouseArea`. [#2207](https://github.com/iced-rs/iced/pull/2207)
 - `hovered` styling for `Svg` widget. [#2163](https://github.com/iced-rs/iced/pull/2163)
 - Customizable style for `TextEditor`. [#2159](https://github.com/iced-rs/iced/pull/2159)
 - `RawText` variant for `Primitive` in `iced_graphics`. [#2158](https://github.com/iced-rs/iced/pull/2158)

--- a/widget/src/mouse_area.rs
+++ b/widget/src/mouse_area.rs
@@ -31,6 +31,7 @@ pub struct MouseArea<
     on_mouse_enter: Option<Message>,
     on_mouse_move: Option<Box<dyn Fn(Point) -> Message>>,
     on_mouse_exit: Option<Message>,
+    interaction: Option<mouse::Interaction>,
 }
 
 impl<'a, Message, Theme, Renderer> MouseArea<'a, Message, Theme, Renderer> {
@@ -99,6 +100,16 @@ impl<'a, Message, Theme, Renderer> MouseArea<'a, Message, Theme, Renderer> {
         self.on_mouse_exit = Some(message);
         self
     }
+
+    /// The version of the cursor to use when hovering.
+    #[must_use]
+    pub fn mouse_interaction(
+        mut self,
+        interaction: mouse::Interaction,
+    ) -> Self {
+        self.interaction = Some(interaction);
+        self
+    }
 }
 
 /// Local state of the [`MouseArea`].
@@ -123,6 +134,7 @@ impl<'a, Message, Theme, Renderer> MouseArea<'a, Message, Theme, Renderer> {
             on_mouse_enter: None,
             on_mouse_move: None,
             on_mouse_exit: None,
+            interaction: None,
         }
     }
 }
@@ -214,6 +226,14 @@ where
         viewport: &Rectangle,
         renderer: &Renderer,
     ) -> mouse::Interaction {
+        if !cursor.is_over(layout.bounds()) {
+            return mouse::Interaction::default();
+        }
+
+        if let Some(interaction) = self.interaction {
+            return interaction;
+        }
+
         self.content.as_widget().mouse_interaction(
             &tree.children[0],
             layout,

--- a/widget/src/mouse_area.rs
+++ b/widget/src/mouse_area.rs
@@ -101,7 +101,7 @@ impl<'a, Message, Theme, Renderer> MouseArea<'a, Message, Theme, Renderer> {
         self
     }
 
-    /// The version of the cursor to use when hovering.
+    /// The [`mouse::Interaction`] to use when hovering the area.
     #[must_use]
     pub fn mouse_interaction(
         mut self,
@@ -226,21 +226,22 @@ where
         viewport: &Rectangle,
         renderer: &Renderer,
     ) -> mouse::Interaction {
-        if !cursor.is_over(layout.bounds()) {
-            return mouse::Interaction::default();
-        }
-
-        if let Some(interaction) = self.interaction {
-            return interaction;
-        }
-
-        self.content.as_widget().mouse_interaction(
+        let content_interaction = self.content.as_widget().mouse_interaction(
             &tree.children[0],
             layout,
             cursor,
             viewport,
             renderer,
-        )
+        );
+
+        match (self.interaction, content_interaction) {
+            (Some(interaction), mouse::Interaction::Idle)
+                if cursor.is_over(layout.bounds()) =>
+            {
+                interaction
+            }
+            _ => content_interaction,
+        }
     }
 
     fn draw(

--- a/widget/src/mouse_area.rs
+++ b/widget/src/mouse_area.rs
@@ -79,14 +79,14 @@ impl<'a, Message, Theme, Renderer> MouseArea<'a, Message, Theme, Renderer> {
 
     /// The message to emit when the mouse enters the area.
     #[must_use]
-    pub fn on_mouse_enter(mut self, message: Message) -> Self {
+    pub fn on_enter(mut self, message: Message) -> Self {
         self.on_mouse_enter = Some(message);
         self
     }
 
     /// The message to emit when the mouse moves in the area.
     #[must_use]
-    pub fn on_mouse_move<F>(mut self, build_message: F) -> Self
+    pub fn on_move<F>(mut self, build_message: F) -> Self
     where
         F: Fn(Point) -> Message + 'static,
     {
@@ -96,17 +96,14 @@ impl<'a, Message, Theme, Renderer> MouseArea<'a, Message, Theme, Renderer> {
 
     /// The message to emit when the mouse exits the area.
     #[must_use]
-    pub fn on_mouse_exit(mut self, message: Message) -> Self {
+    pub fn on_exit(mut self, message: Message) -> Self {
         self.on_mouse_exit = Some(message);
         self
     }
 
     /// The [`mouse::Interaction`] to use when hovering the area.
     #[must_use]
-    pub fn mouse_interaction(
-        mut self,
-        interaction: mouse::Interaction,
-    ) -> Self {
+    pub fn interaction(mut self, interaction: mouse::Interaction) -> Self {
         self.interaction = Some(interaction);
         self
     }


### PR DESCRIPTION
The widget `MouseArea` allows to create button-like behavior but gives more control than `Button`. Currently there is no obvious way to change the mouse `Interaction` with the widget. I feel like `MouseArea` would be the most straightforward place to implement this.

This change adds the option to override the `Interaction` of the contained widget and set a custom one using the `mouse_interaction` callback.