### PR TITLE
Add `text::Wrapping` support

### DIFF
--- a/core/src/renderer/null.rs
+++ b/core/src/renderer/null.rs
@@ -161,6 +161,7 @@ impl text::Editor for () {
         _new_font: Self::Font,
         _new_size: Pixels,
         _new_line_height: text::LineHeight,
+        _new_wrapping: text::Wrapping,
         _new_highlighter: &mut impl text::Highlighter,
     ) {
     }

--- a/core/src/text.rs
+++ b/core/src/text.rs
@@ -41,6 +41,9 @@ pub struct Text<Content = String, Font = crate::Font> {
 
     /// The [`Shaping`] strategy of the [`Text`].
     pub shaping: Shaping,
+
+    /// The [`Wrapping`] strategy of the [`Text`].
+    pub wrapping: Wrapping,
 }
 
 /// The shaping strategy of some text.
@@ -65,6 +68,22 @@ pub enum Shaping {
     ///
     /// Advanced shaping is expensive! You should only enable it when necessary.
     Advanced,
+}
+
+/// The wrapping strategy of some text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum Wrapping {
+    /// No wrapping.
+    None,
+    /// Wraps at the word level.
+    ///
+    /// This is the default.
+    #[default]
+    Word,
+    /// Wraps at the glyph level.
+    Glyph,
+    /// Wraps at the word level, or fallback to glyph level if a word can't fit on a line by itself.
+    WordOrGlyph,
 }
 
 /// The height of a line of text in a paragraph.

--- a/core/src/text/editor.rs
+++ b/core/src/text/editor.rs
@@ -1,6 +1,6 @@
 //! Edit text.
 use crate::text::highlighter::{self, Highlighter};
-use crate::text::LineHeight;
+use crate::text::{LineHeight, Wrapping};
 use crate::{Pixels, Point, Rectangle, Size};
 
 use std::sync::Arc;
@@ -50,6 +50,7 @@ pub trait Editor: Sized + Default {
         new_font: Self::Font,
         new_size: Pixels,
         new_line_height: LineHeight,
+        new_wrapping: Wrapping,
         new_highlighter: &mut impl Highlighter,
     );
 

--- a/core/src/text/paragraph.rs
+++ b/core/src/text/paragraph.rs
@@ -95,6 +95,7 @@ impl<P: Paragraph> Plain<P> {
             horizontal_alignment: text.horizontal_alignment,
             vertical_alignment: text.vertical_alignment,
             shaping: text.shaping,
+            wrapping: text.wrapping,
         }) {
             Difference::None => {}
             Difference::Bounds => {

--- a/core/src/widget/text.rs
+++ b/core/src/widget/text.rs
@@ -11,7 +11,7 @@ use crate::{
     Widget,
 };
 
-pub use text::{LineHeight, Shaping};
+pub use text::{LineHeight, Shaping, Wrapping};
 
 /// A paragraph of text.
 #[allow(missing_debug_implementations)]
@@ -29,6 +29,7 @@ where
     vertical_alignment: alignment::Vertical,
     font: Option<Renderer::Font>,
     shaping: Shaping,
+    wrapping: Wrapping,
     class: Theme::Class<'a>,
 }
 
@@ -48,7 +49,8 @@ where
             height: Length::Shrink,
             horizontal_alignment: alignment::Horizontal::Left,
             vertical_alignment: alignment::Vertical::Top,
-            shaping: Shaping::Basic,
+            shaping: Shaping::default(),
+            wrapping: Wrapping::default(),
             class: Theme::default(),
         }
     }
@@ -112,6 +114,12 @@ where
     /// Sets the [`Shaping`] strategy of the [`Text`].
     pub fn shaping(mut self, shaping: Shaping) -> Self {
         self.shaping = shaping;
+        self
+    }
+
+    /// Sets the [`Wrapping`] strategy of the [`Text`].
+    pub fn wrapping(mut self, wrapping: Wrapping) -> Self {
+        self.wrapping = wrapping;
         self
     }
 
@@ -198,6 +206,7 @@ where
             self.horizontal_alignment,
             self.vertical_alignment,
             self.shaping,
