### PR TITLE
Text editor shrinking to content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `text_shaping` method for `Tooltip`. [#2172](https://github.com/iced-rs/iced/pull/2172)
 - `interaction` method for `MouseArea`. [#2207](https://github.com/iced-rs/iced/pull/2207)
 - `hovered` styling for `Svg` widget. [#2163](https://github.com/iced-rs/iced/pull/2163)
+- `height` method for `TextEditor`. [#2221](https://github.com/iced-rs/iced/pull/2221)
 - Customizable style for `TextEditor`. [#2159](https://github.com/iced-rs/iced/pull/2159)
 - Border width styling for `Toggler`. [#2219](https://github.com/iced-rs/iced/pull/2219)
 - `RawText` variant for `Primitive` in `iced_graphics`. [#2158](https://github.com/iced-rs/iced/pull/2158)
@@ -118,6 +119,7 @@ Many thanks to...
 - @derezzedex
 - @DoomDuck
 - @dtzxporter
+- @Dworv
 - @fogarecious
 - @GyulyVGC
 - @hicaru

--- a/core/src/renderer/null.rs
+++ b/core/src/renderer/null.rs
@@ -150,6 +150,10 @@ impl text::Editor for () {
         Size::ZERO
     }
 
+    fn min_bounds(&self) -> Size {
+        Size::ZERO
+    }
+
     fn update(
         &mut self,
         _new_bounds: Size,

--- a/core/src/text/editor.rs
+++ b/core/src/text/editor.rs
@@ -36,6 +36,10 @@ pub trait Editor: Sized + Default {
     /// Returns the current boundaries of the [`Editor`].
     fn bounds(&self) -> Size;
 
+    /// Returns the minimum boundaries to fit the current contents of
+    /// the [`Editor`].
+    fn min_bounds(&self) -> Size;
+
     /// Updates the [`Editor`] with some new attributes.
     fn update(
         &mut self,

--- a/examples/editor/src/main.rs
+++ b/examples/editor/src/main.rs
@@ -191,6 +191,7 @@ impl Application for Editor {
         column![
             controls,
             text_editor(&self.content)
+                .height(Length::Fill)
                 .on_action(Message::ActionPerformed)
                 .highlight::<Highlighter>(
                     highlighter::Settings {

--- a/graphics/src/text/editor.rs
+++ b/graphics/src/text/editor.rs
@@ -470,6 +470,12 @@ impl editor::Editor for Editor {
         self.internal().bounds
     }
 
+    fn min_bounds(&self) -> Size {
+        let internal = self.internal();
+
+        text::measure(internal.editor.buffer())
+    }
+
     fn update(
         &mut self,
         new_bounds: Size,

--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -139,6 +139,17 @@ where
         self.style = style.into();
         self
     }
+
+    /// Choose whether or not to shrink the size of the editor to its contents.
+    pub fn shrink_to_content(mut self, shrink: bool) -> Self {
+        if shrink {
+            self.height = Length::Shrink;
+        } else {
+            self.height = Length::Fill;
+        }
+
+        self
+    }
 }
 
 /// The content of a [`TextEditor`].
@@ -360,7 +371,17 @@ where
             state.highlighter.borrow_mut().deref_mut(),
         );
 
-        layout::Node::new(limits.max())
+        if self.height == Length::Fill {
+            layout::Node::new(limits.max())
+        } else {
+            let lines_height = self
+                .line_height
+                .to_absolute(self.text_size.unwrap_or(renderer.default_size()))
+                .0
+                * internal.editor.line_count() as f32;
+            let height = lines_height + self.padding.top + self.padding.bottom;
+            layout::Node::new(limits.max_height(height).max())
+        }
     }
 
     fn on_event(


### PR DESCRIPTION
I wanted to have a column with a mix of `text-editor`s and other elements, but the current implementation meant I needed to  create editors with fixed heights so that they wouldn't consume the entire space (not ideal). This PR resolves this issue by giving the option to shrink. Editors still default to filling the limit height.

Example usage: 
```rs
let editor = TextEditor::new(content).shrink_to_content(true);
```

No shrinking:
https://vimeo.com/907639154?share=copy

With shrinking
https://vimeo.com/907639138?share=copy

I'm not super familiar with how general layouts tend to work in GUI development, its possible that there are some oversights in my code and I may have overcomplicated the solution (as far as I could with 20 lines of code).
