### PR TITLE
feature doc to Component trait

### DIFF
--- a/widget/src/lazy.rs
+++ b/widget/src/lazy.rs
@@ -29,6 +29,7 @@ use std::hash::{Hash, Hasher as H};
 use std::rc::Rc;
 
 /// A widget that only rebuilds its contents when necessary.
+#[cfg(feature = "lazy")]
 #[allow(missing_debug_implementations)]
 pub struct Lazy<'a, Message, Theme, Renderer, Dependency, View> {
     dependency: Dependency,

--- a/widget/src/lazy/component.rs
+++ b/widget/src/lazy/component.rs
@@ -30,6 +30,7 @@ use std::rc::Rc;
 ///
 /// Additionally, a [`Component`] is capable of producing a `Message` to notify
 /// the parent application of any relevant interactions.
+#[cfg(feature = "lazy")]
 pub trait Component<Message, Theme = crate::Theme, Renderer = crate::Renderer> {
     /// The internal state of this [`Component`].
     type State: Default;

--- a/widget/src/lazy/helpers.rs
+++ b/widget/src/lazy/helpers.rs
@@ -1,8 +1,9 @@
 use crate::core::{self, Element, Size};
-use crate::lazy::component::{self, Component};
-use crate::lazy::{Lazy, Responsive};
+use crate::lazy::component;
 
 use std::hash::Hash;
+
+pub use crate::lazy::{Component, Lazy, Responsive};
 
 /// Creates a new [`Lazy`] widget with the given data `Dependency` and a
 /// closure that can turn this data into a widget tree.

--- a/widget/src/lazy/responsive.rs
+++ b/widget/src/lazy/responsive.rs
@@ -21,6 +21,7 @@ use std::ops::Deref;
 ///
 /// A [`Responsive`] widget will always try to fill all the available space of
 /// its parent.
+#[cfg(feature = "lazy")]
 #[allow(missing_debug_implementations)]
 pub struct Responsive<
     'a,

--- a/widget/src/lib.rs
+++ b/widget/src/lib.rs
@@ -43,9 +43,6 @@ pub use helpers::*;
 mod lazy;
 
 #[cfg(feature = "lazy")]
-pub use crate::lazy::{Component, Lazy, Responsive};
-
-#[cfg(feature = "lazy")]
 pub use crate::lazy::helpers::*;
 
 #[doc(no_inline)]


### PR DESCRIPTION
The `Component` trait needs the `lazy` feature. Since this is not clear in the documentation this PR adds a note to the documentation of `Component` that the `lazy` trait is needed.