+            self.wrapping,
         )
     }
 
@@ -232,6 +241,7 @@ pub fn layout<Renderer>(
     horizontal_alignment: alignment::Horizontal,
     vertical_alignment: alignment::Vertical,
     shaping: Shaping,
+    wrapping: Wrapping,
 ) -> layout::Node
 where
     Renderer: text::Renderer,
@@ -253,6 +263,7 @@ where
             horizontal_alignment,
             vertical_alignment,
             shaping,
+            wrapping,
         });
 
         paragraph.min_bounds()

--- a/examples/styling/src/main.rs
+++ b/examples/styling/src/main.rs
@@ -78,7 +78,7 @@ impl Styling {
             .on_toggle(Message::CheckboxToggled);
 
         let toggler = toggler(
-            String::from("Toggle me!"),
+            Some("Toggle me!"),
             self.toggler_value,
             Message::TogglerToggled,
         )

--- a/examples/tour/src/main.rs
+++ b/examples/tour/src/main.rs
@@ -358,7 +358,7 @@ impl Tour {
             .push("A toggler is mostly used to enable or disable something.")
             .push(
                 Container::new(toggler(
-                    "Toggle me to continue...".to_owned(),
+                    Some("Toggle me to continue..."),
                     self.toggler,
                     Message::TogglerChanged,
                 ))

--- a/graphics/src/text.rs
+++ b/graphics/src/text.rs
@@ -11,7 +11,7 @@ pub use cosmic_text;
 
 use crate::core::alignment;
 use crate::core::font::{self, Font};
-use crate::core::text::Shaping;
+use crate::core::text::{Shaping, Wrapping};
 use crate::core::{Color, Pixels, Point, Rectangle, Size, Transformation};
 
 use once_cell::sync::OnceCell;
@@ -303,6 +303,16 @@ pub fn to_shaping(shaping: Shaping) -> cosmic_text::Shaping {
     match shaping {
         Shaping::Basic => cosmic_text::Shaping::Basic,
         Shaping::Advanced => cosmic_text::Shaping::Advanced,
+    }
+}
+
+/// Converts some [`Wrapping`] strategy to a [`cosmic_text::Wrap`] strategy.
+pub fn to_wrap(wrapping: Wrapping) -> cosmic_text::Wrap {
+    match wrapping {
+        Wrapping::None => cosmic_text::Wrap::None,
+        Wrapping::Word => cosmic_text::Wrap::Word,
+        Wrapping::Glyph => cosmic_text::Wrap::Glyph,
+        Wrapping::WordOrGlyph => cosmic_text::Wrap::WordOrGlyph,
     }
 }
 

--- a/graphics/src/text/editor.rs
+++ b/graphics/src/text/editor.rs
@@ -500,7 +500,7 @@ impl editor::Editor for Editor {
         if new_bounds != internal.bounds {
             log::trace!("Updating size of `Editor`...");
 
-            buffer_mut_from_editor(&mut internal.editor).set_size(
+            buffer.set_size(
                 font_system.raw(),
                 Some(new_bounds.width),
                 Some(new_bounds.height),

--- a/graphics/src/text/paragraph.rs
+++ b/graphics/src/text/paragraph.rs
@@ -1,7 +1,7 @@
 //! Draw paragraphs.
 use crate::core;
 use crate::core::alignment;
-use crate::core::text::{Hit, Shaping, Span, Text};
+use crate::core::text::{Hit, Shaping, Span, Text, Wrapping};
 use crate::core::{Font, Point, Rectangle, Size};
 use crate::text;
 
@@ -17,6 +17,7 @@ struct Internal {
     buffer: cosmic_text::Buffer,
     font: Font,
     shaping: Shaping,
+    wrapping: Wrapping,
     horizontal_alignment: alignment::Horizontal,
     vertical_alignment: alignment::Vertical,
     bounds: Size,
@@ -94,6 +95,7 @@ impl core::text::Paragraph for Paragraph {
             horizontal_alignment: text.horizontal_alignment,
             vertical_alignment: text.vertical_alignment,
             shaping: text.shaping,
+            wrapping: text.wrapping,
             bounds: text.bounds,
             min_bounds,
             version: font_system.version(),
@@ -160,6 +162,7 @@ impl core::text::Paragraph for Paragraph {
             horizontal_alignment: text.horizontal_alignment,
             vertical_alignment: text.vertical_alignment,
             shaping: text.shaping,
+            wrapping: text.wrapping,
             bounds: text.bounds,
             min_bounds,
             version: font_system.version(),
@@ -192,6 +195,7 @@ impl core::text::Paragraph for Paragraph {
             || metrics.line_height != text.line_height.to_absolute(text.size).0
             || paragraph.font != text.font
             || paragraph.shaping != text.shaping
+            || paragraph.wrapping != text.wrapping
             || paragraph.horizontal_alignment != text.horizontal_alignment
             || paragraph.vertical_alignment != text.vertical_alignment
         {
@@ -387,6 +391,7 @@ impl Default for Internal {
             }),
             font: Font::default(),
             shaping: Shaping::default(),
+            wrapping: Wrapping::default(),
             horizontal_alignment: alignment::Horizontal::Left,
             vertical_alignment: alignment::Vertical::Top,
             bounds: Size::ZERO,

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -408,6 +408,7 @@ impl Renderer {
                         horizontal_alignment: alignment::Horizontal::Left,
                         vertical_alignment: alignment::Vertical::Top,
                         shaping: core::text::Shaping::Basic,
+                        wrapping: core::text::Wrapping::Word,
                     };
 
                     renderer.fill_text(

--- a/widget/src/checkbox.rs
+++ b/widget/src/checkbox.rs
@@ -50,6 +50,7 @@ pub struct Checkbox<
     text_size: Option<Pixels>,
     text_line_height: text::LineHeight,
     text_shaping: text::Shaping,
+    text_wrapping: text::Wrapping,
     font: Option<Renderer::Font>,
     icon: Icon<Renderer::Font>,
     class: Theme::Class<'a>,
@@ -81,7 +82,8 @@ where
             spacing: Self::DEFAULT_SPACING,
             text_size: None,
             text_line_height: text::LineHeight::default(),
-            text_shaping: text::Shaping::Basic,
+            text_shaping: text::Shaping::default(),
+            text_wrapping: text::Wrapping::default(),
             font: None,
             icon: Icon {
                 font: Renderer::ICON_FONT,
@@ -155,6 +157,12 @@ where
     /// Sets the [`text::Shaping`] strategy of the [`Checkbox`].
     pub fn text_shaping(mut self, shaping: text::Shaping) -> Self {
         self.text_shaping = shaping;
+        self
+    }
+
+    /// Sets the [`text::Wrapping`] strategy of the [`Checkbox`].
+    pub fn text_wrapping(mut self, wrapping: text::Wrapping) -> Self {
+        self.text_wrapping = wrapping;
         self
     }
 
@@ -240,6 +248,7 @@ where
                     alignment::Horizontal::Left,
                     alignment::Vertical::Top,
                     self.text_shaping,
+                    self.text_wrapping,
                 )
             },
         )
@@ -348,6 +357,7 @@ where
                         horizontal_alignment: alignment::Horizontal::Center,
                         vertical_alignment: alignment::Vertical::Center,
                         shaping: *shaping,
+                        wrapping: text::Wrapping::default(),
                     },
                     bounds.center(),
                     style.icon_color,

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -767,7 +767,7 @@ where
 ///
 /// [`Toggler`]: crate::Toggler
 pub fn toggler<'a, Message, Theme, Renderer>(
-    label: impl Into<Option<String>>,
+    label: Option<impl text::IntoFragment<'a>>,
     is_checked: bool,
     f: impl Fn(bool) -> Message + 'a,
 ) -> Toggler<'a, Message, Theme, Renderer>

--- a/widget/src/overlay/menu.rs
+++ b/widget/src/overlay/menu.rs
@@ -532,6 +532,7 @@ where
                     horizontal_alignment: alignment::Horizontal::Left,
                     vertical_alignment: alignment::Vertical::Center,
                     shaping: self.text_shaping,
+                    wrapping: text::Wrapping::default(),
                 },
                 Point::new(bounds.x + self.padding.left, bounds.center_y()),
                 if is_selected {

--- a/widget/src/pick_list.rs
+++ b/widget/src/pick_list.rs
@@ -81,7 +81,7 @@ where
             padding: crate::button::DEFAULT_PADDING,
             text_size: None,
             text_line_height: text::LineHeight::default(),
-            text_shaping: text::Shaping::Basic,
+            text_shaping: text::Shaping::default(),
             font: None,
             handle: Handle::default(),
             class: <Theme as Catalog>::default(),
@@ -250,6 +250,7 @@ where
             horizontal_alignment: alignment::Horizontal::Left,
             vertical_alignment: alignment::Vertical::Center,
             shaping: self.text_shaping,
+            wrapping: text::Wrapping::default(),
         };
 
         for (option, paragraph) in options.iter().zip(state.options.iter_mut())
@@ -515,6 +516,7 @@ where
                     horizontal_alignment: alignment::Horizontal::Right,
                     vertical_alignment: alignment::Vertical::Center,
                     shaping,
+                    wrapping: text::Wrapping::default(),
                 },
                 Point::new(
                     bounds.x + bounds.width - self.padding.right,
@@ -544,6 +546,7 @@ where
                     horizontal_alignment: alignment::Horizontal::Left,
                     vertical_alignment: alignment::Vertical::Center,
                     shaping: self.text_shaping,
+                    wrapping: text::Wrapping::default(),
                 },
                 Point::new(bounds.x + self.padding.left, bounds.center_y()),
                 if is_selected {

--- a/widget/src/radio.rs
+++ b/widget/src/radio.rs
@@ -82,6 +82,7 @@ where
     text_size: Option<Pixels>,
     text_line_height: text::LineHeight,
     text_shaping: text::Shaping,
+    text_wrapping: text::Wrapping,
     font: Option<Renderer::Font>,
     class: Theme::Class<'a>,
 }
@@ -122,10 +123,11 @@ where
             label: label.into(),
             width: Length::Shrink,
             size: Self::DEFAULT_SIZE,
-            spacing: Self::DEFAULT_SPACING, //15
+            spacing: Self::DEFAULT_SPACING,
             text_size: None,
             text_line_height: text::LineHeight::default(),
-            text_shaping: text::Shaping::Basic,
+            text_shaping: text::Shaping::default(),
+            text_wrapping: text::Wrapping::default(),
             font: None,
             class: Theme::default(),
         }
@@ -167,6 +169,12 @@ where
     /// Sets the [`text::Shaping`] strategy of the [`Radio`] button.
     pub fn text_shaping(mut self, shaping: text::Shaping) -> Self {
         self.text_shaping = shaping;
+        self
+    }
+
+    /// Sets the [`text::Wrapping`] strategy of the [`Radio`] button.
+    pub fn text_wrapping(mut self, wrapping: text::Wrapping) -> Self {
+        self.text_wrapping = wrapping;
         self
     }
 
@@ -245,6 +253,7 @@ where
                     alignment::Horizontal::Left,
                     alignment::Vertical::Top,
                     self.text_shaping,
+                    self.text_wrapping,
                 )
             },
         )

--- a/widget/src/text/rich.rs
+++ b/widget/src/text/rich.rs
@@ -5,7 +5,7 @@ use crate::core::mouse;
 use crate::core::renderer;
 use crate::core::text::{Paragraph, Span};
 use crate::core::widget::text::{
-    self, Catalog, LineHeight, Shaping, Style, StyleFn,
+    self, Catalog, LineHeight, Shaping, Style, StyleFn, Wrapping,
 };
 use crate::core::widget::tree::{self, Tree};
 use crate::core::{
@@ -29,6 +29,7 @@ where
     font: Option<Renderer::Font>,
     align_x: alignment::Horizontal,
     align_y: alignment::Vertical,
+    wrapping: Wrapping,
     class: Theme::Class<'a>,
 }
 
@@ -50,6 +51,7 @@ where
             font: None,
             align_x: alignment::Horizontal::Left,
             align_y: alignment::Vertical::Top,
+            wrapping: Wrapping::default(),
             class: Theme::default(),
         }
     }
