### PR TITLE
`Themer` widget

### DIFF
--- a/core/src/layout/flex.rs
+++ b/core/src/layout/flex.rs
@@ -59,7 +59,7 @@ impl Axis {
 /// padding and alignment to the items as needed.
 ///
 /// It returns a new layout [`Node`].
-pub fn resolve<Message, Renderer>(
+pub fn resolve<Message, Theme, Renderer>(
     axis: Axis,
     renderer: &Renderer,
     limits: &Limits,
@@ -68,7 +68,7 @@ pub fn resolve<Message, Renderer>(
     padding: Padding,
     spacing: f32,
     align_items: Alignment,
-    items: &[Element<'_, Message, Renderer>],
+    items: &[Element<'_, Message, Theme, Renderer>],
     trees: &mut [widget::Tree],
 ) -> Node
 where

--- a/core/src/overlay.rs
+++ b/core/src/overlay.rs
@@ -14,7 +14,7 @@ use crate::widget::Tree;
 use crate::{Clipboard, Layout, Point, Rectangle, Shell, Size, Vector};
 
 /// An interactive component that can be displayed on top of other widgets.
-pub trait Overlay<Message, Renderer>
+pub trait Overlay<Message, Theme, Renderer>
 where
     Renderer: crate::Renderer,
 {
@@ -36,7 +36,7 @@ where
     fn draw(
         &self,
         renderer: &mut Renderer,
-        theme: &Renderer::Theme,
+        theme: &Theme,
         style: &renderer::Style,
         layout: Layout<'_>,
         cursor: mouse::Cursor,
@@ -106,7 +106,7 @@ where
         &'a mut self,
         _layout: Layout<'_>,
         _renderer: &Renderer,
-    ) -> Option<Element<'a, Message, Renderer>> {
+    ) -> Option<Element<'a, Message, Theme, Renderer>> {
         None
     }
 }
@@ -115,12 +115,12 @@ where
 ///
 /// This method will generally only be used by advanced users that are
 /// implementing the [`Widget`](crate::Widget) trait.
-pub fn from_children<'a, Message, Renderer>(
-    children: &'a mut [crate::Element<'_, Message, Renderer>],
+pub fn from_children<'a, Message, Theme, Renderer>(
+    children: &'a mut [crate::Element<'_, Message, Theme, Renderer>],
     tree: &'a mut Tree,
     layout: Layout<'_>,
     renderer: &Renderer,
-) -> Option<Element<'a, Message, Renderer>>
+) -> Option<Element<'a, Message, Theme, Renderer>>
 where
     Renderer: crate::Renderer,
 {

--- a/core/src/overlay/group.rs
+++ b/core/src/overlay/group.rs
@@ -11,14 +11,15 @@ use crate::{
 /// An [`Overlay`] container that displays multiple overlay [`overlay::Element`]
 /// children.
 #[allow(missing_debug_implementations)]
-pub struct Group<'a, Message, Renderer> {
-    children: Vec<overlay::Element<'a, Message, Renderer>>,
+pub struct Group<'a, Message, Theme, Renderer> {
+    children: Vec<overlay::Element<'a, Message, Theme, Renderer>>,
 }
 
-impl<'a, Message, Renderer> Group<'a, Message, Renderer>
+impl<'a, Message, Theme, Renderer> Group<'a, Message, Theme, Renderer>
 where
-    Renderer: 'a + crate::Renderer,
     Message: 'a,
+    Theme: 'a,
+    Renderer: 'a + crate::Renderer,
 {
     /// Creates an empty [`Group`].
     pub fn new() -> Self {
@@ -27,7 +28,7 @@ where
 
     /// Creates a [`Group`] with the given elements.
     pub fn with_children(
-        children: Vec<overlay::Element<'a, Message, Renderer>>,
+        children: Vec<overlay::Element<'a, Message, Theme, Renderer>>,
     ) -> Self {
         Group { children }
     }
@@ -35,30 +36,32 @@ where
     /// Adds an [`overlay::Element`] to the [`Group`].
     pub fn push(
         mut self,
-        child: impl Into<overlay::Element<'a, Message, Renderer>>,
+        child: impl Into<overlay::Element<'a, Message, Theme, Renderer>>,
     ) -> Self {
         self.children.push(child.into());
         self
     }
 
     /// Turns the [`Group`] into an overlay [`overlay::Element`].
-    pub fn overlay(self) -> overlay::Element<'a, Message, Renderer> {
+    pub fn overlay(self) -> overlay::Element<'a, Message, Theme, Renderer> {
         overlay::Element::new(Point::ORIGIN, Box::new(self))
     }
 }
 
-impl<'a, Message, Renderer> Default for Group<'a, Message, Renderer>
+impl<'a, Message, Theme, Renderer> Default
+    for Group<'a, Message, Theme, Renderer>
 where
-    Renderer: 'a + crate::Renderer,
     Message: 'a,
+    Theme: 'a,
+    Renderer: 'a + crate::Renderer,
 {
     fn default() -> Self {
         Self::with_children(Vec::new())
     }
 }
 
-impl<'a, Message, Renderer> Overlay<Message, Renderer>
-    for Group<'a, Message, Renderer>
+impl<'a, Message, Theme, Renderer> Overlay<Message, Theme, Renderer>
+    for Group<'a, Message, Theme, Renderer>
 where
     Renderer: crate::Renderer,
 {
@@ -106,7 +109,7 @@ where
     fn draw(
         &self,
         renderer: &mut Renderer,
-        theme: &<Renderer as crate::Renderer>::Theme,
+        theme: &Theme,
         style: &renderer::Style,
         layout: Layout<'_>,
         cursor: mouse::Cursor,
@@ -166,7 +169,7 @@ where
         &'b mut self,
         layout: Layout<'_>,
         renderer: &Renderer,
-    ) -> Option<overlay::Element<'b, Message, Renderer>> {
+    ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
         let children = self
             .children
             .iter_mut()
@@ -178,13 +181,14 @@ where
     }
 }
 
-impl<'a, Message, Renderer> From<Group<'a, Message, Renderer>>
-    for overlay::Element<'a, Message, Renderer>
+impl<'a, Message, Theme, Renderer> From<Group<'a, Message, Theme, Renderer>>
+    for overlay::Element<'a, Message, Theme, Renderer>
 where
-    Renderer: 'a + crate::Renderer,
     Message: 'a,
