### PR TITLE
add catppuccin, tokyo night, kanagawa, moonfly, nightfly and oxocarbon themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Custom` variant to `command::Action`. [#2146](https://github.com/iced-rs/iced/pull/2146)
 - Mouse movement events for `MouseArea`. [#2147](https://github.com/iced-rs/iced/pull/2147)
 - Dracula, Nord, Solarized, and Gruvbox variants for `Theme`. [#2170](https://github.com/iced-rs/iced/pull/2170)
+- Catppuccin, Tokyo Night, Kanagawa, Moonfly, Nightfly and Oxocarbon variants for `Theme`. [#2233](https://github.com/iced-rs/iced/pull/2233)
+
 - `From<T> where T: Into<PathBuf>` for `svg::Handle`. [#2235](https://github.com/iced-rs/iced/pull/2235)
 - `on_open` and `on_close` handlers for `PickList`. [#2174](https://github.com/iced-rs/iced/pull/2174)
 - Support for generic `Element` in `Tooltip`. [#2228](https://github.com/iced-rs/iced/pull/2228)

--- a/style/src/theme.rs
+++ b/style/src/theme.rs
@@ -48,6 +48,14 @@ pub enum Theme {
     GruvboxLight,
     /// The built-in Gruvbox Dark variant.
     GruvboxDark,
+    /// The built-in Catppuccin Latte variant.
+    CatppuccinLatte,
+    /// The built-in Catppuccin Frappé variant.
+    CatppuccinFrappe,
+    /// The built-in Catppuccin Macchiato variant.
+    CatppuccinMacchiato,
+    /// The built-in Catppuccin Mocha variant.
+    CatppuccinMocha,
     /// A [`Theme`] that uses a [`Custom`] palette.
     Custom(Arc<Custom>),
 }
@@ -63,6 +71,10 @@ impl Theme {
         Self::SolarizedDark,
         Self::GruvboxLight,
         Self::GruvboxDark,
+        Self::CatppuccinLatte,
+        Self::CatppuccinFrappe,
+        Self::CatppuccinMacchiato,
+        Self::CatppuccinMocha,
     ];
 
     /// Creates a new custom [`Theme`] from the given [`Palette`].
@@ -91,6 +103,10 @@ impl Theme {
             Self::SolarizedDark => Palette::SOLARIZED_DARK,
             Self::GruvboxLight => Palette::GRUVBOX_LIGHT,
             Self::GruvboxDark => Palette::GRUVBOX_DARK,
+            Self::CatppuccinLatte => Palette::CATPPUCCIN_LATTE,
+            Self::CatppuccinFrappe => Palette::CATPPUCCIN_FRAPPE,
+            Self::CatppuccinMacchiato => Palette::CATPPUCCIN_MACCHIATO,
+            Self::CatppuccinMocha => Palette::CATPPUCCIN_MOCHA,
             Self::Custom(custom) => custom.palette,
         }
     }
@@ -106,6 +122,12 @@ impl Theme {
             Self::SolarizedDark => &palette::EXTENDED_SOLARIZED_DARK,
             Self::GruvboxLight => &palette::EXTENDED_GRUVBOX_LIGHT,
             Self::GruvboxDark => &palette::EXTENDED_GRUVBOX_DARK,
+            Self::CatppuccinLatte => &palette::EXTENDED_CATPPUCCIN_LATTE,
+            Self::CatppuccinFrappe => &palette::EXTENDED_CATPPUCCIN_FRAPPE,
+            Self::CatppuccinMacchiato => {
+                &palette::EXTENDED_CATPPUCCIN_MACCHIATO
+            }
+            Self::CatppuccinMocha => &palette::EXTENDED_CATPPUCCIN_MOCHA,
             Self::Custom(custom) => &custom.extended,
         }
     }
@@ -122,6 +144,10 @@ impl fmt::Display for Theme {
             Self::SolarizedDark => write!(f, "Solarized Dark"),
             Self::GruvboxLight => write!(f, "Gruvbox Light"),
             Self::GruvboxDark => write!(f, "Gruvbox Dark"),
+            Self::CatppuccinLatte => write!(f, "Catppuccin Latte"),
+            Self::CatppuccinFrappe => write!(f, "Catppuccin Frappé"),
+            Self::CatppuccinMacchiato => write!(f, "Catppuccin Macchiato"),
+            Self::CatppuccinMocha => write!(f, "Catppuccin Mocha"),
             Self::Custom(custom) => custom.fmt(f),
         }
     }

--- a/style/src/theme.rs
+++ b/style/src/theme.rs
@@ -62,6 +62,18 @@ pub enum Theme {
     TokyoNightStorm,
     /// The built-in Tokyo Night Light variant.
     TokyoNightLight,
+    /// The built-in Kanagawa Wave variant.
+    KanagawaWave,
+    /// The built-in Kanagawa Dragon variant.
+    KanagawaDragon,
+    /// The built-in Kanagawa Lotus variant.
+    KanagawaLotus,
+    /// The built-in Moonfly variant.
+    Moonfly,
+    /// The built-in Nightfly variant.
+    Nightfly,
+    /// The built-in Oxocarbon variant.
+    Oxocarbon,
     /// A [`Theme`] that uses a [`Custom`] palette.
     Custom(Arc<Custom>),
 }
@@ -84,6 +96,12 @@ impl Theme {
         Self::TokyoNight,
         Self::TokyoNightStorm,
         Self::TokyoNightLight,
+        Self::KanagawaWave,
+        Self::KanagawaDragon,
+        Self::KanagawaLotus,
+        Self::Moonfly,
+        Self::Nightfly,
+        Self::Oxocarbon,
     ];
 
     /// Creates a new custom [`Theme`] from the given [`Palette`].
@@ -119,6 +137,12 @@ impl Theme {
             Self::TokyoNight => Palette::TOKYO_NIGHT,
             Self::TokyoNightStorm => Palette::TOKYO_NIGHT_STORM,
             Self::TokyoNightLight => Palette::TOKYO_NIGHT_LIGHT,
+            Self::KanagawaWave => Palette::KANAGAWA_WAVE,
+            Self::KanagawaDragon => Palette::KANAGAWA_DRAGON,
+            Self::KanagawaLotus => Palette::KANAGAWA_LOTUS,
+            Self::Moonfly => Palette::MOONFLY,
+            Self::Nightfly => Palette::NIGHTFLY,
+            Self::Oxocarbon => Palette::OXOCARBON,
             Self::Custom(custom) => custom.palette,
         }
     }
@@ -143,6 +167,12 @@ impl Theme {
             Self::TokyoNight => &palette::EXTENDED_TOKYO_NIGHT,
             Self::TokyoNightStorm => &palette::EXTENDED_TOKYO_NIGHT_STORM,
             Self::TokyoNightLight => &palette::EXTENDED_TOKYO_NIGHT_LIGHT,
+            Self::KanagawaWave => &palette::EXTENDED_KANAGAWA_WAVE,
+            Self::KanagawaDragon => &palette::EXTENDED_KANAGAWA_DRAGON,
+            Self::KanagawaLotus => &palette::EXTENDED_KANAGAWA_LOTUS,
+            Self::Moonfly => &palette::EXTENDED_MOONFLY,
+            Self::Nightfly => &palette::EXTENDED_NIGHTFLY,
+            Self::Oxocarbon => &palette::EXTENDED_OXOCARBON,
             Self::Custom(custom) => &custom.extended,
         }
     }
@@ -166,6 +196,12 @@ impl fmt::Display for Theme {
             Self::TokyoNight => write!(f, "Tokyo Night"),
             Self::TokyoNightStorm => write!(f, "Tokyo Night Storm"),
             Self::TokyoNightLight => write!(f, "Tokyo Night Light"),
+            Self::KanagawaWave => write!(f, "Kanagawa Wave"),
+            Self::KanagawaDragon => write!(f, "Kanagawa Dragon"),
+            Self::KanagawaLotus => write!(f, "Kanagawa Lotus"),
+            Self::Moonfly => write!(f, "Moonfly"),
+            Self::Nightfly => write!(f, "Nightfly"),
+            Self::Oxocarbon => write!(f, "Oxocarbon"),
             Self::Custom(custom) => custom.fmt(f),
         }
     }

--- a/style/src/theme.rs
+++ b/style/src/theme.rs
@@ -56,6 +56,12 @@ pub enum Theme {
     CatppuccinMacchiato,
     /// The built-in Catppuccin Mocha variant.
     CatppuccinMocha,
+    /// The built-in Tokyo Night variant.
+    TokyoNight,
+    /// The built-in Tokyo Night Storm variant.
+    TokyoNightStorm,
+    /// The built-in Tokyo Night Light variant.
+    TokyoNightLight,
     /// A [`Theme`] that uses a [`Custom`] palette.
     Custom(Arc<Custom>),
 }
@@ -75,6 +81,9 @@ impl Theme {
         Self::CatppuccinFrappe,
         Self::CatppuccinMacchiato,
         Self::CatppuccinMocha,
+        Self::TokyoNight,
+        Self::TokyoNightStorm,
+        Self::TokyoNightLight,
     ];
 
     /// Creates a new custom [`Theme`] from the given [`Palette`].
@@ -107,6 +116,9 @@ impl Theme {
             Self::CatppuccinFrappe => Palette::CATPPUCCIN_FRAPPE,
             Self::CatppuccinMacchiato => Palette::CATPPUCCIN_MACCHIATO,
             Self::CatppuccinMocha => Palette::CATPPUCCIN_MOCHA,
+            Self::TokyoNight => Palette::TOKYO_NIGHT,
+            Self::TokyoNightStorm => Palette::TOKYO_NIGHT_STORM,
+            Self::TokyoNightLight => Palette::TOKYO_NIGHT_LIGHT,
             Self::Custom(custom) => custom.palette,
         }
     }
@@ -128,6 +140,9 @@ impl Theme {
                 &palette::EXTENDED_CATPPUCCIN_MACCHIATO
             }
             Self::CatppuccinMocha => &palette::EXTENDED_CATPPUCCIN_MOCHA,
+            Self::TokyoNight => &palette::EXTENDED_TOKYO_NIGHT,
+            Self::TokyoNightStorm => &palette::EXTENDED_TOKYO_NIGHT_STORM,
+            Self::TokyoNightLight => &palette::EXTENDED_TOKYO_NIGHT_LIGHT,
             Self::Custom(custom) => &custom.extended,
         }
     }
@@ -148,6 +163,9 @@ impl fmt::Display for Theme {
             Self::CatppuccinFrappe => write!(f, "Catppuccin Frappé"),
             Self::CatppuccinMacchiato => write!(f, "Catppuccin Macchiato"),
             Self::CatppuccinMocha => write!(f, "Catppuccin Mocha"),
+            Self::TokyoNight => write!(f, "Tokyo Night"),
+            Self::TokyoNightStorm => write!(f, "Tokyo Night Storm"),
+            Self::TokyoNightLight => write!(f, "Tokyo Night Light"),
             Self::Custom(custom) => custom.fmt(f),
         }
     }

--- a/style/src/theme/palette.rs
+++ b/style/src/theme/palette.rs
@@ -68,9 +68,9 @@ impl Palette {
         ),
     };
 
-    /// The built-in Dracula variant of a [`Palette`].
+    /// The built-in [Dracula] variant of a [`Palette`].
     ///
-    /// Source: https://draculatheme.com
+    /// [Dracula]: https://draculatheme.com
     pub const DRACULA: Self = Self {
         background: color!(0x282A36), // BACKGROUND
         text: color!(0xf8f8f2),       // FOREGROUND
@@ -79,9 +79,9 @@ impl Palette {
         danger: color!(0xff5555),     // RED
     };
 
-    /// The built-in Nord variant of a [`Palette`].
+    /// The built-in [Nord] variant of a [`Palette`].
     ///
-    /// Source: https://www.nordtheme.com/docs/colors-and-palettes
+    /// [Nord]: https://www.nordtheme.com/docs/colors-and-palettes
     pub const NORD: Self = Self {
         background: color!(0x2e3440), // nord0
         text: color!(0xeceff4),       // nord6
@@ -90,9 +90,9 @@ impl Palette {
         danger: color!(0xbf616a),     // nord11
     };
 
-    /// The built-in Solarized Light variant of a [`Palette`].
+    /// The built-in [Solarized] Light variant of a [`Palette`].
     ///
-    /// Source: https://ethanschoonover.com/solarized
+    /// [Solarized]: https://ethanschoonover.com/solarized
     pub const SOLARIZED_LIGHT: Self = Self {
         background: color!(0xfdf6e3), // base3
         text: color!(0x657b83),       // base00
@@ -101,9 +101,9 @@ impl Palette {
         danger: color!(0xdc322f),     // red
     };
 
-    /// The built-in Solarized Dark variant of a [`Palette`].
+    /// The built-in [Solarized] Dark variant of a [`Palette`].
     ///
-    /// Source: https://ethanschoonover.com/solarized
+    /// [Solarized]: https://ethanschoonover.com/solarized
     pub const SOLARIZED_DARK: Self = Self {
         background: color!(0x002b36), // base03
         text: color!(0x839496),       // base0
@@ -112,9 +112,9 @@ impl Palette {
         danger: color!(0xdc322f),     // red
     };
 
-    /// The built-in Gruvbox Light variant of a [`Palette`].
+    /// The built-in [Gruvbox] Light variant of a [`Palette`].
     ///
-    /// Source: https://github.com/morhetz/gruvbox
+    /// [Gruvbox]: https://github.com/morhetz/gruvbox
     pub const GRUVBOX_LIGHT: Self = Self {
         background: color!(0xfbf1c7), // light BG_0
         text: color!(0x282828),       // light FG0_29
@@ -123,9 +123,9 @@ impl Palette {
         danger: color!(0xcc241d),     // light RED_1
     };
 
-    /// The built-in Gruvbox Dark variant of a [`Palette`].
+    /// The built-in [Gruvbox] Dark variant of a [`Palette`].
     ///
-    /// Source: https://github.com/morhetz/gruvbox
+    /// [Gruvbox]: https://github.com/morhetz/gruvbox
     pub const GRUVBOX_DARK: Self = Self {
         background: color!(0x282828), // dark BG_0
         text: color!(0xfbf1c7),       // dark FG0_29
@@ -134,9 +134,9 @@ impl Palette {
         danger: color!(0xcc241d),     // dark RED_1
     };
 
-    /// The built-in Catppuccin Latte variant of a [`Palette`].
+    /// The built-in [Catppuccin] Latte variant of a [`Palette`].
     ///
-    /// Source: https://github.com/catppuccin/catppuccin
+    /// [Catppuccin]: https://github.com/catppuccin/catppuccin
     pub const CATPPUCCIN_LATTE: Self = Self {
         background: color!(0xeff1f5), // Base
         text: color!(0x4c4f69),       // Text
@@ -145,9 +145,9 @@ impl Palette {
         danger: color!(0xd20f39),     // Red
     };
 
-    /// The built-in Catppuccin Frappé variant of a [`Palette`].
+    /// The built-in [Catppuccin] Frappé variant of a [`Palette`].
     ///
-    /// Source: https://github.com/catppuccin/catppuccin
+    /// [Catppuccin]: https://github.com/catppuccin/catppuccin
     pub const CATPPUCCIN_FRAPPE: Self = Self {
         background: color!(0x303446), // Base
         text: color!(0xc6d0f5),       // Text
@@ -156,9 +156,9 @@ impl Palette {
         danger: color!(0xe78284),     // Red
     };
 
-    /// The built-in Catppuccin Macchiato variant of a [`Palette`].
+    /// The built-in [Catppuccin] Macchiato variant of a [`Palette`].
     ///
-    /// Source: https://github.com/catppuccin/catppuccin
+    /// [Catppuccin]: https://github.com/catppuccin/catppuccin
     pub const CATPPUCCIN_MACCHIATO: Self = Self {
         background: color!(0x24273a), // Base
         text: color!(0xcad3f5),       // Text
@@ -167,9 +167,9 @@ impl Palette {
         danger: color!(0xed8796),     // Red
     };
 
-    /// The built-in Catppuccin Mocha variant of a [`Palette`].
+    /// The built-in [Catppuccin] Mocha variant of a [`Palette`].
     ///
-    /// Source: https://github.com/catppuccin/catppuccin
+    /// [Catppuccin]: https://github.com/catppuccin/catppuccin
     pub const CATPPUCCIN_MOCHA: Self = Self {
         background: color!(0x1e1e2e), // Base
         text: color!(0xcdd6f4),       // Text
@@ -178,9 +178,9 @@ impl Palette {
         danger: color!(0xf38ba8),     // Red
     };
 
-    /// The built-in Tokyo Night variant of a [`Palette`].
+    /// The built-in [Tokyo Night] variant of a [`Palette`].
     ///
-    /// Source: https://github.com/enkia/tokyo-night-vscode-theme
+    /// [Tokyo Night]: https://github.com/enkia/tokyo-night-vscode-theme
     pub const TOKYO_NIGHT: Self = Self {
         background: color!(0x1a1b26), // Background (Night)
         text: color!(0x9aa5ce),       // Text
@@ -189,9 +189,9 @@ impl Palette {
         danger: color!(0xf7768e),     // Red
     };
 
-    /// The built-in Tokyo Night Storm variant of a [`Palette`].
+    /// The built-in [Tokyo Night] Storm variant of a [`Palette`].
     ///
-    /// Source: https://github.com/enkia/tokyo-night-vscode-theme
+    /// [Tokyo Night]: https://github.com/enkia/tokyo-night-vscode-theme
     pub const TOKYO_NIGHT_STORM: Self = Self {
         background: color!(0x24283b), // Background (Storm)
         text: color!(0x9aa5ce),       // Text
@@ -200,9 +200,9 @@ impl Palette {
         danger: color!(0xf7768e),     // Red
     };
 
-    /// The built-in Tokyo Night Light variant of a [`Palette`].
+    /// The built-in [Tokyo Night] Light variant of a [`Palette`].
     ///
-    /// Source: https://github.com/enkia/tokyo-night-vscode-theme
+    /// [Tokyo Night]: https://github.com/enkia/tokyo-night-vscode-theme
     pub const TOKYO_NIGHT_LIGHT: Self = Self {
         background: color!(0xd5d6db), // Background
         text: color!(0x565a6e),       // Text
@@ -211,9 +211,9 @@ impl Palette {
         danger: color!(0x8c4351),     // Red
     };
 
-    /// The built-in Kanagawa Wave variant of a [`Palette`].
+    /// The built-in [Kanagawa] Wave variant of a [`Palette`].
     ///
-    /// Source: https://github.com/rebelot/kanagawa.nvim
+    /// [Kanagawa]: https://github.com/rebelot/kanagawa.nvim
     pub const KANAGAWA_WAVE: Self = Self {
         background: color!(0x363646), // Sumi Ink 3
         text: color!(0xCD7BA),        // Fuji White
@@ -222,9 +222,9 @@ impl Palette {
         danger: color!(0xC34043),     // Autumn Red
     };
 
-    /// The built-in Kanagawa Dragon variant of a [`Palette`].
+    /// The built-in [Kanagawa] Dragon variant of a [`Palette`].
     ///
-    /// Source: https://github.com/rebelot/kanagawa.nvim
+    /// [Kanagawa]: https://github.com/rebelot/kanagawa.nvim
     pub const KANAGAWA_DRAGON: Self = Self {
         background: color!(0x181616), // Dragon Black 3
         text: color!(0xc5c9c5),       // Dragon White
@@ -233,9 +233,9 @@ impl Palette {
         danger: color!(0xc4746e),     // Dragon Red
     };
 
-    /// The built-in Kanagawa Lotus variant of a [`Palette`].
+    /// The built-in [Kanagawa] Lotus variant of a [`Palette`].
     ///
-    /// Source: https://github.com/rebelot/kanagawa.nvim
+    /// [Kanagawa]: https://github.com/rebelot/kanagawa.nvim
     pub const KANAGAWA_LOTUS: Self = Self {
         background: color!(0xf2ecbc), // Lotus White 3
         text: color!(0x545464),       // Lotus Ink 1
@@ -244,9 +244,9 @@ impl Palette {
         danger: color!(0xc84053),     // Lotus Red
     };
 
-    /// The built-in Moonfly variant of a [`Palette`].
+    /// The built-in [Moonfly] variant of a [`Palette`].
     ///
-    /// Source: https://github.com/bluz71/vim-moonfly-colors
+    /// [Moonfly]: https://github.com/bluz71/vim-moonfly-colors
     pub const MOONFLY: Self = Self {
         background: color!(0x080808), // Background
         text: color!(0xbdbdbd),       // Foreground
@@ -255,9 +255,9 @@ impl Palette {
         danger: color!(0xff5454),     // Red (normal)
     };
 
-    /// The built-in Nightfly variant of a [`Palette`].
+    /// The built-in [Nightfly] variant of a [`Palette`].
     ///
-    /// Source: https://github.com/bluz71/vim-nightfly-colors
+    /// [Nightfly]: https://github.com/bluz71/vim-nightfly-colors
     pub const NIGHTFLY: Self = Self {
         background: color!(0x011627), // Background
         text: color!(0xbdc1c6),       // Foreground
@@ -266,9 +266,9 @@ impl Palette {
         danger: color!(0xfc514e),     // Red (normal)
     };
 
-    /// The built-in Oxocarbon variant of a [`Palette`].
+    /// The built-in [Oxocarbon] variant of a [`Palette`].
     ///
-    /// Source: https://github.com/nyoom-engineering/oxocarbon.nvim
+    /// [Oxocarbon]: https://github.com/nyoom-engineering/oxocarbon.nvim
     pub const OXOCARBON: Self = Self {
         background: color!(0x232323),
         text: color!(0xd0d0d0),

--- a/style/src/theme/palette.rs
+++ b/style/src/theme/palette.rs
@@ -133,6 +133,50 @@ impl Palette {
         success: color!(0x98971a),    // dark GREEN_2
         danger: color!(0xcc241d),     // dark RED_1
     };
+
+    /// The built-in Catppuccin Latte variant of a [`Palette`].
+    ///
+    /// Source: https://github.com/catppuccin/catppuccin
+    pub const CATPPUCCIN_LATTE: Self = Self {
+        background: color!(0xeff1f5), // Base
+        text: color!(0x4c4f69),       // Text
+        primary: color!(0x1e66f5),    // Blue
+        success: color!(0x40a02b),    // Green
+        danger: color!(0xd20f39),     // Red
+    };
+
+    /// The built-in Catppuccin Frappé variant of a [`Palette`].
+    ///
+    /// Source: https://github.com/catppuccin/catppuccin
+    pub const CATPPUCCIN_FRAPPE: Self = Self {
+        background: color!(0x303446), // Base
+        text: color!(0xc6d0f5),       // Text
+        primary: color!(0x8caaee),    // Blue
+        success: color!(0xa6d189),    // Green
+        danger: color!(0xe78284),     // Red
+    };
+
+    /// The built-in Catppuccin Macchiato variant of a [`Palette`].
+    ///
+    /// Source: https://github.com/catppuccin/catppuccin
+    pub const CATPPUCCIN_MACCHIATO: Self = Self {
+        background: color!(0x24273a), // Base
+        text: color!(0xcad3f5),       // Text
+        primary: color!(0x8aadf4),    // Blue
+        success: color!(0xa6da95),    // Green
+        danger: color!(0xed8796),     // Red
+    };
+
+    /// The built-in Catppuccin Mocha variant of a [`Palette`].
+    ///
+    /// Source: https://github.com/catppuccin/catppuccin
+    pub const CATPPUCCIN_MOCHA: Self = Self {
+        background: color!(0x1e1e2e), // Base
+        text: color!(0xcdd6f4),       // Text
+        primary: color!(0x89b4fa),    // Blue
+        success: color!(0xa6e3a1),    // Green
+        danger: color!(0xf38ba8),     // Red
+    };
 }
 
 /// An extended set of colors generated from a [`Palette`].
@@ -183,6 +227,22 @@ pub static EXTENDED_GRUVBOX_LIGHT: Lazy<Extended> =
 /// The built-in Gruvbox Dark variant of an [`Extended`] palette.
 pub static EXTENDED_GRUVBOX_DARK: Lazy<Extended> =
     Lazy::new(|| Extended::generate(Palette::GRUVBOX_DARK));
+
+/// The built-in Catppuccin Latte variant of an [`Extended`] palette.
+pub static EXTENDED_CATPPUCCIN_LATTE: Lazy<Extended> =
+    Lazy::new(|| Extended::generate(Palette::CATPPUCCIN_LATTE));
+
+/// The built-in Catppuccin Frappé variant of an [`Extended`] palette.
+pub static EXTENDED_CATPPUCCIN_FRAPPE: Lazy<Extended> =
+    Lazy::new(|| Extended::generate(Palette::CATPPUCCIN_FRAPPE));
+
+/// The built-in Catppuccin Macchiato variant of an [`Extended`] palette.
+pub static EXTENDED_CATPPUCCIN_MACCHIATO: Lazy<Extended> =
+    Lazy::new(|| Extended::generate(Palette::CATPPUCCIN_MACCHIATO));
+
+/// The built-in Catppuccin Mocha variant of an [`Extended`] palette.
+pub static EXTENDED_CATPPUCCIN_MOCHA: Lazy<Extended> =
+    Lazy::new(|| Extended::generate(Palette::CATPPUCCIN_MOCHA));
 
 impl Extended {
     /// Generates an [`Extended`] palette from a simple [`Palette`].

--- a/style/src/theme/palette.rs
+++ b/style/src/theme/palette.rs
@@ -177,6 +177,39 @@ impl Palette {
         success: color!(0xa6e3a1),    // Green
         danger: color!(0xf38ba8),     // Red
     };
+
+    /// The built-in Tokyo Night variant of a [`Palette`].
+    ///
+    /// Source: https://github.com/enkia/tokyo-night-vscode-theme
+    pub const TOKYO_NIGHT: Self = Self {
+        background: color!(0x1a1b26), // Background (Night)
+        text: color!(0x9aa5ce),       // Text
+        primary: color!(0x2ac3de),    // Blue
+        success: color!(0x9ece6a),    // Green
+        danger: color!(0xf7768e),     // Red
+    };
+
+    /// The built-in Tokyo Night Storm variant of a [`Palette`].
+    ///
+    /// Source: https://github.com/enkia/tokyo-night-vscode-theme
+    pub const TOKYO_NIGHT_STORM: Self = Self {
+        background: color!(0x24283b), // Background (Storm)
+        text: color!(0x9aa5ce),       // Text
+        primary: color!(0x2ac3de),    // Blue
+        success: color!(0x9ece6a),    // Green
+        danger: color!(0xf7768e),     // Red
+    };
+
+    /// The built-in Tokyo Night Light variant of a [`Palette`].
+    ///
+    /// Source: https://github.com/enkia/tokyo-night-vscode-theme
+    pub const TOKYO_NIGHT_LIGHT: Self = Self {
+        background: color!(0xd5d6db), // Background
+        text: color!(0x565a6e),       // Text
+        primary: color!(0x166775),    // Blue
+        success: color!(0x485e30),    // Green
+        danger: color!(0x8c4351),     // Red
+    };
 }
 
 /// An extended set of colors generated from a [`Palette`].
@@ -243,6 +276,18 @@ pub static EXTENDED_CATPPUCCIN_MACCHIATO: Lazy<Extended> =
 /// The built-in Catppuccin Mocha variant of an [`Extended`] palette.
 pub static EXTENDED_CATPPUCCIN_MOCHA: Lazy<Extended> =
     Lazy::new(|| Extended::generate(Palette::CATPPUCCIN_MOCHA));
+
+/// The built-in Tokyo Night variant of an [`Extended`] palette.
+pub static EXTENDED_TOKYO_NIGHT: Lazy<Extended> =
+    Lazy::new(|| Extended::generate(Palette::TOKYO_NIGHT));
+
+/// The built-in Tokyo Night Storm variant of an [`Extended`] palette.
+pub static EXTENDED_TOKYO_NIGHT_STORM: Lazy<Extended> =
+    Lazy::new(|| Extended::generate(Palette::TOKYO_NIGHT_STORM));
+
+/// The built-in Tokyo Night variant of an [`Extended`] palette.
+pub static EXTENDED_TOKYO_NIGHT_LIGHT: Lazy<Extended> =
+    Lazy::new(|| Extended::generate(Palette::TOKYO_NIGHT_LIGHT));
 
 impl Extended {
     /// Generates an [`Extended`] palette from a simple [`Palette`].

--- a/style/src/theme/palette.rs
+++ b/style/src/theme/palette.rs
@@ -210,6 +210,72 @@ impl Palette {
         success: color!(0x485e30),    // Green
         danger: color!(0x8c4351),     // Red
     };
+
+    /// The built-in Kanagawa Wave variant of a [`Palette`].
+    ///
+    /// Source: https://github.com/rebelot/kanagawa.nvim
+    pub const KANAGAWA_WAVE: Self = Self {
+        background: color!(0x363646), // Sumi Ink 3
+        text: color!(0xCD7BA),        // Fuji White
+        primary: color!(0x2D4F67),    // Wave Blue 2
+        success: color!(0x76946A),    // Autumn Green
+        danger: color!(0xC34043),     // Autumn Red
+    };
+
+    /// The built-in Kanagawa Dragon variant of a [`Palette`].
+    ///
+    /// Source: https://github.com/rebelot/kanagawa.nvim
+    pub const KANAGAWA_DRAGON: Self = Self {
+        background: color!(0x181616), // Dragon Black 3
+        text: color!(0xc5c9c5),       // Dragon White
+        primary: color!(0x223249),    // Wave Blue 1
+        success: color!(0x8a9a7b),    // Dragon Green 2
+        danger: color!(0xc4746e),     // Dragon Red
+    };
+
+    /// The built-in Kanagawa Lotus variant of a [`Palette`].
+    ///
+    /// Source: https://github.com/rebelot/kanagawa.nvim
+    pub const KANAGAWA_LOTUS: Self = Self {
+        background: color!(0xf2ecbc), // Lotus White 3
+        text: color!(0x545464),       // Lotus Ink 1
+        primary: color!(0xc9cbd1),    // Lotus Violet 3
+        success: color!(0x6f894e),    // Lotus Green
+        danger: color!(0xc84053),     // Lotus Red
+    };
+
+    /// The built-in Moonfly variant of a [`Palette`].
+    ///
+    /// Source: https://github.com/bluz71/vim-moonfly-colors
+    pub const MOONFLY: Self = Self {
+        background: color!(0x080808), // Background
+        text: color!(0xbdbdbd),       // Foreground
+        primary: color!(0x80a0ff),    // Blue (normal)
+        success: color!(0x8cc85f),    // Green (normal)
+        danger: color!(0xff5454),     // Red (normal)
+    };
+
+    /// The built-in Nightfly variant of a [`Palette`].
+    ///
+    /// Source: https://github.com/bluz71/vim-nightfly-colors
+    pub const NIGHTFLY: Self = Self {
+        background: color!(0x011627), // Background
+        text: color!(0xbdc1c6),       // Foreground
+        primary: color!(0x82aaff),    // Blue (normal)
+        success: color!(0xa1cd5e),    // Green (normal)
+        danger: color!(0xfc514e),     // Red (normal)
+    };
+
+    /// The built-in Oxocarbon variant of a [`Palette`].
+    ///
+    /// Source: https://github.com/nyoom-engineering/oxocarbon.nvim
+    pub const OXOCARBON: Self = Self {
+        background: color!(0x232323),
+        text: color!(0xd0d0d0),
+        primary: color!(0x00b4ff),
+        success: color!(0x00c15a),
+        danger: color!(0xf62d0f),
+    };
 }
 
 /// An extended set of colors generated from a [`Palette`].
@@ -288,6 +354,30 @@ pub static EXTENDED_TOKYO_NIGHT_STORM: Lazy<Extended> =
 /// The built-in Tokyo Night variant of an [`Extended`] palette.
 pub static EXTENDED_TOKYO_NIGHT_LIGHT: Lazy<Extended> =
     Lazy::new(|| Extended::generate(Palette::TOKYO_NIGHT_LIGHT));
+
+/// The built-in Kanagawa Wave variant of an [`Extended`] palette.
+pub static EXTENDED_KANAGAWA_WAVE: Lazy<Extended> =
+    Lazy::new(|| Extended::generate(Palette::KANAGAWA_WAVE));
+
+/// The built-in Kanagawa Dragon variant of an [`Extended`] palette.
+pub static EXTENDED_KANAGAWA_DRAGON: Lazy<Extended> =
+    Lazy::new(|| Extended::generate(Palette::KANAGAWA_DRAGON));
+
+/// The built-in Kanagawa Lotus variant of an [`Extended`] palette.
+pub static EXTENDED_KANAGAWA_LOTUS: Lazy<Extended> =
+    Lazy::new(|| Extended::generate(Palette::KANAGAWA_LOTUS));
+
+/// The built-in Moonfly variant of an [`Extended`] palette.
+pub static EXTENDED_MOONFLY: Lazy<Extended> =
+    Lazy::new(|| Extended::generate(Palette::MOONFLY));
+
+/// The built-in Nightfly variant of an [`Extended`] palette.
+pub static EXTENDED_NIGHTFLY: Lazy<Extended> =
+    Lazy::new(|| Extended::generate(Palette::NIGHTFLY));
+
+/// The built-in Oxocarbon variant of an [`Extended`] palette.
+pub static EXTENDED_OXOCARBON: Lazy<Extended> =
+    Lazy::new(|| Extended::generate(Palette::OXOCARBON));
 
 impl Extended {
     /// Generates an [`Extended`] palette from a simple [`Palette`].


### PR DESCRIPTION
Add themes and color palettes from:
1. https://github.com/catppuccin/catppuccin 
2. https://github.com/enkia/tokyo-night-vscode-theme
3. https://github.com/rebelot/kanagawa.nvim
4. https://github.com/bluz71/vim-moonfly-colors
5. https://github.com/bluz71/vim-nightfly-colors
6. https://github.com/nyoom-engineering/oxocarbon.nvim

Continuation of https://github.com/iced-rs/iced/pull/2170

CC: @hecrj 