@@ -115,6 +117,12 @@ where
         alignment: impl Into<alignment::Vertical>,
     ) -> Self {
         self.align_y = alignment.into();
+        self
+    }
+
+    /// Sets the [`Wrapping`] strategy of the [`Rich`] text.
+    pub fn wrapping(mut self, wrapping: Wrapping) -> Self {
+        self.wrapping = wrapping;
         self
     }
 
@@ -218,6 +226,7 @@ where
             self.font,
             self.align_x,
             self.align_y,
+            self.wrapping,
         )
     }
 
@@ -444,6 +453,7 @@ fn layout<Link, Renderer>(
     font: Option<Renderer::Font>,
     horizontal_alignment: alignment::Horizontal,
     vertical_alignment: alignment::Vertical,
+    wrapping: Wrapping,
 ) -> layout::Node
 where
     Link: Clone,
@@ -464,6 +474,7 @@ where
             horizontal_alignment,
             vertical_alignment,
             shaping: Shaping::Advanced,
+            wrapping,
         };
 
         if state.spans != spans {
@@ -480,6 +491,7 @@ where
                 horizontal_alignment,
                 vertical_alignment,
                 shaping: Shaping::Advanced,
+                wrapping,
             }) {
                 core::text::Difference::None => {}
                 core::text::Difference::Bounds => {

--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -9,7 +9,7 @@ use crate::core::mouse;
 use crate::core::renderer;
 use crate::core::text::editor::{Cursor, Editor as _};
 use crate::core::text::highlighter::{self, Highlighter};
-use crate::core::text::{self, LineHeight, Text};
+use crate::core::text::{self, LineHeight, Text, Wrapping};
 use crate::core::time::{Duration, Instant};
 use crate::core::widget::operation;
 use crate::core::widget::{self, Widget};
@@ -47,6 +47,7 @@ pub struct TextEditor<
     width: Length,
     height: Length,
     padding: Padding,
+    wrapping: Wrapping,
     class: Theme::Class<'a>,
     key_binding: Option<Box<dyn Fn(KeyPress) -> Option<Binding<Message>> + 'a>>,
     on_edit: Option<Box<dyn Fn(Action) -> Message + 'a>>,
@@ -74,6 +75,7 @@ where
             width: Length::Fill,
             height: Length::Shrink,
             padding: Padding::new(5.0),
+            wrapping: Wrapping::default(),
             class: Theme::default(),
             key_binding: None,
             on_edit: None,
@@ -148,6 +150,12 @@ where
         self
     }
 
+    /// Sets the [`Wrapping`] strategy of the [`TextEditor`].
+    pub fn wrapping(mut self, wrapping: Wrapping) -> Self {
+        self.wrapping = wrapping;
+        self
+    }
+
     /// Highlights the [`TextEditor`] using the given syntax and theme.
     #[cfg(feature = "highlighter")]
     pub fn highlight(
@@ -186,6 +194,7 @@ where
             width: self.width,
             height: self.height,
             padding: self.padding,
+            wrapping: self.wrapping,
             class: self.class,
             key_binding: self.key_binding,
             on_edit: self.on_edit,
@@ -496,6 +505,7 @@ where
             self.font.unwrap_or_else(|| renderer.default_font()),
             self.text_size.unwrap_or_else(|| renderer.default_size()),
             self.line_height,
+            self.wrapping,
             state.highlighter.borrow_mut().deref_mut(),
         );
 
@@ -784,6 +794,7 @@ where
                         horizontal_alignment: alignment::Horizontal::Left,
                         vertical_alignment: alignment::Vertical::Top,
                         shaping: text::Shaping::Advanced,
+                        wrapping: self.wrapping,
                     },
                     text_bounds.position(),
                     style.placeholder,

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -251,6 +251,7 @@ where
             horizontal_alignment: alignment::Horizontal::Left,
             vertical_alignment: alignment::Vertical::Center,
             shaping: text::Shaping::Advanced,
