### PR TITLE
Fixed horizontal_space() and vertical_space() helper functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Black images when using OpenGL backend in `iced_wgpu`. [#2259](https://github.com/iced-rs/iced/pull/2259)
+- Documentation for `horizontal_space` and `vertical_space` helpers. [#2265](https://github.com/iced-rs/iced/pull/2265)
 
 Many thanks to...
 
 - @PolyMeilex
+- @rizzen-yazston
 
 ## [0.12.0] - 2024-02-15
 ### Added

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -302,16 +302,18 @@ where
     ComboBox::new(state, placeholder, selection, on_selected)
 }
 
-/// Creates a new horizontal [`Space`] with the given [`Length`].
+/// Creates a new [`Space`] widget that fills the available
+/// horizontal space.
 ///
-/// [`Space`]: crate::Space
+/// This can be useful to separate widgets in a [`Row`].
 pub fn horizontal_space() -> Space {
     Space::with_width(Length::Fill)
 }
 
-/// Creates a new vertical [`Space`] with the given [`Length`].
+/// Creates a new [`Space`] widget that fills the available
+/// vertical space.
 ///
-/// [`Space`]: crate::Space
+/// This can be useful to separate widgets in a [`Column`].
 pub fn vertical_space() -> Space {
     Space::with_height(Length::Fill)
 }


### PR DESCRIPTION
Just a simply fix to 2 helper functions of widget crate.

`cargo clippy` and `cargo fmt` commands was executed.

Fixes #2257.