+    Theme: 'a,
+    Renderer: 'a + crate::Renderer,
 {
-    fn from(group: Group<'a, Message, Renderer>) -> Self {
+    fn from(group: Group<'a, Message, Theme, Renderer>) -> Self {
         group.overlay()
     }
 }

--- a/core/src/renderer.rs
+++ b/core/src/renderer.rs
@@ -9,9 +9,6 @@ use crate::{Background, Border, Color, Rectangle, Shadow, Size, Vector};
 
 /// A component that can be used by widgets to draw themselves on a screen.
 pub trait Renderer: Sized {
-    /// The supported theme of the [`Renderer`].
-    type Theme;
-
     /// Draws the primitives recorded in the given closure in a new layer.
     ///
     /// The layer will clip its contents to the provided `bounds`.

--- a/core/src/renderer/null.rs
+++ b/core/src/renderer/null.rs
@@ -19,8 +19,6 @@ impl Null {
 }
 
 impl Renderer for Null {
-    type Theme = ();
-
     fn with_layer(&mut self, _bounds: Rectangle, _f: impl FnOnce(&mut Self)) {}
 
     fn with_translation(

--- a/core/src/widget.rs
+++ b/core/src/widget.rs
@@ -39,7 +39,7 @@ use crate::{Clipboard, Length, Rectangle, Shell, Size};
 /// [`geometry`]: https://github.com/iced-rs/iced/tree/0.10/examples/geometry
 /// [`lyon`]: https://github.com/nical/lyon
 /// [`iced_wgpu`]: https://github.com/iced-rs/iced/tree/0.10/wgpu
-pub trait Widget<Message, Renderer>
+pub trait Widget<Message, Theme, Renderer>
 where
     Renderer: crate::Renderer,
 {
@@ -70,7 +70,7 @@ where
         &self,
         tree: &Tree,
         renderer: &mut Renderer,
-        theme: &Renderer::Theme,
+        theme: &Theme,
         style: &renderer::Style,
         layout: Layout<'_>,
         cursor: mouse::Cursor,
@@ -146,7 +146,7 @@ where
         _state: &'a mut Tree,
         _layout: Layout<'_>,
         _renderer: &Renderer,
-    ) -> Option<overlay::Element<'a, Message, Renderer>> {
+    ) -> Option<overlay::Element<'a, Message, Theme, Renderer>> {
         None
     }
 }

--- a/core/src/widget/text.rs
+++ b/core/src/widget/text.rs
@@ -15,10 +15,10 @@ pub use text::{LineHeight, Shaping};
 
 /// A paragraph of text.
 #[allow(missing_debug_implementations)]
-pub struct Text<'a, Renderer>
+pub struct Text<'a, Theme, Renderer>
 where
+    Theme: StyleSheet,
     Renderer: text::Renderer,
-    Renderer::Theme: StyleSheet,
 {
     content: Cow<'a, str>,
     size: Option<Pixels>,
@@ -29,13 +29,13 @@ where
     vertical_alignment: alignment::Vertical,
     font: Option<Renderer::Font>,
     shaping: Shaping,
-    style: <Renderer::Theme as StyleSheet>::Style,
+    style: Theme::Style,
 }
 
-impl<'a, Renderer> Text<'a, Renderer>
+impl<'a, Theme, Renderer> Text<'a, Theme, Renderer>
 where
+    Theme: StyleSheet,
     Renderer: text::Renderer,
-    Renderer::Theme: StyleSheet,
 {
     /// Create a new fragment of [`Text`] with the given contents.
     pub fn new(content: impl Into<Cow<'a, str>>) -> Self {
@@ -74,10 +74,7 @@ where
     }
 
     /// Sets the style of the [`Text`].
-    pub fn style(
-        mut self,
-        style: impl Into<<Renderer::Theme as StyleSheet>::Style>,
-    ) -> Self {
+    pub fn style(mut self, style: impl Into<Theme::Style>) -> Self {
         self.style = style.into();
         self
     }
@@ -123,10 +120,11 @@ where
 #[derive(Debug, Default)]
 pub struct State<P: Paragraph>(P);
 
-impl<'a, Message, Renderer> Widget<Message, Renderer> for Text<'a, Renderer>
+impl<'a, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
+    for Text<'a, Theme, Renderer>
 where
+    Theme: StyleSheet,
     Renderer: text::Renderer,
-    Renderer::Theme: StyleSheet,
 {
     fn tag(&self) -> tree::Tag {
         tree::Tag::of::<State<Renderer::Paragraph>>()
@@ -169,7 +167,7 @@ where
         &self,
         tree: &Tree,
         renderer: &mut Renderer,
-        theme: &Renderer::Theme,
+        theme: &Theme,
         style: &renderer::Style,
         layout: Layout<'_>,
         _cursor_position: mouse::Cursor,
@@ -272,21 +270,23 @@ pub fn draw<Renderer>(
     );
 }
 
-impl<'a, Message, Renderer> From<Text<'a, Renderer>>
-    for Element<'a, Message, Renderer>
+impl<'a, Message, Theme, Renderer> From<Text<'a, Theme, Renderer>>
+    for Element<'a, Message, Theme, Renderer>
 where
+    Theme: StyleSheet + 'a,
     Renderer: text::Renderer + 'a,
-    Renderer::Theme: StyleSheet,
 {
-    fn from(text: Text<'a, Renderer>) -> Element<'a, Message, Renderer> {
+    fn from(
+        text: Text<'a, Theme, Renderer>,
+    ) -> Element<'a, Message, Theme, Renderer> {
         Element::new(text)
     }
 }
 
-impl<'a, Renderer> Clone for Text<'a, Renderer>
+impl<'a, Theme, Renderer> Clone for Text<'a, Theme, Renderer>
 where
+    Theme: StyleSheet,
     Renderer: text::Renderer,
-    Renderer::Theme: StyleSheet,
 {
     fn clone(&self) -> Self {
         Self {
@@ -304,20 +304,21 @@ where
     }
 }
 
-impl<'a, Renderer> From<&'a str> for Text<'a, Renderer>
+impl<'a, Theme, Renderer> From<&'a str> for Text<'a, Theme, Renderer>
 where
+    Theme: StyleSheet,
     Renderer: text::Renderer,
-    Renderer::Theme: StyleSheet,
 {
     fn from(content: &'a str) -> Self {
         Self::new(content)
     }
 }
 
-impl<'a, Message, Renderer> From<&'a str> for Element<'a, Message, Renderer>
+impl<'a, Message, Theme, Renderer> From<&'a str>
+    for Element<'a, Message, Theme, Renderer>
 where
+    Theme: StyleSheet + 'a,
     Renderer: text::Renderer + 'a,
-    Renderer::Theme: StyleSheet,
 {
     fn from(content: &'a str) -> Self {
         Text::from(content).into()

--- a/core/src/widget/tree.rs
+++ b/core/src/widget/tree.rs
@@ -31,8 +31,8 @@ impl Tree {
     }
 
     /// Creates a new [`Tree`] for the provided [`Widget`].
-    pub fn new<'a, Message, Renderer>(
-        widget: impl Borrow<dyn Widget<Message, Renderer> + 'a>,
+    pub fn new<'a, Message, Theme, Renderer>(
+        widget: impl Borrow<dyn Widget<Message, Theme, Renderer> + 'a>,
     ) -> Self
     where
         Renderer: crate::Renderer,
@@ -54,9 +54,9 @@ impl Tree {
     /// Otherwise, the whole [`Tree`] is recreated.
     ///
     /// [`Widget::diff`]: crate::Widget::diff
-    pub fn diff<'a, Message, Renderer>(
+    pub fn diff<'a, Message, Theme, Renderer>(
         &mut self,
-        new: impl Borrow<dyn Widget<Message, Renderer> + 'a>,
+        new: impl Borrow<dyn Widget<Message, Theme, Renderer> + 'a>,
     ) where
         Renderer: crate::Renderer,
     {
@@ -68,9 +68,9 @@ impl Tree {
     }
 
     /// Reconciles the children of the tree with the provided list of widgets.
-    pub fn diff_children<'a, Message, Renderer>(
+    pub fn diff_children<'a, Message, Theme, Renderer>(
         &mut self,
-        new_children: &[impl Borrow<dyn Widget<Message, Renderer> + 'a>],
+        new_children: &[impl Borrow<dyn Widget<Message, Theme, Renderer> + 'a>],
     ) where
         Renderer: crate::Renderer,
     {

--- a/examples/clock/src/main.rs
+++ b/examples/clock/src/main.rs
@@ -82,7 +82,7 @@ impl Application for Clock {
     }
 }
 
-impl<Message> canvas::Program<Message, Renderer> for Clock {
+impl<Message> canvas::Program<Message> for Clock {
     type State = ();
 
     fn draw(

--- a/examples/color_palette/src/main.rs
+++ b/examples/color_palette/src/main.rs
@@ -298,7 +298,7 @@ impl<C: ColorSpace + Copy> ColorPicker<C> {
             range: RangeInclusive<f64>,
             component: f32,
             update: impl Fn(f32) -> C + 'a,
-        ) -> Slider<'a, f64, C, iced::Renderer> {
+        ) -> Slider<'a, f64, C> {
             Slider::new(range, f64::from(component), move |v| update(v as f32))
                 .step(0.01)
         }

--- a/examples/component/src/main.rs
+++ b/examples/component/src/main.rs
@@ -48,7 +48,7 @@ impl Sandbox for Component {
 mod numeric_input {
     use iced::alignment::{self, Alignment};
     use iced::widget::{button, component, row, text, text_input, Component};
-    use iced::{Element, Length, Renderer};
+    use iced::{Element, Length};
 
     pub struct NumericInput<Message> {
         value: Option<u32>,
@@ -81,7 +81,7 @@ mod numeric_input {
         }
     }
 
-    impl<Message> Component<Message, Renderer> for NumericInput<Message> {
+    impl<Message> Component<Message> for NumericInput<Message> {
         type State = ();
         type Event = Event;
 
@@ -111,7 +111,7 @@ mod numeric_input {
             }
         }
 
-        fn view(&self, _state: &Self::State) -> Element<Event, Renderer> {
+        fn view(&self, _state: &Self::State) -> Element<Event> {
             let button = |label, on_press| {
                 button(
                     text(label)
@@ -145,7 +145,7 @@ mod numeric_input {
         }
     }
 
-    impl<'a, Message> From<NumericInput<Message>> for Element<'a, Message, Renderer>
+    impl<'a, Message> From<NumericInput<Message>> for Element<'a, Message>
     where
         Message: 'a,
     {

--- a/examples/custom_quad/src/main.rs
+++ b/examples/custom_quad/src/main.rs
@@ -29,7 +29,7 @@ mod quad {
         }
     }
 
-    impl<Message, Renderer> Widget<Message, Renderer> for CustomQuad
+    impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer> for CustomQuad
     where
         Renderer: renderer::Renderer,
     {
@@ -53,7 +53,7 @@ mod quad {
             &self,
             _state: &widget::Tree,
             renderer: &mut Renderer,
-            _theme: &Renderer::Theme,
+            _theme: &Theme,
             _style: &renderer::Style,
             layout: Layout<'_>,
             _cursor: mouse::Cursor,
@@ -74,10 +74,7 @@ mod quad {
         }
     }
 
-    impl<'a, Message, Renderer> From<CustomQuad> for Element<'a, Message, Renderer>
-    where
-        Renderer: renderer::Renderer,
-    {
+    impl<'a, Message> From<CustomQuad> for Element<'a, Message> {
         fn from(circle: CustomQuad) -> Self {
             Self::new(circle)
         }

--- a/examples/custom_shader/src/main.rs
+++ b/examples/custom_shader/src/main.rs
@@ -8,8 +8,8 @@ use iced::widget::shader::wgpu;
 use iced::widget::{checkbox, column, container, row, shader, slider, text};
 use iced::window;
 use iced::{
-    Alignment, Application, Color, Command, Element, Length, Renderer,
-    Subscription, Theme,
+    Alignment, Application, Color, Command, Element, Length, Subscription,
+    Theme,
 };
 
 fn main() -> iced::Result {
@@ -72,7 +72,7 @@ impl Application for IcedCubes {
         Command::none()
     }
 
-    fn view(&self) -> Element<'_, Self::Message, Renderer<Self::Theme>> {
+    fn view(&self) -> Element<'_, Self::Message> {
         let top_controls = row![
             control(
                 "Amount",

--- a/examples/custom_widget/src/main.rs
+++ b/examples/custom_widget/src/main.rs
@@ -29,7 +29,7 @@ mod circle {
         Circle::new(radius)
     }
 
-    impl<Message, Renderer> Widget<Message, Renderer> for Circle
+    impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer> for Circle
     where
         Renderer: renderer::Renderer,
     {
@@ -53,7 +53,7 @@ mod circle {
             &self,
             _state: &widget::Tree,
             renderer: &mut Renderer,
-            _theme: &Renderer::Theme,
+            _theme: &Theme,
             _style: &renderer::Style,
             layout: Layout<'_>,
             _cursor: mouse::Cursor,
@@ -70,7 +70,8 @@ mod circle {
         }
     }
 
-    impl<'a, Message, Renderer> From<Circle> for Element<'a, Message, Renderer>
+    impl<'a, Message, Theme, Renderer> From<Circle>
+        for Element<'a, Message, Theme, Renderer>
     where
         Renderer: renderer::Renderer,
     {

--- a/examples/geometry/src/main.rs
+++ b/examples/geometry/src/main.rs
@@ -15,7 +15,7 @@ mod rainbow {
         Rainbow
     }
 
-    impl<Message> Widget<Message, Renderer> for Rainbow {
+    impl<Message> Widget<Message, Theme, Renderer> for Rainbow {
         fn size(&self) -> Size<Length> {
             Size {
                 width: Length::Fill,
@@ -139,7 +139,7 @@ mod rainbow {
         }
     }
 
-    impl<'a, Message> From<Rainbow> for Element<'a, Message, Renderer> {
+    impl<'a, Message> From<Rainbow> for Element<'a, Message> {
         fn from(rainbow: Rainbow) -> Self {
             Self::new(rainbow)
         }

--- a/examples/integration/src/controls.rs
+++ b/examples/integration/src/controls.rs
@@ -29,8 +29,9 @@ impl Controls {
 }
 
 impl Program for Controls {
-    type Renderer = Renderer<Theme>;
+    type Theme = Theme;
     type Message = Message;
+    type Renderer = Renderer;
 
     fn update(&mut self, message: Message) -> Command<Message> {
         match message {
@@ -45,7 +46,7 @@ impl Program for Controls {
         Command::none()
     }
 
-    fn view(&self) -> Element<Message, Renderer<Theme>> {
+    fn view(&self) -> Element<Message, Theme, Renderer> {
         let background_color = self.background_color;
         let text = &self.text;
 

--- a/examples/loading_spinners/src/circular.rs
+++ b/examples/loading_spinners/src/circular.rs
@@ -2,14 +2,15 @@
 use iced::advanced::layout;
 use iced::advanced::renderer;
 use iced::advanced::widget::tree::{self, Tree};
-use iced::advanced::{Clipboard, Layout, Renderer, Shell, Widget};
+use iced::advanced::{self, Clipboard, Layout, Shell, Widget};
 use iced::event;
 use iced::mouse;
 use iced::time::Instant;
 use iced::widget::canvas;
 use iced::window::{self, RedrawRequest};
 use iced::{
-    Background, Color, Element, Event, Length, Rectangle, Size, Vector,
+    Background, Color, Element, Event, Length, Rectangle, Renderer, Size,
+    Vector,
 };
 
 use super::easing::{self, Easing};
@@ -230,7 +231,7 @@ struct State {
     cache: canvas::Cache,
 }
 
-impl<'a, Message, Theme> Widget<Message, iced::Renderer<Theme>>
+impl<'a, Message, Theme> Widget<Message, Theme, Renderer>
     for Circular<'a, Theme>
 where
     Message: 'a + Clone,
@@ -254,7 +255,7 @@ where
     fn layout(
         &self,
         _tree: &mut Tree,
-        _renderer: &iced::Renderer<Theme>,
+        _renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
         layout::atomic(limits, self.size, self.size)
@@ -266,7 +267,7 @@ where
         event: Event,
         _layout: Layout<'_>,
         _cursor: mouse::Cursor,
-        _renderer: &iced::Renderer<Theme>,
+        _renderer: &Renderer,
         _clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, Message>,
         _viewport: &Rectangle,
@@ -290,13 +291,15 @@ where
     fn draw(
         &self,
         tree: &Tree,
-        renderer: &mut iced::Renderer<Theme>,
+        renderer: &mut Renderer,
         theme: &Theme,
         _style: &renderer::Style,
         layout: Layout<'_>,
         _cursor: mouse::Cursor,
         _viewport: &Rectangle,
     ) {
+        use advanced::Renderer as _;
+
         let state = tree.state.downcast_ref::<State>();
         let bounds = layout.bounds();
         let custom_style =
@@ -361,7 +364,7 @@ where
 }
 
 impl<'a, Message, Theme> From<Circular<'a, Theme>>
-    for Element<'a, Message, iced::Renderer<Theme>>
+    for Element<'a, Message, Theme, Renderer>
 where
     Message: Clone + 'a,
     Theme: StyleSheet + 'a,

--- a/examples/loading_spinners/src/linear.rs
+++ b/examples/loading_spinners/src/linear.rs
@@ -2,7 +2,7 @@
 use iced::advanced::layout;
 use iced::advanced::renderer::{self, Quad};
 use iced::advanced::widget::tree::{self, Tree};
-use iced::advanced::{Clipboard, Layout, Shell, Widget};
+use iced::advanced::{self, Clipboard, Layout, Shell, Widget};
 use iced::event;
 use iced::mouse;
 use iced::time::Instant;
@@ -14,29 +14,27 @@ use super::easing::{self, Easing};
 use std::time::Duration;
 
 #[allow(missing_debug_implementations)]
-pub struct Linear<'a, Renderer>
+pub struct Linear<'a, Theme>
 where
-    Renderer: iced::advanced::Renderer,
-    Renderer::Theme: StyleSheet,
+    Theme: StyleSheet,
 {
     width: Length,
     height: Length,
-    style: <Renderer::Theme as StyleSheet>::Style,
+    style: Theme::Style,
     easing: &'a Easing,
     cycle_duration: Duration,
 }
 
-impl<'a, Renderer> Linear<'a, Renderer>
+impl<'a, Theme> Linear<'a, Theme>
 where
-    Renderer: iced::advanced::Renderer,
-    Renderer::Theme: StyleSheet,
+    Theme: StyleSheet,
 {
     /// Creates a new [`Linear`] with the given content.
     pub fn new() -> Self {
         Linear {
             width: Length::Fixed(100.0),
             height: Length::Fixed(4.0),
-            style: <Renderer::Theme as StyleSheet>::Style::default(),
+            style: Theme::Style::default(),
             easing: &easing::STANDARD,
             cycle_duration: Duration::from_millis(600),
         }
@@ -55,11 +53,8 @@ where
     }
 
     /// Sets the style variant of this [`Linear`].
-    pub fn style(
-        mut self,
-        style: <Renderer::Theme as StyleSheet>::Style,
-    ) -> Self {
-        self.style = style;
+    pub fn style(mut self, style: impl Into<Theme::Style>) -> Self {
+        self.style = style.into();
         self
     }
 
@@ -76,10 +71,9 @@ where
     }
 }
 
-impl<'a, Renderer> Default for Linear<'a, Renderer>
+impl<'a, Theme> Default for Linear<'a, Theme>
 where
-    Renderer: iced::advanced::Renderer,
-    Renderer::Theme: StyleSheet,
+    Theme: StyleSheet,
 {
     fn default() -> Self {
         Self::new()
@@ -151,11 +145,12 @@ impl State {
     }
 }
 
-impl<'a, Message, Renderer> Widget<Message, Renderer> for Linear<'a, Renderer>
+impl<'a, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
+    for Linear<'a, Theme>
 where
-    Message: 'a + Clone,
-    Renderer: 'a + iced::advanced::Renderer,
-    Renderer::Theme: StyleSheet,
+    Message: Clone + 'a,
+    Theme: StyleSheet + 'a,
+    Renderer: advanced::Renderer + 'a,
 {
     fn tag(&self) -> tree::Tag {
         tree::Tag::of::<State>()
@@ -207,7 +202,7 @@ where
         &self,
         tree: &Tree,
         renderer: &mut Renderer,
-        theme: &Renderer::Theme,
+        theme: &Theme,
         _style: &renderer::Style,
         layout: Layout<'_>,
         _cursor: mouse::Cursor,
@@ -262,14 +257,14 @@ where
     }
 }
 
-impl<'a, Message, Renderer> From<Linear<'a, Renderer>>
-    for Element<'a, Message, Renderer>
+impl<'a, Message, Theme, Renderer> From<Linear<'a, Theme>>
+    for Element<'a, Message, Theme, Renderer>
 where
     Message: Clone + 'a,
+    Theme: StyleSheet + 'a,
     Renderer: iced::advanced::Renderer + 'a,
-    Renderer::Theme: StyleSheet,
 {
-    fn from(linear: Linear<'a, Renderer>) -> Self {
+    fn from(linear: Linear<'a, Theme>) -> Self {
         Self::new(linear)
     }
 }

--- a/examples/modal/src/main.rs
+++ b/examples/modal/src/main.rs
@@ -234,17 +234,17 @@ mod modal {
     use iced::{Color, Element, Event, Length, Point, Rectangle, Size, Vector};
 
     /// A widget that centers a modal element over some base element
-    pub struct Modal<'a, Message, Renderer> {
-        base: Element<'a, Message, Renderer>,
-        modal: Element<'a, Message, Renderer>,
+    pub struct Modal<'a, Message, Theme, Renderer> {
+        base: Element<'a, Message, Theme, Renderer>,
+        modal: Element<'a, Message, Theme, Renderer>,
         on_blur: Option<Message>,
     }
 
-    impl<'a, Message, Renderer> Modal<'a, Message, Renderer> {
+    impl<'a, Message, Theme, Renderer> Modal<'a, Message, Theme, Renderer> {
         /// Returns a new [`Modal`]
         pub fn new(
-            base: impl Into<Element<'a, Message, Renderer>>,
-            modal: impl Into<Element<'a, Message, Renderer>>,
+            base: impl Into<Element<'a, Message, Theme, Renderer>>,
+            modal: impl Into<Element<'a, Message, Theme, Renderer>>,
         ) -> Self {
             Self {
                 base: base.into(),
@@ -263,8 +263,8 @@ mod modal {
         }
     }
 
-    impl<'a, Message, Renderer> Widget<Message, Renderer>
-        for Modal<'a, Message, Renderer>
+    impl<'a, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
+        for Modal<'a, Message, Theme, Renderer>
     where
         Renderer: advanced::Renderer,
         Message: Clone,
@@ -324,7 +324,7 @@ mod modal {
             &self,
             state: &widget::Tree,
             renderer: &mut Renderer,
-            theme: &<Renderer as advanced::Renderer>::Theme,
+            theme: &Theme,
             style: &renderer::Style,
             layout: Layout<'_>,
             cursor: mouse::Cursor,
@@ -346,7 +346,7 @@ mod modal {
             state: &'b mut widget::Tree,
             layout: Layout<'_>,
             _renderer: &Renderer,
-        ) -> Option<overlay::Element<'b, Message, Renderer>> {
+        ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
             Some(overlay::Element::new(
                 layout.position(),
                 Box::new(Overlay {
@@ -391,15 +391,16 @@ mod modal {
         }
     }
 
-    struct Overlay<'a, 'b, Message, Renderer> {
-        content: &'b mut Element<'a, Message, Renderer>,
+    struct Overlay<'a, 'b, Message, Theme, Renderer> {
+        content: &'b mut Element<'a, Message, Theme, Renderer>,
         tree: &'b mut widget::Tree,
         size: Size,
         on_blur: Option<Message>,
     }
 
-    impl<'a, 'b, Message, Renderer> overlay::Overlay<Message, Renderer>
-        for Overlay<'a, 'b, Message, Renderer>
+    impl<'a, 'b, Message, Theme, Renderer>
+        overlay::Overlay<Message, Theme, Renderer>
+        for Overlay<'a, 'b, Message, Theme, Renderer>
     where
         Renderer: advanced::Renderer,
         Message: Clone,
@@ -463,7 +464,7 @@ mod modal {
         fn draw(
             &self,
             renderer: &mut Renderer,
-            theme: &Renderer::Theme,
+            theme: &Theme,
             style: &renderer::Style,
             layout: Layout<'_>,
             cursor: mouse::Cursor,
@@ -524,7 +525,7 @@ mod modal {
             &'c mut self,
             layout: Layout<'_>,
             renderer: &Renderer,
-        ) -> Option<overlay::Element<'c, Message, Renderer>> {
+        ) -> Option<overlay::Element<'c, Message, Theme, Renderer>> {
             self.content.as_widget_mut().overlay(
                 self.tree,
                 layout.children().next().unwrap(),
@@ -533,13 +534,14 @@ mod modal {
         }
     }
 
-    impl<'a, Message, Renderer> From<Modal<'a, Message, Renderer>>
-        for Element<'a, Message, Renderer>
+    impl<'a, Message, Theme, Renderer> From<Modal<'a, Message, Theme, Renderer>>
+        for Element<'a, Message, Theme, Renderer>
     where
-        Renderer: 'a + advanced::Renderer,
+        Theme: 'a,
         Message: 'a + Clone,
+        Renderer: 'a + advanced::Renderer,
     {
-        fn from(modal: Modal<'a, Message, Renderer>) -> Self {
+        fn from(modal: Modal<'a, Message, Theme, Renderer>) -> Self {
             Element::new(modal)
         }
     }

--- a/examples/multitouch/src/main.rs
+++ b/examples/multitouch/src/main.rs
@@ -96,7 +96,7 @@ impl Application for Multitouch {
     }
 }
 
-impl canvas::Program<Message, Renderer> for State {
+impl canvas::Program<Message> for State {
     type State = ();
 
     fn update(

--- a/examples/screenshot/src/main.rs
+++ b/examples/screenshot/src/main.rs
@@ -7,7 +7,7 @@ use iced::window;
 use iced::window::screenshot::{self, Screenshot};
 use iced::{
     Alignment, Application, Command, ContentFit, Element, Length, Rectangle,
-    Renderer, Subscription, Theme,
+    Subscription, Theme,
 };
 
 use ::image as img;
@@ -131,7 +131,7 @@ impl Application for Example {
         Command::none()
     }
 
-    fn view(&self) -> Element<'_, Self::Message, Renderer<Self::Theme>> {
+    fn view(&self) -> Element<'_, Self::Message> {
         let image: Element<Message> = if let Some(screenshot) = &self.screenshot
         {
             image(image::Handle::from_pixels(

--- a/examples/toast/src/main.rs
+++ b/examples/toast/src/main.rs
@@ -177,7 +177,6 @@ mod toast {
     use std::fmt;
     use std::time::{Duration, Instant};
 
-    use iced::advanced;
     use iced::advanced::layout::{self, Layout};
     use iced::advanced::overlay;
     use iced::advanced::renderer;
@@ -314,7 +313,7 @@ mod toast {
         }
     }
 
-    impl<'a, Message> Widget<Message, Renderer> for Manager<'a, Message> {
+    impl<'a, Message> Widget<Message, Theme, Renderer> for Manager<'a, Message> {
         fn size(&self) -> Size<Length> {
             self.content.as_widget().size()
         }
@@ -457,7 +456,7 @@ mod toast {
             state: &'b mut Tree,
             layout: Layout<'_>,
             renderer: &Renderer,
-        ) -> Option<overlay::Element<'b, Message, Renderer>> {
+        ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
             let instants = state.state.downcast_mut::<Vec<Option<Instant>>>();
 
             let (content_state, toasts_state) = state.children.split_at_mut(1);
@@ -496,7 +495,7 @@ mod toast {
         timeout_secs: u64,
     }
 
-    impl<'a, 'b, Message> overlay::Overlay<Message, Renderer>
+    impl<'a, 'b, Message> overlay::Overlay<Message, Theme, Renderer>
         for Overlay<'a, 'b, Message>
     {
         fn layout(
@@ -601,7 +600,7 @@ mod toast {
         fn draw(
             &self,
             renderer: &mut Renderer,
-            theme: &<Renderer as advanced::Renderer>::Theme,
+            theme: &Theme,
             style: &renderer::Style,
             layout: Layout<'_>,
             cursor: mouse::Cursor,

--- a/examples/tour/src/main.rs
+++ b/examples/tour/src/main.rs
@@ -5,7 +5,7 @@ use iced::widget::{
     scrollable, slider, text, text_input, toggler, vertical_space,
 };
 use iced::widget::{Button, Column, Container, Slider};
-use iced::{Color, Element, Font, Length, Pixels, Renderer, Sandbox, Settings};
+use iced::{Color, Element, Font, Length, Pixels, Sandbox, Settings};
 
 pub fn main() -> iced::Result {
     #[cfg(target_arch = "wasm32")]
@@ -697,7 +697,7 @@ fn button<'a, Message: Clone>(label: &str) -> Button<'a, Message> {
 fn color_slider<'a>(
     component: f32,
     update: impl Fn(f32) -> Color + 'a,
-) -> Slider<'a, f64, StepMessage, Renderer> {
+) -> Slider<'a, f64, StepMessage> {
     slider(0.0..=1.0, f64::from(component), move |c| {
         StepMessage::TextColorChanged(update(c as f32))
     })

--- a/graphics/src/renderer.rs
+++ b/graphics/src/renderer.rs
@@ -12,19 +12,17 @@ use crate::text;
 use crate::Primitive;
 
 use std::borrow::Cow;
-use std::marker::PhantomData;
 
 /// A backend-agnostic renderer that supports all the built-in widgets.
 #[derive(Debug)]
-pub struct Renderer<B: Backend, Theme> {
+pub struct Renderer<B: Backend> {
     backend: B,
     default_font: Font,
     default_text_size: Pixels,
     primitives: Vec<Primitive<B::Primitive>>,
-    theme: PhantomData<Theme>,
 }
 
-impl<B: Backend, T> Renderer<B, T> {
+impl<B: Backend> Renderer<B> {
     /// Creates a new [`Renderer`] from the given [`Backend`].
     pub fn new(
         backend: B,
@@ -36,7 +34,6 @@ impl<B: Backend, T> Renderer<B, T> {
             default_font,
             default_text_size,
             primitives: Vec::new(),
-            theme: PhantomData,
         }
     }
 
@@ -93,9 +90,7 @@ impl<B: Backend, T> Renderer<B, T> {
     }
 }
 
-impl<B: Backend, T> iced_core::Renderer for Renderer<B, T> {
-    type Theme = T;
-
+impl<B: Backend> iced_core::Renderer for Renderer<B> {
     fn with_layer(&mut self, bounds: Rectangle, f: impl FnOnce(&mut Self)) {
         let current = self.start_layer();
 
@@ -134,7 +129,7 @@ impl<B: Backend, T> iced_core::Renderer for Renderer<B, T> {
     }
 }
 
-impl<B, T> core::text::Renderer for Renderer<B, T>
+impl<B> core::text::Renderer for Renderer<B>
 where
     B: Backend + backend::Text,
 {
@@ -210,7 +205,7 @@ where
     }
 }
 
-impl<B, T> image::Renderer for Renderer<B, T>
+impl<B> image::Renderer for Renderer<B>
 where
     B: Backend + backend::Image,
 {
@@ -234,7 +229,7 @@ where
     }
 }
 
-impl<B, T> svg::Renderer for Renderer<B, T>
+impl<B> svg::Renderer for Renderer<B>
 where
     B: Backend + backend::Svg,
 {

--- a/renderer/src/compositor.rs
+++ b/renderer/src/compositor.rs
@@ -5,10 +5,10 @@ use crate::{Renderer, Settings};
 
 use std::env;
 
-pub enum Compositor<Theme> {
-    TinySkia(iced_tiny_skia::window::Compositor<Theme>),
+pub enum Compositor {
+    TinySkia(iced_tiny_skia::window::Compositor),
     #[cfg(feature = "wgpu")]
-    Wgpu(iced_wgpu::window::Compositor<Theme>),
+    Wgpu(iced_wgpu::window::Compositor),
 }
 
 pub enum Surface {
@@ -17,9 +17,9 @@ pub enum Surface {
     Wgpu(iced_wgpu::window::Surface<'static>),
 }
 
-impl<Theme> crate::graphics::Compositor for Compositor<Theme> {
+impl crate::graphics::Compositor for Compositor {
     type Settings = Settings;
-    type Renderer = Renderer<Theme>;
+    type Renderer = Renderer;
     type Surface = Surface;
 
     fn new<W: Window + Clone>(
@@ -225,11 +225,11 @@ impl Candidate {
         )
     }
 
-    fn build<Theme, W: Window>(
+    fn build<W: Window>(
         self,
         settings: Settings,
         _compatible_window: W,
-    ) -> Result<Compositor<Theme>, Error> {
+    ) -> Result<Compositor, Error> {
         match self {
             Self::TinySkia => {
                 let compositor = iced_tiny_skia::window::compositor::new(

--- a/renderer/src/geometry.rs
+++ b/renderer/src/geometry.rs
@@ -29,7 +29,7 @@ macro_rules! delegate {
 }
 
 impl Frame {
-    pub fn new<Theme>(renderer: &Renderer<Theme>, size: Size) -> Self {
+    pub fn new(renderer: &Renderer, size: Size) -> Self {
         match renderer {
             Renderer::TinySkia(_) => {
                 Frame::TinySkia(iced_tiny_skia::geometry::Frame::new(size))

--- a/renderer/src/geometry/cache.rs
+++ b/renderer/src/geometry/cache.rs
@@ -54,9 +54,9 @@ impl Cache {
     /// Otherwise, the previously stored [`Geometry`] will be returned. The
     /// [`Cache`] is not cleared in this case. In other words, it will keep
     /// returning the stored [`Geometry`] if needed.
-    pub fn draw<Theme>(
+    pub fn draw(
         &self,
-        renderer: &Renderer<Theme>,
+        renderer: &Renderer,
         bounds: Size,
         draw_fn: impl FnOnce(&mut Frame),
     ) -> Geometry {

--- a/renderer/src/lib.rs
+++ b/renderer/src/lib.rs
@@ -32,10 +32,10 @@ use std::borrow::Cow;
 /// The default graphics renderer for [`iced`].
 ///
 /// [`iced`]: https://github.com/iced-rs/iced
-pub enum Renderer<Theme> {
-    TinySkia(iced_tiny_skia::Renderer<Theme>),
+pub enum Renderer {
+    TinySkia(iced_tiny_skia::Renderer),
     #[cfg(feature = "wgpu")]
-    Wgpu(iced_wgpu::Renderer<Theme>),
+    Wgpu(iced_wgpu::Renderer),
 }
 
 macro_rules! delegate {
@@ -48,7 +48,7 @@ macro_rules! delegate {
     };
 }
 
-impl<T> Renderer<T> {
+impl Renderer {
     pub fn draw_mesh(&mut self, mesh: Mesh) {
         match self {
             Self::TinySkia(_) => {
@@ -64,9 +64,7 @@ impl<T> Renderer<T> {
     }
 }
 
-impl<T> core::Renderer for Renderer<T> {
-    type Theme = T;
-
+impl core::Renderer for Renderer {
     fn with_layer(&mut self, bounds: Rectangle, f: impl FnOnce(&mut Self)) {
         match self {
             Self::TinySkia(renderer) => {
@@ -148,15 +146,14 @@ impl<T> core::Renderer for Renderer<T> {
     }
 }
 
-impl<T> text::Renderer for Renderer<T> {
+impl text::Renderer for Renderer {
     type Font = Font;
     type Paragraph = Paragraph;
     type Editor = Editor;
 
-    const ICON_FONT: Font = iced_tiny_skia::Renderer::<T>::ICON_FONT;
-    const CHECKMARK_ICON: char = iced_tiny_skia::Renderer::<T>::CHECKMARK_ICON;
-    const ARROW_DOWN_ICON: char =
-        iced_tiny_skia::Renderer::<T>::ARROW_DOWN_ICON;
+    const ICON_FONT: Font = iced_tiny_skia::Renderer::ICON_FONT;
+    const CHECKMARK_ICON: char = iced_tiny_skia::Renderer::CHECKMARK_ICON;
+    const ARROW_DOWN_ICON: char = iced_tiny_skia::Renderer::ARROW_DOWN_ICON;
 
     fn default_font(&self) -> Self::Font {
         delegate!(self, renderer, renderer.default_font())
@@ -214,7 +211,7 @@ impl<T> text::Renderer for Renderer<T> {
 }
 
 #[cfg(feature = "image")]
-impl<T> crate::core::image::Renderer for Renderer<T> {
+impl crate::core::image::Renderer for Renderer {
     type Handle = crate::core::image::Handle;
 
     fn dimensions(
@@ -235,7 +232,7 @@ impl<T> crate::core::image::Renderer for Renderer<T> {
 }
 
 #[cfg(feature = "svg")]
-impl<T> crate::core::svg::Renderer for Renderer<T> {
+impl crate::core::svg::Renderer for Renderer {
     fn dimensions(&self, handle: &crate::core::svg::Handle) -> core::Size<u32> {
         delegate!(self, renderer, renderer.dimensions(handle))
     }
@@ -251,7 +248,7 @@ impl<T> crate::core::svg::Renderer for Renderer<T> {
 }
 
 #[cfg(feature = "geometry")]
-impl<T> crate::graphics::geometry::Renderer for Renderer<T> {
+impl crate::graphics::geometry::Renderer for Renderer {
     type Geometry = crate::Geometry;
 
     fn draw(&mut self, layers: Vec<Self::Geometry>) {
@@ -283,7 +280,7 @@ impl<T> crate::graphics::geometry::Renderer for Renderer<T> {
 }
 
 #[cfg(feature = "wgpu")]
-impl<T> iced_wgpu::primitive::pipeline::Renderer for Renderer<T> {
+impl iced_wgpu::primitive::pipeline::Renderer for Renderer {
     fn draw_pipeline_primitive(
         &mut self,
         bounds: Rectangle,

--- a/runtime/src/multi_window/program.rs
+++ b/runtime/src/multi_window/program.rs
@@ -12,6 +12,9 @@ pub trait Program: Sized {
     /// The type of __messages__ your [`Program`] will produce.
     type Message: std::fmt::Debug + Send;
 
+    /// The theme used to draw the [`Program`].
+    type Theme;
+
     /// Handles a __message__ and updates the state of the [`Program`].
     ///
     /// This is where you define your __update logic__. All the __messages__,
@@ -28,5 +31,5 @@ pub trait Program: Sized {
     fn view(
         &self,
         window: window::Id,
-    ) -> Element<'_, Self::Message, Self::Renderer>;
+    ) -> Element<'_, Self::Message, Self::Theme, Self::Renderer>;
 }

--- a/runtime/src/multi_window/state.rs
+++ b/runtime/src/multi_window/state.rs
@@ -92,7 +92,7 @@ where
         bounds: Size,
         cursor: mouse::Cursor,
         renderer: &mut P::Renderer,
-        theme: &<P::Renderer as iced_core::Renderer>::Theme,
+        theme: &P::Theme,
         style: &renderer::Style,
         clipboard: &mut dyn Clipboard,
         debug: &mut Debug,
@@ -252,7 +252,7 @@ fn build_user_interfaces<'a, P: Program>(
     renderer: &mut P::Renderer,
     size: Size,
     debug: &mut Debug,
-) -> Vec<UserInterface<'a, P::Message, P::Renderer>> {
+) -> Vec<UserInterface<'a, P::Message, P::Theme, P::Renderer>> {
     caches
         .drain(..)
         .map(|cache| {
@@ -267,7 +267,7 @@ fn build_user_interface<'a, P: Program>(
     renderer: &mut P::Renderer,
     size: Size,
     debug: &mut Debug,
-) -> UserInterface<'a, P::Message, P::Renderer> {
+) -> UserInterface<'a, P::Message, P::Theme, P::Renderer> {
     debug.view_started();
     let view = program.view();
     debug.view_finished();

--- a/runtime/src/overlay/nested.rs
+++ b/runtime/src/overlay/nested.rs
@@ -10,16 +10,18 @@ use crate::core::{
 
 /// An overlay container that displays nested overlays
 #[allow(missing_debug_implementations)]
-pub struct Nested<'a, Message, Renderer> {
-    overlay: overlay::Element<'a, Message, Renderer>,
+pub struct Nested<'a, Message, Theme, Renderer> {
+    overlay: overlay::Element<'a, Message, Theme, Renderer>,
 }
 
-impl<'a, Message, Renderer> Nested<'a, Message, Renderer>
+impl<'a, Message, Theme, Renderer> Nested<'a, Message, Theme, Renderer>
 where
     Renderer: renderer::Renderer,
 {
     /// Creates a nested overlay from the provided [`overlay::Element`]
-    pub fn new(element: overlay::Element<'a, Message, Renderer>) -> Self {
+    pub fn new(
+        element: overlay::Element<'a, Message, Theme, Renderer>,
+    ) -> Self {
         Self { overlay: element }
     }
 
@@ -38,8 +40,8 @@ where
         _position: Point,
         translation: Vector,
     ) -> layout::Node {
-        fn recurse<Message, Renderer>(
-            element: &mut overlay::Element<'_, Message, Renderer>,
+        fn recurse<Message, Theme, Renderer>(
+            element: &mut overlay::Element<'_, Message, Theme, Renderer>,
             renderer: &Renderer,
             bounds: Size,
             translation: Vector,
@@ -71,16 +73,16 @@ where
     pub fn draw(
         &mut self,
         renderer: &mut Renderer,
-        theme: &<Renderer as renderer::Renderer>::Theme,
+        theme: &Theme,
         style: &renderer::Style,
         layout: Layout<'_>,
         cursor: mouse::Cursor,
     ) {
-        fn recurse<Message, Renderer>(
-            element: &mut overlay::Element<'_, Message, Renderer>,
+        fn recurse<Message, Theme, Renderer>(
+            element: &mut overlay::Element<'_, Message, Theme, Renderer>,
             layout: Layout<'_>,
             renderer: &mut Renderer,
-            theme: &<Renderer as renderer::Renderer>::Theme,
+            theme: &Theme,
             style: &renderer::Style,
             cursor: mouse::Cursor,
         ) where
@@ -144,8 +146,8 @@ where
         renderer: &Renderer,
         operation: &mut dyn widget::Operation<Message>,
     ) {
-        fn recurse<Message, Renderer>(
-            element: &mut overlay::Element<'_, Message, Renderer>,
+        fn recurse<Message, Theme, Renderer>(
+            element: &mut overlay::Element<'_, Message, Theme, Renderer>,
             layout: Layout<'_>,
             renderer: &Renderer,
             operation: &mut dyn widget::Operation<Message>,
@@ -178,8 +180,8 @@ where
         clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, Message>,
     ) -> event::Status {
-        fn recurse<Message, Renderer>(
-            element: &mut overlay::Element<'_, Message, Renderer>,
+        fn recurse<Message, Theme, Renderer>(
+            element: &mut overlay::Element<'_, Message, Theme, Renderer>,
             layout: Layout<'_>,
             event: Event,
             cursor: mouse::Cursor,
@@ -267,8 +269,8 @@ where
         viewport: &Rectangle,
         renderer: &Renderer,
     ) -> mouse::Interaction {
-        fn recurse<Message, Renderer>(
-            element: &mut overlay::Element<'_, Message, Renderer>,
+        fn recurse<Message, Theme, Renderer>(
+            element: &mut overlay::Element<'_, Message, Theme, Renderer>,
             layout: Layout<'_>,
             cursor: mouse::Cursor,
             viewport: &Rectangle,
@@ -318,8 +320,8 @@ where
         renderer: &Renderer,
         cursor_position: Point,
     ) -> bool {
-        fn recurse<Message, Renderer>(
-            element: &mut overlay::Element<'_, Message, Renderer>,
+        fn recurse<Message, Theme, Renderer>(
+            element: &mut overlay::Element<'_, Message, Theme, Renderer>,
             layout: Layout<'_>,
             renderer: &Renderer,
             cursor_position: Point,

--- a/runtime/src/program.rs
+++ b/runtime/src/program.rs
@@ -13,6 +13,9 @@ pub trait Program: Sized {
     /// The graphics backend to use to draw the [`Program`].
     type Renderer: Renderer + text::Renderer;
 
+    /// The theme used to draw the [`Program`].
+    type Theme;
+
     /// The type of __messages__ your [`Program`] will produce.
     type Message: std::fmt::Debug + Send;
 
@@ -29,5 +32,5 @@ pub trait Program: Sized {
     /// Returns the widgets to display in the [`Program`].
     ///
     /// These widgets can produce __messages__ based on user interaction.
-    fn view(&self) -> Element<'_, Self::Message, Self::Renderer>;
+    fn view(&self) -> Element<'_, Self::Message, Self::Theme, Self::Renderer>;
 }

--- a/runtime/src/program/state.rs
+++ b/runtime/src/program/state.rs
@@ -91,7 +91,7 @@ where
         bounds: Size,
         cursor: mouse::Cursor,
         renderer: &mut P::Renderer,
-        theme: &<P::Renderer as iced_core::Renderer>::Theme,
+        theme: &P::Theme,
         style: &renderer::Style,
         clipboard: &mut dyn Clipboard,
         debug: &mut Debug,
@@ -219,7 +219,7 @@ fn build_user_interface<'a, P: Program>(
     renderer: &mut P::Renderer,
     size: Size,
     debug: &mut Debug,
-) -> UserInterface<'a, P::Message, P::Renderer> {
+) -> UserInterface<'a, P::Message, P::Theme, P::Renderer> {
     debug.view_started();
     let view = program.view();
     debug.view_finished();

--- a/runtime/src/user_interface.rs
+++ b/runtime/src/user_interface.rs
@@ -23,15 +23,15 @@ use crate::overlay;
 ///
 /// [`integration`]: https://github.com/iced-rs/iced/tree/0.10/examples/integration
 #[allow(missing_debug_implementations)]
-pub struct UserInterface<'a, Message, Renderer> {
-    root: Element<'a, Message, Renderer>,
+pub struct UserInterface<'a, Message, Theme, Renderer> {
+    root: Element<'a, Message, Theme, Renderer>,
     base: layout::Node,
     state: widget::Tree,
     overlay: Option<layout::Node>,
     bounds: Size,
 }
 
-impl<'a, Message, Renderer> UserInterface<'a, Message, Renderer>
+impl<'a, Message, Theme, Renderer> UserInterface<'a, Message, Theme, Renderer>
 where
     Renderer: crate::core::Renderer,
 {
@@ -54,7 +54,7 @@ where
     /// #
     /// # impl Counter {
     /// #     pub fn new() -> Self { Counter }
-    /// #     pub fn view(&self) -> iced_core::Element<(), Renderer> { unimplemented!() }
+    /// #     pub fn view(&self) -> iced_core::Element<(), (), Renderer> { unimplemented!() }
     /// #     pub fn update(&mut self, _: ()) {}
     /// # }
     /// use iced_runtime::core::Size;
@@ -86,7 +86,7 @@ where
     ///     cache = user_interface.into_cache();
     /// }
     /// ```
-    pub fn build<E: Into<Element<'a, Message, Renderer>>>(
+    pub fn build<E: Into<Element<'a, Message, Theme, Renderer>>>(
         root: E,
         bounds: Size,
         cache: Cache,
@@ -130,7 +130,7 @@ where
     /// #
     /// # impl Counter {
     /// #     pub fn new() -> Self { Counter }
-    /// #     pub fn view(&self) -> iced_core::Element<(), Renderer> { unimplemented!() }
+    /// #     pub fn view(&self) -> iced_core::Element<(), (), Renderer> { unimplemented!() }
     /// #     pub fn update(&mut self, _: ()) {}
     /// # }
     /// use iced_runtime::core::clipboard;
@@ -384,7 +384,7 @@ where
     /// #
     /// # impl Counter {
     /// #     pub fn new() -> Self { Counter }
-    /// #     pub fn view(&self) -> Element<(), Renderer> { unimplemented!() }
+    /// #     pub fn view(&self) -> Element<(), (), Renderer> { unimplemented!() }
     /// #     pub fn update(&mut self, _: ()) {}
     /// # }
     /// use iced_runtime::core::clipboard;
@@ -439,7 +439,7 @@ where
     pub fn draw(
         &mut self,
         renderer: &mut Renderer,
-        theme: &Renderer::Theme,
+        theme: &Theme,
         style: &renderer::Style,
         cursor: mouse::Cursor,
     ) -> mouse::Interaction {

--- a/src/application.rs
+++ b/src/application.rs
@@ -139,7 +139,7 @@ pub trait Application: Sized {
     /// Returns the widgets to display in the [`Application`].
     ///
     /// These widgets can produce __messages__ based on user interaction.
-    fn view(&self) -> Element<'_, Self::Message, crate::Renderer<Self::Theme>>;
+    fn view(&self) -> Element<'_, Self::Message, Self::Theme, crate::Renderer>;
 
     /// Returns the current [`Theme`] of the [`Application`].
     ///
@@ -208,7 +208,7 @@ pub trait Application: Sized {
         Ok(crate::shell::application::run::<
             Instance<Self>,
             Self::Executor,
-            crate::renderer::Compositor<Self::Theme>,
+            crate::renderer::Compositor,
         >(settings.into(), renderer_settings)?)
     }
 }
@@ -219,14 +219,15 @@ impl<A> crate::runtime::Program for Instance<A>
 where
     A: Application,
 {
-    type Renderer = crate::Renderer<A::Theme>;
     type Message = A::Message;
+    type Theme = A::Theme;
+    type Renderer = crate::Renderer;
 
     fn update(&mut self, message: Self::Message) -> Command<Self::Message> {
         self.0.update(message)
     }
 
-    fn view(&self) -> Element<'_, Self::Message, Self::Renderer> {
+    fn view(&self) -> Element<'_, Self::Message, Self::Theme, Self::Renderer> {
         self.0.view()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,8 +271,12 @@ pub mod overlay {
     /// This is an alias of an [`overlay::Element`] with a default `Renderer`.
     ///
     /// [`overlay::Element`]: crate::core::overlay::Element
-    pub type Element<'a, Message, Renderer = crate::Renderer> =
-        crate::core::overlay::Element<'a, Message, Renderer>;
+    pub type Element<
+        'a,
+        Message,
+        Theme = crate::Renderer,
+        Renderer = crate::Renderer,
+    > = crate::core::overlay::Element<'a, Message, Theme, Renderer>;
 
     pub use iced_widget::overlay::*;
 }
@@ -302,19 +306,21 @@ pub use error::Error;
 pub use event::Event;
 pub use executor::Executor;
 pub use font::Font;
+pub use renderer::Renderer;
 pub use sandbox::Sandbox;
 pub use settings::Settings;
 pub use subscription::Subscription;
 pub use theme::Theme;
 
-/// The default renderer.
-pub type Renderer<Theme = style::Theme> = renderer::Renderer<Theme>;
-
 /// A generic widget.
 ///
 /// This is an alias of an `iced_native` element with a default `Renderer`.
-pub type Element<'a, Message, Renderer = crate::Renderer> =
-    crate::core::Element<'a, Message, Renderer>;
+pub type Element<
+    'a,
+    Message,
+    Theme = crate::Theme,
+    Renderer = crate::Renderer,
+> = crate::core::Element<'a, Message, Theme, Renderer>;
 
 /// The result of running an [`Application`].
 ///

--- a/src/multi_window/application.rs
+++ b/src/multi_window/application.rs
@@ -114,7 +114,7 @@ pub trait Application: Sized {
     fn view(
         &self,
         window: window::Id,
-    ) -> Element<'_, Self::Message, crate::Renderer<Self::Theme>>;
+    ) -> Element<'_, Self::Message, Self::Theme, crate::Renderer>;
 
     /// Returns the current [`Theme`] of the `window` of the [`Application`].
     ///
@@ -185,7 +185,7 @@ pub trait Application: Sized {
         Ok(crate::shell::multi_window::run::<
             Instance<Self>,
             Self::Executor,
-            crate::renderer::Compositor<Self::Theme>,
+            crate::renderer::Compositor,
         >(settings.into(), renderer_settings)?)
     }
 }
@@ -196,8 +196,9 @@ impl<A> crate::runtime::multi_window::Program for Instance<A>
 where
     A: Application,
 {
-    type Renderer = crate::Renderer<A::Theme>;
     type Message = A::Message;
+    type Theme = A::Theme;
+    type Renderer = crate::Renderer;
 
     fn update(&mut self, message: Self::Message) -> Command<Self::Message> {
         self.0.update(message)
@@ -206,7 +207,7 @@ where
     fn view(
         &self,
         window: window::Id,
-    ) -> Element<'_, Self::Message, Self::Renderer> {
+    ) -> Element<'_, Self::Message, Self::Theme, Self::Renderer> {
         self.0.view(window)
     }
 }

--- a/tiny_skia/src/lib.rs
+++ b/tiny_skia/src/lib.rs
@@ -28,4 +28,4 @@ pub use settings::Settings;
 ///
 /// [`tiny-skia`]: https://github.com/RazrFalcon/tiny-skia
 /// [`iced`]: https://github.com/iced-rs/iced
-pub type Renderer<Theme> = iced_graphics::Renderer<Backend, Theme>;
+pub type Renderer = iced_graphics::Renderer<Backend>;

--- a/tiny_skia/src/window/compositor.rs
+++ b/tiny_skia/src/window/compositor.rs
@@ -5,13 +5,11 @@ use crate::graphics::{Error, Viewport};
 use crate::{Backend, Primitive, Renderer, Settings};
 
 use std::collections::VecDeque;
-use std::marker::PhantomData;
 use std::num::NonZeroU32;
 
-pub struct Compositor<Theme> {
+pub struct Compositor {
     context: softbuffer::Context<Box<dyn compositor::Window>>,
     settings: Settings,
-    _theme: PhantomData<Theme>,
 }
 
 pub struct Surface {
@@ -25,9 +23,9 @@ pub struct Surface {
     max_age: u8,
 }
 
-impl<Theme> crate::graphics::Compositor for Compositor<Theme> {
+impl crate::graphics::Compositor for Compositor {
     type Settings = Settings;
-    type Renderer = Renderer<Theme>;
+    type Renderer = Renderer;
     type Surface = Surface;
 
     fn new<W: compositor::Window>(
@@ -138,19 +136,15 @@ impl<Theme> crate::graphics::Compositor for Compositor<Theme> {
     }
 }
 
-pub fn new<W: compositor::Window, Theme>(
+pub fn new<W: compositor::Window>(
     settings: Settings,
     compatible_window: W,
-) -> Compositor<Theme> {
+) -> Compositor {
     #[allow(unsafe_code)]
     let context = softbuffer::Context::new(Box::new(compatible_window) as _)
         .expect("Create softbuffer context");
 
-    Compositor {
-        context,
-        settings,
-        _theme: PhantomData,
-    }
+    Compositor { context, settings }
 }
 
 pub fn present<T: AsRef<str>>(

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -63,4 +63,4 @@ mod image;
 ///
 /// [`wgpu`]: https://github.com/gfx-rs/wgpu-rs
 /// [`iced`]: https://github.com/iced-rs/iced
-pub type Renderer<Theme> = iced_graphics::Renderer<Backend, Theme>;
+pub type Renderer = iced_graphics::Renderer<Backend>;

--- a/wgpu/src/primitive/pipeline.rs
+++ b/wgpu/src/primitive/pipeline.rs
@@ -67,7 +67,7 @@ pub trait Renderer: crate::core::Renderer {
     );
 }
 
-impl<Theme> Renderer for crate::Renderer<Theme> {
+impl Renderer for crate::Renderer {
     fn draw_pipeline_primitive(
         &mut self,
         bounds: Rectangle,

--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -6,21 +6,18 @@ use crate::graphics::compositor;
 use crate::graphics::{Error, Viewport};
 use crate::{Backend, Primitive, Renderer, Settings};
 
-use std::marker::PhantomData;
-
 /// A window graphics backend for iced powered by `wgpu`.
 #[allow(missing_debug_implementations)]
-pub struct Compositor<Theme> {
+pub struct Compositor {
     settings: Settings,
     instance: wgpu::Instance,
     adapter: wgpu::Adapter,
     device: wgpu::Device,
     queue: wgpu::Queue,
     format: wgpu::TextureFormat,
-    theme: PhantomData<Theme>,
 }
 
-impl<Theme> Compositor<Theme> {
+impl Compositor {
     /// Requests a new [`Compositor`] with the given [`Settings`].
     ///
     /// Returns `None` if no compatible graphics adapter could be found.
@@ -123,7 +120,6 @@ impl<Theme> Compositor<Theme> {
             device,
             queue,
             format,
-            theme: PhantomData,
         })
     }
 
@@ -135,10 +131,10 @@ impl<Theme> Compositor<Theme> {
 
 /// Creates a [`Compositor`] and its [`Backend`] for the given [`Settings`] and
 /// window.
-pub fn new<W: compositor::Window, Theme>(
+pub fn new<W: compositor::Window>(
     settings: Settings,
     compatible_window: W,
-) -> Result<Compositor<Theme>, Error> {
+) -> Result<Compositor, Error> {
     let compositor = futures::executor::block_on(Compositor::request(
         settings,
         Some(compatible_window),
@@ -149,8 +145,8 @@ pub fn new<W: compositor::Window, Theme>(
 }
 
 /// Presents the given primitives with the given [`Compositor`] and [`Backend`].
-pub fn present<Theme, T: AsRef<str>>(
-    compositor: &mut Compositor<Theme>,
+pub fn present<T: AsRef<str>>(
+    compositor: &mut Compositor,
     backend: &mut Backend,
     surface: &mut wgpu::Surface<'static>,
     primitives: &[Primitive],
@@ -203,9 +199,9 @@ pub fn present<Theme, T: AsRef<str>>(
     }
 }
 
-impl<Theme> graphics::Compositor for Compositor<Theme> {
+impl graphics::Compositor for Compositor {
     type Settings = Settings;
-    type Renderer = Renderer<Theme>;
+    type Renderer = Renderer;
     type Surface = wgpu::Surface<'static>;
 
     fn new<W: compositor::Window>(
@@ -314,8 +310,8 @@ impl<Theme> graphics::Compositor for Compositor<Theme> {
 /// Renders the current surface to an offscreen buffer.
 ///
 /// Returns RGBA bytes of the texture data.
-pub fn screenshot<Theme, T: AsRef<str>>(
-    compositor: &Compositor<Theme>,
+pub fn screenshot<T: AsRef<str>>(
+    compositor: &Compositor,
     backend: &mut Backend,
     primitives: &[Primitive],
     viewport: &Viewport,

--- a/widget/src/canvas.rs
+++ b/widget/src/canvas.rs
@@ -30,9 +30,8 @@ use std::marker::PhantomData;
 /// # use iced_widget::canvas::{self, Canvas, Fill, Frame, Geometry, Path, Program};
 /// # use iced_widget::core::{Color, Rectangle};
 /// # use iced_widget::core::mouse;
-/// # use iced_widget::style::Theme;
+/// # use iced_widget::{Renderer, Theme};
 /// #
-/// # pub type Renderer = iced_widget::renderer::Renderer<Theme>;
 /// // First, we define the data we need for drawing
 /// #[derive(Debug)]
 /// struct Circle {
@@ -62,22 +61,23 @@ use std::marker::PhantomData;
 /// let canvas = Canvas::new(Circle { radius: 50.0 });
 /// ```
 #[derive(Debug)]
-pub struct Canvas<P, Message, Renderer = crate::Renderer>
+pub struct Canvas<P, Message, Theme = crate::Theme, Renderer = crate::Renderer>
 where
     Renderer: geometry::Renderer,
-    P: Program<Message, Renderer>,
+    P: Program<Message, Theme, Renderer>,
 {
     width: Length,
     height: Length,
     program: P,
     message_: PhantomData<Message>,
-    theme_: PhantomData<Renderer>,
+    theme_: PhantomData<Theme>,
+    renderer_: PhantomData<Renderer>,
 }
 
-impl<P, Message, Renderer> Canvas<P, Message, Renderer>
+impl<P, Message, Theme, Renderer> Canvas<P, Message, Theme, Renderer>
 where
+    P: Program<Message, Theme, Renderer>,
     Renderer: geometry::Renderer,
-    P: Program<Message, Renderer>,
 {
     const DEFAULT_SIZE: f32 = 100.0;
 
@@ -89,6 +89,7 @@ where
             program,
             message_: PhantomData,
             theme_: PhantomData,
+            renderer_: PhantomData,
         }
     }
 
@@ -105,11 +106,11 @@ where
     }
 }
 
-impl<P, Message, Renderer> Widget<Message, Renderer>
-    for Canvas<P, Message, Renderer>
+impl<P, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
+    for Canvas<P, Message, Theme, Renderer>
 where
     Renderer: geometry::Renderer,
-    P: Program<Message, Renderer>,
+    P: Program<Message, Theme, Renderer>,
 {
     fn tag(&self) -> tree::Tag {
         struct Tag<T>(T);
@@ -192,7 +193,7 @@ where
         &self,
         tree: &Tree,
         renderer: &mut Renderer,
-        theme: &Renderer::Theme,
+        theme: &Theme,
         _style: &renderer::Style,
         layout: Layout<'_>,
         cursor: mouse::Cursor,
@@ -217,16 +218,17 @@ where
     }
 }
 
-impl<'a, P, Message, Renderer> From<Canvas<P, Message, Renderer>>
-    for Element<'a, Message, Renderer>
+impl<'a, P, Message, Theme, Renderer> From<Canvas<P, Message, Theme, Renderer>>
+    for Element<'a, Message, Theme, Renderer>
 where
     Message: 'a,
+    Theme: 'a,
     Renderer: 'a + geometry::Renderer,
-    P: Program<Message, Renderer> + 'a,
+    P: 'a + Program<Message, Theme, Renderer>,
 {
     fn from(
-        canvas: Canvas<P, Message, Renderer>,
-    ) -> Element<'a, Message, Renderer> {
+        canvas: Canvas<P, Message, Theme, Renderer>,
+    ) -> Element<'a, Message, Theme, Renderer> {
         Element::new(canvas)
     }
 }

--- a/widget/src/canvas/program.rs
+++ b/widget/src/canvas/program.rs
@@ -9,7 +9,7 @@ use crate::graphics::geometry;
 /// application.
 ///
 /// [`Canvas`]: crate::Canvas
-pub trait Program<Message, Renderer = crate::Renderer>
+pub trait Program<Message, Theme = crate::Theme, Renderer = crate::Renderer>
 where
     Renderer: geometry::Renderer,
 {
@@ -49,7 +49,7 @@ where
         &self,
         state: &Self::State,
         renderer: &Renderer,
-        theme: &Renderer::Theme,
+        theme: &Theme,
         bounds: Rectangle,
         cursor: mouse::Cursor,
     ) -> Vec<Renderer::Geometry>;
@@ -70,10 +70,10 @@ where
     }
 }
 
-impl<Message, Renderer, T> Program<Message, Renderer> for &T
+impl<Message, Theme, Renderer, T> Program<Message, Theme, Renderer> for &T
 where
     Renderer: geometry::Renderer,
-    T: Program<Message, Renderer>,
+    T: Program<Message, Theme, Renderer>,
 {
     type State = T::State;
 
@@ -91,7 +91,7 @@ where
         &self,
         state: &Self::State,
         renderer: &Renderer,
-        theme: &Renderer::Theme,
+        theme: &Theme,
         bounds: Rectangle,
         cursor: mouse::Cursor,
     ) -> Vec<Renderer::Geometry> {

--- a/widget/src/checkbox.rs
+++ b/widget/src/checkbox.rs
@@ -12,7 +12,7 @@ use crate::core::{
     Clipboard, Element, Layout, Length, Pixels, Rectangle, Shell, Size, Widget,
 };
 
-pub use iced_style::checkbox::{Appearance, StyleSheet};
+pub use crate::style::checkbox::{Appearance, StyleSheet};
 
 /// A box that can be checked.
 ///
@@ -20,7 +20,7 @@ pub use iced_style::checkbox::{Appearance, StyleSheet};
 ///
 /// ```no_run
 /// # type Checkbox<'a, Message> =
-/// #     iced_widget::Checkbox<'a, Message, iced_widget::renderer::Renderer<iced_widget::style::Theme>>;
+/// #     iced_widget::Checkbox<'a, Message, iced_widget::style::Theme, iced_widget::renderer::Renderer>;
 /// #
 /// pub enum Message {
 ///     CheckboxToggled(bool),
@@ -33,10 +33,14 @@ pub use iced_style::checkbox::{Appearance, StyleSheet};
 ///
 /// ![Checkbox drawn by `iced_wgpu`](https://github.com/iced-rs/iced/blob/7760618fb112074bc40b148944521f312152012a/docs/images/checkbox.png?raw=true)
 #[allow(missing_debug_implementations)]
-pub struct Checkbox<'a, Message, Renderer = crate::Renderer>
-where
+pub struct Checkbox<
+    'a,
+    Message,
+    Theme = crate::Theme,
+    Renderer = crate::Renderer,
+> where
+    Theme: StyleSheet + crate::text::StyleSheet,
     Renderer: text::Renderer,
-    Renderer::Theme: StyleSheet + crate::text::StyleSheet,
 {
     is_checked: bool,
     on_toggle: Box<dyn Fn(bool) -> Message + 'a>,
@@ -49,13 +53,13 @@ where
     text_shaping: text::Shaping,
     font: Option<Renderer::Font>,
     icon: Icon<Renderer::Font>,
-    style: <Renderer::Theme as StyleSheet>::Style,
+    style: <Theme as StyleSheet>::Style,
 }
 
-impl<'a, Message, Renderer> Checkbox<'a, Message, Renderer>
+impl<'a, Message, Theme, Renderer> Checkbox<'a, Message, Theme, Renderer>
 where
     Renderer: text::Renderer,
-    Renderer::Theme: StyleSheet + crate::text::StyleSheet,
+    Theme: StyleSheet + crate::text::StyleSheet,
 {
     /// The default size of a [`Checkbox`].
     const DEFAULT_SIZE: f32 = 20.0;
@@ -153,18 +157,18 @@ where
     /// Sets the style of the [`Checkbox`].
     pub fn style(
         mut self,
-        style: impl Into<<Renderer::Theme as StyleSheet>::Style>,
+        style: impl Into<<Theme as StyleSheet>::Style>,
     ) -> Self {
         self.style = style.into();
         self
     }
 }
 
-impl<'a, Message, Renderer> Widget<Message, Renderer>
-    for Checkbox<'a, Message, Renderer>
+impl<'a, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
+    for Checkbox<'a, Message, Theme, Renderer>
 where
+    Theme: StyleSheet + crate::text::StyleSheet,
     Renderer: text::Renderer,
-    Renderer::Theme: StyleSheet + crate::text::StyleSheet,
 {
     fn tag(&self) -> tree::Tag {
         tree::Tag::of::<widget::text::State<Renderer::Paragraph>>()
@@ -261,7 +265,7 @@ where
         &self,
         tree: &Tree,
         renderer: &mut Renderer,
-        theme: &Renderer::Theme,
+        theme: &Theme,
         style: &renderer::Style,
         layout: Layout<'_>,
         cursor: mouse::Cursor,
@@ -335,16 +339,16 @@ where
     }
 }
 
-impl<'a, Message, Renderer> From<Checkbox<'a, Message, Renderer>>
-    for Element<'a, Message, Renderer>
+impl<'a, Message, Theme, Renderer> From<Checkbox<'a, Message, Theme, Renderer>>
+    for Element<'a, Message, Theme, Renderer>
 where
     Message: 'a,
+    Theme: 'a + StyleSheet + crate::text::StyleSheet,
     Renderer: 'a + text::Renderer,
-    Renderer::Theme: StyleSheet + crate::text::StyleSheet,
 {
     fn from(
-        checkbox: Checkbox<'a, Message, Renderer>,
-    ) -> Element<'a, Message, Renderer> {
+        checkbox: Checkbox<'a, Message, Theme, Renderer>,
+    ) -> Element<'a, Message, Theme, Renderer> {
         Element::new(checkbox)
     }
 }

--- a/widget/src/column.rs
+++ b/widget/src/column.rs
@@ -12,17 +12,18 @@ use crate::core::{
 
 /// A container that distributes its contents vertically.
 #[allow(missing_debug_implementations)]
-pub struct Column<'a, Message, Renderer = crate::Renderer> {
+pub struct Column<'a, Message, Theme = crate::Theme, Renderer = crate::Renderer>
+{
     spacing: f32,
     padding: Padding,
     width: Length,
     height: Length,
     max_width: f32,
     align_items: Alignment,
-    children: Vec<Element<'a, Message, Renderer>>,
+    children: Vec<Element<'a, Message, Theme, Renderer>>,
 }
 
-impl<'a, Message, Renderer> Column<'a, Message, Renderer>
+impl<'a, Message, Theme, Renderer> Column<'a, Message, Theme, Renderer>
 where
     Renderer: crate::core::Renderer,
 {
@@ -41,7 +42,7 @@ where
 
     /// Creates a [`Column`] with the given elements.
     pub fn with_children(
-        children: impl IntoIterator<Item = Element<'a, Message, Renderer>>,
+        children: impl IntoIterator<Item = Element<'a, Message, Theme, Renderer>>,
     ) -> Self {
         children.into_iter().fold(Self::new(), Self::push)
     }
@@ -89,7 +90,7 @@ where
     /// Adds an element to the [`Column`].
     pub fn push(
         mut self,
-        child: impl Into<Element<'a, Message, Renderer>>,
+        child: impl Into<Element<'a, Message, Theme, Renderer>>,
     ) -> Self {
         let child = child.into();
         let size = child.as_widget().size_hint();
@@ -116,8 +117,8 @@ where
     }
 }
 
-impl<'a, Message, Renderer> Widget<Message, Renderer>
-    for Column<'a, Message, Renderer>
+impl<'a, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
+    for Column<'a, Message, Theme, Renderer>
 where
     Renderer: crate::core::Renderer,
 {
@@ -233,7 +234,7 @@ where
         &self,
         tree: &Tree,
         renderer: &mut Renderer,
-        theme: &Renderer::Theme,
+        theme: &Theme,
         style: &renderer::Style,
         layout: Layout<'_>,
         cursor: mouse::Cursor,
@@ -258,18 +259,19 @@ where
         tree: &'b mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
-    ) -> Option<overlay::Element<'b, Message, Renderer>> {
+    ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
         overlay::from_children(&mut self.children, tree, layout, renderer)
     }
 }
 
-impl<'a, Message, Renderer> From<Column<'a, Message, Renderer>>
-    for Element<'a, Message, Renderer>
+impl<'a, Message, Theme, Renderer> From<Column<'a, Message, Theme, Renderer>>
+    for Element<'a, Message, Theme, Renderer>
 where
     Message: 'a,
+    Theme: 'a,
     Renderer: crate::core::Renderer + 'a,
 {
-    fn from(column: Column<'a, Message, Renderer>) -> Self {
+    fn from(column: Column<'a, Message, Theme, Renderer>) -> Self {
         Self::new(column)
     }
 }

--- a/widget/src/container.rs
+++ b/widget/src/container.rs
@@ -19,10 +19,14 @@ pub use iced_style::container::{Appearance, StyleSheet};
 ///
 /// It is normally used for alignment purposes.
 #[allow(missing_debug_implementations)]
-pub struct Container<'a, Message, Renderer = crate::Renderer>
-where
+pub struct Container<
+    'a,
+    Message,
+    Theme = crate::Theme,
+    Renderer = crate::Renderer,
+> where
+    Theme: StyleSheet,
     Renderer: crate::core::Renderer,
-    Renderer::Theme: StyleSheet,
 {
     id: Option<Id>,
     padding: Padding,
@@ -32,19 +36,19 @@ where
     max_height: f32,
     horizontal_alignment: alignment::Horizontal,
     vertical_alignment: alignment::Vertical,
-    style: <Renderer::Theme as StyleSheet>::Style,
-    content: Element<'a, Message, Renderer>,
+    style: Theme::Style,
+    content: Element<'a, Message, Theme, Renderer>,
 }
 
-impl<'a, Message, Renderer> Container<'a, Message, Renderer>
+impl<'a, Message, Theme, Renderer> Container<'a, Message, Theme, Renderer>
 where
+    Theme: StyleSheet,
     Renderer: crate::core::Renderer,
-    Renderer::Theme: StyleSheet,
 {
     /// Creates an empty [`Container`].
     pub fn new<T>(content: T) -> Self
     where
-        T: Into<Element<'a, Message, Renderer>>,
+        T: Into<Element<'a, Message, Theme, Renderer>>,
     {
         let content = content.into();
         let size = content.as_widget().size_hint();
@@ -124,20 +128,17 @@ where
     }
 
     /// Sets the style of the [`Container`].
-    pub fn style(
-        mut self,
-        style: impl Into<<Renderer::Theme as StyleSheet>::Style>,
-    ) -> Self {
+    pub fn style(mut self, style: impl Into<Theme::Style>) -> Self {
         self.style = style.into();
         self
     }
 }
 
-impl<'a, Message, Renderer> Widget<Message, Renderer>
-    for Container<'a, Message, Renderer>
+impl<'a, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
+    for Container<'a, Message, Theme, Renderer>
 where
+    Theme: StyleSheet,
     Renderer: crate::core::Renderer,
-    Renderer::Theme: StyleSheet,
 {
     fn tag(&self) -> tree::Tag {
         self.content.as_widget().tag()
@@ -246,7 +247,7 @@ where
         &self,
         tree: &Tree,
         renderer: &mut Renderer,
-        theme: &Renderer::Theme,
+        theme: &Theme,
         renderer_style: &renderer::Style,
         layout: Layout<'_>,
         cursor: mouse::Cursor,
@@ -278,7 +279,7 @@ where
         tree: &'b mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
-    ) -> Option<overlay::Element<'b, Message, Renderer>> {
+    ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
         self.content.as_widget_mut().overlay(
             tree,
             layout.children().next().unwrap(),
@@ -287,16 +288,16 @@ where
     }
 }
 
-impl<'a, Message, Renderer> From<Container<'a, Message, Renderer>>
-    for Element<'a, Message, Renderer>
+impl<'a, Message, Theme, Renderer> From<Container<'a, Message, Theme, Renderer>>
+    for Element<'a, Message, Theme, Renderer>
 where
     Message: 'a,
+    Theme: 'a + StyleSheet,
     Renderer: 'a + crate::core::Renderer,
-    Renderer::Theme: StyleSheet,
 {
     fn from(
-        column: Container<'a, Message, Renderer>,
-    ) -> Element<'a, Message, Renderer> {
+        column: Container<'a, Message, Theme, Renderer>,
+    ) -> Element<'a, Message, Theme, Renderer> {
         Element::new(column)
     }
 }

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -20,7 +20,7 @@ use crate::text_editor::{self, TextEditor};
 use crate::text_input::{self, TextInput};
 use crate::toggler::{self, Toggler};
 use crate::tooltip::{self, Tooltip};
-use crate::{Column, MouseArea, Row, Space, VerticalSlider};
+use crate::{Column, MouseArea, Row, Space, Themer, VerticalSlider};
 
 use std::borrow::Cow;
 use std::ops::RangeInclusive;
@@ -420,4 +420,15 @@ where
     Renderer: core::Renderer,
 {
     MouseArea::new(widget)
+}
+
+/// A widget that applies any `Theme` to its contents.
+pub fn themer<'a, Message, Theme, Renderer>(
+    theme: Theme,
+    content: impl Into<Element<'a, Message, Theme, Renderer>>,
+) -> Themer<'a, Message, Theme, Renderer>
+where
+    Renderer: core::Renderer,
+{
+    Themer::new(theme, content)
 }

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -54,20 +54,20 @@ macro_rules! row {
 /// Creates a new [`Container`] with the provided content.
 ///
 /// [`Container`]: crate::Container
-pub fn container<'a, Message, Renderer>(
-    content: impl Into<Element<'a, Message, Renderer>>,
-) -> Container<'a, Message, Renderer>
+pub fn container<'a, Message, Theme, Renderer>(
+    content: impl Into<Element<'a, Message, Theme, Renderer>>,
+) -> Container<'a, Message, Theme, Renderer>
 where
+    Theme: container::StyleSheet,
     Renderer: core::Renderer,
-    Renderer::Theme: container::StyleSheet,
 {
     Container::new(content)
 }
 
 /// Creates a new [`Column`] with the given children.
-pub fn column<'a, Message, Renderer>(
-    children: impl IntoIterator<Item = Element<'a, Message, Renderer>>,
-) -> Column<'a, Message, Renderer>
+pub fn column<'a, Message, Theme, Renderer>(
+    children: impl IntoIterator<Item = Element<'a, Message, Theme, Renderer>>,
+) -> Column<'a, Message, Theme, Renderer>
 where
     Renderer: core::Renderer,
 {
@@ -75,9 +75,9 @@ where
 }
 
 /// Creates a new [`keyed::Column`] with the given children.
-pub fn keyed_column<'a, Key, Message, Renderer>(
-    children: impl IntoIterator<Item = (Key, Element<'a, Message, Renderer>)>,
-) -> keyed::Column<'a, Key, Message, Renderer>
+pub fn keyed_column<'a, Key, Message, Theme, Renderer>(
+    children: impl IntoIterator<Item = (Key, Element<'a, Message, Theme, Renderer>)>,
+) -> keyed::Column<'a, Key, Message, Theme, Renderer>
 where
     Key: Copy + PartialEq,
     Renderer: core::Renderer,
@@ -88,9 +88,9 @@ where
 /// Creates a new [`Row`] with the given children.
 ///
 /// [`Row`]: crate::Row
-pub fn row<'a, Message, Renderer>(
-    children: impl IntoIterator<Item = Element<'a, Message, Renderer>>,
-) -> Row<'a, Message, Renderer>
+pub fn row<'a, Message, Theme, Renderer>(
+    children: impl IntoIterator<Item = Element<'a, Message, Theme, Renderer>>,
+) -> Row<'a, Message, Theme, Renderer>
 where
     Renderer: core::Renderer,
 {
@@ -100,12 +100,12 @@ where
 /// Creates a new [`Scrollable`] with the provided content.
 ///
 /// [`Scrollable`]: crate::Scrollable
-pub fn scrollable<'a, Message, Renderer>(
-    content: impl Into<Element<'a, Message, Renderer>>,
-) -> Scrollable<'a, Message, Renderer>
+pub fn scrollable<'a, Message, Theme, Renderer>(
+    content: impl Into<Element<'a, Message, Theme, Renderer>>,
+) -> Scrollable<'a, Message, Theme, Renderer>
 where
+    Theme: scrollable::StyleSheet,
     Renderer: core::Renderer,
-    Renderer::Theme: scrollable::StyleSheet,
 {
     Scrollable::new(content)
 }
@@ -113,13 +113,12 @@ where
 /// Creates a new [`Button`] with the provided content.
 ///
 /// [`Button`]: crate::Button
-pub fn button<'a, Message, Renderer>(
-    content: impl Into<Element<'a, Message, Renderer>>,
-) -> Button<'a, Message, Renderer>
+pub fn button<'a, Message, Theme, Renderer>(
+    content: impl Into<Element<'a, Message, Theme, Renderer>>,
+) -> Button<'a, Message, Theme, Renderer>
 where
     Renderer: core::Renderer,
-    Renderer::Theme: button::StyleSheet,
-    <Renderer::Theme as button::StyleSheet>::Style: Default,
+    Theme: button::StyleSheet,
 {
     Button::new(content)
 }
@@ -128,14 +127,14 @@ where
 ///
 /// [`Tooltip`]: crate::Tooltip
 /// [`tooltip::Position`]: crate::tooltip::Position
-pub fn tooltip<'a, Message, Renderer>(
-    content: impl Into<Element<'a, Message, Renderer>>,
+pub fn tooltip<'a, Message, Theme, Renderer>(
+    content: impl Into<Element<'a, Message, Theme, Renderer>>,
     tooltip: impl ToString,
     position: tooltip::Position,
-) -> crate::Tooltip<'a, Message, Renderer>
+) -> crate::Tooltip<'a, Message, Theme, Renderer>
 where
+    Theme: container::StyleSheet + text::StyleSheet,
     Renderer: core::text::Renderer,
-    Renderer::Theme: container::StyleSheet + text::StyleSheet,
 {
     Tooltip::new(content, tooltip.to_string(), position)
 }
@@ -143,10 +142,12 @@ where
 /// Creates a new [`Text`] widget with the provided content.
 ///
 /// [`Text`]: core::widget::Text
-pub fn text<'a, Renderer>(text: impl ToString) -> Text<'a, Renderer>
+pub fn text<'a, Theme, Renderer>(
+    text: impl ToString,
+) -> Text<'a, Theme, Renderer>
 where
+    Theme: text::StyleSheet,
     Renderer: core::text::Renderer,
-    Renderer::Theme: text::StyleSheet,
 {
     Text::new(text.to_string())
 }
@@ -154,14 +155,14 @@ where
 /// Creates a new [`Checkbox`].
 ///
 /// [`Checkbox`]: crate::Checkbox
-pub fn checkbox<'a, Message, Renderer>(
+pub fn checkbox<'a, Message, Theme, Renderer>(
     label: impl Into<String>,
     is_checked: bool,
     f: impl Fn(bool) -> Message + 'a,
-) -> Checkbox<'a, Message, Renderer>
+) -> Checkbox<'a, Message, Theme, Renderer>
 where
+    Theme: checkbox::StyleSheet + text::StyleSheet,
     Renderer: core::text::Renderer,
-    Renderer::Theme: checkbox::StyleSheet + text::StyleSheet,
 {
     Checkbox::new(label, is_checked, f)
 }
@@ -169,16 +170,16 @@ where
 /// Creates a new [`Radio`].
 ///
 /// [`Radio`]: crate::Radio
-pub fn radio<Message, Renderer, V>(
+pub fn radio<Message, Theme, Renderer, V>(
     label: impl Into<String>,
     value: V,
     selected: Option<V>,
     on_click: impl FnOnce(V) -> Message,
-) -> Radio<Message, Renderer>
+) -> Radio<Message, Theme, Renderer>
 where
     Message: Clone,
+    Theme: radio::StyleSheet,
     Renderer: core::text::Renderer,
-    Renderer::Theme: radio::StyleSheet,
     V: Copy + Eq,
 {
     Radio::new(label, value, selected, on_click)
@@ -187,14 +188,14 @@ where
 /// Creates a new [`Toggler`].
 ///
 /// [`Toggler`]: crate::Toggler
-pub fn toggler<'a, Message, Renderer>(
+pub fn toggler<'a, Message, Theme, Renderer>(
     label: impl Into<Option<String>>,
     is_checked: bool,
     f: impl Fn(bool) -> Message + 'a,
-) -> Toggler<'a, Message, Renderer>
+) -> Toggler<'a, Message, Theme, Renderer>
 where
     Renderer: core::text::Renderer,
-    Renderer::Theme: toggler::StyleSheet,
+    Theme: toggler::StyleSheet,
 {
     Toggler::new(label, is_checked, f)
 }
@@ -202,14 +203,14 @@ where
 /// Creates a new [`TextInput`].
 ///
 /// [`TextInput`]: crate::TextInput
-pub fn text_input<'a, Message, Renderer>(
+pub fn text_input<'a, Message, Theme, Renderer>(
     placeholder: &str,
     value: &str,
-) -> TextInput<'a, Message, Renderer>
+) -> TextInput<'a, Message, Theme, Renderer>
 where
     Message: Clone,
+    Theme: text_input::StyleSheet,
     Renderer: core::text::Renderer,
-    Renderer::Theme: text_input::StyleSheet,
 {
     TextInput::new(placeholder, value)
 }
@@ -217,13 +218,13 @@ where
 /// Creates a new [`TextEditor`].
 ///
 /// [`TextEditor`]: crate::TextEditor
-pub fn text_editor<Message, Renderer>(
+pub fn text_editor<Message, Theme, Renderer>(
     content: &text_editor::Content<Renderer>,
-) -> TextEditor<'_, core::text::highlighter::PlainText, Message, Renderer>
+) -> TextEditor<'_, core::text::highlighter::PlainText, Message, Theme, Renderer>
 where
     Message: Clone,
+    Theme: text_editor::StyleSheet,
     Renderer: core::text::Renderer,
-    Renderer::Theme: text_editor::StyleSheet,
 {
     TextEditor::new(content)
 }
@@ -231,16 +232,15 @@ where
 /// Creates a new [`Slider`].
 ///
 /// [`Slider`]: crate::Slider
-pub fn slider<'a, T, Message, Renderer>(
+pub fn slider<'a, T, Message, Theme>(
     range: std::ops::RangeInclusive<T>,
     value: T,
     on_change: impl Fn(T) -> Message + 'a,
-) -> Slider<'a, T, Message, Renderer>
+) -> Slider<'a, T, Message, Theme>
 where
     T: Copy + From<u8> + std::cmp::PartialOrd,
     Message: Clone,
-    Renderer: core::Renderer,
-    Renderer::Theme: slider::StyleSheet,
+    Theme: slider::StyleSheet,
 {
     Slider::new(range, value, on_change)
 }
@@ -248,16 +248,15 @@ where
 /// Creates a new [`VerticalSlider`].
 ///
 /// [`VerticalSlider`]: crate::VerticalSlider
-pub fn vertical_slider<'a, T, Message, Renderer>(
+pub fn vertical_slider<'a, T, Message, Theme>(
     range: std::ops::RangeInclusive<T>,
     value: T,
     on_change: impl Fn(T) -> Message + 'a,
-) -> VerticalSlider<'a, T, Message, Renderer>
+) -> VerticalSlider<'a, T, Message, Theme>
 where
     T: Copy + From<u8> + std::cmp::PartialOrd,
     Message: Clone,
-    Renderer: core::Renderer,
-    Renderer::Theme: slider::StyleSheet,
+    Theme: slider::StyleSheet,
 {
     VerticalSlider::new(range, value, on_change)
 }
@@ -265,21 +264,21 @@ where
 /// Creates a new [`PickList`].
 ///
 /// [`PickList`]: crate::PickList
-pub fn pick_list<'a, Message, Renderer, T>(
+pub fn pick_list<'a, Message, Theme, Renderer, T>(
     options: impl Into<Cow<'a, [T]>>,
     selected: Option<T>,
     on_selected: impl Fn(T) -> Message + 'a,
-) -> PickList<'a, T, Message, Renderer>
+) -> PickList<'a, T, Message, Theme, Renderer>
 where
     T: ToString + PartialEq + 'static,
     [T]: ToOwned<Owned = Vec<T>>,
     Renderer: core::text::Renderer,
-    Renderer::Theme: pick_list::StyleSheet
+    Theme: pick_list::StyleSheet
         + scrollable::StyleSheet
         + overlay::menu::StyleSheet
         + container::StyleSheet,
-    <Renderer::Theme as overlay::menu::StyleSheet>::Style:
-        From<<Renderer::Theme as pick_list::StyleSheet>::Style>,
+    <Theme as overlay::menu::StyleSheet>::Style:
+        From<<Theme as pick_list::StyleSheet>::Style>,
 {
     PickList::new(options, selected, on_selected)
 }
@@ -287,16 +286,16 @@ where
 /// Creates a new [`ComboBox`].
 ///
 /// [`ComboBox`]: crate::ComboBox
-pub fn combo_box<'a, T, Message, Renderer>(
+pub fn combo_box<'a, T, Message, Theme, Renderer>(
     state: &'a combo_box::State<T>,
     placeholder: &str,
     selection: Option<&T>,
     on_selected: impl Fn(T) -> Message + 'static,
-) -> ComboBox<'a, T, Message, Renderer>
+) -> ComboBox<'a, T, Message, Theme, Renderer>
 where
     T: std::fmt::Display + Clone,
+    Theme: text_input::StyleSheet + overlay::menu::StyleSheet,
     Renderer: core::text::Renderer,
-    Renderer::Theme: text_input::StyleSheet + overlay::menu::StyleSheet,
 {
     ComboBox::new(state, placeholder, selection, on_selected)
 }
@@ -318,10 +317,9 @@ pub fn vertical_space(height: impl Into<Length>) -> Space {
 /// Creates a horizontal [`Rule`] with the given height.
 ///
 /// [`Rule`]: crate::Rule
-pub fn horizontal_rule<Renderer>(height: impl Into<Pixels>) -> Rule<Renderer>
+pub fn horizontal_rule<Theme>(height: impl Into<Pixels>) -> Rule<Theme>
 where
-    Renderer: core::Renderer,
-    Renderer::Theme: rule::StyleSheet,
+    Theme: rule::StyleSheet,
 {
     Rule::horizontal(height)
 }
@@ -329,10 +327,9 @@ where
 /// Creates a vertical [`Rule`] with the given width.
 ///
 /// [`Rule`]: crate::Rule
-pub fn vertical_rule<Renderer>(width: impl Into<Pixels>) -> Rule<Renderer>
+pub fn vertical_rule<Theme>(width: impl Into<Pixels>) -> Rule<Theme>
 where
-    Renderer: core::Renderer,
-    Renderer::Theme: rule::StyleSheet,
+    Theme: rule::StyleSheet,
 {
     Rule::vertical(width)
 }
@@ -344,13 +341,12 @@ where
 ///   * the current value of the [`ProgressBar`].
 ///
 /// [`ProgressBar`]: crate::ProgressBar
-pub fn progress_bar<Renderer>(
+pub fn progress_bar<Theme>(
     range: RangeInclusive<f32>,
     value: f32,
-) -> ProgressBar<Renderer>
+) -> ProgressBar<Theme>
 where
-    Renderer: core::Renderer,
-    Renderer::Theme: progress_bar::StyleSheet,
+    Theme: progress_bar::StyleSheet,
 {
     ProgressBar::new(range, value)
 }
@@ -368,12 +364,9 @@ pub fn image<Handle>(handle: impl Into<Handle>) -> crate::Image<Handle> {
 /// [`Svg`]: crate::Svg
 /// [`Handle`]: crate::svg::Handle
 #[cfg(feature = "svg")]
-pub fn svg<Renderer>(
-    handle: impl Into<core::svg::Handle>,
-) -> crate::Svg<Renderer>
+pub fn svg<Theme>(handle: impl Into<core::svg::Handle>) -> crate::Svg<Theme>
 where
-    Renderer: core::svg::Renderer,
-    Renderer::Theme: crate::svg::StyleSheet,
+    Theme: crate::svg::StyleSheet,
 {
     crate::Svg::new(handle)
 }
@@ -382,12 +375,12 @@ where
 ///
 /// [`Canvas`]: crate::Canvas
 #[cfg(feature = "canvas")]
-pub fn canvas<P, Message, Renderer>(
+pub fn canvas<P, Message, Theme, Renderer>(
     program: P,
-) -> crate::Canvas<P, Message, Renderer>
+) -> crate::Canvas<P, Message, Theme, Renderer>
 where
     Renderer: crate::graphics::geometry::Renderer,
-    P: crate::canvas::Program<Message, Renderer>,
+    P: crate::canvas::Program<Message, Theme, Renderer>,
 {
     crate::Canvas::new(program)
 }
@@ -420,9 +413,9 @@ where
 }
 
 /// A container intercepting mouse events.
-pub fn mouse_area<'a, Message, Renderer>(
-    widget: impl Into<Element<'a, Message, Renderer>>,
-) -> MouseArea<'a, Message, Renderer>
+pub fn mouse_area<'a, Message, Theme, Renderer>(
+    widget: impl Into<Element<'a, Message, Theme, Renderer>>,
+) -> MouseArea<'a, Message, Theme, Renderer>
 where
     Renderer: core::Renderer,
 {

--- a/widget/src/image.rs
+++ b/widget/src/image.rs
@@ -159,7 +159,8 @@ pub fn draw<Renderer, Handle>(
     }
 }
 
-impl<Message, Renderer, Handle> Widget<Message, Renderer> for Image<Handle>
+impl<Message, Theme, Renderer, Handle> Widget<Message, Theme, Renderer>
+    for Image<Handle>
 where
     Renderer: image::Renderer<Handle = Handle>,
     Handle: Clone + Hash,
@@ -191,7 +192,7 @@ where
         &self,
         _state: &Tree,
         renderer: &mut Renderer,
-        _theme: &Renderer::Theme,
+        _theme: &Theme,
         _style: &renderer::Style,
         layout: Layout<'_>,
         _cursor: mouse::Cursor,
@@ -207,13 +208,13 @@ where
     }
 }
 
-impl<'a, Message, Renderer, Handle> From<Image<Handle>>
-    for Element<'a, Message, Renderer>
+impl<'a, Message, Theme, Renderer, Handle> From<Image<Handle>>
+    for Element<'a, Message, Theme, Renderer>
 where
     Renderer: image::Renderer<Handle = Handle>,
     Handle: Clone + Hash + 'a,
 {
-    fn from(image: Image<Handle>) -> Element<'a, Message, Renderer> {
+    fn from(image: Image<Handle>) -> Element<'a, Message, Theme, Renderer> {
         Element::new(image)
     }
 }

--- a/widget/src/image/viewer.rs
+++ b/widget/src/image/viewer.rs
@@ -84,7 +84,8 @@ impl<Handle> Viewer<Handle> {
     }
 }
 
-impl<Message, Renderer, Handle> Widget<Message, Renderer> for Viewer<Handle>
+impl<Message, Theme, Renderer, Handle> Widget<Message, Theme, Renderer>
+    for Viewer<Handle>
 where
     Renderer: image::Renderer<Handle = Handle>,
     Handle: Clone + Hash,
@@ -305,7 +306,7 @@ where
         &self,
         tree: &Tree,
         renderer: &mut Renderer,
-        _theme: &Renderer::Theme,
+        _theme: &Theme,
         _style: &renderer::Style,
         layout: Layout<'_>,
         _cursor: mouse::Cursor,
@@ -390,14 +391,14 @@ impl State {
     }
 }
 
-impl<'a, Message, Renderer, Handle> From<Viewer<Handle>>
-    for Element<'a, Message, Renderer>
+impl<'a, Message, Theme, Renderer, Handle> From<Viewer<Handle>>
+    for Element<'a, Message, Theme, Renderer>
 where
     Renderer: 'a + image::Renderer<Handle = Handle>,
     Message: 'a,
     Handle: Clone + Hash + 'a,
 {
-    fn from(viewer: Viewer<Handle>) -> Element<'a, Message, Renderer> {
+    fn from(viewer: Viewer<Handle>) -> Element<'a, Message, Theme, Renderer> {
         Element::new(viewer)
     }
 }

--- a/widget/src/keyed/column.rs
+++ b/widget/src/keyed/column.rs
@@ -13,8 +13,13 @@ use crate::core::{
 
 /// A container that distributes its contents vertically.
 #[allow(missing_debug_implementations)]
-pub struct Column<'a, Key, Message, Renderer = crate::Renderer>
-where
+pub struct Column<
+    'a,
+    Key,
+    Message,
+    Theme = crate::Theme,
+    Renderer = crate::Renderer,
+> where
     Key: Copy + PartialEq,
 {
     spacing: f32,
@@ -24,10 +29,11 @@ where
     max_width: f32,
     align_items: Alignment,
     keys: Vec<Key>,
-    children: Vec<Element<'a, Message, Renderer>>,
+    children: Vec<Element<'a, Message, Theme, Renderer>>,
 }
 
-impl<'a, Key, Message, Renderer> Column<'a, Key, Message, Renderer>
+impl<'a, Key, Message, Theme, Renderer>
+    Column<'a, Key, Message, Theme, Renderer>
 where
     Key: Copy + PartialEq,
     Renderer: crate::core::Renderer,
@@ -48,7 +54,9 @@ where
 
     /// Creates a [`Column`] with the given elements.
     pub fn with_children(
-        children: impl IntoIterator<Item = (Key, Element<'a, Message, Renderer>)>,
+        children: impl IntoIterator<
+            Item = (Key, Element<'a, Message, Theme, Renderer>),
+        >,
     ) -> Self {
         children
             .into_iter()
@@ -99,7 +107,7 @@ where
     pub fn push(
         mut self,
         key: Key,
-        child: impl Into<Element<'a, Message, Renderer>>,
+        child: impl Into<Element<'a, Message, Theme, Renderer>>,
     ) -> Self {
         let child = child.into();
         let size = child.as_widget().size_hint();
@@ -135,8 +143,8 @@ where
     keys: Vec<Key>,
 }
 
-impl<'a, Key, Message, Renderer> Widget<Message, Renderer>
-    for Column<'a, Key, Message, Renderer>
+impl<'a, Key, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
+    for Column<'a, Key, Message, Theme, Renderer>
 where
     Renderer: crate::core::Renderer,
     Key: Copy + PartialEq + 'static,
@@ -285,7 +293,7 @@ where
         &self,
         tree: &Tree,
         renderer: &mut Renderer,
-        theme: &Renderer::Theme,
+        theme: &Theme,
         style: &renderer::Style,
         layout: Layout<'_>,
         cursor: mouse::Cursor,
@@ -308,19 +316,21 @@ where
         tree: &'b mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
-    ) -> Option<overlay::Element<'b, Message, Renderer>> {
+    ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
         overlay::from_children(&mut self.children, tree, layout, renderer)
     }
 }
 
-impl<'a, Key, Message, Renderer> From<Column<'a, Key, Message, Renderer>>
-    for Element<'a, Message, Renderer>
+impl<'a, Key, Message, Theme, Renderer>
+    From<Column<'a, Key, Message, Theme, Renderer>>
+    for Element<'a, Message, Theme, Renderer>
 where
     Key: Copy + PartialEq + 'static,
     Message: 'a,
+    Theme: 'a,
     Renderer: crate::core::Renderer + 'a,
 {
-    fn from(column: Column<'a, Key, Message, Renderer>) -> Self {
+    fn from(column: Column<'a, Key, Message, Theme, Renderer>) -> Self {
         Self::new(column)
     }
 }

--- a/widget/src/lazy/cache.rs
+++ b/widget/src/lazy/cache.rs
@@ -4,10 +4,10 @@ use crate::core::Element;
 use ouroboros::self_referencing;
 
 #[self_referencing(pub_extras)]
-pub struct Cache<'a, Message: 'a, Renderer: 'a> {
-    pub element: Element<'a, Message, Renderer>,
+pub struct Cache<'a, Message: 'a, Theme: 'a, Renderer: 'a> {
+    pub element: Element<'a, Message, Theme, Renderer>,
 
     #[borrows(mut element)]
     #[covariant]
-    overlay: Option<overlay::Element<'this, Message, Renderer>>,
+    overlay: Option<overlay::Element<'this, Message, Theme, Renderer>>,
 }

--- a/widget/src/lazy/helpers.rs
+++ b/widget/src/lazy/helpers.rs
@@ -7,13 +7,13 @@ use std::hash::Hash;
 /// Creates a new [`Lazy`] widget with the given data `Dependency` and a
 /// closure that can turn this data into a widget tree.
 #[cfg(feature = "lazy")]
-pub fn lazy<'a, Message, Renderer, Dependency, View>(
+pub fn lazy<'a, Message, Theme, Renderer, Dependency, View>(
     dependency: Dependency,
     view: impl Fn(&Dependency) -> View + 'a,
-) -> Lazy<'a, Message, Renderer, Dependency, View>
+) -> Lazy<'a, Message, Theme, Renderer, Dependency, View>
 where
     Dependency: Hash + 'a,
-    View: Into<Element<'static, Message, Renderer>>,
+    View: Into<Element<'static, Message, Theme, Renderer>>,
 {
     Lazy::new(dependency, view)
 }
@@ -21,13 +21,14 @@ where
 /// Turns an implementor of [`Component`] into an [`Element`] that can be
 /// embedded in any application.
 #[cfg(feature = "lazy")]
-pub fn component<'a, C, Message, Renderer>(
+pub fn component<'a, C, Message, Theme, Renderer>(
     component: C,
-) -> Element<'a, Message, Renderer>
+) -> Element<'a, Message, Theme, Renderer>
 where
-    C: Component<Message, Renderer> + 'a,
+    C: Component<Message, Theme, Renderer> + 'a,
     C::State: 'static,
     Message: 'a,
+    Theme: 'a,
     Renderer: core::Renderer + 'a,
 {
     component::view(component)
@@ -40,9 +41,9 @@ where
 /// the [`Responsive`] widget and, therefore, can be used to build the
 /// contents of the widget in a responsive way.
 #[cfg(feature = "lazy")]
-pub fn responsive<'a, Message, Renderer>(
-    f: impl Fn(Size) -> Element<'a, Message, Renderer> + 'a,
-) -> Responsive<'a, Message, Renderer>
+pub fn responsive<'a, Message, Theme, Renderer>(
+    f: impl Fn(Size) -> Element<'a, Message, Theme, Renderer> + 'a,
+) -> Responsive<'a, Message, Theme, Renderer>
 where
     Renderer: core::Renderer,
 {

--- a/widget/src/lib.rs
+++ b/widget/src/lib.rs
@@ -132,4 +132,5 @@ pub mod qr_code;
 #[doc(no_inline)]
 pub use qr_code::QRCode;
 
-type Renderer<Theme = style::Theme> = renderer::Renderer<Theme>;
+pub use crate::style::theme::{self, Theme};
+pub use renderer::Renderer;

--- a/widget/src/lib.rs
+++ b/widget/src/lib.rs
@@ -19,6 +19,7 @@ pub use iced_style as style;
 mod column;
 mod mouse_area;
 mod row;
+mod themer;
 
 pub mod button;
 pub mod checkbox;
@@ -91,6 +92,8 @@ pub use text_editor::TextEditor;
 #[doc(no_inline)]
 pub use text_input::TextInput;
 #[doc(no_inline)]
+pub use themer::Themer;
+#[doc(no_inline)]
 pub use toggler::Toggler;
 #[doc(no_inline)]
 pub use tooltip::Tooltip;
@@ -132,5 +135,5 @@ pub mod qr_code;
 #[doc(no_inline)]
 pub use qr_code::QRCode;
 
-pub use crate::style::theme::{self, Theme};
 pub use renderer::Renderer;
+pub use style::theme::{self, Theme};

--- a/widget/src/mouse_area.rs
+++ b/widget/src/mouse_area.rs
@@ -13,8 +13,13 @@ use crate::core::{
 
 /// Emit messages on mouse events.
 #[allow(missing_debug_implementations)]
-pub struct MouseArea<'a, Message, Renderer> {
-    content: Element<'a, Message, Renderer>,
+pub struct MouseArea<
+    'a,
+    Message,
+    Theme = crate::Theme,
+    Renderer = crate::Renderer,
+> {
+    content: Element<'a, Message, Theme, Renderer>,
     on_press: Option<Message>,
     on_release: Option<Message>,
     on_right_press: Option<Message>,
@@ -23,7 +28,7 @@ pub struct MouseArea<'a, Message, Renderer> {
     on_middle_release: Option<Message>,
 }
 
-impl<'a, Message, Renderer> MouseArea<'a, Message, Renderer> {
+impl<'a, Message, Theme, Renderer> MouseArea<'a, Message, Theme, Renderer> {
     /// The message to emit on a left button press.
     #[must_use]
     pub fn on_press(mut self, message: Message) -> Self {
@@ -73,9 +78,11 @@ struct State {
     // TODO: Support on_mouse_enter and on_mouse_exit
 }
 
-impl<'a, Message, Renderer> MouseArea<'a, Message, Renderer> {
+impl<'a, Message, Theme, Renderer> MouseArea<'a, Message, Theme, Renderer> {
     /// Creates a [`MouseArea`] with the given content.
-    pub fn new(content: impl Into<Element<'a, Message, Renderer>>) -> Self {
+    pub fn new(
+        content: impl Into<Element<'a, Message, Theme, Renderer>>,
+    ) -> Self {
         MouseArea {
             content: content.into(),
             on_press: None,
@@ -88,8 +95,8 @@ impl<'a, Message, Renderer> MouseArea<'a, Message, Renderer> {
     }
 }
 
-impl<'a, Message, Renderer> Widget<Message, Renderer>
-    for MouseArea<'a, Message, Renderer>
+impl<'a, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
+    for MouseArea<'a, Message, Theme, Renderer>
 where
     Renderer: renderer::Renderer,
     Message: Clone,
@@ -188,7 +195,7 @@ where
         &self,
         tree: &Tree,
         renderer: &mut Renderer,
-        theme: &Renderer::Theme,
+        theme: &Theme,
         renderer_style: &renderer::Style,
         layout: Layout<'_>,
         cursor: mouse::Cursor,
@@ -210,7 +217,7 @@ where
         tree: &'b mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
-    ) -> Option<overlay::Element<'b, Message, Renderer>> {
+    ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
         self.content.as_widget_mut().overlay(
             &mut tree.children[0],
             layout,
@@ -219,23 +226,24 @@ where
     }
 }
 
-impl<'a, Message, Renderer> From<MouseArea<'a, Message, Renderer>>
-    for Element<'a, Message, Renderer>
+impl<'a, Message, Theme, Renderer> From<MouseArea<'a, Message, Theme, Renderer>>
+    for Element<'a, Message, Theme, Renderer>
 where
     Message: 'a + Clone,
+    Theme: 'a,
     Renderer: 'a + renderer::Renderer,
 {
     fn from(
-        area: MouseArea<'a, Message, Renderer>,
-    ) -> Element<'a, Message, Renderer> {
+        area: MouseArea<'a, Message, Theme, Renderer>,
+    ) -> Element<'a, Message, Theme, Renderer> {
         Element::new(area)
     }
 }
 
 /// Processes the given [`Event`] and updates the [`State`] of an [`MouseArea`]
 /// accordingly.
-fn update<Message: Clone, Renderer>(
-    widget: &mut MouseArea<'_, Message, Renderer>,
+fn update<Message: Clone, Theme, Renderer>(
+    widget: &mut MouseArea<'_, Message, Theme, Renderer>,
     event: &Event,
     layout: Layout<'_>,
     cursor: mouse::Cursor,

--- a/widget/src/pane_grid/content.rs
+++ b/widget/src/pane_grid/content.rs
@@ -12,23 +12,27 @@ use crate::pane_grid::{Draggable, TitleBar};
 ///
 /// [`Pane`]: super::Pane
 #[allow(missing_debug_implementations)]
-pub struct Content<'a, Message, Renderer = crate::Renderer>
-where
+pub struct Content<
+    'a,
+    Message,
+    Theme = crate::Theme,
+    Renderer = crate::Renderer,
+> where
+    Theme: container::StyleSheet,
     Renderer: crate::core::Renderer,
-    Renderer::Theme: container::StyleSheet,
 {
-    title_bar: Option<TitleBar<'a, Message, Renderer>>,
-    body: Element<'a, Message, Renderer>,
-    style: <Renderer::Theme as container::StyleSheet>::Style,
+    title_bar: Option<TitleBar<'a, Message, Theme, Renderer>>,
+    body: Element<'a, Message, Theme, Renderer>,
+    style: Theme::Style,
 }
 
-impl<'a, Message, Renderer> Content<'a, Message, Renderer>
+impl<'a, Message, Theme, Renderer> Content<'a, Message, Theme, Renderer>
 where
+    Theme: container::StyleSheet,
     Renderer: crate::core::Renderer,
-    Renderer::Theme: container::StyleSheet,
 {
     /// Creates a new [`Content`] with the provided body.
-    pub fn new(body: impl Into<Element<'a, Message, Renderer>>) -> Self {
+    pub fn new(body: impl Into<Element<'a, Message, Theme, Renderer>>) -> Self {
         Self {
             title_bar: None,
             body: body.into(),
@@ -39,26 +43,23 @@ where
     /// Sets the [`TitleBar`] of this [`Content`].
     pub fn title_bar(
         mut self,
-        title_bar: TitleBar<'a, Message, Renderer>,
+        title_bar: TitleBar<'a, Message, Theme, Renderer>,
     ) -> Self {
         self.title_bar = Some(title_bar);
         self
     }
 
     /// Sets the style of the [`Content`].
-    pub fn style(
-        mut self,
-        style: impl Into<<Renderer::Theme as container::StyleSheet>::Style>,
-    ) -> Self {
+    pub fn style(mut self, style: impl Into<Theme::Style>) -> Self {
         self.style = style.into();
         self
     }
 }
 
-impl<'a, Message, Renderer> Content<'a, Message, Renderer>
+impl<'a, Message, Theme, Renderer> Content<'a, Message, Theme, Renderer>
 where
+    Theme: container::StyleSheet,
     Renderer: crate::core::Renderer,
-    Renderer::Theme: container::StyleSheet,
 {
     pub(super) fn state(&self) -> Tree {
         let children = if let Some(title_bar) = self.title_bar.as_ref() {
@@ -92,14 +93,12 @@ where
         &self,
         tree: &Tree,
         renderer: &mut Renderer,
-        theme: &Renderer::Theme,
+        theme: &Theme,
         style: &renderer::Style,
         layout: Layout<'_>,
         cursor: mouse::Cursor,
         viewport: &Rectangle,
     ) {
-        use container::StyleSheet;
-
         let bounds = layout.bounds();
 
         {
@@ -331,7 +330,7 @@ where
         tree: &'b mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
-    ) -> Option<overlay::Element<'b, Message, Renderer>> {
+    ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
         if let Some(title_bar) = self.title_bar.as_mut() {
             let mut children = layout.children();
             let title_bar_layout = children.next()?;
@@ -359,10 +358,11 @@ where
     }
 }
 
-impl<'a, Message, Renderer> Draggable for &Content<'a, Message, Renderer>
+impl<'a, Message, Theme, Renderer> Draggable
+    for &Content<'a, Message, Theme, Renderer>
 where
+    Theme: container::StyleSheet,
     Renderer: crate::core::Renderer,
-    Renderer::Theme: container::StyleSheet,
 {
     fn can_be_dragged_at(
         &self,
@@ -380,11 +380,12 @@ where
     }
 }
 
-impl<'a, T, Message, Renderer> From<T> for Content<'a, Message, Renderer>
+impl<'a, T, Message, Theme, Renderer> From<T>
+    for Content<'a, Message, Theme, Renderer>
 where
-    T: Into<Element<'a, Message, Renderer>>,
+    T: Into<Element<'a, Message, Theme, Renderer>>,
+    Theme: container::StyleSheet,
     Renderer: crate::core::Renderer,
-    Renderer::Theme: container::StyleSheet,
 {
     fn from(element: T) -> Self {
         Self::new(element)

--- a/widget/src/pane_grid/title_bar.rs
+++ b/widget/src/pane_grid/title_bar.rs
@@ -13,27 +13,31 @@ use crate::core::{
 ///
 /// [`Pane`]: super::Pane
 #[allow(missing_debug_implementations)]
-pub struct TitleBar<'a, Message, Renderer = crate::Renderer>
-where
+pub struct TitleBar<
+    'a,
+    Message,
+    Theme = crate::Theme,
+    Renderer = crate::Renderer,
+> where
+    Theme: container::StyleSheet,
     Renderer: crate::core::Renderer,
-    Renderer::Theme: container::StyleSheet,
 {
-    content: Element<'a, Message, Renderer>,
-    controls: Option<Element<'a, Message, Renderer>>,
+    content: Element<'a, Message, Theme, Renderer>,
+    controls: Option<Element<'a, Message, Theme, Renderer>>,
     padding: Padding,
     always_show_controls: bool,
-    style: <Renderer::Theme as container::StyleSheet>::Style,
+    style: Theme::Style,
 }
 
-impl<'a, Message, Renderer> TitleBar<'a, Message, Renderer>
+impl<'a, Message, Theme, Renderer> TitleBar<'a, Message, Theme, Renderer>
 where
+    Theme: container::StyleSheet,
     Renderer: crate::core::Renderer,
-    Renderer::Theme: container::StyleSheet,
 {
     /// Creates a new [`TitleBar`] with the given content.
     pub fn new<E>(content: E) -> Self
     where
-        E: Into<Element<'a, Message, Renderer>>,
+        E: Into<Element<'a, Message, Theme, Renderer>>,
     {
         Self {
             content: content.into(),
@@ -47,7 +51,7 @@ where
     /// Sets the controls of the [`TitleBar`].
     pub fn controls(
         mut self,
-        controls: impl Into<Element<'a, Message, Renderer>>,
+        controls: impl Into<Element<'a, Message, Theme, Renderer>>,
     ) -> Self {
         self.controls = Some(controls.into());
         self
@@ -60,10 +64,7 @@ where
     }
 
     /// Sets the style of the [`TitleBar`].
-    pub fn style(
-        mut self,
-        style: impl Into<<Renderer::Theme as container::StyleSheet>::Style>,
-    ) -> Self {
+    pub fn style(mut self, style: impl Into<Theme::Style>) -> Self {
         self.style = style.into();
         self
     }
@@ -82,10 +83,10 @@ where
     }
 }
 
-impl<'a, Message, Renderer> TitleBar<'a, Message, Renderer>
+impl<'a, Message, Theme, Renderer> TitleBar<'a, Message, Theme, Renderer>
 where
+    Theme: container::StyleSheet,
     Renderer: crate::core::Renderer,
-    Renderer::Theme: container::StyleSheet,
 {
     pub(super) fn state(&self) -> Tree {
         let children = if let Some(controls) = self.controls.as_ref() {
@@ -119,15 +120,13 @@ where
         &self,
         tree: &Tree,
         renderer: &mut Renderer,
-        theme: &Renderer::Theme,
+        theme: &Theme,
         inherited_style: &renderer::Style,
         layout: Layout<'_>,
         cursor: mouse::Cursor,
         viewport: &Rectangle,
         show_controls: bool,
     ) {
-        use container::StyleSheet;
-
         let bounds = layout.bounds();
         let style = theme.appearance(&self.style);
         let inherited_style = renderer::Style {
@@ -406,7 +405,7 @@ where
         tree: &'b mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
-    ) -> Option<overlay::Element<'b, Message, Renderer>> {
+    ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
         let mut children = layout.children();
         let padded = children.next()?;
 

--- a/widget/src/progress_bar.rs
+++ b/widget/src/progress_bar.rs
@@ -13,8 +13,7 @@ pub use iced_style::progress_bar::{Appearance, StyleSheet};
 ///
 /// # Example
 /// ```no_run
-/// # type ProgressBar =
-/// #     iced_widget::ProgressBar<iced_widget::renderer::Renderer<iced_widget::style::Theme>>;
+/// # type ProgressBar = iced_widget::ProgressBar<iced_widget::style::Theme>;
 /// #
 /// let value = 50.0;
 ///
@@ -23,22 +22,20 @@ pub use iced_style::progress_bar::{Appearance, StyleSheet};
 ///
 /// ![Progress bar drawn with `iced_wgpu`](https://user-images.githubusercontent.com/18618951/71662391-a316c200-2d51-11ea-9cef-52758cab85e3.png)
 #[allow(missing_debug_implementations)]
-pub struct ProgressBar<Renderer = crate::Renderer>
+pub struct ProgressBar<Theme = crate::Theme>
 where
-    Renderer: crate::core::Renderer,
-    Renderer::Theme: StyleSheet,
+    Theme: StyleSheet,
 {
     range: RangeInclusive<f32>,
     value: f32,
     width: Length,
     height: Option<Length>,
-    style: <Renderer::Theme as StyleSheet>::Style,
+    style: Theme::Style,
 }
 
-impl<Renderer> ProgressBar<Renderer>
+impl<Theme> ProgressBar<Theme>
 where
-    Renderer: crate::core::Renderer,
-    Renderer::Theme: StyleSheet,
+    Theme: StyleSheet,
 {
     /// The default height of a [`ProgressBar`].
     pub const DEFAULT_HEIGHT: f32 = 30.0;
@@ -71,19 +68,17 @@ where
     }
 
     /// Sets the style of the [`ProgressBar`].
-    pub fn style(
-        mut self,
-        style: impl Into<<Renderer::Theme as StyleSheet>::Style>,
-    ) -> Self {
+    pub fn style(mut self, style: impl Into<Theme::Style>) -> Self {
         self.style = style.into();
         self
     }
 }
 
-impl<Message, Renderer> Widget<Message, Renderer> for ProgressBar<Renderer>
+impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer>
+    for ProgressBar<Theme>
 where
     Renderer: crate::core::Renderer,
-    Renderer::Theme: StyleSheet,
+    Theme: StyleSheet,
 {
     fn size(&self) -> Size<Length> {
         Size {
@@ -109,7 +104,7 @@ where
         &self,
         _state: &Tree,
         renderer: &mut Renderer,
-        theme: &Renderer::Theme,
+        theme: &Theme,
         _style: &renderer::Style,
         layout: Layout<'_>,
         _cursor: mouse::Cursor,
@@ -152,16 +147,16 @@ where
     }
 }
 
-impl<'a, Message, Renderer> From<ProgressBar<Renderer>>
-    for Element<'a, Message, Renderer>
+impl<'a, Message, Theme, Renderer> From<ProgressBar<Theme>>
+    for Element<'a, Message, Theme, Renderer>
 where
     Message: 'a,
+    Theme: StyleSheet + 'a,
     Renderer: 'a + crate::core::Renderer,
-    Renderer::Theme: StyleSheet,
 {
     fn from(
-        progress_bar: ProgressBar<Renderer>,
-    ) -> Element<'a, Message, Renderer> {
+        progress_bar: ProgressBar<Theme>,
+    ) -> Element<'a, Message, Theme, Renderer> {
         Element::new(progress_bar)
     }
 }

--- a/widget/src/qr_code.rs
+++ b/widget/src/qr_code.rs
@@ -49,7 +49,7 @@ impl<'a> QRCode<'a> {
     }
 }
 
-impl<'a, Message, Theme> Widget<Message, Renderer<Theme>> for QRCode<'a> {
+impl<'a, Message, Theme> Widget<Message, Theme, Renderer> for QRCode<'a> {
     fn size(&self) -> Size<Length> {
         Size {
             width: Length::Shrink,
@@ -60,7 +60,7 @@ impl<'a, Message, Theme> Widget<Message, Renderer<Theme>> for QRCode<'a> {
     fn layout(
         &self,
         _tree: &mut Tree,
-        _renderer: &Renderer<Theme>,
+        _renderer: &Renderer,
         _limits: &layout::Limits,
     ) -> layout::Node {
         let side_length = (self.state.width + 2 * QUIET_ZONE) as f32
@@ -72,7 +72,7 @@ impl<'a, Message, Theme> Widget<Message, Renderer<Theme>> for QRCode<'a> {
     fn draw(
         &self,
         _state: &Tree,
-        renderer: &mut Renderer<Theme>,
+        renderer: &mut Renderer,
         _theme: &Theme,
         _style: &renderer::Style,
         layout: Layout<'_>,
@@ -128,7 +128,7 @@ impl<'a, Message, Theme> Widget<Message, Renderer<Theme>> for QRCode<'a> {
 }
 
 impl<'a, Message, Theme> From<QRCode<'a>>
-    for Element<'a, Message, Renderer<Theme>>
+    for Element<'a, Message, Theme, Renderer>
 {
     fn from(qr_code: QRCode<'a>) -> Self {
         Self::new(qr_code)

--- a/widget/src/radio.rs
+++ b/widget/src/radio.rs
@@ -20,7 +20,7 @@ pub use iced_style::radio::{Appearance, StyleSheet};
 /// # Example
 /// ```no_run
 /// # type Radio<Message> =
-/// #     iced_widget::Radio<Message, iced_widget::renderer::Renderer<iced_widget::style::Theme>>;
+/// #     iced_widget::Radio<Message, iced_widget::style::Theme, iced_widget::renderer::Renderer>;
 /// #
 /// # use iced_widget::column;
 /// #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -69,10 +69,10 @@ pub use iced_style::radio::{Appearance, StyleSheet};
 /// let content = column![a, b, c, all];
 /// ```
 #[allow(missing_debug_implementations)]
-pub struct Radio<Message, Renderer = crate::Renderer>
+pub struct Radio<Message, Theme = crate::Theme, Renderer = crate::Renderer>
 where
+    Theme: StyleSheet,
     Renderer: text::Renderer,
-    Renderer::Theme: StyleSheet,
 {
     is_selected: bool,
     on_click: Message,
@@ -84,14 +84,14 @@ where
     text_line_height: text::LineHeight,
     text_shaping: text::Shaping,
     font: Option<Renderer::Font>,
-    style: <Renderer::Theme as StyleSheet>::Style,
+    style: Theme::Style,
 }
 
-impl<Message, Renderer> Radio<Message, Renderer>
+impl<Message, Theme, Renderer> Radio<Message, Theme, Renderer>
 where
     Message: Clone,
+    Theme: StyleSheet,
     Renderer: text::Renderer,
-    Renderer::Theme: StyleSheet,
 {
     /// The default size of a [`Radio`] button.
     pub const DEFAULT_SIZE: f32 = 28.0;
@@ -178,20 +178,18 @@ where
     }
 
     /// Sets the style of the [`Radio`] button.
-    pub fn style(
-        mut self,
-        style: impl Into<<Renderer::Theme as StyleSheet>::Style>,
-    ) -> Self {
+    pub fn style(mut self, style: impl Into<Theme::Style>) -> Self {
         self.style = style.into();
         self
     }
 }
 
-impl<Message, Renderer> Widget<Message, Renderer> for Radio<Message, Renderer>
+impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer>
+    for Radio<Message, Theme, Renderer>
 where
     Message: Clone,
+    Theme: StyleSheet + crate::text::StyleSheet,
     Renderer: text::Renderer,
-    Renderer::Theme: StyleSheet + crate::text::StyleSheet,
 {
     fn tag(&self) -> tree::Tag {
         tree::Tag::of::<widget::text::State<Renderer::Paragraph>>()
@@ -286,7 +284,7 @@ where
         &self,
         tree: &Tree,
         renderer: &mut Renderer,
-        theme: &Renderer::Theme,
+        theme: &Theme,
         style: &renderer::Style,
         layout: Layout<'_>,
         cursor: mouse::Cursor,
@@ -356,14 +354,16 @@ where
     }
 }
 
-impl<'a, Message, Renderer> From<Radio<Message, Renderer>>
-    for Element<'a, Message, Renderer>
+impl<'a, Message, Theme, Renderer> From<Radio<Message, Theme, Renderer>>
+    for Element<'a, Message, Theme, Renderer>
 where
     Message: 'a + Clone,
+    Theme: StyleSheet + crate::text::StyleSheet + 'a,
     Renderer: 'a + text::Renderer,
-    Renderer::Theme: StyleSheet + crate::text::StyleSheet,
 {
-    fn from(radio: Radio<Message, Renderer>) -> Element<'a, Message, Renderer> {
+    fn from(
+        radio: Radio<Message, Theme, Renderer>,
+    ) -> Element<'a, Message, Theme, Renderer> {
         Element::new(radio)
     }
 }

--- a/widget/src/row.rs
+++ b/widget/src/row.rs
@@ -12,16 +12,16 @@ use crate::core::{
 
 /// A container that distributes its contents horizontally.
 #[allow(missing_debug_implementations)]
-pub struct Row<'a, Message, Renderer = crate::Renderer> {
+pub struct Row<'a, Message, Theme = crate::Theme, Renderer = crate::Renderer> {
     spacing: f32,
     padding: Padding,
     width: Length,
     height: Length,
     align_items: Alignment,
-    children: Vec<Element<'a, Message, Renderer>>,
+    children: Vec<Element<'a, Message, Theme, Renderer>>,
 }
 
-impl<'a, Message, Renderer> Row<'a, Message, Renderer>
+impl<'a, Message, Theme, Renderer> Row<'a, Message, Theme, Renderer>
 where
     Renderer: crate::core::Renderer,
 {
@@ -39,7 +39,7 @@ where
 
     /// Creates a [`Row`] with the given elements.
     pub fn with_children(
-        children: impl IntoIterator<Item = Element<'a, Message, Renderer>>,
+        children: impl IntoIterator<Item = Element<'a, Message, Theme, Renderer>>,
     ) -> Self {
         children.into_iter().fold(Self::new(), Self::push)
     }
@@ -81,7 +81,7 @@ where
     /// Adds an [`Element`] to the [`Row`].
     pub fn push(
         mut self,
-        child: impl Into<Element<'a, Message, Renderer>>,
+        child: impl Into<Element<'a, Message, Theme, Renderer>>,
     ) -> Self {
         let child = child.into();
         let size = child.as_widget().size_hint();
@@ -108,8 +108,8 @@ where
     }
 }
 
-impl<'a, Message, Renderer> Widget<Message, Renderer>
-    for Row<'a, Message, Renderer>
+impl<'a, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
+    for Row<'a, Message, Theme, Renderer>
 where
     Renderer: crate::core::Renderer,
 {
@@ -223,7 +223,7 @@ where
         &self,
         tree: &Tree,
         renderer: &mut Renderer,
-        theme: &Renderer::Theme,
+        theme: &Theme,
         style: &renderer::Style,
         layout: Layout<'_>,
         cursor: mouse::Cursor,
@@ -248,18 +248,19 @@ where
         tree: &'b mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
-    ) -> Option<overlay::Element<'b, Message, Renderer>> {
+    ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
         overlay::from_children(&mut self.children, tree, layout, renderer)
     }
 }
 
-impl<'a, Message, Renderer> From<Row<'a, Message, Renderer>>
-    for Element<'a, Message, Renderer>
+impl<'a, Message, Theme, Renderer> From<Row<'a, Message, Theme, Renderer>>
+    for Element<'a, Message, Theme, Renderer>
 where
     Message: 'a,
+    Theme: 'a,
     Renderer: crate::core::Renderer + 'a,
 {
-    fn from(row: Row<'a, Message, Renderer>) -> Self {
+    fn from(row: Row<'a, Message, Theme, Renderer>) -> Self {
         Self::new(row)
     }
 }

--- a/widget/src/rule.rs
+++ b/widget/src/rule.rs
@@ -11,21 +11,19 @@ pub use crate::style::rule::{Appearance, FillMode, StyleSheet};
 
 /// Display a horizontal or vertical rule for dividing content.
 #[allow(missing_debug_implementations)]
-pub struct Rule<Renderer = crate::Renderer>
+pub struct Rule<Theme = crate::Theme>
 where
-    Renderer: crate::core::Renderer,
-    Renderer::Theme: StyleSheet,
+    Theme: StyleSheet,
 {
     width: Length,
     height: Length,
     is_horizontal: bool,
-    style: <Renderer::Theme as StyleSheet>::Style,
+    style: Theme::Style,
 }
 
-impl<Renderer> Rule<Renderer>
+impl<Theme> Rule<Theme>
 where
-    Renderer: crate::core::Renderer,
-    Renderer::Theme: StyleSheet,
+    Theme: StyleSheet,
 {
     /// Creates a horizontal [`Rule`] with the given height.
     pub fn horizontal(height: impl Into<Pixels>) -> Self {
@@ -48,19 +46,16 @@ where
     }
 
     /// Sets the style of the [`Rule`].
-    pub fn style(
-        mut self,
-        style: impl Into<<Renderer::Theme as StyleSheet>::Style>,
-    ) -> Self {
+    pub fn style(mut self, style: impl Into<Theme::Style>) -> Self {
         self.style = style.into();
         self
     }
 }
 
-impl<Message, Renderer> Widget<Message, Renderer> for Rule<Renderer>
+impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer> for Rule<Theme>
 where
     Renderer: crate::core::Renderer,
-    Renderer::Theme: StyleSheet,
+    Theme: StyleSheet,
 {
     fn size(&self) -> Size<Length> {
         Size {
@@ -82,7 +77,7 @@ where
         &self,
         _state: &Tree,
         renderer: &mut Renderer,
-        theme: &Renderer::Theme,
+        theme: &Theme,
         _style: &renderer::Style,
         layout: Layout<'_>,
         _cursor: mouse::Cursor,
@@ -132,14 +127,14 @@ where
     }
 }
 
-impl<'a, Message, Renderer> From<Rule<Renderer>>
-    for Element<'a, Message, Renderer>
+impl<'a, Message, Theme, Renderer> From<Rule<Theme>>
+    for Element<'a, Message, Theme, Renderer>
 where
     Message: 'a,
+    Theme: StyleSheet + 'a,
     Renderer: 'a + crate::core::Renderer,
-    Renderer::Theme: StyleSheet,
 {
-    fn from(rule: Rule<Renderer>) -> Element<'a, Message, Renderer> {
+    fn from(rule: Rule<Theme>) -> Element<'a, Message, Theme, Renderer> {
         Element::new(rule)
     }
 }

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -21,27 +21,33 @@ pub use operation::scrollable::{AbsoluteOffset, RelativeOffset};
 /// A widget that can vertically display an infinite amount of content with a
 /// scrollbar.
 #[allow(missing_debug_implementations)]
-pub struct Scrollable<'a, Message, Renderer = crate::Renderer>
-where
+pub struct Scrollable<
+    'a,
+    Message,
+    Theme = crate::Theme,
+    Renderer = crate::Renderer,
+> where
+    Theme: StyleSheet,
     Renderer: crate::core::Renderer,
-    Renderer::Theme: StyleSheet,
 {
     id: Option<Id>,
     width: Length,
     height: Length,
     direction: Direction,
-    content: Element<'a, Message, Renderer>,
+    content: Element<'a, Message, Theme, Renderer>,
     on_scroll: Option<Box<dyn Fn(Viewport) -> Message + 'a>>,
-    style: <Renderer::Theme as StyleSheet>::Style,
+    style: Theme::Style,
 }
 
-impl<'a, Message, Renderer> Scrollable<'a, Message, Renderer>
+impl<'a, Message, Theme, Renderer> Scrollable<'a, Message, Theme, Renderer>
 where
+    Theme: StyleSheet,
     Renderer: crate::core::Renderer,
-    Renderer::Theme: StyleSheet,
 {
     /// Creates a new [`Scrollable`].
-    pub fn new(content: impl Into<Element<'a, Message, Renderer>>) -> Self {
+    pub fn new(
+        content: impl Into<Element<'a, Message, Theme, Renderer>>,
+    ) -> Self {
         Scrollable {
             id: None,
             width: Length::Shrink,
@@ -86,10 +92,7 @@ where
     }
 
     /// Sets the style of the [`Scrollable`] .
-    pub fn style(
-        mut self,
-        style: impl Into<<Renderer::Theme as StyleSheet>::Style>,
-    ) -> Self {
+    pub fn style(mut self, style: impl Into<Theme::Style>) -> Self {
         self.style = style.into();
         self
     }
@@ -198,11 +201,11 @@ pub enum Alignment {
     End,
 }
 
-impl<'a, Message, Renderer> Widget<Message, Renderer>
-    for Scrollable<'a, Message, Renderer>
+impl<'a, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
+    for Scrollable<'a, Message, Theme, Renderer>
 where
+    Theme: StyleSheet,
     Renderer: crate::core::Renderer,
-    Renderer::Theme: StyleSheet,
 {
     fn tag(&self) -> tree::Tag {
         tree::Tag::of::<State>()
@@ -324,7 +327,7 @@ where
         &self,
         tree: &Tree,
         renderer: &mut Renderer,
-        theme: &Renderer::Theme,
+        theme: &Theme,
         style: &renderer::Style,
         layout: Layout<'_>,
         cursor: mouse::Cursor,
@@ -382,7 +385,7 @@ where
         tree: &'b mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
-    ) -> Option<overlay::Element<'b, Message, Renderer>> {
+    ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
         self.content
             .as_widget_mut()
             .overlay(
@@ -404,16 +407,17 @@ where
     }
 }
 
-impl<'a, Message, Renderer> From<Scrollable<'a, Message, Renderer>>
-    for Element<'a, Message, Renderer>
+impl<'a, Message, Theme, Renderer>
+    From<Scrollable<'a, Message, Theme, Renderer>>
+    for Element<'a, Message, Theme, Renderer>
 where
     Message: 'a,
+    Theme: StyleSheet + 'a,
     Renderer: 'a + crate::core::Renderer,
-    Renderer::Theme: StyleSheet,
 {
     fn from(
-        text_input: Scrollable<'a, Message, Renderer>,
-    ) -> Element<'a, Message, Renderer> {
+        text_input: Scrollable<'a, Message, Theme, Renderer>,
+    ) -> Element<'a, Message, Theme, Renderer> {
         Element::new(text_input)
     }
 }
@@ -841,18 +845,18 @@ pub fn mouse_interaction(
 }
 
 /// Draws a [`Scrollable`].
-pub fn draw<Renderer>(
+pub fn draw<Theme, Renderer>(
     state: &State,
     renderer: &mut Renderer,
-    theme: &Renderer::Theme,
+    theme: &Theme,
     layout: Layout<'_>,
     cursor: mouse::Cursor,
     direction: Direction,
-    style: &<Renderer::Theme as StyleSheet>::Style,
+    style: &Theme::Style,
     draw_content: impl FnOnce(&mut Renderer, Layout<'_>, mouse::Cursor, &Rectangle),
 ) where
+    Theme: StyleSheet,
     Renderer: crate::core::Renderer,
-    Renderer::Theme: StyleSheet,
 {
     let bounds = layout.bounds();
     let content_layout = layout.children().next().unwrap();

--- a/widget/src/shader.rs
+++ b/widget/src/shader.rs
@@ -56,7 +56,8 @@ impl<Message, P: Program<Message>> Shader<Message, P> {
     }
 }
 
-impl<P, Message, Renderer> Widget<Message, Renderer> for Shader<Message, P>
+impl<P, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
+    for Shader<Message, P>
 where
     P: Program<Message>,
     Renderer: pipeline::Renderer,
@@ -150,7 +151,7 @@ where
         &self,
         tree: &widget::Tree,
         renderer: &mut Renderer,
-        _theme: &Renderer::Theme,
+        _theme: &Theme,
         _style: &renderer::Style,
         layout: Layout<'_>,
         cursor_position: mouse::Cursor,
@@ -166,14 +167,16 @@ where
     }
 }
 
-impl<'a, Message, Renderer, P> From<Shader<Message, P>>
-    for Element<'a, Message, Renderer>
+impl<'a, Message, Theme, Renderer, P> From<Shader<Message, P>>
+    for Element<'a, Message, Theme, Renderer>
 where
     Message: 'a,
     Renderer: pipeline::Renderer,
     P: Program<Message> + 'a,
 {
-    fn from(custom: Shader<Message, P>) -> Element<'a, Message, Renderer> {
+    fn from(
+        custom: Shader<Message, P>,
+    ) -> Element<'a, Message, Theme, Renderer> {
         Element::new(custom)
     }
 }

--- a/widget/src/space.rs
+++ b/widget/src/space.rs
@@ -41,7 +41,7 @@ impl Space {
     }
 }
 
-impl<Message, Renderer> Widget<Message, Renderer> for Space
+impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer> for Space
 where
     Renderer: core::Renderer,
 {
@@ -65,7 +65,7 @@ where
         &self,
         _state: &Tree,
         _renderer: &mut Renderer,
-        _theme: &Renderer::Theme,
+        _theme: &Theme,
         _style: &renderer::Style,
         _layout: Layout<'_>,
         _cursor: mouse::Cursor,
@@ -74,12 +74,13 @@ where
     }
 }
 
-impl<'a, Message, Renderer> From<Space> for Element<'a, Message, Renderer>
+impl<'a, Message, Theme, Renderer> From<Space>
+    for Element<'a, Message, Theme, Renderer>
 where
     Renderer: core::Renderer,
     Message: 'a,
 {
-    fn from(space: Space) -> Element<'a, Message, Renderer> {
+    fn from(space: Space) -> Element<'a, Message, Theme, Renderer> {
         Element::new(space)
     }
 }

--- a/widget/src/svg.rs
+++ b/widget/src/svg.rs
@@ -20,22 +20,20 @@ pub use svg::Handle;
 /// [`Svg`] images can have a considerable rendering cost when resized,
 /// specially when they are complex.
 #[allow(missing_debug_implementations)]
-pub struct Svg<Renderer = crate::Renderer>
+pub struct Svg<Theme = crate::Theme>
 where
-    Renderer: svg::Renderer,
-    Renderer::Theme: StyleSheet,
+    Theme: StyleSheet,
 {
     handle: Handle,
     width: Length,
     height: Length,
     content_fit: ContentFit,
-    style: <Renderer::Theme as StyleSheet>::Style,
+    style: <Theme as StyleSheet>::Style,
 }
 
-impl<Renderer> Svg<Renderer>
+impl<Theme> Svg<Theme>
 where
-    Renderer: svg::Renderer,
-    Renderer::Theme: StyleSheet,
+    Theme: StyleSheet,
 {
     /// Creates a new [`Svg`] from the given [`Handle`].
     pub fn new(handle: impl Into<Handle>) -> Self {
@@ -82,19 +80,16 @@ where
 
     /// Sets the style variant of this [`Svg`].
     #[must_use]
-    pub fn style(
-        mut self,
-        style: <Renderer::Theme as StyleSheet>::Style,
-    ) -> Self {
-        self.style = style;
+    pub fn style(mut self, style: impl Into<Theme::Style>) -> Self {
+        self.style = style.into();
         self
     }
 }
 
-impl<Message, Renderer> Widget<Message, Renderer> for Svg<Renderer>
+impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer> for Svg<Theme>
 where
+    Theme: iced_style::svg::StyleSheet,
     Renderer: svg::Renderer,
-    Renderer::Theme: iced_style::svg::StyleSheet,
 {
     fn size(&self) -> Size<Length> {
         Size {
@@ -138,7 +133,7 @@ where
         &self,
         _state: &Tree,
         renderer: &mut Renderer,
-        theme: &Renderer::Theme,
+        theme: &Theme,
         _style: &renderer::Style,
         layout: Layout<'_>,
         cursor: mouse::Cursor,
@@ -186,13 +181,13 @@ where
     }
 }
 
-impl<'a, Message, Renderer> From<Svg<Renderer>>
-    for Element<'a, Message, Renderer>
+impl<'a, Message, Theme, Renderer> From<Svg<Theme>>
+    for Element<'a, Message, Theme, Renderer>
 where
+    Theme: iced_style::svg::StyleSheet + 'a,
     Renderer: svg::Renderer + 'a,
-    Renderer::Theme: iced_style::svg::StyleSheet,
 {
-    fn from(icon: Svg<Renderer>) -> Element<'a, Message, Renderer> {
+    fn from(icon: Svg<Theme>) -> Element<'a, Message, Theme, Renderer> {
         Element::new(icon)
     }
 }

--- a/widget/src/text.rs
+++ b/widget/src/text.rs
@@ -2,5 +2,5 @@
 pub use crate::core::widget::text::*;
 
 /// A paragraph.
-pub type Text<'a, Renderer = crate::Renderer> =
-    crate::core::widget::Text<'a, Renderer>;
+pub type Text<'a, Theme = crate::Theme, Renderer = crate::Renderer> =
+    crate::core::widget::Text<'a, Theme, Renderer>;

--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -23,11 +23,16 @@ pub use text::editor::{Action, Edit, Motion};
 
 /// A multi-line text input.
 #[allow(missing_debug_implementations)]
-pub struct TextEditor<'a, Highlighter, Message, Renderer = crate::Renderer>
-where
+pub struct TextEditor<
+    'a,
+    Highlighter,
+    Message,
+    Theme = crate::Theme,
+    Renderer = crate::Renderer,
+> where
     Highlighter: text::Highlighter,
+    Theme: StyleSheet,
     Renderer: text::Renderer,
-    Renderer::Theme: StyleSheet,
 {
     content: &'a Content<Renderer>,
     font: Option<Renderer::Font>,
@@ -36,20 +41,20 @@ where
     width: Length,
     height: Length,
     padding: Padding,
-    style: <Renderer::Theme as StyleSheet>::Style,
+    style: Theme::Style,
     on_edit: Option<Box<dyn Fn(Action) -> Message + 'a>>,
     highlighter_settings: Highlighter::Settings,
     highlighter_format: fn(
         &Highlighter::Highlight,
-        &Renderer::Theme,
+        &Theme,
     ) -> highlighter::Format<Renderer::Font>,
 }
 
-impl<'a, Message, Renderer>
-    TextEditor<'a, highlighter::PlainText, Message, Renderer>
+impl<'a, Message, Theme, Renderer>
+    TextEditor<'a, highlighter::PlainText, Message, Theme, Renderer>
 where
+    Theme: StyleSheet,
     Renderer: text::Renderer,
-    Renderer::Theme: StyleSheet,
 {
     /// Creates new [`TextEditor`] with the given [`Content`].
     pub fn new(content: &'a Content<Renderer>) -> Self {
@@ -71,12 +76,12 @@ where
     }
 }
 
-impl<'a, Highlighter, Message, Renderer>
-    TextEditor<'a, Highlighter, Message, Renderer>
+impl<'a, Highlighter, Message, Theme, Renderer>
+    TextEditor<'a, Highlighter, Message, Theme, Renderer>
 where
     Highlighter: text::Highlighter,
+    Theme: StyleSheet,
     Renderer: text::Renderer,
-    Renderer::Theme: StyleSheet,
 {
     /// Sets the message that should be produced when some action is performed in
     /// the [`TextEditor`].
@@ -111,9 +116,9 @@ where
         settings: H::Settings,
         to_format: fn(
             &H::Highlight,
-            &Renderer::Theme,
+            &Theme,
         ) -> highlighter::Format<Renderer::Font>,
-    ) -> TextEditor<'a, H, Message, Renderer> {
+    ) -> TextEditor<'a, H, Message, Theme, Renderer> {
         TextEditor {
             content: self.content,
             font: self.font,
@@ -130,10 +135,7 @@ where
     }
 
     /// Sets the style of the [`TextEditor`].
-    pub fn style(
-        mut self,
-        style: impl Into<<Renderer::Theme as StyleSheet>::Style>,
-    ) -> Self {
+    pub fn style(mut self, style: impl Into<Theme::Style>) -> Self {
         self.style = style.into();
         self
     }
@@ -292,12 +294,12 @@ struct State<Highlighter: text::Highlighter> {
     highlighter_format_address: usize,
 }
 
-impl<'a, Highlighter, Message, Renderer> Widget<Message, Renderer>
-    for TextEditor<'a, Highlighter, Message, Renderer>
+impl<'a, Highlighter, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
+    for TextEditor<'a, Highlighter, Message, Theme, Renderer>
 where
     Highlighter: text::Highlighter,
+    Theme: StyleSheet,
     Renderer: text::Renderer,
-    Renderer::Theme: StyleSheet,
 {
     fn tag(&self) -> widget::tree::Tag {
         widget::tree::Tag::of::<State<Highlighter>>()
@@ -433,7 +435,7 @@ where
         &self,
         tree: &widget::Tree,
         renderer: &mut Renderer,
-        theme: &<Renderer as renderer::Renderer>::Theme,
+        theme: &Theme,
         style: &renderer::Style,
         layout: Layout<'_>,
         cursor: mouse::Cursor,
@@ -551,17 +553,17 @@ where
     }
 }
 
-impl<'a, Highlighter, Message, Renderer>
-    From<TextEditor<'a, Highlighter, Message, Renderer>>
-    for Element<'a, Message, Renderer>
+impl<'a, Highlighter, Message, Theme, Renderer>
+    From<TextEditor<'a, Highlighter, Message, Theme, Renderer>>
+    for Element<'a, Message, Theme, Renderer>
 where
     Highlighter: text::Highlighter,
     Message: 'a,
+    Theme: StyleSheet + 'a,
     Renderer: text::Renderer,
-    Renderer::Theme: StyleSheet,
 {
     fn from(
-        text_editor: TextEditor<'a, Highlighter, Message, Renderer>,
+        text_editor: TextEditor<'a, Highlighter, Message, Theme, Renderer>,
     ) -> Self {
         Self::new(text_editor)
     }

--- a/widget/src/themer.rs
+++ b/widget/src/themer.rs
@@ -1,0 +1,268 @@
+use crate::core::event::{self, Event};
+use crate::core::layout;
+use crate::core::mouse;
+use crate::core::overlay;
+use crate::core::renderer;
+use crate::core::widget::tree::{self, Tree};
+use crate::core::widget::Operation;
+use crate::core::{
+    Clipboard, Element, Layout, Length, Point, Rectangle, Shell, Size, Vector,
+    Widget,
+};
+
+/// A widget that applies any `Theme` to its contents.
+///
+/// This widget can be useful to leverage multiple `Theme`
+/// types in an application.
+#[allow(missing_debug_implementations)]
+pub struct Themer<'a, Message, Theme, Renderer>
+where
+    Renderer: crate::core::Renderer,
+{
+    content: Element<'a, Message, Theme, Renderer>,
+    theme: Theme,
+}
+
+impl<'a, Message, Theme, Renderer> Themer<'a, Message, Theme, Renderer>
+where
+    Renderer: crate::core::Renderer,
+{
+    /// Creates an empty [`Themer`] that applies the given `Theme`
+    /// to the provided `content`.
+    pub fn new<T>(theme: Theme, content: T) -> Self
+    where
+        T: Into<Element<'a, Message, Theme, Renderer>>,
+    {
+        Self {
+            theme,
+            content: content.into(),
+        }
+    }
+}
+
+impl<'a, AnyTheme, Message, Theme, Renderer> Widget<Message, AnyTheme, Renderer>
+    for Themer<'a, Message, Theme, Renderer>
+where
+    Renderer: crate::core::Renderer,
+{
+    fn tag(&self) -> tree::Tag {
+        self.content.as_widget().tag()
+    }
+
+    fn state(&self) -> tree::State {
+        self.content.as_widget().state()
+    }
+
+    fn children(&self) -> Vec<Tree> {
+        self.content.as_widget().children()
+    }
+
+    fn diff(&self, tree: &mut Tree) {
+        self.content.as_widget().diff(tree);
+    }
+
+    fn size(&self) -> Size<Length> {
+        self.content.as_widget().size()
+    }
+
+    fn layout(
+        &self,
+        tree: &mut Tree,
+        renderer: &Renderer,
+        limits: &layout::Limits,
+    ) -> layout::Node {
+        self.content.as_widget().layout(tree, renderer, limits)
+    }
+
+    fn operate(
+        &self,
+        tree: &mut Tree,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+        operation: &mut dyn Operation<Message>,
+    ) {
+        self.content
+            .as_widget()
+            .operate(tree, layout, renderer, operation);
+    }
+
+    fn on_event(
+        &mut self,
+        tree: &mut Tree,
+        event: Event,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        renderer: &Renderer,
+        clipboard: &mut dyn Clipboard,
+        shell: &mut Shell<'_, Message>,
+        viewport: &Rectangle,
+    ) -> event::Status {
+        self.content.as_widget_mut().on_event(
+            tree, event, layout, cursor, renderer, clipboard, shell, viewport,
+        )
+    }
+
+    fn mouse_interaction(
+        &self,
+        tree: &Tree,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+        renderer: &Renderer,
+    ) -> mouse::Interaction {
+        self.content
+            .as_widget()
+            .mouse_interaction(tree, layout, cursor, viewport, renderer)
+    }
+
+    fn draw(
+        &self,
+        tree: &Tree,
+        renderer: &mut Renderer,
+        _theme: &AnyTheme,
+        renderer_style: &renderer::Style,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+    ) {
+        self.content.as_widget().draw(
+            tree,
+            renderer,
+            &self.theme,
+            renderer_style,
+            layout,
+            cursor,
+            viewport,
+        );
+    }
+
+    fn overlay<'b>(
+        &'b mut self,
+        tree: &'b mut Tree,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+    ) -> Option<overlay::Element<'b, Message, AnyTheme, Renderer>> {
+        struct Overlay<'a, Message, Theme, Renderer> {
+            theme: &'a Theme,
+            content: overlay::Element<'a, Message, Theme, Renderer>,
+        }
+
+        impl<'a, AnyTheme, Message, Theme, Renderer>
+            overlay::Overlay<Message, AnyTheme, Renderer>
+            for Overlay<'a, Message, Theme, Renderer>
+        where
+            Renderer: crate::core::Renderer,
+        {
+            fn layout(
+                &mut self,
+                renderer: &Renderer,
+                bounds: Size,
+                position: Point,
+                translation: Vector,
+            ) -> layout::Node {
+                self.content.layout(
+                    renderer,
+                    bounds,
+                    translation + (position - Point::ORIGIN),
+                )
+            }
+
+            fn draw(
+                &self,
+                renderer: &mut Renderer,
+                _theme: &AnyTheme,
+                style: &renderer::Style,
+                layout: Layout<'_>,
+                cursor: mouse::Cursor,
+            ) {
+                self.content
+                    .draw(renderer, self.theme, style, layout, cursor);
+            }
+
+            fn on_event(
+                &mut self,
+                event: Event,
+                layout: Layout<'_>,
+                cursor: mouse::Cursor,
+                renderer: &Renderer,
+                clipboard: &mut dyn Clipboard,
+                shell: &mut Shell<'_, Message>,
+            ) -> event::Status {
+                self.content
+                    .on_event(event, layout, cursor, renderer, clipboard, shell)
+            }
+
+            fn operate(
+                &mut self,
+                layout: Layout<'_>,
+                renderer: &Renderer,
+                operation: &mut dyn Operation<Message>,
+            ) {
+                self.content.operate(layout, renderer, operation);
+            }
+
+            fn mouse_interaction(
+                &self,
+                layout: Layout<'_>,
+                cursor: mouse::Cursor,
+                viewport: &Rectangle,
+                renderer: &Renderer,
+            ) -> mouse::Interaction {
+                self.content
+                    .mouse_interaction(layout, cursor, viewport, renderer)
+            }
+
+            fn is_over(
+                &self,
+                layout: Layout<'_>,
+                renderer: &Renderer,
+                cursor_position: Point,
+            ) -> bool {
+                self.content.is_over(layout, renderer, cursor_position)
+            }
+
+            fn overlay<'b>(
+                &'b mut self,
+                layout: Layout<'_>,
+                renderer: &Renderer,
+            ) -> Option<overlay::Element<'b, Message, AnyTheme, Renderer>>
+            {
+                self.content
+                    .overlay(layout, renderer)
+                    .map(|content| Overlay {
+                        theme: self.theme,
+                        content,
+                    })
+                    .map(|overlay| {
+                        overlay::Element::new(Point::ORIGIN, Box::new(overlay))
+                    })
+            }
+        }
+
+        self.content
+            .as_widget_mut()
+            .overlay(tree, layout, renderer)
+            .map(|content| Overlay {
+                theme: &self.theme,
+                content,
+            })
+            .map(|overlay| {
+                overlay::Element::new(Point::ORIGIN, Box::new(overlay))
+            })
+    }
+}
+
+impl<'a, AnyTheme, Message, Theme, Renderer>
+    From<Themer<'a, Message, Theme, Renderer>>
+    for Element<'a, Message, AnyTheme, Renderer>
+where
+    Message: 'a,
+    Theme: 'a,
+    Renderer: 'a + crate::core::Renderer,
+{
+    fn from(
+        themer: Themer<'a, Message, Theme, Renderer>,
+    ) -> Element<'a, Message, AnyTheme, Renderer> {
+        Element::new(themer)
+    }
+}

--- a/widget/src/toggler.rs
+++ b/widget/src/toggler.rs
@@ -21,7 +21,7 @@ pub use crate::style::toggler::{Appearance, StyleSheet};
 ///
 /// ```no_run
 /// # type Toggler<'a, Message> =
-/// #     iced_widget::Toggler<'a, Message, iced_widget::renderer::Renderer<iced_widget::style::Theme>>;
+/// #     iced_widget::Toggler<'a, Message, iced_widget::style::Theme, iced_widget::renderer::Renderer>;
 /// #
 /// pub enum Message {
 ///     TogglerToggled(bool),
@@ -32,10 +32,14 @@ pub use crate::style::toggler::{Appearance, StyleSheet};
 /// Toggler::new(String::from("Toggle me!"), is_toggled, |b| Message::TogglerToggled(b));
 /// ```
 #[allow(missing_debug_implementations)]
-pub struct Toggler<'a, Message, Renderer = crate::Renderer>
-where
+pub struct Toggler<
+    'a,
+    Message,
+    Theme = crate::Theme,
+    Renderer = crate::Renderer,
+> where
+    Theme: StyleSheet,
     Renderer: text::Renderer,
-    Renderer::Theme: StyleSheet,
 {
     is_toggled: bool,
     on_toggle: Box<dyn Fn(bool) -> Message + 'a>,
@@ -48,13 +52,13 @@ where
     text_shaping: text::Shaping,
     spacing: f32,
     font: Option<Renderer::Font>,
-    style: <Renderer::Theme as StyleSheet>::Style,
+    style: Theme::Style,
 }
 
-impl<'a, Message, Renderer> Toggler<'a, Message, Renderer>
+impl<'a, Message, Theme, Renderer> Toggler<'a, Message, Theme, Renderer>
 where
+    Theme: StyleSheet,
     Renderer: text::Renderer,
-    Renderer::Theme: StyleSheet,
 {
     /// The default size of a [`Toggler`].
     pub const DEFAULT_SIZE: f32 = 20.0;
@@ -145,20 +149,17 @@ where
     }
 
     /// Sets the style of the [`Toggler`].
-    pub fn style(
-        mut self,
-        style: impl Into<<Renderer::Theme as StyleSheet>::Style>,
-    ) -> Self {
+    pub fn style(mut self, style: impl Into<Theme::Style>) -> Self {
         self.style = style.into();
         self
     }
 }
 
-impl<'a, Message, Renderer> Widget<Message, Renderer>
-    for Toggler<'a, Message, Renderer>
+impl<'a, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
+    for Toggler<'a, Message, Theme, Renderer>
 where
+    Theme: StyleSheet + crate::text::StyleSheet,
     Renderer: text::Renderer,
-    Renderer::Theme: StyleSheet + crate::text::StyleSheet,
 {
     fn tag(&self) -> tree::Tag {
         tree::Tag::of::<widget::text::State<Renderer::Paragraph>>()
@@ -261,7 +262,7 @@ where
         &self,
         tree: &Tree,
         renderer: &mut Renderer,
-        theme: &Renderer::Theme,
+        theme: &Theme,
         style: &renderer::Style,
         layout: Layout<'_>,
         cursor: mouse::Cursor,
@@ -349,16 +350,16 @@ where
     }
 }
 
-impl<'a, Message, Renderer> From<Toggler<'a, Message, Renderer>>
-    for Element<'a, Message, Renderer>
+impl<'a, Message, Theme, Renderer> From<Toggler<'a, Message, Theme, Renderer>>
+    for Element<'a, Message, Theme, Renderer>
 where
     Message: 'a,
-    Renderer: 'a + text::Renderer,
-    Renderer::Theme: StyleSheet + crate::text::StyleSheet,
+    Theme: StyleSheet + crate::text::StyleSheet + 'a,
+    Renderer: text::Renderer + 'a,
 {
     fn from(
-        toggler: Toggler<'a, Message, Renderer>,
-    ) -> Element<'a, Message, Renderer> {
+        toggler: Toggler<'a, Message, Theme, Renderer>,
+    ) -> Element<'a, Message, Theme, Renderer> {
         Element::new(toggler)
     }
 }

--- a/widget/src/vertical_slider.rs
+++ b/widget/src/vertical_slider.rs
@@ -28,7 +28,7 @@ use crate::core::{
 /// # Example
 /// ```no_run
 /// # type VerticalSlider<'a, T, Message> =
-/// #     iced_widget::VerticalSlider<'a, T, Message, iced_widget::renderer::Renderer<iced_widget::style::Theme>>;
+/// #     iced_widget::VerticalSlider<'a, T, Message, iced_widget::style::Theme>;
 /// #
 /// #[derive(Clone)]
 /// pub enum Message {
@@ -40,10 +40,9 @@ use crate::core::{
 /// VerticalSlider::new(0.0..=100.0, value, Message::SliderChanged);
 /// ```
 #[allow(missing_debug_implementations)]
-pub struct VerticalSlider<'a, T, Message, Renderer = crate::Renderer>
+pub struct VerticalSlider<'a, T, Message, Theme = crate::Theme>
 where
-    Renderer: core::Renderer,
-    Renderer::Theme: StyleSheet,
+    Theme: StyleSheet,
 {
     range: RangeInclusive<T>,
     step: T,
@@ -52,15 +51,14 @@ where
     on_release: Option<Message>,
     width: f32,
     height: Length,
-    style: <Renderer::Theme as StyleSheet>::Style,
+    style: Theme::Style,
 }
 
-impl<'a, T, Message, Renderer> VerticalSlider<'a, T, Message, Renderer>
+impl<'a, T, Message, Theme> VerticalSlider<'a, T, Message, Theme>
 where
     T: Copy + From<u8> + std::cmp::PartialOrd,
     Message: Clone,
-    Renderer: core::Renderer,
-    Renderer::Theme: StyleSheet,
+    Theme: StyleSheet,
 {
     /// The default width of a [`VerticalSlider`].
     pub const DEFAULT_WIDTH: f32 = 22.0;
@@ -125,10 +123,7 @@ where
     }
 
     /// Sets the style of the [`VerticalSlider`].
-    pub fn style(
-        mut self,
-        style: impl Into<<Renderer::Theme as StyleSheet>::Style>,
-    ) -> Self {
+    pub fn style(mut self, style: impl Into<Theme::Style>) -> Self {
         self.style = style.into();
         self
     }
@@ -140,13 +135,13 @@ where
     }
 }
 
-impl<'a, T, Message, Renderer> Widget<Message, Renderer>
-    for VerticalSlider<'a, T, Message, Renderer>
+impl<'a, T, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
+    for VerticalSlider<'a, T, Message, Theme>
 where
     T: Copy + Into<f64> + num_traits::FromPrimitive,
     Message: Clone,
+    Theme: StyleSheet,
     Renderer: core::Renderer,
-    Renderer::Theme: StyleSheet,
 {
     fn tag(&self) -> tree::Tag {
         tree::Tag::of::<State>()
@@ -201,7 +196,7 @@ where
         &self,
         tree: &Tree,
         renderer: &mut Renderer,
-        theme: &Renderer::Theme,
+        theme: &Theme,
         _style: &renderer::Style,
         layout: Layout<'_>,
         cursor: mouse::Cursor,
@@ -231,17 +226,18 @@ where
     }
 }
 
-impl<'a, T, Message, Renderer> From<VerticalSlider<'a, T, Message, Renderer>>
-    for Element<'a, Message, Renderer>
+impl<'a, T, Message, Theme, Renderer>
+    From<VerticalSlider<'a, T, Message, Theme>>
+    for Element<'a, Message, Theme, Renderer>
 where
-    T: 'a + Copy + Into<f64> + num_traits::FromPrimitive,
-    Message: 'a + Clone,
-    Renderer: 'a + core::Renderer,
-    Renderer::Theme: StyleSheet,
+    T: Copy + Into<f64> + num_traits::FromPrimitive + 'a,
+    Message: Clone + 'a,
+    Theme: StyleSheet + 'a,
+    Renderer: core::Renderer + 'a,
 {
     fn from(
-        slider: VerticalSlider<'a, T, Message, Renderer>,
-    ) -> Element<'a, Message, Renderer> {
+        slider: VerticalSlider<'a, T, Message, Theme>,
+    ) -> Element<'a, Message, Theme, Renderer> {
         Element::new(slider)
     }
 }
@@ -337,19 +333,19 @@ where
 }
 
 /// Draws a [`VerticalSlider`].
-pub fn draw<T, R>(
-    renderer: &mut R,
+pub fn draw<T, Theme, Renderer>(
+    renderer: &mut Renderer,
     layout: Layout<'_>,
     cursor: mouse::Cursor,
     state: &State,
     value: T,
     range: &RangeInclusive<T>,
-    style_sheet: &dyn StyleSheet<Style = <R::Theme as StyleSheet>::Style>,
-    style: &<R::Theme as StyleSheet>::Style,
+    style_sheet: &Theme,
+    style: &Theme::Style,
 ) where
     T: Into<f64> + Copy,
-    R: core::Renderer,
-    R::Theme: StyleSheet,
+    Theme: StyleSheet,
+    Renderer: core::Renderer,
 {
     let bounds = layout.bounds();
     let is_mouse_over = cursor.is_over(bounds);

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -39,7 +39,7 @@ use std::sync::Arc;
 /// can be toggled by pressing `F12`.
 pub trait Application: Program
 where
-    <Self::Renderer as core::Renderer>::Theme: StyleSheet,
+    Self::Theme: StyleSheet,
 {
     /// The data needed to initialize your [`Application`].
     type Flags;
@@ -61,12 +61,10 @@ where
     fn title(&self) -> String;
 
     /// Returns the current `Theme` of the [`Application`].
-    fn theme(&self) -> <Self::Renderer as core::Renderer>::Theme;
+    fn theme(&self) -> Self::Theme;
 
     /// Returns the `Style` variation of the `Theme`.
-    fn style(
-        &self,
-    ) -> <<Self::Renderer as core::Renderer>::Theme as StyleSheet>::Style {
+    fn style(&self) -> <Self::Theme as StyleSheet>::Style {
         Default::default()
     }
 
@@ -107,7 +105,7 @@ where
     A: Application + 'static,
     E: Executor + 'static,
     C: Compositor<Renderer = A::Renderer> + 'static,
-    <A::Renderer as core::Renderer>::Theme: StyleSheet,
+    A::Theme: StyleSheet,
 {
     use futures::task;
     use futures::Future;
@@ -258,7 +256,7 @@ async fn run_instance<A, E, C>(
     A: Application + 'static,
     E: Executor + 'static,
     C: Compositor<Renderer = A::Renderer> + 'static,
-    <A::Renderer as core::Renderer>::Theme: StyleSheet,
+    A::Theme: StyleSheet,
 {
     use futures::stream::StreamExt;
     use winit::event;
@@ -579,9 +577,9 @@ pub fn build_user_interface<'a, A: Application>(
     renderer: &mut A::Renderer,
     size: Size,
     debug: &mut Debug,
-) -> UserInterface<'a, A::Message, A::Renderer>
+) -> UserInterface<'a, A::Message, A::Theme, A::Renderer>
 where
-    <A::Renderer as core::Renderer>::Theme: StyleSheet,
+    A::Theme: StyleSheet,
 {
     debug.view_started();
     let view = application.view();
@@ -612,7 +610,7 @@ pub fn update<A: Application, C, E: Executor>(
     window: &winit::window::Window,
 ) where
     C: Compositor<Renderer = A::Renderer> + 'static,
-    <A::Renderer as core::Renderer>::Theme: StyleSheet,
+    A::Theme: StyleSheet,
 {
     for message in messages.drain(..) {
         debug.log_message(&message);
@@ -663,7 +661,7 @@ pub fn run_command<A, C, E>(
     A: Application,
     E: Executor,
     C: Compositor<Renderer = A::Renderer> + 'static,
-    <A::Renderer as core::Renderer>::Theme: StyleSheet,
+    A::Theme: StyleSheet,
 {
     use crate::runtime::command;
     use crate::runtime::system;

--- a/winit/src/application/state.rs
+++ b/winit/src/application/state.rs
@@ -1,6 +1,5 @@
 use crate::application::{self, StyleSheet as _};
 use crate::conversion;
-use crate::core;
 use crate::core::mouse;
 use crate::core::{Color, Size};
 use crate::graphics::Viewport;
@@ -15,7 +14,7 @@ use winit::window::Window;
 #[allow(missing_debug_implementations)]
 pub struct State<A: Application>
 where
-    <A::Renderer as core::Renderer>::Theme: application::StyleSheet,
+    A::Theme: application::StyleSheet,
 {
     title: String,
     scale_factor: f64,
@@ -23,14 +22,14 @@ where
     viewport_version: usize,
     cursor_position: Option<winit::dpi::PhysicalPosition<f64>>,
     modifiers: winit::keyboard::ModifiersState,
-    theme: <A::Renderer as core::Renderer>::Theme,
+    theme: A::Theme,
     appearance: application::Appearance,
     application: PhantomData<A>,
 }
 
 impl<A: Application> State<A>
 where
-    <A::Renderer as core::Renderer>::Theme: application::StyleSheet,
+    A::Theme: application::StyleSheet,
 {
     /// Creates a new [`State`] for the provided [`Application`] and window.
     pub fn new(application: &A, window: &Window) -> Self {
@@ -107,7 +106,7 @@ where
     }
 
     /// Returns the current theme of the [`State`].
-    pub fn theme(&self) -> &<A::Renderer as core::Renderer>::Theme {
+    pub fn theme(&self) -> &A::Theme {
         &self.theme
     }
 

--- a/winit/src/multi_window.rs
+++ b/winit/src/multi_window.rs
@@ -40,7 +40,7 @@ use std::time::Instant;
 /// can be toggled by pressing `F12`.
 pub trait Application: Program
 where
-    <Self::Renderer as core::Renderer>::Theme: StyleSheet,
+    Self::Theme: StyleSheet,
 {
     /// The data needed to initialize your [`Application`].
     type Flags;
@@ -62,15 +62,10 @@ where
     fn title(&self, window: window::Id) -> String;
 
     /// Returns the current `Theme` of the [`Application`].
-    fn theme(
-        &self,
-        window: window::Id,
-    ) -> <Self::Renderer as core::Renderer>::Theme;
+    fn theme(&self, window: window::Id) -> Self::Theme;
 
     /// Returns the `Style` variation of the `Theme`.
-    fn style(
-        &self,
-    ) -> <<Self::Renderer as core::Renderer>::Theme as StyleSheet>::Style {
+    fn style(&self) -> <Self::Theme as StyleSheet>::Style {
         Default::default()
     }
 
@@ -112,7 +107,7 @@ where
     A: Application + 'static,
     E: Executor + 'static,
     C: Compositor<Renderer = A::Renderer> + 'static,
-    <A::Renderer as core::Renderer>::Theme: StyleSheet,
+    A::Theme: StyleSheet,
 {
     use winit::event_loop::EventLoopBuilder;
 
@@ -325,7 +320,7 @@ async fn run_instance<A, E, C>(
     A: Application + 'static,
     E: Executor + 'static,
     C: Compositor<Renderer = A::Renderer> + 'static,
-    <A::Renderer as core::Renderer>::Theme: StyleSheet,
+    A::Theme: StyleSheet,
 {
     use winit::event;
     use winit::event_loop::ControlFlow;
@@ -793,9 +788,9 @@ fn build_user_interface<'a, A: Application>(
     size: Size,
     debug: &mut Debug,
     id: window::Id,
-) -> UserInterface<'a, A::Message, A::Renderer>
+) -> UserInterface<'a, A::Message, A::Theme, A::Renderer>
 where
-    <A::Renderer as core::Renderer>::Theme: StyleSheet,
+    A::Theme: StyleSheet,
 {
     debug.view_started();
     let view = application.view(id);
@@ -823,7 +818,7 @@ fn update<A: Application, C, E: Executor>(
     ui_caches: &mut HashMap<window::Id, user_interface::Cache>,
 ) where
     C: Compositor<Renderer = A::Renderer> + 'static,
-    <A::Renderer as core::Renderer>::Theme: StyleSheet,
+    A::Theme: StyleSheet,
 {
     for message in messages.drain(..) {
         debug.log_message(&message);
@@ -866,7 +861,7 @@ fn run_command<A, C, E>(
     A: Application,
     E: Executor,
     C: Compositor<Renderer = A::Renderer> + 'static,
-    <A::Renderer as core::Renderer>::Theme: StyleSheet,
+    A::Theme: StyleSheet,
 {
     use crate::runtime::clipboard;
     use crate::runtime::system;
@@ -1142,9 +1137,9 @@ pub fn build_user_interfaces<'a, A: Application, C: Compositor>(
     debug: &mut Debug,
     window_manager: &mut WindowManager<A, C>,
     mut cached_user_interfaces: HashMap<window::Id, user_interface::Cache>,
-) -> HashMap<window::Id, UserInterface<'a, A::Message, A::Renderer>>
+) -> HashMap<window::Id, UserInterface<'a, A::Message, A::Theme, A::Renderer>>
 where
-    <A::Renderer as core::Renderer>::Theme: StyleSheet,
+    A::Theme: StyleSheet,
     C: Compositor<Renderer = A::Renderer>,
 {
     cached_user_interfaces

--- a/winit/src/multi_window/state.rs
+++ b/winit/src/multi_window/state.rs
@@ -1,5 +1,4 @@
 use crate::conversion;
-use crate::core;
 use crate::core::{mouse, window};
 use crate::core::{Color, Size};
 use crate::graphics::Viewport;
@@ -14,7 +13,7 @@ use winit::window::Window;
 /// The state of a multi-windowed [`Application`].
 pub struct State<A: Application>
 where
-    <A::Renderer as core::Renderer>::Theme: application::StyleSheet,
+    A::Theme: application::StyleSheet,
 {
     title: String,
     scale_factor: f64,
@@ -22,13 +21,13 @@ where
     viewport_version: u64,
     cursor_position: Option<winit::dpi::PhysicalPosition<f64>>,
     modifiers: winit::keyboard::ModifiersState,
-    theme: <A::Renderer as core::Renderer>::Theme,
+    theme: A::Theme,
     appearance: application::Appearance,
 }
 
 impl<A: Application> Debug for State<A>
 where
-    <A::Renderer as core::Renderer>::Theme: application::StyleSheet,
+    A::Theme: application::StyleSheet,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("multi_window::State")
@@ -44,7 +43,7 @@ where
 
 impl<A: Application> State<A>
 where
-    <A::Renderer as core::Renderer>::Theme: application::StyleSheet,
+    A::Theme: application::StyleSheet,
 {
     /// Creates a new [`State`] for the provided [`Application`]'s `window`.
     pub fn new(
@@ -124,7 +123,7 @@ where
     }
 
     /// Returns the current theme of the [`State`].
-    pub fn theme(&self) -> &<A::Renderer as core::Renderer>::Theme {
+    pub fn theme(&self) -> &A::Theme {
         &self.theme
     }
 

--- a/winit/src/multi_window/window_manager.rs
+++ b/winit/src/multi_window/window_manager.rs
@@ -12,7 +12,7 @@ use winit::monitor::MonitorHandle;
 #[allow(missing_debug_implementations)]
 pub struct WindowManager<A: Application, C: Compositor>
 where
-    <A::Renderer as crate::core::Renderer>::Theme: StyleSheet,
+    A::Theme: StyleSheet,
     C: Compositor<Renderer = A::Renderer>,
 {
     aliases: BTreeMap<winit::window::WindowId, Id>,
@@ -23,7 +23,7 @@ impl<A, C> WindowManager<A, C>
 where
     A: Application,
     C: Compositor<Renderer = A::Renderer>,
-    <A::Renderer as crate::core::Renderer>::Theme: StyleSheet,
+    A::Theme: StyleSheet,
 {
     pub fn new() -> Self {
         Self {
@@ -109,7 +109,7 @@ impl<A, C> Default for WindowManager<A, C>
 where
     A: Application,
     C: Compositor<Renderer = A::Renderer>,
-    <A::Renderer as crate::core::Renderer>::Theme: StyleSheet,
+    A::Theme: StyleSheet,
 {
     fn default() -> Self {
         Self::new()
@@ -121,7 +121,7 @@ pub struct Window<A, C>
 where
     A: Application,
     C: Compositor<Renderer = A::Renderer>,
-    <A::Renderer as crate::core::Renderer>::Theme: StyleSheet,
+    A::Theme: StyleSheet,
 {
     pub raw: Arc<winit::window::Window>,
     pub state: State<A>,
@@ -136,7 +136,7 @@ impl<A, C> Window<A, C>
 where
     A: Application,
     C: Compositor<Renderer = A::Renderer>,
-    <A::Renderer as crate::core::Renderer>::Theme: StyleSheet,
+    A::Theme: StyleSheet,
 {
     pub fn position(&self) -> Option<Point> {
         self.raw


### PR DESCRIPTION
This PR removes the `Theme` associated type in the `Renderer` trait and introduces a `Theme` generic type in `Widget` instead.

Additionally, this PR implements a new widget: `Themer`, which can be used to apply any given theme type to any subtree of the `view` tree.