### PR TITLE
Fix dead documentation link in wgpu/README.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Missing feature flag docs for `time::every`. [#2188](https://github.com/iced-rs/iced/pull/2188)
 - Event loop not being resumed on Windows while resizing. [#2214](https://github.com/iced-rs/iced/pull/2214)
 - Alpha mode misconfiguration in `iced_wgpu`. [#2231](https://github.com/iced-rs/iced/pull/2231)
+- Outdated documentation leading to a dead link. [#2232](https://github.com/iced-rs/iced/pull/2232)
 
 Many thanks to...
 
@@ -135,6 +136,7 @@ Many thanks to...
 - @jim-ec
 - @joshuamegnauth54
 - @jpttrssn
+- @julianbraha
 - @Koranir
 - @lufte
 - @matze

--- a/wgpu/README.md
+++ b/wgpu/README.md
@@ -4,7 +4,7 @@
 [![License](https://img.shields.io/crates/l/iced_wgpu.svg)](https://github.com/iced-rs/iced/blob/master/LICENSE)
 [![Discord Server](https://img.shields.io/discord/628993209984614400?label=&labelColor=6A7EC2&logo=discord&logoColor=ffffff&color=7389D8)](https://discord.gg/3xZJ65GAhd)
 
-`iced_wgpu` is a [`wgpu`] renderer for [`iced_native`]. For now, it is the default renderer of Iced on [native platforms].
+`iced_wgpu` is a [`wgpu`] renderer for [`iced_runtime`]. For now, it is the default renderer of Iced on [native platforms].
 
 [`wgpu`] supports most modern graphics backends: Vulkan, Metal, and DX12 (OpenGL and WebGL are still WIP). Additionally, it will support the incoming [WebGPU API].
 
@@ -20,7 +20,7 @@ Currently, `iced_wgpu` supports the following primitives:
 </p>
 
 [documentation]: https://docs.rs/iced_wgpu
-[`iced_native`]: ../native
+[`iced_runtime`]: ../runtime
 [`wgpu`]: https://github.com/gfx-rs/wgpu
 [native platforms]: https://github.com/gfx-rs/wgpu#supported-platforms
 [WebGPU API]: https://gpuweb.github.io/gpuweb/


### PR DESCRIPTION
Similar to #2024, this fixes another dead link to `iced_native`