### PR TITLE
Add "Select All" functionality on Ctrl+A to TextEditor

### DIFF
--- a/core/src/text/editor.rs
+++ b/core/src/text/editor.rs
@@ -70,6 +70,8 @@ pub enum Action {
     SelectWord,
     /// Select the line at the current cursor.
     SelectLine,
+    /// Select the entire buffer.
+    SelectAll,
     /// Perform an [`Edit`].
     Edit(Edit),
     /// Click the [`Editor`] at the given [`Point`].

--- a/graphics/src/text/editor.rs
+++ b/graphics/src/text/editor.rs
@@ -385,6 +385,27 @@ impl editor::Editor for Editor {
                     }));
                 }
             }
+            Action::SelectAll => {
+                let buffer = editor.buffer();
+                if buffer.lines.len() > 1
+                    || buffer
+                        .lines
+                        .first()
+                        .is_some_and(|line| !line.text().is_empty())
+                {
+                    let cursor = editor.cursor();
+                    editor.set_select_opt(Some(cosmic_text::Cursor {
+                        line: 0,
+                        index: 0,
+                        ..cursor
+                    }));
+
+                    editor.action(
+                        font_system.raw(),
+                        motion_to_action(Motion::DocumentEnd),
+                    );
+                }
+            }
 
             // Editing events
             Action::Edit(edit) => {

--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -762,6 +762,11 @@ impl Update {
                         {
                             return Some(Self::Paste);
                         }
+                        keyboard::Key::Character("a")
+                            if modifiers.command() =>
+                        {
+                            return Some(Self::Action(Action::SelectAll));
+                        }
                         _ => {}
                     }
 


### PR DESCRIPTION
Closes #2153.

In principle, a very simple implementation: I created `Action::SelectAll`, which is reacted to by moving the selection to the start and the cursor to the end of the buffer. I've tested with a local project in my NixOS Linux box and it seemed to work fine, I could also use this to copy the whole buffer etc.

I also added some code to only perform this selection if the buffer isn't empty, which seems consistent with most text editors I've tried (and also with `TextInput`). Some platforms (such as some browsers and messaging apps) do, however, allow Ctrl+A to select all even on an empty buffer, so, if this is desired, let me know - but the behavior I chose seems to be consistent with `SelectWord` and `SelectLine`, for example.

Since `modifiers.command()` is used, this should cleanly translate to Cmd+A on MacOS, but I haven't tested explicitly.

Finally, there was a performance concern over at https://github.com/iced-rs/iced/issues/2153#issuecomment-1911303804. I'm not sure how up-to-date that comment is (it's possible `TextEditor`'s code has changed significantly since then), but, in principle, this implementation seems to perform fine, even with hundreds of thousands of lines of text (pasting those lines took much longer (upwards of 15s) than selecting all of them, which took less than a second).

**NOTE:** In my empty buffer check, I use `Option::is_some_and`, which is a Rust 1.70.0+ feature. Let me know if I should replace it if this doesn't meet MSRV criteria. And feel free to drop any further suggestions!

**NOTE:** I didn't make any changes to `TextInput`; it appears to already have support for Ctrl+A functionality.