### PR TITLE
Use `core::ptr::eq` to speed up `PartialEq` on `image::Bytes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Assert dimensions of quads are normal in `iced_tiny_skia`. [#2082](https://github.com/iced-rs/iced/pull/2082)
 - Remove `position` from `overlay::Element`. [#2226](https://github.com/iced-rs/iced/pull/2226)
 - Add a capacity limit to the `GlyphCache` in `iced_tiny_skia`. [#2210](https://github.com/iced-rs/iced/pull/2210)
+- Use pointer equality to speed up `PartialEq` implementation of `image::Bytes`. [#2220](https://github.com/iced-rs/iced/pull/2220)
 
 ### Fixed
 - Clipping of `TextInput` selection. [#2199](https://github.com/iced-rs/iced/pull/2199)
@@ -114,6 +115,7 @@ Many thanks to...
 - @Davidster
 - @Decodetalkers
 - @derezzedex
+- @DoomDuck
 - @dtzxporter
 - @fogarecious
 - @GyulyVGC

--- a/core/src/image.rs
+++ b/core/src/image.rs
@@ -112,7 +112,9 @@ impl std::hash::Hash for Bytes {
 
 impl PartialEq for Bytes {
     fn eq(&self, other: &Self) -> bool {
-        self.as_ref() == other.as_ref()
+        let a = self.as_ref();
+        let b = other.as_ref();
+        core::ptr::eq(a, b) || a == b
     }
 }
 


### PR DESCRIPTION
## Why
When loading images from memory `iced` takes a long time comparing `image::Handle`s.
To improve its speed using `core::ptr::eq` checks if the slices are identical  both the start pointer and the length.

## Effectiveness
I have not seen the optimization happen in either the standard library nor the results given by the compiler.
I also think I have seen the cost of `image::Handle`'s comparison in some `perf` data.