### PR TITLE
`extend` and `from_vec` methods for `Column` and `Row`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `extend` and `from_vec` methods for `Column` and `Row`. [#2264](https://github.com/iced-rs/iced/pull/2264)
+
+### Fixed
+- Black images when using OpenGL backend in `iced_wgpu`. [#2259](https://github.com/iced-rs/iced/pull/2259)
+
+Many thanks to...
+
+- @PolyMeilex
 
 ## [0.12.0] - 2024-02-15
 ### Added
@@ -116,9 +125,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Alpha mode misconfiguration in `iced_wgpu`. [#2231](https://github.com/iced-rs/iced/pull/2231)
 - Outdated documentation leading to a dead link. [#2232](https://github.com/iced-rs/iced/pull/2232)
 
-## Patched
-- Black images when using OpenGL backend in `iced_wgpu`. [#2259](https://github.com/iced-rs/iced/pull/2259)
-- `extend` and `from_vec` methods for `Column` and `Row`. [#2264](https://github.com/iced-rs/iced/pull/2264)
 
 Many thanks to...
 
@@ -160,7 +166,6 @@ Many thanks to...
 - @nicksenger
 - @Nisatru
 - @nyurik
-- @PolyMeilex
 - @Remmirad
 - @ripytide
 - @snaggen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Patched
 - Black images when using OpenGL backend in `iced_wgpu`. [#2259](https://github.com/iced-rs/iced/pull/2259)
+- `extend` and `from_vec` methods for `Column` and `Row`. [#2264](https://github.com/iced-rs/iced/pull/2264)
 
 Many thanks to...
 

--- a/widget/src/column.rs
+++ b/widget/src/column.rs
@@ -30,16 +30,7 @@ where
 {
     /// Creates an empty [`Column`].
     pub fn new() -> Self {
-        Column {
-            spacing: 0.0,
-            padding: Padding::ZERO,
-            width: Length::Shrink,
-            height: Length::Shrink,
-            max_width: f32::INFINITY,
-            align_items: Alignment::Start,
-            clip: false,
-            children: Vec::new(),
-        }
+        Self::from_vec(Vec::new())
     }
 
     /// Creates a [`Column`] with the given elements.
@@ -47,6 +38,28 @@ where
         children: impl IntoIterator<Item = Element<'a, Message, Theme, Renderer>>,
     ) -> Self {
         Self::new().extend(children)
+    }
+
+    /// Creates a [`Column`] from an already allocated [`Vec`].
+    ///
+    /// Keep in mind that the [`Column`] will not inspect the [`Vec`], which means
+    /// it won't automatically adapt to the sizing strategy of its contents.
+    ///
+    /// If any of the children have a [`Length::Fill`] strategy, you will need to
+    /// call [`Column::width`] or [`Column::height`] accordingly.
+    pub fn from_vec(
+        children: Vec<Element<'a, Message, Theme, Renderer>>,
+    ) -> Self {
+        Self {
+            spacing: 0.0,
+            padding: Padding::ZERO,
+            width: Length::Shrink,
+            height: Length::Shrink,
+            max_width: f32::INFINITY,
+            align_items: Alignment::Start,
+            clip: false,
+            children,
+        }
     }
 
     /// Sets the vertical spacing _between_ elements.

--- a/widget/src/column.rs
+++ b/widget/src/column.rs
@@ -46,7 +46,7 @@ where
     pub fn with_children(
         children: impl IntoIterator<Item = Element<'a, Message, Theme, Renderer>>,
     ) -> Self {
-        children.into_iter().fold(Self::new(), Self::push)
+        Self::new().extend(children)
     }
 
     /// Sets the vertical spacing _between_ elements.
@@ -126,6 +126,14 @@ where
         } else {
             self
         }
+    }
+
+    /// Extends the [`Column`] with the given children.
+    pub fn extend(
+        self,
+        children: impl IntoIterator<Item = Element<'a, Message, Theme, Renderer>>,
+    ) -> Self {
+        children.into_iter().fold(self, Self::push)
     }
 }
 

--- a/widget/src/row.rs
+++ b/widget/src/row.rs
@@ -43,7 +43,7 @@ where
     pub fn with_children(
         children: impl IntoIterator<Item = Element<'a, Message, Theme, Renderer>>,
     ) -> Self {
-        children.into_iter().fold(Self::new(), Self::push)
+        Self::new().extend(children)
     }
 
     /// Sets the horizontal spacing _between_ elements.
@@ -117,6 +117,14 @@ where
         } else {
             self
         }
+    }
+
+    /// Extends the [`Row`] with the given children.
+    pub fn extend(
+        self,
+        children: impl IntoIterator<Item = Element<'a, Message, Theme, Renderer>>,
+    ) -> Self {
+        children.into_iter().fold(self, Self::push)
     }
 }
 

--- a/widget/src/row.rs
+++ b/widget/src/row.rs
@@ -28,15 +28,7 @@ where
 {
     /// Creates an empty [`Row`].
     pub fn new() -> Self {
-        Row {
-            spacing: 0.0,
-            padding: Padding::ZERO,
-            width: Length::Shrink,
-            height: Length::Shrink,
-            align_items: Alignment::Start,
-            clip: false,
-            children: Vec::new(),
-        }
+        Self::from_vec(Vec::new())
     }
 
     /// Creates a [`Row`] with the given elements.
@@ -44,6 +36,27 @@ where
         children: impl IntoIterator<Item = Element<'a, Message, Theme, Renderer>>,
     ) -> Self {
         Self::new().extend(children)
+    }
+
+    /// Creates a [`Row`] from an already allocated [`Vec`].
+    ///
+    /// Keep in mind that the [`Row`] will not inspect the [`Vec`], which means
+    /// it won't automatically adapt to the sizing strategy of its contents.
+    ///
+    /// If any of the children have a [`Length::Fill`] strategy, you will need to
+    /// call [`Row::width`] or [`Row::height`] accordingly.
+    pub fn from_vec(
+        children: Vec<Element<'a, Message, Theme, Renderer>>,
+    ) -> Self {
+        Self {
+            spacing: 0.0,
+            padding: Padding::ZERO,
+            width: Length::Shrink,
+            height: Length::Shrink,
+            align_items: Alignment::Start,
+            clip: false,
+            children,
+        }
     }
 
     /// Sets the horizontal spacing _between_ elements.


### PR DESCRIPTION
Introduces `extend` and `from_vec` methods for `Column` and `Row`, improving ergonomics and performance in some circumstances.