### PR TITLE
fix: make pane_grid appearance items visible to others.

### DIFF
--- a/widget/src/pane_grid.rs
+++ b/widget/src/pane_grid.rs
@@ -1118,11 +1118,11 @@ impl<'a, T> Contents<'a, T> {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Appearance {
     /// The appearance of a hovered region highlight.
-    hovered_region: Highlight,
+    pub hovered_region: Highlight,
     /// The appearance of a picked split.
-    picked_split: Line,
+    pub picked_split: Line,
     /// The appearance of a hovered split.
-    hovered_split: Line,
+    pub hovered_split: Line,
 }
 
 /// The appearance of a highlight of the [`PaneGrid`].


### PR DESCRIPTION
The core team is busy and does not have time to mentor nor babysit new contributors. If a member of the core team thinks that reviewing and understanding your work will take more time and effort than writing it from scratch by themselves, your contribution will be dismissed. It is your responsibility to communicate and figure out how to reduce the likelihood of this!

Read the contributing guidelines for more details: https://github.com/iced-rs/iced/blob/master/CONTRIBUTING.md
