### PR TITLE
Fix `block_on` in `iced_wgpu` hanging Wasm builds

### DIFF
--- a/futures/src/backend/wasm/wasm_bindgen.rs
+++ b/futures/src/backend/wasm/wasm_bindgen.rs
@@ -1,4 +1,4 @@
-//! A `wasm-bindgein-futures` backend.
+//! A `wasm-bindgen-futures` backend.
 
 /// A `wasm-bindgen-futures` executor.
 #[derive(Debug)]

--- a/graphics/src/compositor.rs
+++ b/graphics/src/compositor.rs
@@ -6,6 +6,7 @@ use crate::core::Color;
 use crate::futures::{MaybeSend, MaybeSync};
 
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
+use std::future::Future;
 use thiserror::Error;
 
 /// A graphics compositor that can draw to windows.
@@ -23,7 +24,7 @@ pub trait Compositor: Sized {
     fn new<W: Window + Clone>(
         settings: Self::Settings,
         compatible_window: W,
-    ) -> Result<Self, Error>;
+    ) -> impl Future<Output = Result<Self, Error>>;
 
     /// Creates a [`Self::Renderer`] for the [`Compositor`].
     fn create_renderer(&self) -> Self::Renderer;

--- a/tiny_skia/src/window/compositor.rs
+++ b/tiny_skia/src/window/compositor.rs
@@ -5,6 +5,7 @@ use crate::graphics::{Error, Viewport};
 use crate::{Backend, Primitive, Renderer, Settings};
 
 use std::collections::VecDeque;
+use std::future::{self, Future};
 use std::num::NonZeroU32;
 
 pub struct Compositor {
@@ -31,8 +32,8 @@ impl crate::graphics::Compositor for Compositor {
     fn new<W: compositor::Window>(
         settings: Self::Settings,
         compatible_window: W,
-    ) -> Result<Self, Error> {
-        Ok(new(settings, compatible_window))
+    ) -> impl Future<Output = Result<Self, Error>> {
+        future::ready(Ok(new(settings, compatible_window)))
     }
 
     fn create_renderer(&self) -> Self::Renderer {

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -97,7 +97,7 @@ where
 
 /// Runs an [`Application`] with an executor, compositor, and the provided
 /// settings.
-pub fn run<A, E, C>(
+pub async fn run<A, E, C>(
     settings: Settings<A::Flags>,
     compositor_settings: C::Settings,
 ) -> Result<(), Error>
@@ -188,7 +188,7 @@ where
         };
     }
 
-    let compositor = C::new(compositor_settings, window.clone())?;
+    let compositor = C::new(compositor_settings, window.clone()).await?;
     let mut renderer = compositor.create_renderer();
 
     for font in settings.fonts {

--- a/winit/src/multi_window.rs
+++ b/winit/src/multi_window.rs
@@ -12,7 +12,9 @@ use crate::core::widget::operation;
 use crate::core::window;
 use crate::core::{Point, Size};
 use crate::futures::futures::channel::mpsc;
-use crate::futures::futures::{task, Future, StreamExt};
+use crate::futures::futures::executor;
+use crate::futures::futures::task;
+use crate::futures::futures::{Future, StreamExt};
 use crate::futures::{Executor, Runtime, Subscription};
 use crate::graphics::{compositor, Compositor};
 use crate::multi_window::window_manager::WindowManager;
@@ -183,7 +185,8 @@ where
         };
     }
 
-    let mut compositor = C::new(compositor_settings, main_window.clone())?;
+    let mut compositor =
+        executor::block_on(C::new(compositor_settings, main_window.clone()))?;
 
     let mut window_manager = WindowManager::new();
     let _ = window_manager.insert(


### PR DESCRIPTION
This PR removes a `block_on` use in `iced_wgpu` by making `Compositor::new` async and running the whole event loop inside an executor.

As a result, Wasm builds no longer freeze the whole tab.