### PR TITLE
Use `TypeId` to identify `subscription::Map`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `size_hint` not being called from `element::Map`. [#2224](https://github.com/iced-rs/iced/pull/2224)
 - `size_hint` not being called from `element::Explain`. [#2225](https://github.com/iced-rs/iced/pull/2225)
 - Slow touch scrolling for `TextEditor` widget. [#2140](https://github.com/iced-rs/iced/pull/2140)
+- `Subscription::map` using unreliable function pointer hash to identify mappers. [#2237](https://github.com/iced-rs/iced/pull/2237)
 
 Many thanks to...
 

--- a/futures/src/subscription.rs
+++ b/futures/src/subscription.rs
@@ -89,14 +89,22 @@ impl<Message> Subscription<Message> {
     }
 
     /// Transforms the [`Subscription`] output with the given function.
-    pub fn map<A>(
-        mut self,
-        f: impl Fn(Message) -> A + MaybeSend + Clone + 'static,
-    ) -> Subscription<A>
+    ///
+    /// # Panics
+    /// The closure provided must be a non-capturing closure. The method
+    /// will panic in debug mode otherwise.
+    pub fn map<F, A>(mut self, f: F) -> Subscription<A>
     where
         Message: 'static,
+        F: Fn(Message) -> A + MaybeSend + Clone + 'static,
         A: 'static,
     {
+        debug_assert!(
+            std::mem::size_of::<F>() == 0,
+            "the closure {} provided in `Subscription::map` is capturing",
+            std::any::type_name::<F>(),
+        );
+
         Subscription {
             recipes: self
                 .recipes

--- a/futures/src/subscription.rs
+++ b/futures/src/subscription.rs
@@ -160,7 +160,6 @@ struct Map<A, B, F>
 where
     F: Fn(A) -> B + 'static,
 {
-    id: TypeId,
     recipe: Box<dyn Recipe<Output = A>>,
     mapper: F,
 }
@@ -170,11 +169,7 @@ where
     F: Fn(A) -> B + 'static,
 {
     fn new(recipe: Box<dyn Recipe<Output = A>>, mapper: F) -> Self {
-        Map {
-            id: TypeId::of::<F>(),
-            recipe,
-            mapper,
-        }
+        Map { recipe, mapper }
     }
 }
 
@@ -187,7 +182,7 @@ where
     type Output = B;
 
     fn hash(&self, state: &mut Hasher) {
-        self.id.hash(state);
+        TypeId::of::<F>().hash(state);
         self.recipe.hash(state);
     }
 


### PR DESCRIPTION
This PR fixes #2236. The idea here is to use the `TypeId` of a closure instead of the hash of a function pointer in `subscription::Map`, which I am assuming is more stable.

~~Coincidentally, this also introduces closure support for `Subscription::map`!~~