### PR TITLE
Add a configuration to scrollable to always show the scrollbar. Adds a disabled style for scrollbar.

### DIFF
--- a/style/src/scrollable.rs
+++ b/style/src/scrollable.rs
@@ -52,4 +52,7 @@ pub trait StyleSheet {
     fn dragging(&self, style: &Self::Style) -> Appearance {
         self.hovered(style, true)
     }
+
+    /// Produces the [`Appearance`] of a scrollable when it is disabled.
+    fn disabled(&self, style: &Self::Style) -> Appearance;
 }

--- a/style/src/theme.rs
+++ b/style/src/theme.rs
@@ -1249,6 +1249,34 @@ impl scrollable::StyleSheet for Theme {
             Scrollable::Custom(custom) => custom.dragging(self),
         }
     }
+
+    fn disabled(&self, style: &Self::Style) -> scrollable::Appearance {
+        if let Scrollable::Custom(custom) = style {
+            return custom.disabled(self);
+        }
+
+        let active = self.active(style);
+
+        scrollable::Appearance {
+            scrollbar: scrollable::Scrollbar {
+                scroller: scrollable::Scroller {
+                    color: Color {
+                        a: active.scrollbar.scroller.color.a * 0.5,
+                        ..active.scrollbar.scroller.color
+                    },
+                    border: Border {
+                        color: Color {
+                            a: active.scrollbar.scroller.border.color.a * 0.5,
+                            ..active.scrollbar.scroller.border.color
+                        },
+                        ..active.scrollbar.scroller.border
+                    },
+                },
+                ..active.scrollbar
+            },
+            ..active
+        }
+    }
 }
 
 /// The style of text.


### PR DESCRIPTION
Disabled styles are used when a scrollbar is shown, but no content is overflowing.