### PR TITLE
feat(window): adds skip_taskbar for windows

### DIFF
--- a/core/src/window/settings/windows.rs
+++ b/core/src/window/settings/windows.rs
@@ -9,6 +9,9 @@ pub struct PlatformSpecific {
 
     /// Drag and drop support
     pub drag_and_drop: bool,
+
+    /// Whether show or hide the window icon in the taskbar.
+    pub skip_taskbar: bool,
 }
 
 impl Default for PlatformSpecific {
@@ -16,6 +19,7 @@ impl Default for PlatformSpecific {
         Self {
             parent: None,
             drag_and_drop: true,
+            skip_taskbar: false,
         }
     }
 }

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -84,6 +84,9 @@ pub fn window_settings(
         }
         window_builder = window_builder
             .with_drag_and_drop(settings.platform_specific.drag_and_drop);
+
+        window_builder = window_builder
+            .with_skip_taskbar(settings.platform_specific.skip_taskbar);
     }
 
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
Trivial to add into the current way PlatformSpecific is implemented.

It would allow me to write a task tray app for windows.