### PR TITLE
Add `size_hint` method to `Component` trait

### DIFF
--- a/examples/component/src/main.rs
+++ b/examples/component/src/main.rs
@@ -48,7 +48,7 @@ impl Sandbox for Component {
 mod numeric_input {
     use iced::alignment::{self, Alignment};
     use iced::widget::{button, component, row, text, text_input, Component};
-    use iced::{Element, Length};
+    use iced::{Element, Length, Size};
 
     pub struct NumericInput<Message> {
         value: Option<u32>,
@@ -142,6 +142,13 @@ mod numeric_input {
             .align_items(Alignment::Center)
             .spacing(10)
             .into()
+        }
+
+        fn size_hint(&self) -> Size<Length> {
+            Size {
+                width: Length::Fill,
+                height: Length::Shrink,
+            }
         }
     }
 

--- a/widget/src/lazy/component.rs
+++ b/widget/src/lazy/component.rs
@@ -62,6 +62,17 @@ pub trait Component<Message, Theme = crate::Theme, Renderer = crate::Renderer> {
         _operation: &mut dyn widget::Operation<Message>,
     ) {
     }
+
+    /// Returns a [`Size`] hint for laying out the [`Component`].
+    ///
+    /// This hint may be used by some widget containers to adjust their sizing strategy
+    /// during construction.
+    fn size_hint(&self) -> Size<Length> {
+        Size {
+            width: Length::Shrink,
+            height: Length::Shrink,
+        }
+    }
 }
 
 struct Tag<T>(T);
@@ -255,10 +266,12 @@ where
     }
 
     fn size_hint(&self) -> Size<Length> {
-        Size {
-            width: Length::Shrink,
-            height: Length::Shrink,
-        }
+        self.state
+            .borrow()
+            .as_ref()
+            .expect("Borrow instance state")
+            .borrow_component()
+            .size_hint()
     }
 
     fn layout(


### PR DESCRIPTION
This can be used to aid the sizing strategy of some containers directly in the component definition, instead of stating the sizes explicitly in `view` logic.