### PR TITLE
ProgressBar buffer, vertical, reverse

### DIFF
--- a/examples/progress_bar/src/main.rs
+++ b/examples/progress_bar/src/main.rs
@@ -1,4 +1,4 @@
-use iced::widget::{column, progress_bar, slider};
+use iced::widget::{checkbox, column, progress_bar, slider};
 use iced::{Element, Sandbox, Settings};
 
 pub fn main() -> iced::Result {
@@ -8,11 +8,17 @@ pub fn main() -> iced::Result {
 #[derive(Default)]
 struct Progress {
     value: f32,
+    buffer: f32,
+    reverse: bool,
+    vertical: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
 enum Message {
-    SliderChanged(f32),
+    ValueChanged(f32),
+    BufferChanged(f32),
+    Reverse(bool),
+    Vertical(bool),
 }
 
 impl Sandbox for Progress {
@@ -28,16 +34,26 @@ impl Sandbox for Progress {
 
     fn update(&mut self, message: Message) {
         match message {
-            Message::SliderChanged(x) => self.value = x,
+            Message::ValueChanged(x) => self.value = x,
+            Message::BufferChanged(x) => self.buffer = x,
+            Message::Reverse(f) => self.reverse = f,
+            Message::Vertical(f) => self.vertical = f,
         }
     }
 
     fn view(&self) -> Element<Message> {
         column![
-            progress_bar(0.0..=100.0, self.value),
-            slider(0.0..=100.0, self.value, Message::SliderChanged).step(0.01)
+            checkbox("Vertical", self.vertical).on_toggle(Message::Vertical),
+            checkbox("Reverse", self.reverse).on_toggle(Message::Reverse),
+            progress_bar(0.0..=100.0, self.value)
+                .buffer(self.buffer)
+                .vertical_f(self.vertical)
+                .reverse_f(self.reverse),
+            slider(0.0..=100.0, self.value, Message::ValueChanged).step(0.01),
+            slider(0.0..=100.0, self.buffer, Message::BufferChanged).step(0.01),
         ]
         .padding(20)
+        .spacing(8)
         .into()
     }
 }

--- a/examples/scrollable/src/main.rs
+++ b/examples/scrollable/src/main.rs
@@ -348,6 +348,7 @@ fn progress_bar_custom_style(theme: &Theme) -> progress_bar::Appearance {
     progress_bar::Appearance {
         background: theme.extended_palette().background.strong.color.into(),
         bar: Color::from_rgb8(250, 85, 134).into(),
+        buffer: Color::from_rgba8(85, 250, 134, 0.5).into(),
         border_radius: 0.0.into(),
     }
 }

--- a/style/src/progress_bar.rs
+++ b/style/src/progress_bar.rs
@@ -7,8 +7,13 @@ use crate::core::Background;
 pub struct Appearance {
     /// The [`Background`] of the progress bar.
     pub background: Background,
+
     /// The [`Background`] of the bar of the progress bar.
     pub bar: Background,
+
+    /// The [`Background`] of the buffer bar of the progress bar.
+    pub buffer: Background,
+
     /// The border radius of the progress bar.
     pub border_radius: border::Radius,
 }

--- a/style/src/theme.rs
+++ b/style/src/theme.rs
@@ -1018,6 +1018,7 @@ impl progress_bar::StyleSheet for Theme {
         let from_palette = |bar: Color| progress_bar::Appearance {
             background: palette.background.strong.color.into(),
             bar: bar.into(),
+            buffer: Color { a: 0.25, ..bar }.into(),
             border_radius: 2.0.into(),
         };
 

--- a/widget/src/progress_bar.rs
+++ b/widget/src/progress_bar.rs
@@ -178,7 +178,7 @@ where
                     ..Default::default()
                 },
                 bkg,
-            )
+            );
         };
 
         //фон

--- a/widget/src/progress_bar/progress.rs
+++ b/widget/src/progress_bar/progress.rs
@@ -36,7 +36,7 @@ pub fn get_progress_rect(
 ) -> Rectangle {
     let bar_size = get_progress_offset(bounds, value, range, vertical);
 
-    let bar_rect = match (vertical, reverse) {
+    match (vertical, reverse) {
         (false, false) => Rectangle {
             x: bounds.x,
             y: bounds.y,
@@ -61,7 +61,5 @@ pub fn get_progress_rect(
             width: bounds.width,
             height: bar_size,
         },
-    };
-
-    bar_rect
+    }
 }

--- a/widget/src/progress_bar/progress.rs
+++ b/widget/src/progress_bar/progress.rs
@@ -1,0 +1,67 @@
+use std::ops::RangeInclusive;
+
+use crate::core::Rectangle;
+
+pub fn get_progress_offset(
+    bounds: Rectangle,
+    value: f32,
+    range: RangeInclusive<f32>,
+    vertical: bool,
+) -> f32 {
+    let (start, end) = range.into_inner();
+
+    let percent = if value < start {
+        0.
+    } else if value > end {
+        1.
+    } else {
+        (value - start) / (end - start)
+    };
+
+    let (size, _offset) = if vertical {
+        (bounds.height, bounds.y)
+    } else {
+        (bounds.width, bounds.x)
+    };
+
+    size * percent
+}
+
+pub fn get_progress_rect(
+    bounds: Rectangle,
+    value: f32,
+    range: RangeInclusive<f32>,
+    vertical: bool,
+    reverse: bool,
+) -> Rectangle {
+    let bar_size = get_progress_offset(bounds, value, range, vertical);
+
+    let bar_rect = match (vertical, reverse) {
+        (false, false) => Rectangle {
+            x: bounds.x,
+            y: bounds.y,
+            width: bar_size,
+            height: bounds.height,
+        },
+        (false, true) => Rectangle {
+            x: bounds.x + bounds.width - bar_size,
+            y: bounds.y,
+            width: bar_size,
+            height: bounds.height,
+        },
+        (true, false) => Rectangle {
+            x: bounds.x,
+            y: bounds.y + bounds.height - bar_size,
+            width: bounds.width,
+            height: bar_size,
+        },
+        (true, true) => Rectangle {
+            x: bounds.x,
+            y: bounds.y,
+            width: bounds.width,
+            height: bar_size,
+        },
+    };
+
+    bar_rect
+}


### PR DESCRIPTION
Improved the `ProgressBar` widget:
Added a `buffer` property (additional bar like value)
Added a `vertical` and a `reverse` orientation (`width` and `height` are replaced with `length` and `size` for that)
