### PR TITLE
Refactor tooltip function to accept a generic element as a tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dracula, Nord, Solarized, and Gruvbox variants for `Theme`. [#2170](https://github.com/iced-rs/iced/pull/2170)
 - `From<T> where T: Into<PathBuf>` for `svg::Handle`. [#2235](https://github.com/iced-rs/iced/pull/2235)
 - `on_open` and `on_close` handlers for `PickList`. [#2174](https://github.com/iced-rs/iced/pull/2174)
+- Support for generic `Element` in `Tooltip`. [#2228](https://github.com/iced-rs/iced/pull/2228)
 
 ### Changed
 - Enable WebGPU backend in `wgpu` by default instead of WebGL. [#2068](https://github.com/iced-rs/iced/pull/2068)

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -123,7 +123,8 @@ where
     Button::new(content)
 }
 
-/// Creates a new [`Tooltip`] with the provided content, tooltip element, and [`tooltip::Position`].
+/// Creates a new [`Tooltip`] for the provided content with the given
+/// [`Element`] and [`tooltip::Position`].
 ///
 /// [`Tooltip`]: crate::Tooltip
 /// [`tooltip::Position`]: crate::tooltip::Position

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -123,20 +123,20 @@ where
     Button::new(content)
 }
 
-/// Creates a new [`Tooltip`] with the provided content, tooltip text, and [`tooltip::Position`].
+/// Creates a new [`Tooltip`] with the provided content, tooltip element, and [`tooltip::Position`].
 ///
 /// [`Tooltip`]: crate::Tooltip
 /// [`tooltip::Position`]: crate::tooltip::Position
 pub fn tooltip<'a, Message, Theme, Renderer>(
     content: impl Into<Element<'a, Message, Theme, Renderer>>,
-    tooltip: impl ToString,
+    tooltip: impl Into<Element<'a, Message, Theme, Renderer>>,
     position: tooltip::Position,
 ) -> crate::Tooltip<'a, Message, Theme, Renderer>
 where
     Theme: container::StyleSheet + text::StyleSheet,
     Renderer: core::text::Renderer,
 {
-    Tooltip::new(content, tooltip.to_string(), position)
+    Tooltip::new(content, tooltip, position)
 }
 
 /// Creates a new [`Text`] widget with the provided content.

--- a/widget/src/tooltip.rs
+++ b/widget/src/tooltip.rs
@@ -319,7 +319,7 @@ where
     fn layout(&mut self, renderer: &Renderer, bounds: Size) -> layout::Node {
         let viewport = Rectangle::with_size(bounds);
 
-        let text_layout = self.tooltip.as_widget().layout(
+        let tooltip_layout = self.tooltip.as_widget().layout(
             self.state,
             renderer,
             &layout::Limits::new(
@@ -331,7 +331,7 @@ where
             .shrink(Padding::new(self.padding)),
         );
 
-        let text_bounds = text_layout.bounds();
+        let text_bounds = tooltip_layout.bounds();
         let x_center = self.position.x
             + (self.content_bounds.width - text_bounds.width) / 2.0;
         let y_center = self.position.y
@@ -408,7 +408,8 @@ where
 
         layout::Node::with_children(
             tooltip_bounds.size(),
-            vec![text_layout.translate(Vector::new(self.padding, self.padding))],
+            vec![tooltip_layout
+                .translate(Vector::new(self.padding, self.padding))],
         )
         .translate(Vector::new(tooltip_bounds.x, tooltip_bounds.y))
     }

--- a/widget/src/tooltip.rs
+++ b/widget/src/tooltip.rs
@@ -319,8 +319,7 @@ where
     fn layout(&mut self, renderer: &Renderer, bounds: Size) -> layout::Node {
         let viewport = Rectangle::with_size(bounds);
 
-        let text_layout = Widget::<Message, Theme, Renderer>::layout(
-            self.tooltip.as_widget(),
+        let text_layout = self.tooltip.as_widget().layout(
             self.state,
             renderer,
             &layout::Limits::new(
@@ -430,8 +429,7 @@ where
             text_color: style.text_color.unwrap_or(inherited_style.text_color),
         };
 
-        Widget::<Message, Theme, Renderer>::draw(
-            self.tooltip.as_widget(),
+        self.tooltip.as_widget().draw(
             self.state,
             renderer,
             theme,


### PR DESCRIPTION

Allows for a more flexible tooltip element that can be further customized.