### PR TITLE
tiny_skia: Add a capacity limit to `GlyphCache`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use `Radians` for angle fields in `Arc` and `arc::Elliptical`. [#2027](https://github.com/iced-rs/iced/pull/2027)
 - Assert dimensions of quads are normal in `iced_tiny_skia`. [#2082](https://github.com/iced-rs/iced/pull/2082)
 - Remove `position` from `overlay::Element`. [#2226](https://github.com/iced-rs/iced/pull/2226)
+- Add a capacity limit to the `GlyphCache` in `iced_tiny_skia`. [#2210](https://github.com/iced-rs/iced/pull/2210)
 
 ### Fixed
 - Clipping of `TextInput` selection. [#2199](https://github.com/iced-rs/iced/pull/2199)
@@ -126,6 +127,7 @@ Many thanks to...
 - @lufte
 - @matze
 - @MichalLebeda
+- @MoSal
 - @MrAntix
 - @nicksenger
 - @Nisatru

--- a/tiny_skia/src/text.rs
+++ b/tiny_skia/src/text.rs
@@ -273,6 +273,7 @@ struct GlyphCache {
 
 impl GlyphCache {
     const TRIM_INTERVAL: usize = 300;
+    const CAPACITY_LIMIT: usize = 16 * 1024;
 
     fn new() -> Self {
         GlyphCache::default()
@@ -359,11 +360,16 @@ impl GlyphCache {
     }
 
     pub fn trim(&mut self) {
-        if self.trim_count > Self::TRIM_INTERVAL {
+        if self.trim_count > Self::TRIM_INTERVAL
+            || self.recently_used.len() >= Self::CAPACITY_LIMIT
+        {
             self.entries
                 .retain(|key, _| self.recently_used.contains(key));
 
             self.recently_used.clear();
+
+            self.entries.shrink_to(Self::CAPACITY_LIMIT);
+            self.recently_used.shrink_to(Self::CAPACITY_LIMIT);
 
             self.trim_count = 0;
         } else {


### PR DESCRIPTION
 * Trim the cache if `recently_used` size reaches the limit, even if a trim interval hasn't passed.
 * Shrink `entries` and `recently_used` to the limit when trimming.