### PR TITLE
Workaround issue with winit on windows not resuming the event loop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Slow touch scrolling for `TextEditor` widget. [#2140](https://github.com/iced-rs/iced/pull/2140)
 - `Subscription::map` using unreliable function pointer hash to identify mappers. [#2237](https://github.com/iced-rs/iced/pull/2237)
 - Missing feature flag docs for `time::every`. [#2188](https://github.com/iced-rs/iced/pull/2188)
+- Event loop not being resumed on Windows while resizing. [#2214](https://github.com/iced-rs/iced/pull/2214)
 
 Many thanks to...
 

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -213,8 +213,7 @@ where
 
     let mut context = task::Context::from_waker(task::noop_waker_ref());
 
-    #[allow(unused_mut)]
-    let mut process_event =
+    let process_event =
         move |event, event_loop: &winit::event_loop::EventLoopWindowTarget<_>| {
             if event_loop.exiting() {
                 return;
@@ -244,20 +243,24 @@ where
     // since the event loop does not resume during resize interaction.
     // More details: https://github.com/rust-windowing/winit/issues/3272
     #[cfg(target_os = "windows")]
-    let _ = event_loop.run(move |event, event_loop| {
-        if matches!(
-            event,
-            winit::event::Event::WindowEvent {
-                event: winit::event::WindowEvent::Resized(_),
-                ..
+    {
+        let mut process_event = process_event;
+
+        let _ = event_loop.run(move |event, event_loop| {
+            if matches!(
+                event,
+                winit::event::Event::WindowEvent {
+                    event: winit::event::WindowEvent::Resized(_),
+                    ..
+                }
+            ) {
+                process_event(event, event_loop);
+                process_event(winit::event::Event::AboutToWait, event_loop);
+            } else {
+                process_event(event, event_loop);
             }
-        ) {
-            process_event(event, event_loop);
-            process_event(winit::event::Event::AboutToWait, event_loop);
-        } else {
-            process_event(event, event_loop);
-        }
-    });
+        });
+    }
 
     Ok(())
 }

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -213,25 +213,50 @@ where
 
     let mut context = task::Context::from_waker(task::noop_waker_ref());
 
-    let _ = event_loop.run(move |event, event_loop| {
-        if event_loop.exiting() {
-            return;
-        }
+    #[allow(unused_mut)]
+    let mut process_event =
+        move |event, event_loop: &winit::event_loop::EventLoopWindowTarget<_>| {
+            if event_loop.exiting() {
+                return;
+            }
 
-        event_sender.start_send(event).expect("Send event");
+            event_sender.start_send(event).expect("Send event");
 
-        let poll = instance.as_mut().poll(&mut context);
+            let poll = instance.as_mut().poll(&mut context);
 
-        match poll {
-            task::Poll::Pending => {
-                if let Ok(Some(flow)) = control_receiver.try_next() {
-                    event_loop.set_control_flow(flow);
+            match poll {
+                task::Poll::Pending => {
+                    if let Ok(Some(flow)) = control_receiver.try_next() {
+                        event_loop.set_control_flow(flow);
+                    }
+                }
+                task::Poll::Ready(_) => {
+                    event_loop.exit();
                 }
             }
-            task::Poll::Ready(_) => {
-                event_loop.exit();
-            }
         };
+
+    #[cfg(not(target_os = "windows"))]
+    let _ = event_loop.run(process_event);
+
+    // TODO: Remove when unnecessary
+    // On Windows, we emulate an `AboutToWait` event after every `Resized` event
+    // since the event loop does not resume during resize interaction.
+    // More details: https://github.com/rust-windowing/winit/issues/3272
+    #[cfg(target_os = "windows")]
+    let _ = event_loop.run(move |event, event_loop| {
+        if matches!(
+            event,
+            winit::event::Event::WindowEvent {
+                event: winit::event::WindowEvent::Resized(_),
+                ..
+            }
+        ) {
+            process_event(event, event_loop);
+            process_event(winit::event::Event::AboutToWait, event_loop);
+        } else {
+            process_event(event, event_loop);
+        }
     });
 
     Ok(())


### PR DESCRIPTION
With this fix specific to windows, we can at least process events that are scheduled when the user is resizing the window on win32 platform targets. This workaround can be removed if winit fixes the issue.

Works around: https://github.com/rust-windowing/winit/issues/3272