### PR TITLE
Fix scrollbar dragged state after release left mouse button

### DIFF
--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -390,6 +390,21 @@ where
             )
         };
 
+        if matches!(
+            event,
+            Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left))
+                | Event::Touch(
+                    touch::Event::FingerLifted { .. }
+                        | touch::Event::FingerLost { .. }
+                )
+        ) {
+            state.scroll_area_touched_at = None;
+            state.x_scroller_grabbed_at = None;
+            state.y_scroller_grabbed_at = None;
+
+            return event_status;
+        }
+
         if let event::Status::Captured = event_status {
             return event::Status::Captured;
         }
@@ -479,10 +494,7 @@ where
                             );
                         }
                     }
-                    touch::Event::FingerLifted { .. }
-                    | touch::Event::FingerLost { .. } => {
-                        state.scroll_area_touched_at = None;
-                    }
+                    _ => {}
                 }
 
                 event_status = event::Status::Captured;
@@ -492,15 +504,6 @@ where
 
         if let Some(scroller_grabbed_at) = state.y_scroller_grabbed_at {
             match event {
-                Event::Mouse(mouse::Event::ButtonReleased(
-                    mouse::Button::Left,
-                ))
-                | Event::Touch(touch::Event::FingerLifted { .. })
-                | Event::Touch(touch::Event::FingerLost { .. }) => {
-                    state.y_scroller_grabbed_at = None;
-
-                    event_status = event::Status::Captured;
-                }
                 Event::Mouse(mouse::Event::CursorMoved { .. })
                 | Event::Touch(touch::Event::FingerMoved { .. }) => {
                     if let Some(scrollbar) = scrollbars.y {
@@ -572,15 +575,6 @@ where
 
         if let Some(scroller_grabbed_at) = state.x_scroller_grabbed_at {
             match event {
-                Event::Mouse(mouse::Event::ButtonReleased(
-                    mouse::Button::Left,
-                ))
-                | Event::Touch(touch::Event::FingerLifted { .. })
-                | Event::Touch(touch::Event::FingerLost { .. }) => {
-                    state.x_scroller_grabbed_at = None;
-
-                    event_status = event::Status::Captured;
-                }
                 Event::Mouse(mouse::Event::CursorMoved { .. })
                 | Event::Touch(touch::Event::FingerMoved { .. }) => {
                     let Some(cursor_position) = cursor.position() else {


### PR DESCRIPTION
**Description:**
Ensure the correct handling of event_status after checking all possible events. Previously, it was returned before checking Mouse Events, resulting in the scrollbar being dragged continuously from the first click onwards.

**Before:**
- The scrollbar is still dragged even after releasing the left button.

![ezgif-1-5d725d3d5f](https://github.com/iced-rs/iced/assets/5161344/6e2519c5-2846-40c5-8582-23d5023f4e1b)


**After:**
- The scrollbar is released when the left button is no longer clicked.

![ezgif-1-cc0517bf70](https://github.com/iced-rs/iced/assets/5161344/d740ea5a-43e7-4de4-be25-cd77c0fedd84)
