### PR TITLE
Small fix to the Information struct docs and fix memory info. in the system_information example.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Clippy map transformations. [#2090](https://github.com/iced-rs/iced/pull/2090)
 - Inline format args for ease of reading. [#2089](https://github.com/iced-rs/iced/pull/2089)
 - Stuck scrolling in `Scrollable` with touch events. [#1940](https://github.com/iced-rs/iced/pull/1940)
+- Incorrect unit in `system::Information`. [#2223](https://github.com/iced-rs/iced/pull/2223)
 
 Many thanks to...
 
@@ -89,6 +90,7 @@ Many thanks to...
 - @arslee07
 - @AustinMReppert
 - @avsaase
+- @brianch
 - @bungoboingo
 - @Calastrophe
 - @casperstorm
@@ -114,6 +116,7 @@ Many thanks to...
 - @nyurik
 - @Remmirad
 - @ripytide
+- @Tahinli
 - @tarkah
 - @tzemanovic
 - @william-shere

--- a/examples/system_information/src/main.rs
+++ b/examples/system_information/src/main.rs
@@ -102,19 +102,19 @@ impl Application for Example {
                 ));
 
                 let memory_readable =
-                    ByteSize::kb(information.memory_total).to_string();
+                    ByteSize::b(information.memory_total).to_string();
 
                 let memory_total = text(format!(
-                    "Memory (total): {} kb ({memory_readable})",
+                    "Memory (total): {} bytes ({memory_readable})",
                     information.memory_total,
                 ));
 
                 let memory_text = if let Some(memory_used) =
                     information.memory_used
                 {
-                    let memory_readable = ByteSize::kb(memory_used).to_string();
+                    let memory_readable = ByteSize::b(memory_used).to_string();
 
-                    format!("{memory_used} kb ({memory_readable})")
+                    format!("{memory_used} bytes ({memory_readable})")
                 } else {
                     String::from("None")
                 };

--- a/runtime/src/system/information.rs
+++ b/runtime/src/system/information.rs
@@ -18,9 +18,9 @@ pub struct Information {
     pub cpu_brand: String,
     /// The number of physical cores on the processor
     pub cpu_cores: Option<usize>,
-    /// Total RAM size, KB
+    /// Total RAM size, in bytes
     pub memory_total: u64,
-    /// Memory used by this process, KB
+    /// Memory used by this process, in bytes
     pub memory_used: Option<u64>,
     /// Underlying graphics backend for rendering
     pub graphics_backend: String,


### PR DESCRIPTION
This fixes https://github.com/iced-rs/iced/issues/2222.

The sysinfo [total_memory()](https://docs.rs/sysinfo/0.30.5/sysinfo/struct.System.html#method.total_memory) called by Iced [here](https://github.com/iced-rs/iced/blob/5540ac07e4695cc4e268979eca4efeb604b7c77f/winit/src/system.rs#L36) returns the value in bytes and not kylobytes as the documentation in the `Information` struct previously said (the same for the process' memory usage).