### PR TITLE
Enable image widget by default (without any image load/codec support)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,7 +7,7 @@ jobs:
     - uses: hecrj/setup-rust-action@v1
     - uses: actions/checkout@master
     - name: Check standalone `iced_widget` crate
-      run: cargo check --package iced_widget --features image,svg,canvas
+      run: cargo check --package iced_widget --features svg,canvas
 
   wasm:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,6 @@ maintenance = { status = "actively-developed" }
 default = ["wgpu"]
 # Enable the `wgpu` GPU-accelerated renderer backend
 wgpu = ["iced_renderer/wgpu", "iced_widget/wgpu"]
-# Enables the `Image` widget
-image = ["iced_widget/image", "dep:image"]
 # Enables the `Svg` widget
 svg = ["iced_widget/svg"]
 # Enables the `Canvas` widget
@@ -31,6 +29,8 @@ canvas = ["iced_widget/canvas"]
 qr_code = ["iced_widget/qr_code"]
 # Enables lazy widgets
 lazy = ["iced_widget/lazy"]
+# Enables image load support
+image = ["iced_core/image", "image/default"]
 # Enables a debug view in native platforms (press F12)
 debug = ["iced_winit/debug"]
 # Enables `tokio` as the `executor::Default` on native platforms
@@ -68,7 +68,6 @@ iced_highlighter.optional = true
 thiserror.workspace = true
 
 image.workspace = true
-image.optional = true
 
 [profile.release-opt]
 inherits = "release"
@@ -129,7 +128,7 @@ glam = "0.25"
 glyphon = "0.5"
 guillotiere = "0.6"
 half = "2.2"
-image = "0.24"
+image = { version = "0.24", default-features = false }
 kamadak-exif = "0.5"
 kurbo = "0.10"
 log = "0.4"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,6 +10,9 @@ homepage.workspace = true
 categories.workspace = true
 keywords.workspace = true
 
+[features]
+image = []
+
 [dependencies]
 bitflags.workspace = true
 glam.workspace = true

