### PR TITLE
Use integer coordinates for input caret

### DIFF
--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -538,7 +538,7 @@ where
                         renderer.fill_quad(
                             renderer::Quad {
                                 bounds: Rectangle {
-                                    x: position.x,
+                                    x: position.x.floor(),
                                     y: position.y,
                                     width: 1.0,
                                     height: self

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -390,7 +390,8 @@ where
                         Some((
                             renderer::Quad {
                                 bounds: Rectangle {
-                                    x: text_bounds.x + text_value_width,
+                                    x: (text_bounds.x + text_value_width)
+                                        .floor(),
                                     y: text_bounds.y,
                                     width: 1.0,
                                     height: text_bounds.height,


### PR DESCRIPTION
This should stop the caret from changing thickness in screens with an integral scale factor.
