### PR TITLE
Add Command + ArrowLeft/Right input behavior for macOS

### DIFF
--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -726,7 +726,7 @@ impl Update {
                     }
 
                     if let keyboard::Key::Named(named_key) = key.as_ref() {
-                        if let Some(motion) = motion(named_key) {
+                        if let Some(motion) = motion(named_key, modifiers) {
                             let motion = if platform::is_jump_modifier_pressed(
                                 modifiers,
                             ) {
@@ -752,14 +752,22 @@ impl Update {
     }
 }
 
-fn motion(key: key::Named) -> Option<Motion> {
+fn motion(key: key::Named, modifiers: keyboard::Modifiers) -> Option<Motion> {
     match key {
+        key::Named::Home | key::Named::ArrowLeft
+            if platform::is_macos_command_pressed(modifiers) =>
+        {
+            Some(Motion::Home)
+        }
+        key::Named::End | key::Named::ArrowRight
+            if platform::is_macos_command_pressed(modifiers) =>
+        {
+            Some(Motion::End)
+        }
         key::Named::ArrowLeft => Some(Motion::Left),
         key::Named::ArrowRight => Some(Motion::Right),
         key::Named::ArrowUp => Some(Motion::Up),
         key::Named::ArrowDown => Some(Motion::Down),
-        key::Named::Home => Some(Motion::Home),
-        key::Named::End => Some(Motion::End),
         key::Named::PageUp => Some(Motion::PageUp),
         key::Named::PageDown => Some(Motion::PageDown),
         _ => None,
@@ -774,6 +782,18 @@ mod platform {
             modifiers.alt()
         } else {
             modifiers.control()
+        }
+    }
+
+    /// Whether the command key is pressed on a macOS device.
+    ///
+    /// This is relevant for actions like ⌘ + ArrowLeft to move to the beginning of the
+    /// line where the equivalent behavior for `modifiers.command()` is instead a jump.
+    pub fn is_macos_command_pressed(modifiers: keyboard::Modifiers) -> bool {
+        if cfg!(target_os = "macos") {
+            modifiers.logo()
+        } else {
+            false
         }
     }
 }

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -869,6 +869,36 @@ where
 
                             update_cache(state, &self.value);
                         }
+                        keyboard::Key::Named(key::Named::Home)
+                        | keyboard::Key::Named(key::Named::ArrowLeft)
+                            if platform::is_macos_command_pressed(
+                                modifiers,
+                            ) =>
+                        {
+                            if modifiers.shift() {
+                                state.cursor.select_range(
+                                    state.cursor.start(&self.value),
+                                    0,
+                                );
+                            } else {
+                                state.cursor.move_to(0);
+                            }
+                        }
+                        keyboard::Key::Named(key::Named::End)
+                        | keyboard::Key::Named(key::Named::ArrowLeft)
+                            if platform::is_macos_command_pressed(
+                                modifiers,
+                            ) =>
+                        {
+                            if modifiers.shift() {
+                                state.cursor.select_range(
+                                    state.cursor.start(&self.value),
+                                    self.value.len(),
+                                );
+                            } else {
+                                state.cursor.move_to(self.value.len());
+                            }
+                        }
                         keyboard::Key::Named(key::Named::ArrowLeft) => {
                             if platform::is_jump_modifier_pressed(modifiers)
                                 && !self.is_secure
@@ -905,26 +935,6 @@ where
                                 state.cursor.select_right(&self.value);
                             } else {
                                 state.cursor.move_right(&self.value);
-                            }
-                        }
-                        keyboard::Key::Named(key::Named::Home) => {
-                            if modifiers.shift() {
-                                state.cursor.select_range(
-                                    state.cursor.start(&self.value),
-                                    0,
-                                );
-                            } else {
-                                state.cursor.move_to(0);
-                            }
-                        }
-                        keyboard::Key::Named(key::Named::End) => {
-                            if modifiers.shift() {
-                                state.cursor.select_range(
-                                    state.cursor.start(&self.value),
-                                    self.value.len(),
-                                );
-                            } else {
-                                state.cursor.move_to(self.value.len());
                             }
                         }
                         keyboard::Key::Named(key::Named::Escape) => {
@@ -1282,6 +1292,18 @@ mod platform {
             modifiers.alt()
         } else {
             modifiers.control()
+        }
+    }
+
+    /// Whether the command key is pressed on a macOS device.
+    ///
+    /// This is relevant for actions like ⌘ + ArrowLeft to move to the beginning of the
+    /// line where the equivalent behavior for `modifiers.command()` is instead a jump.
+    pub fn is_macos_command_pressed(modifiers: keyboard::Modifiers) -> bool {
+        if cfg!(target_os = "macos") {
+            modifiers.logo()
+        } else {
+            false
         }
     }
 }


### PR DESCRIPTION
This PR adds macOS-specific behavior for the input and text editor for Command + ArrowLeft to behave like Home and Command + ArrowRight to behave like End to match [the native behavior](https://support.apple.com/en-us/HT201236#:~:text=Command–Left%20Arrow%3A%20Move%20the,end%20of%20the%20current%20line.). This behavior is particularly useful for users with MacBooks since they don't have Home/End keys.

I added a new `platform::is_macos_command_pressed` function instead of using `modifiers.command()` since the latter defaults to CTRL on other platforms and represents a jump instead of moving to the beginning/end of the line.

This PR leaves out other shortcuts like Command + ArrowUp -- which would also move to the cursor to the beginning of the line for single line inputs and the beginning of the document for multi-line inputs -- to limit the scope of changes.