### PR TITLE
Call size_hint from Map

### DIFF
--- a/core/src/element.rs
+++ b/core/src/element.rs
@@ -308,6 +308,10 @@ where
         self.widget.size()
     }
 
+    fn size_hint(&self) -> Size<Length> {
+        self.widget.size_hint()
+    }
+
     fn layout(
         &self,
         tree: &mut Tree,


### PR DESCRIPTION
Default `size_hint` implementation calls `size`. This is an issue with the following view, where `component` is a `lazy::Component`:

```rs
column![
  component.map(..),
]
```

This resolves to `Column::push` calling `Map::size_hint` which calls `Component::size` during `view`, and causes a panic because the components internal option state hasn't been set yet, which happens during `Widget::state / diff`.