### PR TITLE
Implement setter for filter_method property of viewer

### DIFF
--- a/widget/src/image/viewer.rs
+++ b/widget/src/image/viewer.rs
@@ -40,6 +40,12 @@ impl<Handle> Viewer<Handle> {
         }
     }
 
+    /// Sets the [`image::FilterMethod`] of the [`Viewer`].
+    pub fn filter_method(mut self, filter_method: image::FilterMethod) -> Self {
+        self.filter_method = filter_method;
+        self
+    }
+
     /// Sets the padding of the [`Viewer`].
     pub fn padding(mut self, padding: impl Into<Pixels>) -> Self {
         self.padding = padding.into().0;


### PR DESCRIPTION
This PR implements a simple setter for a [viewer struct](https://github.com/iced-rs/iced/blob/master/widget/src/image/viewer.rs) in a way, like image struct does. Sorry if this is so by design, don't really see a reason why not implement it.