### PR TITLE
add helper fun for Padding

### DIFF
--- a/core/src/padding.rs
+++ b/core/src/padding.rs
@@ -46,7 +46,7 @@ pub struct Padding {
 }
 
 impl Padding {
-    /// Padding of zero
+    /// [`Padding`] of zero
     pub const ZERO: Padding = Padding {
         top: 0.0,
         right: 0.0,
@@ -54,7 +54,7 @@ impl Padding {
         left: 0.0,
     };
 
-    /// Create a Padding that is equal on all sides
+    /// Create a [`Padding`] that is equal on all sides
     pub const fn new(padding: f32) -> Padding {
         Padding {
             top: padding,
@@ -64,36 +64,60 @@ impl Padding {
         }
     }
 
-    /// Create a top Padding
-    pub const fn top(padding: f32) -> Self {
+    /// Creates a top [`Padding`].
+    pub const fn with_top(padding: f32) -> Self {
         Self {
             top: padding,
             ..Padding::ZERO
         }
     }
 
-    /// Create a bottom Padding
-    pub const fn bottom(padding: f32) -> Self {
+    /// Creates a bottom [`Padding`].
+    pub const fn with_bottom(padding: f32) -> Self {
         Self {
             bottom: padding,
             ..Padding::ZERO
         }
     }
 
-    /// Create a right Padding
-    pub const fn right(padding: f32) -> Self {
+    /// Creates a right [`Padding`].
+    pub const fn with_right(padding: f32) -> Self {
         Self {
             right: padding,
             ..Padding::ZERO
         }
     }
 
-    /// Create a left Padding
-    pub const fn left(padding: f32) -> Self {
+    /// Creates a left [`Padding`].
+    pub const fn with_left(padding: f32) -> Self {
         Self {
             left: padding,
             ..Padding::ZERO
         }
+    }
+
+    /// Changes the top [`Padding`].
+    pub const fn top(mut self, padding: f32) -> Self {
+        self.top = padding;
+        self
+    }
+
+    /// Changes the bottom [`Padding`].
+    pub const fn bottom(mut self, padding: f32) -> Self {
+        self.bottom = padding;
+        self
+    }
+
+    /// Changes the right [`Padding`].
+    pub const fn right(mut self, padding: f32) -> Self {
+        self.right = padding;
+        self
+    }
+
+    /// Changes the left [`Padding`].
+    pub const fn left(mut self, padding: f32) -> Self {
+        self.left = padding;
+        self
     }
 
     /// Returns the total amount of vertical [`Padding`].

--- a/core/src/padding.rs
+++ b/core/src/padding.rs
@@ -64,6 +64,38 @@ impl Padding {
         }
     }
 
+    /// Create a top Padding
+    pub const fn top(padding: f32) -> Self {
+        Self {
+            top: padding,
+            ..Padding::ZERO
+        }
+    }
+
+    /// Create a bottom Padding
+    pub const fn bottom(padding: f32) -> Self {
+        Self {
+            bottom: padding,
+            ..Padding::ZERO
+        }
+    }
+
+    /// Create a right Padding
+    pub const fn right(padding: f32) -> Self {
+        Self {
+            right: padding,
+            ..Padding::ZERO
+        }
+    }
+
+    /// Create a left Padding
+    pub const fn left(padding: f32) -> Self {
+        Self {
+            left: padding,
+            ..Padding::ZERO
+        }
+    }
+
     /// Returns the total amount of vertical [`Padding`].
     pub fn vertical(self) -> f32 {
         self.top + self.bottom

--- a/core/src/padding.rs
+++ b/core/src/padding.rs
@@ -64,6 +64,24 @@ impl Padding {
         }
     }
 
+    /// Creates a [`Padding`] with equal spacing on the right and left sides.
+    pub fn with_horizontal(padding: f32) -> Self {
+        Self {
+            left: padding,
+            right: padding,
+            ..Padding::ZERO
+        }
+    }
+
+    /// Creates a [`Padding`] with equal spacing on the top and bottom sides.
+    pub fn with_vertical(padding: f32) -> Self {
+        Self {
+            top: padding,
+            bottom: padding,
+            ..Padding::ZERO
+        }
+    }
+
     /// Creates a top [`Padding`].
     pub const fn with_top(padding: f32) -> Self {
         Self {


### PR DESCRIPTION
This add some new method to the Padding struct. 

I have some other ideas, like also provide some more method like

```rust 
/// Create a [`Padding`] with equally spaces of the right and left side
    pub fn vertical(padding: f32) -> Self {
        Self {
            left: padding,
            right: padding,
            ..Padding::ZERO
        }
    }
```
and the same for vertical, but that will involve breaking change.

And also provide a constructor API alternative:

```rust 
pub fn vertical(self, padding: f32) -> Self {
        self.left = padding;
        self.right = padding;
        self
    }
```

to allow writting this:

```rust 
let padding = Padding::horizontal(10f32)
            .bottom(5f32);
```

But this will involve, reanaming the method i written like such

```rust 
fn new_top()
fn new_bottom()
fn new_vertical()
```

which is fine imo.

I think it make more sense to provide this funcions rather than

```rust
pub fn vertical(self) -> f32 {
        self.top + self.bottom
    }
```

because i don't really see a lot of use case for this (user perspective).
