### PR TITLE
Implement win32 workaround for multi_window application as well. Also trigger AboutToWait for Moved as well.

### DIFF
--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -250,7 +250,8 @@ where
             if matches!(
                 event,
                 winit::event::Event::WindowEvent {
-                    event: winit::event::WindowEvent::Resized(_),
+                    event: winit::event::WindowEvent::Resized(_)
+                        | winit::event::WindowEvent::Moved(_),
                     ..
                 }
             ) {


### PR DESCRIPTION
Fixes for multi_window as well. Move on windows breaks the event loop as well.