--- a/core/src/image.rs
+++ b/core/src/image.rs
@@ -16,6 +16,7 @@ impl Handle {
     /// Creates an image [`Handle`] pointing to the image of the given path.
     ///
     /// Makes an educated guess about the image format by examining the data in the file.
+    #[cfg(feature = "image")]
     pub fn from_path<T: Into<PathBuf>>(path: T) -> Handle {
         Self::from_data(Data::Path(path.into()))
     }
@@ -43,6 +44,7 @@ impl Handle {
     ///
     /// This is useful if you already have your image loaded in-memory, maybe
     /// because you downloaded or generated it procedurally.
+    #[cfg(feature = "image")]
     pub fn from_memory(
         bytes: impl AsRef<[u8]> + Send + Sync + 'static,
     ) -> Handle {
@@ -70,6 +72,7 @@ impl Handle {
     }
 }
 
+#[cfg(feature = "image")]
 impl<T> From<T> for Handle
 where
     T: Into<PathBuf>,

--- a/graphics/Cargo.toml
+++ b/graphics/Cargo.toml
@@ -16,7 +16,6 @@ all-features = true
 
 [features]
 geometry = ["lyon_path"]
-image = ["dep:image", "kamadak-exif"]
 web-colors = []
 
 [dependencies]
@@ -34,12 +33,8 @@ rustc-hash.workspace = true
 thiserror.workspace = true
 unicode-segmentation.workspace = true
 xxhash-rust.workspace = true
-
 image.workspace = true
-image.optional = true
-
 kamadak-exif.workspace = true
-kamadak-exif.optional = true
 
 lyon_path.workspace = true
 lyon_path.optional = true

--- a/graphics/src/lib.rs
+++ b/graphics/src/lib.rs
@@ -26,15 +26,13 @@ pub mod color;
 pub mod compositor;
 pub mod damage;
 pub mod gradient;
+pub mod image;
 pub mod mesh;
 pub mod renderer;
 pub mod text;
 
 #[cfg(feature = "geometry")]
 pub mod geometry;
-
-#[cfg(feature = "image")]
-pub mod image;
 
 pub use antialiasing::Antialiasing;
 pub use backend::Backend;

--- a/renderer/Cargo.toml
+++ b/renderer/Cargo.toml
@@ -12,7 +12,6 @@ keywords.workspace = true
 
 [features]
 wgpu = ["iced_wgpu"]
-image = ["iced_tiny_skia/image", "iced_wgpu?/image"]
 svg = ["iced_tiny_skia/svg", "iced_wgpu?/svg"]
 geometry = ["iced_graphics/geometry", "iced_tiny_skia/geometry", "iced_wgpu?/geometry"]
 tracing = ["iced_wgpu?/tracing"]

--- a/renderer/src/lib.rs
+++ b/renderer/src/lib.rs
@@ -212,7 +212,6 @@ impl text::Renderer for Renderer {
     }
 }
 
-#[cfg(feature = "image")]
 impl crate::core::image::Renderer for Renderer {
     type Handle = crate::core::image::Handle;
 

--- a/src/window/icon.rs
+++ b/src/window/icon.rs
@@ -54,11 +54,10 @@ pub enum Error {
     InvalidError(#[from] icon::Error),
 
     /// The underlying OS failed to create the icon.
-    #[error("The underlying OS failted to create the window icon: {0}")]
+    #[error("The underlying OS failed to create the window icon: {0}")]
     OsError(#[from] io::Error),
 
     /// The `image` crate reported an error.
-    #[cfg(feature = "image")]
     #[error("Unable to create icon from a file: {0}")]
     ImageError(#[from] image::error::ImageError),
 }

--- a/tiny_skia/Cargo.toml
+++ b/tiny_skia/Cargo.toml
@@ -11,7 +11,6 @@ categories.workspace = true
 keywords.workspace = true
 
 [features]
-image = ["iced_graphics/image"]
 svg = ["resvg"]
 geometry = ["iced_graphics/geometry"]
 

--- a/tiny_skia/src/backend.rs
+++ b/tiny_skia/src/backend.rs
@@ -10,8 +10,6 @@ use std::borrow::Cow;
 
 pub struct Backend {
     text_pipeline: crate::text::Pipeline,
-
-    #[cfg(feature = "image")]
     raster_pipeline: crate::raster::Pipeline,
 
     #[cfg(feature = "svg")]
@@ -22,8 +20,6 @@ impl Backend {
     pub fn new() -> Self {
         Self {
             text_pipeline: crate::text::Pipeline::new(),
-
-            #[cfg(feature = "image")]
             raster_pipeline: crate::raster::Pipeline::new(),
 
             #[cfg(feature = "svg")]
@@ -131,8 +127,6 @@ impl Backend {
         }
 
         self.text_pipeline.trim_cache();
-
-        #[cfg(feature = "image")]
         self.raster_pipeline.trim_cache();
 
         #[cfg(feature = "svg")]
@@ -571,7 +565,6 @@ impl Backend {
                     transformation,
                 );
             }
-            #[cfg(feature = "image")]
             Primitive::Image {
                 handle,
                 filter_method,
@@ -596,12 +589,6 @@ impl Backend {
                     pixels,
                     transform,
                     clip_mask,
-                );
-            }
-            #[cfg(not(feature = "image"))]
-            Primitive::Image { .. } => {
-                log::warn!(
-                    "Unsupported primitive in `iced_tiny_skia`: {primitive:?}",
                 );
             }
             #[cfg(feature = "svg")]
@@ -999,7 +986,6 @@ impl backend::Text for Backend {
     }
 }
 
-#[cfg(feature = "image")]
 impl backend::Image for Backend {
     fn dimensions(
         &self,

--- a/tiny_skia/src/lib.rs
+++ b/tiny_skia/src/lib.rs
@@ -5,11 +5,9 @@ pub mod window;
 
 mod backend;
 mod primitive;
+mod raster;
 mod settings;
 mod text;
-
-#[cfg(feature = "image")]
-mod raster;
 
 #[cfg(feature = "svg")]
 mod vector;

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -16,7 +16,6 @@ all-features = true
 
 [features]
 geometry = ["iced_graphics/geometry", "lyon"]
-image = ["iced_graphics/image"]
 svg = ["resvg/text"]
 web-colors = ["iced_graphics/web-colors"]
 webgl = ["wgpu/webgl"]

--- a/wgpu/src/backend.rs
+++ b/wgpu/src/backend.rs
@@ -41,7 +41,11 @@ impl Backend {
         let quad_pipeline = quad::Pipeline::new(device, format);
         let triangle_pipeline =
             triangle::Pipeline::new(device, format, settings.antialiasing);
-        let image_pipeline = image::Pipeline::new(device, format);
+        let image_pipeline = {
+            let backend = _adapter.get_info().backend;
+
+            image::Pipeline::new(device, format, backend)
+        };
 
         Self {
             quad_pipeline,

--- a/wgpu/src/image.rs
+++ b/wgpu/src/image.rs
@@ -1,6 +1,4 @@
 mod atlas;
-
-#[cfg(feature = "image")]
 mod raster;
 
 #[cfg(feature = "svg")]
@@ -8,6 +6,7 @@ mod vector;
 
 use atlas::Atlas;
 
+use crate::core::image;
 use crate::core::{Rectangle, Size, Transformation};
 use crate::layer;
 use crate::Buffer;
@@ -17,9 +16,6 @@ use std::mem;
 
 use bytemuck::{Pod, Zeroable};
 
-#[cfg(feature = "image")]
-use crate::core::image;
-
 #[cfg(feature = "svg")]
 use crate::core::svg;
 
@@ -28,7 +24,6 @@ use tracing::info_span;
 
 #[derive(Debug)]
 pub struct Pipeline {
-    #[cfg(feature = "image")]
     raster_cache: RefCell<raster::Cache>,
     #[cfg(feature = "svg")]
     vector_cache: RefCell<vector::Cache>,
@@ -332,7 +327,6 @@ impl Pipeline {
         });
 
         Pipeline {
-            #[cfg(feature = "image")]
             raster_cache: RefCell::new(raster::Cache::default()),
 
             #[cfg(feature = "svg")]
@@ -352,7 +346,6 @@ impl Pipeline {
         }
     }
 
-    #[cfg(feature = "image")]
     pub fn dimensions(&self, handle: &image::Handle) -> Size<u32> {
         let mut cache = self.raster_cache.borrow_mut();
         let memory = cache.load(handle);
@@ -386,7 +379,6 @@ impl Pipeline {
         let nearest_instances: &mut Vec<Instance> = &mut Vec::new();
         let linear_instances: &mut Vec<Instance> = &mut Vec::new();
 
-        #[cfg(feature = "image")]
         let mut raster_cache = self.raster_cache.borrow_mut();
 
         #[cfg(feature = "svg")]
@@ -394,7 +386,6 @@ impl Pipeline {
 
         for image in images {
             match &image {
-                #[cfg(feature = "image")]
                 layer::Image::Raster {
                     handle,
                     filter_method,
@@ -419,9 +410,6 @@ impl Pipeline {
                         );
                     }
                 }
-                #[cfg(not(feature = "image"))]
-                layer::Image::Raster { .. } => {}
-
                 #[cfg(feature = "svg")]
                 layer::Image::Vector {
                     handle,
@@ -521,7 +509,6 @@ impl Pipeline {
     }
 
     pub fn end_frame(&mut self) {
-        #[cfg(feature = "image")]
         self.raster_cache.borrow_mut().trim(&mut self.texture_atlas);
 
         #[cfg(feature = "svg")]

--- a/wgpu/src/image/atlas/entry.rs
+++ b/wgpu/src/image/atlas/entry.rs
@@ -11,7 +11,6 @@ pub enum Entry {
 }
 
 impl Entry {
-    #[cfg(feature = "image")]
     pub fn size(&self) -> Size<u32> {
         match self {
             Entry::Contiguous(allocation) => allocation.size(),

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -40,6 +40,7 @@ pub mod geometry;
 mod backend;
 mod buffer;
 mod color;
+mod image;
 mod quad;
 mod text;
 mod triangle;
@@ -55,9 +56,6 @@ pub use backend::Backend;
 pub use layer::Layer;
 pub use primitive::Primitive;
 pub use settings::Settings;
-
-#[cfg(any(feature = "image", feature = "svg"))]
-mod image;
 
 /// A [`wgpu`] graphics renderer for [`iced`].
 ///

--- a/widget/Cargo.toml
+++ b/widget/Cargo.toml
@@ -16,7 +16,6 @@ all-features = true
 
 [features]
 lazy = ["ouroboros"]
-image = ["iced_renderer/image"]
 svg = ["iced_renderer/svg"]
 canvas = ["iced_renderer/geometry"]
 qr_code = ["canvas", "qrcode"]

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -355,7 +355,6 @@ where
 /// Creates a new [`Image`].
 ///
 /// [`Image`]: crate::Image
-#[cfg(feature = "image")]
 pub fn image<Handle>(handle: impl Into<Handle>) -> crate::Image<Handle> {
     crate::Image::new(handle.into())
 }

--- a/widget/src/lib.rs
+++ b/widget/src/lib.rs
@@ -25,6 +25,7 @@ pub mod button;
 pub mod checkbox;
 pub mod combo_box;
 pub mod container;
+pub mod image;
 pub mod keyed;
 pub mod overlay;
 pub mod pane_grid;
@@ -65,6 +66,8 @@ pub use column::Column;
 pub use combo_box::ComboBox;
 #[doc(no_inline)]
 pub use container::Container;
+#[doc(no_inline)]
+pub use image::Image;
 #[doc(no_inline)]
 pub use mouse_area::MouseArea;
 #[doc(no_inline)]
@@ -113,13 +116,6 @@ pub mod svg;
 #[cfg(feature = "svg")]
 #[doc(no_inline)]
 pub use svg::Svg;
-
-#[cfg(feature = "image")]
-pub mod image;
-
-#[cfg(feature = "image")]
-#[doc(no_inline)]
-pub use image::Image;
 
 #[cfg(feature = "canvas")]
 pub mod canvas;


### PR DESCRIPTION
This is a non-breaking change that allows using images loaded with a different library in your program, or raw pixel buffers without including all of the bloat that image-rs is.

It's another attempt at #2244 that is backwards compatible with existing applications because they will already use the image feature if they want the widget.
