### PR TITLE
Add border widths to `Toggler` `StyleSheet`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `interaction` method for `MouseArea`. [#2207](https://github.com/iced-rs/iced/pull/2207)
 - `hovered` styling for `Svg` widget. [#2163](https://github.com/iced-rs/iced/pull/2163)
 - Customizable style for `TextEditor`. [#2159](https://github.com/iced-rs/iced/pull/2159)
+- Border width styling for `Toggler`. [#2219](https://github.com/iced-rs/iced/pull/2219)
 - `RawText` variant for `Primitive` in `iced_graphics`. [#2158](https://github.com/iced-rs/iced/pull/2158)
 - `Stream` support for `Command`. [#2150](https://github.com/iced-rs/iced/pull/2150)
 - Access to bounds/content bounds from a `Scrollable` viewport. [#2072](https://github.com/iced-rs/iced/pull/2072)

--- a/style/src/theme.rs
+++ b/style/src/theme.rs
@@ -797,13 +797,15 @@ impl toggler::StyleSheet for Theme {
                     } else {
                         palette.background.strong.color
                     },
-                    background_border: None,
+                    background_border_width: 0.0,
+                    background_border_color: Color::TRANSPARENT,
                     foreground: if is_active {
                         palette.primary.strong.text
                     } else {
                         palette.background.base.color
                     },
-                    foreground_border: None,
+                    foreground_border_width: 0.0,
+                    foreground_border_color: Color::TRANSPARENT,
                 }
             }
             Toggler::Custom(custom) => custom.active(self, is_active),

--- a/style/src/toggler.rs
+++ b/style/src/toggler.rs
@@ -6,12 +6,16 @@ use iced_core::Color;
 pub struct Appearance {
     /// The background [`Color`] of the toggler.
     pub background: Color,
+    /// The width of the background border of the toggler.
+    pub background_border_width: f32,
     /// The [`Color`] of the background border of the toggler.
-    pub background_border: Option<Color>,
+    pub background_border_color: Color,
     /// The foreground [`Color`] of the toggler.
     pub foreground: Color,
+    /// The width of the foreground border of the toggler.
+    pub foreground_border_width: f32,
     /// The [`Color`] of the foreground border of the toggler.
-    pub foreground_border: Option<Color>,
+    pub foreground_border_color: Color,
 }
 
 /// A set of rules that dictate the style of a toggler.

--- a/widget/src/toggler.rs
+++ b/widget/src/toggler.rs
@@ -315,8 +315,8 @@ where
                 bounds: toggler_background_bounds,
                 border: Border {
                     radius: border_radius.into(),
-                    width: 1.0,
-                    color: style.background_border.unwrap_or(style.background),
+                    width: style.background_border_width,
+                    color: style.background_border_color,
                 },
                 ..renderer::Quad::default()
             },
@@ -340,8 +340,8 @@ where
                 bounds: toggler_foreground_bounds,
                 border: Border {
                     radius: border_radius.into(),
-                    width: 1.0,
-                    color: style.foreground_border.unwrap_or(style.foreground),
+                    width: style.foreground_border_width,
+                    color: style.foreground_border_color,
                 },
                 ..renderer::Quad::default()
             },


### PR DESCRIPTION
This PR adds the possibility to customise the border widths of the `Toggler`.
This is needed in some circumstances and makes it consistent with all other widgets, that already have customisable border widths.
In this way we also remove the need to use `Option`s for the toggler border colors.
