### PR TITLE
Add command for setting mouse passthrough

### DIFF
--- a/runtime/src/window.rs
+++ b/runtime/src/window.rs
@@ -147,6 +147,18 @@ pub enum Action {
 
     /// Screenshot the viewport of the window.
     Screenshot(Id, oneshot::Sender<Screenshot>),
+
+    /// Enables mouse passthrough for the given window.
+    ///
+    /// This disables mouse events for the window and passes mouse events
+    /// through to whatever window is underneath.
+    EnableMousePassthrough(Id),
+
+    /// Disable mouse passthrough for the given window.
+    ///
+    /// This enables mouse events for the window and stops mouse events
+    /// from being passed to whatever is underneath.
+    DisableMousePassthrough(Id),
 }
 
 /// Subscribes to the frames of the window of the running application.
@@ -405,4 +417,20 @@ pub fn screenshot(id: Id) -> Task<Screenshot> {
     task::oneshot(move |channel| {
         crate::Action::Window(Action::Screenshot(id, channel))
     })
+}
+
+/// Enables mouse passthrough for the given window.
+///
+/// This disables mouse events for the window and passes mouse events
+/// through to whatever window is underneath.
+pub fn enable_mouse_passthrough<Message>(id: Id) -> Task<Message> {
+    task::effect(crate::Action::Window(Action::EnableMousePassthrough(id)))
+}
+
+/// Disable mouse passthrough for the given window.
+///
+/// This enables mouse events for the window and stops mouse events
+/// from being passed to whatever is underneath.
+pub fn disable_mouse_passthrough<Message>(id: Id) -> Task<Message> {
+    task::effect(crate::Action::Window(Action::DisableMousePassthrough(id)))
 }

--- a/winit/src/program.rs
+++ b/winit/src/program.rs
@@ -1435,6 +1435,16 @@ fn run_action<P, C>(
                     ));
                 }
             }
+            window::Action::EnableMousePassthrough(id) => {
+                if let Some(window) = window_manager.get_mut(id) {
+                    let _ = window.raw.set_cursor_hittest(false);
+                }
+            }
+            window::Action::DisableMousePassthrough(id) => {
+                if let Some(window) = window_manager.get_mut(id) {
+                    let _ = window.raw.set_cursor_hittest(true);
+                }
+            }
         },
         Action::System(action) => match action {
             system::Action::QueryInformation(_channel) => {


### PR DESCRIPTION
This PR addresses #2283 by exposing `winit`'s ability to set mouse hit testing.

I extended the `window::Action` enum to include two new entries:

- `EnableMousePassthrough`: enables the window passing through mouse events to whatever's underneath
- `DisableMousePassthrough`: disables mouse passthrough, essentially allowing the window to capture mouse events

I also added two respective functions for creating these commands, `enable_mouse_passthrough`, and `disable_mouse_passthrough`.