### PR TITLE
Make the svg function to accept a path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Custom` variant to `command::Action`. [#2146](https://github.com/iced-rs/iced/pull/2146)
 - Mouse movement events for `MouseArea`. [#2147](https://github.com/iced-rs/iced/pull/2147)
 - Dracula, Nord, Solarized, and Gruvbox variants for `Theme`. [#2170](https://github.com/iced-rs/iced/pull/2170)
+- `From<T> where T: Into<PathBuf>` for `svg::Handle`. [#2235](https://github.com/iced-rs/iced/pull/2235)
 
 ### Changed
 - Enable WebGPU backend in `wgpu` by default instead of WebGL. [#2068](https://github.com/iced-rs/iced/pull/2068)
@@ -108,6 +109,7 @@ Many thanks to...
 - @Decodetalkers
 - @derezzedex
 - @dtzxporter
+- @fogarecious
 - @GyulyVGC
 - @hicaru
 - @ids1024

--- a/core/src/svg.rs
+++ b/core/src/svg.rs
@@ -50,6 +50,15 @@ impl Handle {
     }
 }
 
+impl<T> From<T> for Handle
+where
+    T: Into<PathBuf>,
+{
+    fn from(path: T) -> Handle {
+        Handle::from_path(path.into())
+    }
+}
+
 impl Hash for Handle {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.id.hash(state);


### PR DESCRIPTION
Currently, to load an SVG file by the [svg](https://docs.iced.rs/iced/widget/fn.svg.html) function, we have to call [Handle::from_path](https://docs.iced.rs/iced/widget/svg/struct.Handle.html#method.from_path).

```rust
use iced::widget::{svg, svg::Handle};
// ...
svg(Handle::from_path("path-to-pic.svg"));
```

A more ideal way is to pass the path directly into the svg function.

```rust
svg("path-to-pic.svg");
```

This PR enhances the convenience by adding `From<T: Into<PathBuf>>` to the [Svg Handle](https://docs.iced.rs/iced/widget/svg/struct.Handle.html). The modified code achieves consistency with the [image](https://docs.iced.rs/iced/widget/image/index.html) counterpart.
