### PR TITLE
Add `show_window_menu` action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `skip_taskbar` window setting for Windows. [#2211](https://github.com/iced-rs/iced/pull/2211)
 - `fetch_maximized` and `fetch_minimized` commands in `window`. [#2189](https://github.com/iced-rs/iced/pull/2189)
 - `run_with_handle` command in `window`. [#2200](https://github.com/iced-rs/iced/pull/2200)
+- `show_system_menu` command in `window`. [#2243](https://github.com/iced-rs/iced/pull/2243)
 - `text_shaping` method for `Tooltip`. [#2172](https://github.com/iced-rs/iced/pull/2172)
 - `interaction` method for `MouseArea`. [#2207](https://github.com/iced-rs/iced/pull/2207)
 - `hovered` styling for `Svg` widget. [#2163](https://github.com/iced-rs/iced/pull/2163)

--- a/runtime/src/window.rs
+++ b/runtime/src/window.rs
@@ -160,9 +160,11 @@ pub fn change_level<Message>(id: Id, level: Level) -> Command<Message> {
     Command::single(command::Action::Window(Action::ChangeLevel(id, level)))
 }
 
-/// Show window menu at cursor position.
-pub fn show_window_menu<Message>(id: Id) -> Command<Message> {
-    Command::single(command::Action::Window(Action::ShowWindowMenu(id)))
+/// Show the [system menu] at cursor position.
+///
+/// [system menu]: https://en.wikipedia.org/wiki/Common_menus_in_Microsoft_Windows#System_menu
+pub fn show_system_menu<Message>(id: Id) -> Command<Message> {
+    Command::single(command::Action::Window(Action::ShowSystemMenu(id)))
 }
 
 /// Fetches an identifier unique to the window, provided by the underlying windowing system. This is

--- a/runtime/src/window.rs
+++ b/runtime/src/window.rs
@@ -160,6 +160,11 @@ pub fn change_level<Message>(id: Id, level: Level) -> Command<Message> {
     Command::single(command::Action::Window(Action::ChangeLevel(id, level)))
 }
 
+/// Show window menu at cursor position.
+pub fn show_window_menu<Message>(id: Id) -> Command<Message> {
+    Command::single(command::Action::Window(Action::ShowWindowMenu(id)))
+}
+
 /// Fetches an identifier unique to the window, provided by the underlying windowing system. This is
 /// not to be confused with [`Id`].
 pub fn fetch_id<Message>(

--- a/runtime/src/window/action.rs
+++ b/runtime/src/window/action.rs
@@ -81,11 +81,11 @@ pub enum Action<T> {
     GainFocus(Id),
     /// Change the window [`Level`].
     ChangeLevel(Id, Level),
-    /// Show window menu at cursor position.
+    /// Show the system menu at cursor position.
     ///
     /// ## Platform-specific
     /// Android / iOS / macOS / Orbital / Web / X11: Unsupported.
-    ShowWindowMenu(Id),
+    ShowSystemMenu(Id),
     /// Fetch the raw identifier unique to the window.
     FetchId(Id, Box<dyn FnOnce(u64) -> T + 'static>),
     /// Change the window [`Icon`].
@@ -146,7 +146,7 @@ impl<T> Action<T> {
             }
             Self::GainFocus(id) => Action::GainFocus(id),
             Self::ChangeLevel(id, level) => Action::ChangeLevel(id, level),
-            Self::ShowWindowMenu(id) => Action::ShowWindowMenu(id),
+            Self::ShowSystemMenu(id) => Action::ShowSystemMenu(id),
             Self::FetchId(id, o) => {
                 Action::FetchId(id, Box::new(move |s| f(o(s))))
             }
@@ -206,8 +206,8 @@ impl<T> fmt::Debug for Action<T> {
             Self::ChangeLevel(id, level) => {
                 write!(f, "Action::ChangeLevel({id:?}, {level:?})")
             }
-            Self::ShowWindowMenu(id) => {
-                write!(f, "Action::ShowWindowMenu({id:?})")
+            Self::ShowSystemMenu(id) => {
+                write!(f, "Action::ShowSystemMenu({id:?})")
             }
             Self::FetchId(id, _) => write!(f, "Action::FetchId({id:?})"),
             Self::ChangeIcon(id, _icon) => {

--- a/runtime/src/window/action.rs
+++ b/runtime/src/window/action.rs
@@ -81,6 +81,11 @@ pub enum Action<T> {
     GainFocus(Id),
     /// Change the window [`Level`].
     ChangeLevel(Id, Level),
+    /// Show window menu at cursor position.
+    ///
+    /// ## Platform-specific
+    /// Android / iOS / macOS / Orbital / Web / X11: Unsupported.
+    ShowWindowMenu(Id),
     /// Fetch the raw identifier unique to the window.
     FetchId(Id, Box<dyn FnOnce(u64) -> T + 'static>),
     /// Change the window [`Icon`].
@@ -141,6 +146,7 @@ impl<T> Action<T> {
             }
             Self::GainFocus(id) => Action::GainFocus(id),
             Self::ChangeLevel(id, level) => Action::ChangeLevel(id, level),
+            Self::ShowWindowMenu(id) => Action::ShowWindowMenu(id),
             Self::FetchId(id, o) => {
                 Action::FetchId(id, Box::new(move |s| f(o(s))))
             }
@@ -199,6 +205,9 @@ impl<T> fmt::Debug for Action<T> {
             Self::GainFocus(id) => write!(f, "Action::GainFocus({id:?})"),
             Self::ChangeLevel(id, level) => {
                 write!(f, "Action::ChangeLevel({id:?}, {level:?})")
+            }
+            Self::ShowWindowMenu(id) => {
+                write!(f, "Action::ShowWindowMenu({id:?})")
             }
             Self::FetchId(id, _) => write!(f, "Action::FetchId({id:?})"),
             Self::ChangeIcon(id, _icon) => {

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -807,6 +807,14 @@ pub fn run_command<A, C, E>(
                 window::Action::ChangeLevel(_id, level) => {
                     window.set_window_level(conversion::window_level(level));
                 }
+                window::Action::ShowWindowMenu(_id) => {
+                    if let mouse::Cursor::Available(point) = state.cursor() {
+                        window.show_window_menu(winit::dpi::LogicalPosition {
+                            x: point.x,
+                            y: point.y,
+                        });
+                    }
+                }
                 window::Action::FetchId(_id, tag) => {
                     proxy
                         .send_event(tag(window.id().into()))

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -807,7 +807,7 @@ pub fn run_command<A, C, E>(
                 window::Action::ChangeLevel(_id, level) => {
                     window.set_window_level(conversion::window_level(level));
                 }
-                window::Action::ShowWindowMenu(_id) => {
+                window::Action::ShowSystemMenu(_id) => {
                     if let mouse::Cursor::Available(point) = state.cursor() {
                         window.show_window_menu(winit::dpi::LogicalPosition {
                             x: point.x,

--- a/winit/src/multi_window.rs
+++ b/winit/src/multi_window.rs
@@ -6,6 +6,7 @@ pub use state::State;
 
 use crate::conversion;
 use crate::core;
+use crate::core::mouse;
 use crate::core::renderer;
 use crate::core::widget::operation;
 use crate::core::window;
@@ -1056,6 +1057,20 @@ fn run_command<A, C, E>(
                         window
                             .raw
                             .set_window_level(conversion::window_level(level));
+                    }
+                }
+                window::Action::ShowWindowMenu(id) => {
+                    if let Some(window) = window_manager.get_mut(id) {
+                        if let mouse::Cursor::Available(point) =
+                            window.state.cursor()
+                        {
+                            window.raw.show_window_menu(
+                                winit::dpi::LogicalPosition {
+                                    x: point.x,
+                                    y: point.y,
+                                },
+                            );
+                        }
                     }
                 }
                 window::Action::FetchId(id, tag) => {

--- a/winit/src/multi_window.rs
+++ b/winit/src/multi_window.rs
@@ -1059,7 +1059,7 @@ fn run_command<A, C, E>(
                             .set_window_level(conversion::window_level(level));
                     }
                 }
-                window::Action::ShowWindowMenu(id) => {
+                window::Action::ShowSystemMenu(id) => {
                     if let Some(window) = window_manager.get_mut(id) {
                         if let mouse::Cursor::Available(point) =
                             window.state.cursor()


### PR DESCRIPTION
Winit currently supports this only on Windows and Wayland.

This requests that a context menu is shown at the cursor position, like the menu normally triggered by right clicking the title bar. This is important for implementing client side decorations with Iced widgets.
