### PR TITLE
add option for undecorated_shadow on windows

### DIFF
--- a/core/src/window/settings/windows.rs
+++ b/core/src/window/settings/windows.rs
@@ -12,6 +12,12 @@ pub struct PlatformSpecific {
 
     /// Whether show or hide the window icon in the taskbar.
     pub skip_taskbar: bool,
+
+    /// Shows or hides the background drop shadow for undecorated windows.
+    ///
+    /// The shadow is hidden by default.
+    /// Enabling the shadow causes a thin 1px line to appear on the top of the window.
+    pub undecorated_shadow: bool,
 }
 
 impl Default for PlatformSpecific {
@@ -20,6 +26,7 @@ impl Default for PlatformSpecific {
             parent: None,
             drag_and_drop: true,
             skip_taskbar: false,
+            undecorated_shadow: false,
         }
     }
 }

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -87,6 +87,9 @@ pub fn window_settings(
 
         window_builder = window_builder
             .with_skip_taskbar(settings.platform_specific.skip_taskbar);
+
+        window_builder = window_builder
+            .with_undecorated_shadow(settings.platform_specific.undecorated_shadow);
     }
 
     #[cfg(target_os = "macos")]

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -88,8 +88,9 @@ pub fn window_settings(
         window_builder = window_builder
             .with_skip_taskbar(settings.platform_specific.skip_taskbar);
 
-        window_builder = window_builder
-            .with_undecorated_shadow(settings.platform_specific.undecorated_shadow);
+        window_builder = window_builder.with_undecorated_shadow(
+            settings.platform_specific.undecorated_shadow,
+        );
     }
 
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
adds an option to enable undecorated_shadow on windows. something that is needed for client decorations.
this could actually be done on the client side though. since it just makes the window smaller and adds a 1px border around the edge.

