### PR TITLE
[wgpu.image] Workaround WGPU OpenGL heuristics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Alpha mode misconfiguration in `iced_wgpu`. [#2231](https://github.com/iced-rs/iced/pull/2231)
 - Outdated documentation leading to a dead link. [#2232](https://github.com/iced-rs/iced/pull/2232)
 
+## Patched
+- Black images when using OpenGL backend in `iced_wgpu`. [#2259](https://github.com/iced-rs/iced/pull/2259)
+
 Many thanks to...
 
 - @akshayr-mecha
@@ -156,6 +159,7 @@ Many thanks to...
 - @nicksenger
 - @Nisatru
 - @nyurik
+- @PolyMeilex
 - @Remmirad
 - @ripytide
 - @snaggen

--- a/wgpu/src/backend.rs
+++ b/wgpu/src/backend.rs
@@ -27,7 +27,6 @@ pub struct Backend {
     text_pipeline: text::Pipeline,
     triangle_pipeline: triangle::Pipeline,
     pipeline_storage: pipeline::Storage,
-
     #[cfg(any(feature = "image", feature = "svg"))]
     image_pipeline: image::Pipeline,
 }
@@ -35,6 +34,7 @@ pub struct Backend {
 impl Backend {
     /// Creates a new [`Backend`].
     pub fn new(
+        _adapter: &wgpu::Adapter,
         device: &wgpu::Device,
         queue: &wgpu::Queue,
         settings: Settings,
@@ -46,7 +46,11 @@ impl Backend {
             triangle::Pipeline::new(device, format, settings.antialiasing);
 
         #[cfg(any(feature = "image", feature = "svg"))]
-        let image_pipeline = image::Pipeline::new(device, format);
+        let image_pipeline = {
+            let backend = _adapter.get_info().backend;
+
+            image::Pipeline::new(device, format, backend)
+        };
 
         Self {
             quad_pipeline,

--- a/wgpu/src/image.rs
+++ b/wgpu/src/image.rs
@@ -176,7 +176,11 @@ impl Data {
 }
 
 impl Pipeline {
-    pub fn new(device: &wgpu::Device, format: wgpu::TextureFormat) -> Self {
+    pub fn new(
+        device: &wgpu::Device,
+        format: wgpu::TextureFormat,
+        backend: wgpu::Backend,
+    ) -> Self {
         let nearest_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
             address_mode_u: wgpu::AddressMode::ClampToEdge,
             address_mode_v: wgpu::AddressMode::ClampToEdge,
@@ -318,7 +322,7 @@ impl Pipeline {
                 multiview: None,
             });
 
-        let texture_atlas = Atlas::new(device);
+        let texture_atlas = Atlas::new(device, backend);
 
         let texture = device.create_bind_group(&wgpu::BindGroupDescriptor {
             label: Some("iced_wgpu::image texture atlas bind group"),

--- a/wgpu/src/image/atlas.rs
+++ b/wgpu/src/image/atlas.rs
@@ -23,11 +23,15 @@ pub struct Atlas {
 }
 
 impl Atlas {
-    pub fn new(device: &wgpu::Device) -> Self {
-        // We start with 2 layers, to help wgpu figure out that this texture is `GL_TEXTURE_2D_ARRAY` rather
-        // than `GL_TEXTURE_2D`
-        // https://github.com/gfx-rs/wgpu/blob/004e3efe84a320d9331371ed31fa50baa2414911/wgpu-hal/src/gles/mod.rs#L371
-        let layers = vec![Layer::Empty, Layer::Empty];
+    pub fn new(device: &wgpu::Device, backend: wgpu::Backend) -> Self {
+        let layers = match backend {
+            // On the GL backend we start with 2 layers, to help wgpu figure
+            // out that this texture is `GL_TEXTURE_2D_ARRAY` rather than `GL_TEXTURE_2D`
+            // https://github.com/gfx-rs/wgpu/blob/004e3efe84a320d9331371ed31fa50baa2414911/wgpu-hal/src/gles/mod.rs#L371
+            wgpu::Backend::Gl => vec![Layer::Empty, Layer::Empty],
+            _ => vec![Layer::Empty],
+        };
+
         let extent = wgpu::Extent3d {
             width: SIZE,
             height: SIZE,

--- a/wgpu/src/image/atlas.rs
+++ b/wgpu/src/image/atlas.rs
@@ -24,10 +24,14 @@ pub struct Atlas {
 
 impl Atlas {
     pub fn new(device: &wgpu::Device) -> Self {
+        // We start with 2 layers, to help wgpu figure out that this texture is `GL_TEXTURE_2D_ARRAY` rather
+        // than `GL_TEXTURE_2D`
+        // https://github.com/gfx-rs/wgpu/blob/004e3efe84a320d9331371ed31fa50baa2414911/wgpu-hal/src/gles/mod.rs#L371
+        let layers = vec![Layer::Empty, Layer::Empty];
         let extent = wgpu::Extent3d {
             width: SIZE,
             height: SIZE,
-            depth_or_array_layers: 1,
+            depth_or_array_layers: layers.len() as u32,
         };
 
         let texture = device.create_texture(&wgpu::TextureDescriptor {
@@ -55,7 +59,7 @@ impl Atlas {
         Atlas {
             texture,
             texture_view,
-            layers: vec![Layer::Empty],
+            layers,
         }
     }
 

--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -146,7 +146,13 @@ impl Compositor {
 
     /// Creates a new rendering [`Backend`] for this [`Compositor`].
     pub fn create_backend(&self) -> Backend {
-        Backend::new(&self.device, &self.queue, self.settings, self.format)
+        Backend::new(
+            &self.adapter,
+            &self.device,
+            &self.queue,
+            self.settings,
+            self.format,
+        )
     }
 }
 


### PR DESCRIPTION
wgpu OpenGL image rendering has been broken for years (every image is a black rectangle), but finally I accumulated enough willpower to debug and fix this.

So, it turns out that wgpu [has to use heuristics](https://github.com/gfx-rs/wgpu/blob/004e3efe84a320d9331371ed31fa50baa2414911/wgpu-hal/src/gles/mod.rs#L371) to guess that the texture we are creating will be used as `TEXTURE_2D_ARRAY` rather than `TEXTURE_2D`, and OpenGL needs to know that ahead of time, otherwise it will refuse to bind it because of type mismatch.

The real fix should be on wgpu side, but that seems to be known and not obvious problem.
So in the meantime, I just increased default layers allocation in the atlas to 2. That way wgpu will see layer depth 2 and correctly assume that we want to use this texture as `TEXTURE_2D_ARRAY`


EDIT: Found an issue that mentions the array layer limitations: https://github.com/gfx-rs/wgpu/issues/1574

Fixes #1774.
Fixes #2180.