### PR TITLE
Decouple `Key` from `keyboard::Modifiers` and apply them to `text` in `KeyboardInput`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Black images when using OpenGL backend in `iced_wgpu`. [#2259](https://github.com/iced-rs/iced/pull/2259)
 - Documentation for `horizontal_space` and `vertical_space` helpers. [#2265](https://github.com/iced-rs/iced/pull/2265)
 - WebAssembly platform. [#2271](https://github.com/iced-rs/iced/pull/2271)
+- Decouple `Key` from `keyboard::Modifiers` and apply them to `text` in `KeyboardInput`. [#2238](https://github.com/iced-rs/iced/pull/2238)
 
 Many thanks to...
 
 - @PolyMeilex
 - @rizzen-yazston
+- @wash2
 
 ## [0.12.0] - 2024-02-15
 ### Added


### PR DESCRIPTION
Input like "ctrl + [a-z]" produces text like "a" instead of control characters when not accounting for modifiers. For Character keys, in most cases the text from the winit `KeyEvent` should match the received character anyway, so maybe it would be better to pass the text with modifiers accounted for.