### PR TITLE
Fix alpha mode misconfiguration in wgpu renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Subscription::map` using unreliable function pointer hash to identify mappers. [#2237](https://github.com/iced-rs/iced/pull/2237)
 - Missing feature flag docs for `time::every`. [#2188](https://github.com/iced-rs/iced/pull/2188)
 - Event loop not being resumed on Windows while resizing. [#2214](https://github.com/iced-rs/iced/pull/2214)
+- Alpha mode misconfiguration in `iced_wgpu`. [#2231](https://github.com/iced-rs/iced/pull/2231)
 
 Many thanks to...
 
@@ -134,6 +135,7 @@ Many thanks to...
 - @jim-ec
 - @joshuamegnauth54
 - @jpttrssn
+- @Koranir
 - @lufte
 - @matze
 - @MichalLebeda

--- a/examples/gradient/Cargo.toml
+++ b/examples/gradient/Cargo.toml
@@ -5,4 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-iced = { path = "../.." }
+iced.workspace = true
+iced.features = ["debug"]
+
+tracing-subscriber = "0.3"

--- a/examples/gradient/src/main.rs
+++ b/examples/gradient/src/main.rs
@@ -9,6 +9,8 @@ use iced::{
 };
 
 pub fn main() -> iced::Result {
+    tracing_subscriber::fmt::init();
+
     Gradient::run(Settings {
         window: window::Settings {
             transparent: true,

--- a/examples/gradient/src/main.rs
+++ b/examples/gradient/src/main.rs
@@ -1,4 +1,5 @@
-use iced::theme::Palette;
+use iced::application;
+use iced::theme::{self, Theme};
 use iced::widget::{
     checkbox, column, container, horizontal_space, row, slider, text,
 };
@@ -22,7 +23,7 @@ struct Gradient {
     start: Color,
     end: Color,
     angle: Radians,
-    transparent_window: bool,
+    transparent: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -30,7 +31,7 @@ enum Message {
     StartChanged(Color),
     EndChanged(Color),
     AngleChanged(Radians),
-    SetTransparent(bool),
+    TransparentToggled(bool),
 }
 
 impl Sandbox for Gradient {
@@ -41,7 +42,7 @@ impl Sandbox for Gradient {
             start: Color::WHITE,
             end: Color::new(0.0, 0.0, 1.0, 1.0),
             angle: Radians(0.0),
-            transparent_window: false,
+            transparent: false,
         }
     }
 
@@ -54,8 +55,8 @@ impl Sandbox for Gradient {
             Message::StartChanged(color) => self.start = color,
             Message::EndChanged(color) => self.end = color,
             Message::AngleChanged(angle) => self.angle = angle,
-            Message::SetTransparent(transparent) => {
-                self.transparent_window = transparent;
+            Message::TransparentToggled(transparent) => {
+                self.transparent = transparent;
             }
         }
     }
@@ -65,7 +66,7 @@ impl Sandbox for Gradient {
             start,
             end,
             angle,
-            transparent_window,
+            transparent,
         } = *self;
 
         let gradient_box = container(horizontal_space(Length::Fill))
@@ -93,8 +94,8 @@ impl Sandbox for Gradient {
         .align_items(Alignment::Center);
 
         let transparency_toggle = iced::widget::Container::new(
-            checkbox("Transparent window", transparent_window)
-                .on_toggle(Message::SetTransparent),
+            checkbox("Transparent window", transparent)
+                .on_toggle(Message::TransparentToggled),
         )
         .padding(8);
 
@@ -108,17 +109,16 @@ impl Sandbox for Gradient {
         .into()
     }
 
-    fn theme(&self) -> iced::Theme {
-        if self.transparent_window {
-            iced::Theme::custom(
-                String::new(),
-                Palette {
-                    background: Color::TRANSPARENT,
-                    ..iced::Theme::default().palette()
-                },
-            )
+    fn style(&self) -> theme::Application {
+        if self.transparent {
+            theme::Application::custom(|theme: &Theme| {
+                application::Appearance {
+                    background_color: Color::TRANSPARENT,
+                    text_color: theme.palette().text,
+                }
+            })
         } else {
-            iced::Theme::default()
+            theme::Application::Default
         }
     }
 }

--- a/examples/solar_system/src/main.rs
+++ b/examples/solar_system/src/main.rs
@@ -88,7 +88,7 @@ impl Application for SolarSystem {
             }
         }
 
-        theme::Application::from(dark_background as fn(&Theme) -> _)
+        theme::Application::custom(dark_background)
     }
 
     fn subscription(&self) -> Subscription<Message> {

--- a/style/src/theme.rs
+++ b/style/src/theme.rs
@@ -172,6 +172,15 @@ pub enum Application {
     Custom(Box<dyn application::StyleSheet<Style = Theme>>),
 }
 
+impl Application {
+    /// Creates a custom [`Application`] style.
+    pub fn custom(
+        custom: impl application::StyleSheet<Style = Theme> + 'static,
+    ) -> Self {
+        Self::Custom(Box::new(custom))
+    }
+}
+
 impl application::StyleSheet for Theme {
     type Style = Application;
 
@@ -193,14 +202,6 @@ impl<T: Fn(&Theme) -> application::Appearance> application::StyleSheet for T {
 
     fn appearance(&self, style: &Self::Style) -> application::Appearance {
         (self)(style)
-    }
-}
-
-impl<T: Fn(&Theme) -> application::Appearance + 'static> From<T>
-    for Application
-{
-    fn from(f: T) -> Self {
-        Self::Custom(Box::new(f))
     }
 }
 

--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -68,6 +68,8 @@ impl Compositor {
 
                 let mut formats = capabilities.formats.iter().copied();
 
+                log::info!("Available formats: {formats:#?}");
+
                 let format = if color::GAMMA_CORRECTION {
                     formats.find(wgpu::TextureFormat::is_srgb)
                 } else {
@@ -80,12 +82,15 @@ impl Compositor {
                     capabilities.formats.first().copied()
                 });
 
-                let alphas = capabilities.alpha_modes;
-                let preferred_alpha = if alphas
+                let alpha_modes = capabilities.alpha_modes;
+
+                log::info!("Available alpha modes: {alpha_modes:#?}");
+
+                let preferred_alpha = if alpha_modes
                     .contains(&wgpu::CompositeAlphaMode::PostMultiplied)
                 {
                     wgpu::CompositeAlphaMode::PostMultiplied
-                } else if alphas
+                } else if alpha_modes
                     .contains(&wgpu::CompositeAlphaMode::PreMultiplied)
                 {
                     wgpu::CompositeAlphaMode::PreMultiplied


### PR DESCRIPTION
Fixes #2087

Code pretty much copied from Wezterm.

Also adds a transparency toggle to the gradient example.

Tested on Windows 11 and Hyprland