+            wrapping: text::Wrapping::default(),
         };
 
         state.placeholder.update(placeholder_text);
@@ -275,6 +276,7 @@ where
                 horizontal_alignment: alignment::Horizontal::Center,
                 vertical_alignment: alignment::Vertical::Center,
                 shaping: text::Shaping::Advanced,
+                wrapping: text::Wrapping::default(),
             };
 
             state.icon.update(icon_text);
@@ -1432,6 +1434,7 @@ fn replace_paragraph<Renderer>(
         horizontal_alignment: alignment::Horizontal::Left,
         vertical_alignment: alignment::Vertical::Top,
         shaping: text::Shaping::Advanced,
+        wrapping: text::Wrapping::default(),
     });
 }
 

--- a/widget/src/toggler.rs
+++ b/widget/src/toggler.rs
@@ -26,7 +26,7 @@ use crate::core::{
 ///
 /// let is_toggled = true;
 ///
-/// Toggler::new(String::from("Toggle me!"), is_toggled, |b| Message::TogglerToggled(b));
+/// Toggler::new(Some("Toggle me!"), is_toggled, |b| Message::TogglerToggled(b));
 /// ```
 #[allow(missing_debug_implementations)]
 pub struct Toggler<

--- a/widget/src/toggler.rs
+++ b/widget/src/toggler.rs
@@ -40,13 +40,14 @@ pub struct Toggler<
 {
     is_toggled: bool,
     on_toggle: Box<dyn Fn(bool) -> Message + 'a>,
-    label: Option<String>,
+    label: Option<text::Fragment<'a>>,
     width: Length,
     size: f32,
     text_size: Option<Pixels>,
     text_line_height: text::LineHeight,
     text_alignment: alignment::Horizontal,
     text_shaping: text::Shaping,
+    text_wrapping: text::Wrapping,
     spacing: f32,
     font: Option<Renderer::Font>,
     class: Theme::Class<'a>,
@@ -69,7 +70,7 @@ where
     ///     will receive the new state of the [`Toggler`] and must produce a
     ///     `Message`.
     pub fn new<F>(
-        label: impl Into<Option<String>>,
+        label: Option<impl text::IntoFragment<'a>>,
         is_toggled: bool,
         f: F,
     ) -> Self
@@ -79,13 +80,14 @@ where
         Toggler {
             is_toggled,
             on_toggle: Box::new(f),
-            label: label.into(),
+            label: label.map(text::IntoFragment::into_fragment),
             width: Length::Shrink,
             size: Self::DEFAULT_SIZE,
             text_size: None,
             text_line_height: text::LineHeight::default(),
             text_alignment: alignment::Horizontal::Left,
-            text_shaping: text::Shaping::Basic,
+            text_shaping: text::Shaping::default(),
+            text_wrapping: text::Wrapping::default(),
             spacing: Self::DEFAULT_SIZE / 2.0,
             font: None,
             class: Theme::default(),
@@ -128,6 +130,12 @@ where
     /// Sets the [`text::Shaping`] strategy of the [`Toggler`].
     pub fn text_shaping(mut self, shaping: text::Shaping) -> Self {
         self.text_shaping = shaping;
+        self
+    }
+
+    /// Sets the [`text::Wrapping`] strategy of the [`Toggler`].
+    pub fn text_wrapping(mut self, wrapping: text::Wrapping) -> Self {
+        self.text_wrapping = wrapping;
         self
     }
 
@@ -216,6 +224,7 @@ where
                         self.text_alignment,
                         alignment::Vertical::Top,
                         self.text_shaping,
+                        self.text_wrapping,
                     )
                 } else {
                     layout::Node::new(Size::ZERO)


### PR DESCRIPTION
This exposes wrapping strategy for `text` widget. I have kept the default to `Wrapping::Word` which it was in `cosmic_text`,
There are other widgets which are using text, I am not sure if Wrapping should be exposed there.

Sample
<img width="481" alt="image" src="https://github.com/iced-rs/iced/assets/20153307/1ebd2ee1-1ddb-4c69-9a03-058ce888e4f1">
