### PR TITLE
Custom tooltips

### DIFF
--- a/examples/tooltip/src/main.rs
+++ b/examples/tooltip/src/main.rs
@@ -1,6 +1,6 @@
 use iced::theme;
 use iced::widget::tooltip::Position;
-use iced::widget::{button, container, tooltip};
+use iced::widget::{button, column, container, progress_bar, tooltip};
 use iced::{Element, Length, Sandbox, Settings};
 
 pub fn main() -> iced::Result {
@@ -9,11 +9,13 @@ pub fn main() -> iced::Result {
 
 struct Example {
     position: Position,
+    progress: f32,
 }
 
 #[derive(Debug, Clone)]
 enum Message {
     ChangePosition,
+    IncreaseProgress,
 }
 
 impl Sandbox for Example {
@@ -22,6 +24,7 @@ impl Sandbox for Example {
     fn new() -> Self {
         Self {
             position: Position::Bottom,
+            progress: 0.0,
         }
     }
 
@@ -42,11 +45,17 @@ impl Sandbox for Example {
 
                 self.position = position;
             }
+            Message::IncreaseProgress => {
+                if self.progress >= 1.0 {
+                    self.progress = 0.0;
+                }
+                self.progress += 0.1;
+            }
         }
     }
 
     fn view(&self) -> Element<Message> {
-        let tooltip = tooltip(
+        let positioned_tooltip = tooltip(
             button("Press to change position")
                 .on_press(Message::ChangePosition),
             position_to_text(self.position),
@@ -55,7 +64,18 @@ impl Sandbox for Example {
         .gap(10)
         .style(theme::Container::Box);
 
-        container(tooltip)
+        let progress_tooltip = tooltip(
+            button("Press to increase progress")
+                .on_press(Message::IncreaseProgress),
+            progress_bar(0.0..=1.0, self.progress).width(Length::Fixed(100.0)),
+            self.position,
+        );
+
+        let tooltips = column![positioned_tooltip, progress_tooltip]
+            .spacing(100)
+            .align_items(iced::Alignment::Center);
+
+        container(tooltips)
             .width(Length::Fill)
             .height(Length::Fill)
             .center_x()

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -129,14 +129,14 @@ where
 /// [`tooltip::Position`]: crate::tooltip::Position
 pub fn tooltip<'a, Message, Theme, Renderer>(
     content: impl Into<Element<'a, Message, Theme, Renderer>>,
-    tooltip: impl ToString,
+    tooltip: impl Into<Text<'a, Theme, Renderer>>,
     position: tooltip::Position,
 ) -> crate::Tooltip<'a, Message, Theme, Renderer>
 where
     Theme: container::StyleSheet + text::StyleSheet,
     Renderer: core::text::Renderer,
 {
-    Tooltip::new(content, tooltip.to_string(), position)
+    Tooltip::new(content, tooltip, position)
 }
 
 /// Creates a new [`Text`] widget with the provided content.

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -129,7 +129,7 @@ where
 /// [`tooltip::Position`]: crate::tooltip::Position
 pub fn tooltip<'a, Message, Theme, Renderer>(
     content: impl Into<Element<'a, Message, Theme, Renderer>>,
-    tooltip: impl Into<Text<'a, Theme, Renderer>>,
+    tooltip: impl Into<Element<'a, Message, Theme, Renderer>>,
     position: tooltip::Position,
 ) -> crate::Tooltip<'a, Message, Theme, Renderer>
 where

--- a/widget/src/tooltip.rs
+++ b/widget/src/tooltip.rs
@@ -13,8 +13,6 @@ use crate::core::{
 };
 use crate::Text;
 
-use std::borrow::Cow;
-
 /// An element to display a widget over another.
 #[allow(missing_debug_implementations)]
 pub struct Tooltip<
@@ -48,12 +46,12 @@ where
     /// [`Tooltip`]: struct.Tooltip.html
     pub fn new(
         content: impl Into<Element<'a, Message, Theme, Renderer>>,
-        tooltip: impl Into<Cow<'a, str>>,
+        tooltip: impl Into<Text<'a, Theme, Renderer>>,
         position: Position,
     ) -> Self {
         Tooltip {
             content: content.into(),
-            tooltip: Text::new(tooltip),
+            tooltip: tooltip.into(),
             position,
             gap: 0.0,
             padding: Self::DEFAULT_PADDING,

--- a/widget/src/tooltip.rs
+++ b/widget/src/tooltip.rs
@@ -60,26 +60,6 @@ where
         }
     }
 
-    /// Sets the size of the text of the [`Tooltip`].
-    pub fn size(mut self, size: impl Into<Pixels>) -> Self {
-        self.tooltip = self.tooltip.size(size);
-        self
-    }
-
-    /// Sets the [`text::Shaping`] strategy of the [`Tooltip`].
-    pub fn text_shaping(mut self, shaping: text::Shaping) -> Self {
-        self.tooltip = self.tooltip.shaping(shaping);
-        self
-    }
-
-    /// Sets the font of the [`Tooltip`].
-    ///
-    /// [`Font`]: Renderer::Font
-    pub fn font(mut self, font: impl Into<Renderer::Font>) -> Self {
-        self.tooltip = self.tooltip.font(font);
-        self
-    }
-
     /// Sets the gap between the content and its [`Tooltip`].
     pub fn gap(mut self, gap: impl Into<Pixels>) -> Self {
         self.gap = gap.into().0;

--- a/widget/src/tooltip.rs
+++ b/widget/src/tooltip.rs
@@ -211,6 +211,7 @@ where
         tree: &'b mut widget::Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
+        translation: Vector,
     ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
         let state = tree.state.downcast_ref::<State>();
 
@@ -226,12 +227,13 @@ where
             Some(overlay::Element::new(
                 layout.position(),
                 Box::new(Overlay {
+                    position: layout.position() + translation,
                     tooltip: &self.tooltip,
                     state: children.next().unwrap(),
                     cursor_position,
                     content_bounds: layout.bounds(),
                     snap_within_viewport: self.snap_within_viewport,
-                    position: self.position,
+                    positioning: self.position,
                     gap: self.gap,
                     padding: self.padding,
                     style: &self.style,
@@ -297,12 +299,13 @@ where
     Theme: container::StyleSheet + widget::text::StyleSheet,
     Renderer: text::Renderer,
 {
+    position: Point,
     tooltip: &'b Element<'a, Message, Theme, Renderer>,
     state: &'b mut widget::Tree,
     cursor_position: Point,
     content_bounds: Rectangle,
     snap_within_viewport: bool,
-    position: Position,
+    positioning: Position,
     gap: f32,
     padding: f32,
     style: &'b <Theme as container::StyleSheet>::Style,
@@ -338,37 +341,44 @@ where
         );
 
         let text_bounds = text_layout.bounds();
-        let x_center =
-            position.x + (self.content_bounds.width - text_bounds.width) / 2.0;
-        let y_center = position.y
+        let x_center = self.position.x
+            + (self.content_bounds.width - text_bounds.width) / 2.0;
+        let y_center = self.position.y
             + (self.content_bounds.height - text_bounds.height) / 2.0;
 
         let mut tooltip_bounds = {
-            let offset = match self.position {
+            let offset = match self.positioning {
                 Position::Top => Vector::new(
                     x_center,
-                    position.y - text_bounds.height - self.gap - self.padding,
+                    self.position.y
+                        - text_bounds.height
+                        - self.gap
+                        - self.padding,
                 ),
                 Position::Bottom => Vector::new(
                     x_center,
-                    position.y
+                    self.position.y
                         + self.content_bounds.height
                         + self.gap
                         + self.padding,
                 ),
                 Position::Left => Vector::new(
-                    position.x - text_bounds.width - self.gap - self.padding,
+                    self.position.x
+                        - text_bounds.width
+                        - self.gap
+                        - self.padding,
                     y_center,
                 ),
                 Position::Right => Vector::new(
-                    position.x
+                    self.position.x
                         + self.content_bounds.width
                         + self.gap
                         + self.padding,
                     y_center,
                 ),
                 Position::FollowCursor => {
-                    let translation = position - self.content_bounds.position();
+                    let translation =
+                        self.position - self.content_bounds.position();
 
                     Vector::new(
                         self.cursor_position.x,


### PR DESCRIPTION
I refactored the Tooltip::new and the helper::tooltip functions to take in an impl Into<Element> object instead of an impl Into<&str>. This allows for more customization of what is displayed on the tooltip. It also allows us to clean up the tooltip methods since size, text shaping, and font can be changed outside of the Tooltip structure simply by passing in a Text element.

This also doesn't necessarily add complexity to creating a tooltip since we can create a basic text element from a string slice. 

I also expanded on the tooltip example in order to demonstrate its new capabilities. There's an additional button that has a tooltip which display a progress bar. Each time the button is clicked the progress bar increments by 10% and then wraps back down to 0%. 

https://github.com/iced-rs/iced/assets/157531866/f2adcd23-9a49-47b2-b8f6-904e05e22cb9

Thank you