### PR TITLE
Use closures for widget styling

### DIFF
--- a/examples/checkbox/src/main.rs
+++ b/examples/checkbox/src/main.rs
@@ -63,17 +63,16 @@ impl Application for Example {
         let default_checkbox = checkbox("Default", self.default)
             .on_toggle(Message::DefaultToggled);
 
-        let styled_checkbox = |label, style| {
+        let styled_checkbox = |label| {
             checkbox(label, self.styled)
                 .on_toggle_maybe(self.default.then_some(Message::StyledToggled))
-                .style(style)
         };
 
         let checkboxes = row![
-            styled_checkbox("Primary", checkbox::primary),
-            styled_checkbox("Secondary", checkbox::secondary),
-            styled_checkbox("Success", checkbox::success),
-            styled_checkbox("Danger", checkbox::danger),
+            styled_checkbox("Primary").style(checkbox::primary),
+            styled_checkbox("Secondary").style(checkbox::secondary),
+            styled_checkbox("Success").style(checkbox::success),
+            styled_checkbox("Danger").style(checkbox::danger),
         ]
         .spacing(20);
 

--- a/examples/component/src/main.rs
+++ b/examples/component/src/main.rs
@@ -83,7 +83,10 @@ mod numeric_input {
 
     impl<Message, Theme> Component<Message, Theme> for NumericInput<Message>
     where
-        Theme: button::DefaultStyle + text_input::DefaultStyle + 'static,
+        Theme: text::DefaultStyle
+            + button::DefaultStyle
+            + text_input::DefaultStyle
+            + 'static,
     {
         type State = ();
         type Event = Event;
@@ -158,7 +161,10 @@ mod numeric_input {
     impl<'a, Message, Theme> From<NumericInput<Message>>
         for Element<'a, Message, Theme>
     where
-        Theme: button::DefaultStyle + text_input::DefaultStyle + 'static,
+        Theme: text::DefaultStyle
+            + button::DefaultStyle
+            + text_input::DefaultStyle
+            + 'static,
         Message: 'a,
     {
         fn from(numeric_input: NumericInput<Message>) -> Self {

--- a/examples/gradient/src/main.rs
+++ b/examples/gradient/src/main.rs
@@ -1,6 +1,6 @@
 use iced::application;
 use iced::widget::{
-    checkbox, column, container, horizontal_space, row, slider, text, themer,
+    checkbox, column, container, horizontal_space, row, slider, text,
 };
 use iced::{gradient, window};
 use iced::{
@@ -70,16 +70,16 @@ impl Sandbox for Gradient {
             transparent,
         } = *self;
 
-        let gradient = gradient::Linear::new(angle)
-            .add_stop(0.0, start)
-            .add_stop(1.0, end);
+        let gradient_box = container(horizontal_space())
+            .style(move |_theme, _status| {
+                let gradient = gradient::Linear::new(angle)
+                    .add_stop(0.0, start)
+                    .add_stop(1.0, end);
 
-        let gradient_box = themer(
-            gradient,
-            container(horizontal_space())
-                .width(Length::Fill)
-                .height(Length::Fill),
-        );
+                gradient.into()
+            })
+            .width(Length::Fill)
+            .height(Length::Fill);
 
         let angle_picker = row![
             text("Angle").width(64),

--- a/examples/svg/src/main.rs
+++ b/examples/svg/src/main.rs
@@ -41,12 +41,12 @@ impl Sandbox for Tiger {
         ));
 
         let svg = svg(handle).width(Length::Fill).height(Length::Fill).style(
-            if self.apply_color_filter {
-                |_theme, _status| svg::Appearance {
-                    color: Some(color!(0x0000ff)),
-                }
-            } else {
-                |_theme, _status| svg::Appearance::default()
+            |_theme, _status| svg::Appearance {
+                color: if self.apply_color_filter {
+                    Some(color!(0x0000ff))
+                } else {
+                    None
+                },
             },
         );
 

--- a/widget/src/combo_box.rs
+++ b/widget/src/combo_box.rs
@@ -42,7 +42,7 @@ pub struct ComboBox<
     on_option_hovered: Option<Box<dyn Fn(T) -> Message>>,
     on_close: Option<Message>,
     on_input: Option<Box<dyn Fn(String) -> Message>>,
-    menu_style: menu::Style<Theme>,
+    menu_style: menu::Style<'a, Theme>,
     padding: Padding,
     size: Option<f32>,
 }
@@ -125,7 +125,7 @@ where
     }
 
     /// Sets the style of the [`ComboBox`].
-    pub fn style(mut self, style: impl Into<Style<Theme>>) -> Self
+    pub fn style(mut self, style: impl Into<Style<'a, Theme>>) -> Self
     where
         Theme: 'a,
     {
@@ -672,7 +672,7 @@ where
 
             self.state.sync_filtered_options(filtered_options);
 
-            let mut menu = menu::Menu::with_style(
+            let mut menu = menu::Menu::new(
                 menu,
                 &filtered_options.options,
                 hovered_option,
@@ -686,7 +686,7 @@ where
                     (self.on_selected)(x)
                 },
                 self.on_option_hovered.as_deref(),
-                self.menu_style,
+                &self.menu_style,
             )
             .width(bounds.width)
             .padding(self.padding);
@@ -765,27 +765,27 @@ where
 
 /// The style of a [`ComboBox`].
 #[allow(missing_debug_implementations)]
-pub struct Style<Theme> {
+pub struct Style<'a, Theme> {
     /// The style of the [`TextInput`] of the [`ComboBox`].
-    pub text_input: text_input::Style<'static, Theme>,
+    pub text_input: text_input::Style<'a, Theme>,
 
     /// The style of the [`Menu`] of the [`ComboBox`].
     ///
     /// [`Menu`]: menu::Menu
-    pub menu: menu::Style<Theme>,
+    pub menu: menu::Style<'a, Theme>,
 }
 
 /// The default style of a [`ComboBox`].
 pub trait DefaultStyle: Sized {
     /// Returns the default style of a [`ComboBox`].
-    fn default_style() -> Style<Self>;
+    fn default_style() -> Style<'static, Self>;
 }
 
 impl DefaultStyle for Theme {
-    fn default_style() -> Style<Self> {
+    fn default_style() -> Style<'static, Self> {
         Style {
             text_input: Box::new(text_input::default),
-            menu: menu::Style::DEFAULT,
+            menu: menu::DefaultStyle::default_style(),
         }
     }
 }

--- a/widget/src/combo_box.rs
+++ b/widget/src/combo_box.rs
@@ -62,7 +62,7 @@ where
         on_selected: impl Fn(T) -> Message + 'static,
     ) -> Self
     where
-        Theme: DefaultStyle,
+        Theme: DefaultStyle + 'a,
     {
         let style = Theme::default_style();
 
@@ -125,7 +125,10 @@ where
     }
 
     /// Sets the style of the [`ComboBox`].
-    pub fn style(mut self, style: impl Into<Style<Theme>>) -> Self {
+    pub fn style(mut self, style: impl Into<Style<Theme>>) -> Self
+    where
+        Theme: 'a,
+    {
         let style = style.into();
 
         self.text_input = self.text_input.style(style.text_input);
@@ -761,32 +764,16 @@ where
 }
 
 /// The style of a [`ComboBox`].
-#[derive(Debug, PartialEq, Eq)]
+#[allow(missing_debug_implementations)]
 pub struct Style<Theme> {
     /// The style of the [`TextInput`] of the [`ComboBox`].
-    pub text_input: fn(&Theme, text_input::Status) -> text_input::Appearance,
+    pub text_input: text_input::Style<'static, Theme>,
 
     /// The style of the [`Menu`] of the [`ComboBox`].
     ///
     /// [`Menu`]: menu::Menu
     pub menu: menu::Style<Theme>,
 }
-
-impl Style<Theme> {
-    /// The default style of a [`ComboBox`].
-    pub const DEFAULT: Self = Self {
-        text_input: text_input::default,
-        menu: menu::Style::<Theme>::DEFAULT,
-    };
-}
-
-impl<Theme> Clone for Style<Theme> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-
-impl<Theme> Copy for Style<Theme> {}
 
 /// The default style of a [`ComboBox`].
 pub trait DefaultStyle: Sized {
@@ -796,6 +783,9 @@ pub trait DefaultStyle: Sized {
 
 impl DefaultStyle for Theme {
     fn default_style() -> Style<Self> {
-        Style::<Self>::DEFAULT
+        Style {
+            text_input: Box::new(text_input::default),
+            menu: menu::Style::DEFAULT,
+        }
     }
 }

--- a/widget/src/container.rs
+++ b/widget/src/container.rs
@@ -539,6 +539,24 @@ impl Appearance {
     }
 }
 
+impl From<Color> for Appearance {
+    fn from(color: Color) -> Self {
+        Self::default().with_background(color)
+    }
+}
+
+impl From<Gradient> for Appearance {
+    fn from(gradient: Gradient) -> Self {
+        Self::default().with_background(gradient)
+    }
+}
+
+impl From<gradient::Linear> for Appearance {
+    fn from(gradient: gradient::Linear) -> Self {
+        Self::default().with_background(gradient)
+    }
+}
+
 /// The possible status of a [`Container`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Status {
@@ -571,19 +589,19 @@ impl DefaultStyle for Appearance {
 
 impl DefaultStyle for Color {
     fn default_style(&self, _status: Status) -> Appearance {
-        Appearance::default().with_background(*self)
+        Appearance::from(*self)
     }
 }
 
 impl DefaultStyle for Gradient {
     fn default_style(&self, _status: Status) -> Appearance {
-        Appearance::default().with_background(*self)
+        Appearance::from(*self)
     }
 }
 
 impl DefaultStyle for gradient::Linear {
     fn default_style(&self, _status: Status) -> Appearance {
-        Appearance::default().with_background(*self)
+        Appearance::from(*self)
     }
 }
 

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -362,9 +362,11 @@ pub fn image<Handle>(handle: impl Into<Handle>) -> crate::Image<Handle> {
 /// [`Svg`]: crate::Svg
 /// [`Handle`]: crate::svg::Handle
 #[cfg(feature = "svg")]
-pub fn svg<Theme>(handle: impl Into<core::svg::Handle>) -> crate::Svg<Theme>
+pub fn svg<'a, Theme>(
+    handle: impl Into<core::svg::Handle>,
+) -> crate::Svg<'a, Theme>
 where
-    Theme: crate::svg::DefaultStyle,
+    Theme: crate::svg::DefaultStyle + 'a,
 {
     crate::Svg::new(handle)
 }

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -340,12 +340,12 @@ where
 ///   * the current value of the [`ProgressBar`].
 ///
 /// [`ProgressBar`]: crate::ProgressBar
-pub fn progress_bar<Theme>(
+pub fn progress_bar<'a, Theme>(
     range: RangeInclusive<f32>,
     value: f32,
-) -> ProgressBar<Theme>
+) -> ProgressBar<'a, Theme>
 where
-    Theme: progress_bar::DefaultStyle,
+    Theme: progress_bar::DefaultStyle + 'a,
 {
     ProgressBar::new(range, value)
 }

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -194,7 +194,7 @@ pub fn toggler<'a, Message, Theme, Renderer>(
     f: impl Fn(bool) -> Message + 'a,
 ) -> Toggler<'a, Message, Theme, Renderer>
 where
-    Theme: toggler::DefaultStyle,
+    Theme: toggler::DefaultStyle + 'a,
     Renderer: core::text::Renderer,
 {
     Toggler::new(label, is_checked, f)

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -391,9 +391,11 @@ where
 /// [`QRCode`]: crate::QRCode
 /// [`Data`]: crate::qr_code::Data
 #[cfg(feature = "qr_code")]
-pub fn qr_code<Theme>(data: &crate::qr_code::Data) -> crate::QRCode<'_, Theme>
+pub fn qr_code<'a, Theme>(
+    data: &'a crate::qr_code::Data,
+) -> crate::QRCode<'a, Theme>
 where
-    Theme: crate::qr_code::DefaultStyle,
+    Theme: crate::qr_code::DefaultStyle + 'a,
 {
     crate::QRCode::new(data)
 }

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -240,7 +240,7 @@ pub fn slider<'a, T, Message, Theme>(
 where
     T: Copy + From<u8> + std::cmp::PartialOrd,
     Message: Clone,
-    Theme: slider::DefaultStyle,
+    Theme: slider::DefaultStyle + 'a,
 {
     Slider::new(range, value, on_change)
 }
@@ -256,7 +256,7 @@ pub fn vertical_slider<'a, T, Message, Theme>(
 where
     T: Copy + From<u8> + std::cmp::PartialOrd,
     Message: Clone,
-    Theme: vertical_slider::DefaultStyle,
+    Theme: vertical_slider::DefaultStyle + 'a,
 {
     VerticalSlider::new(range, value, on_change)
 }

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -117,7 +117,7 @@ pub fn button<'a, Message, Theme, Renderer>(
     content: impl Into<Element<'a, Message, Theme, Renderer>>,
 ) -> Button<'a, Message, Theme, Renderer>
 where
-    Theme: button::DefaultStyle,
+    Theme: button::DefaultStyle + 'a,
     Renderer: core::Renderer,
 {
     Button::new(content)

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -315,9 +315,9 @@ pub fn vertical_space() -> Space {
 /// Creates a horizontal [`Rule`] with the given height.
 ///
 /// [`Rule`]: crate::Rule
-pub fn horizontal_rule<Theme>(height: impl Into<Pixels>) -> Rule<Theme>
+pub fn horizontal_rule<'a, Theme>(height: impl Into<Pixels>) -> Rule<'a, Theme>
 where
-    Theme: rule::DefaultStyle,
+    Theme: rule::DefaultStyle + 'a,
 {
     Rule::horizontal(height)
 }
@@ -325,9 +325,9 @@ where
 /// Creates a vertical [`Rule`] with the given width.
 ///
 /// [`Rule`]: crate::Rule
-pub fn vertical_rule<Theme>(width: impl Into<Pixels>) -> Rule<Theme>
+pub fn vertical_rule<'a, Theme>(width: impl Into<Pixels>) -> Rule<'a, Theme>
 where
-    Theme: rule::DefaultStyle,
+    Theme: rule::DefaultStyle + 'a,
 {
     Rule::vertical(width)
 }

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -58,7 +58,7 @@ pub fn container<'a, Message, Theme, Renderer>(
     content: impl Into<Element<'a, Message, Theme, Renderer>>,
 ) -> Container<'a, Message, Theme, Renderer>
 where
-    Theme: container::DefaultStyle,
+    Theme: container::DefaultStyle + 'a,
     Renderer: core::Renderer,
 {
     Container::new(content)
@@ -134,7 +134,7 @@ pub fn tooltip<'a, Message, Theme, Renderer>(
     position: tooltip::Position,
 ) -> crate::Tooltip<'a, Message, Theme, Renderer>
 where
-    Theme: container::DefaultStyle,
+    Theme: container::DefaultStyle + 'a,
     Renderer: core::text::Renderer,
 {
     Tooltip::new(content, tooltip, position)

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -14,7 +14,7 @@ use crate::rule::{self, Rule};
 use crate::runtime::Command;
 use crate::scrollable::{self, Scrollable};
 use crate::slider::{self, Slider};
-use crate::text::Text;
+use crate::text::{self, Text};
 use crate::text_editor::{self, TextEditor};
 use crate::text_input::{self, TextInput};
 use crate::toggler::{self, Toggler};
@@ -147,6 +147,7 @@ pub fn text<'a, Theme, Renderer>(
     text: impl ToString,
 ) -> Text<'a, Theme, Renderer>
 where
+    Theme: text::DefaultStyle + 'a,
     Renderer: core::text::Renderer,
 {
     Text::new(text.to_string())

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -209,7 +209,7 @@ pub fn text_input<'a, Message, Theme, Renderer>(
 ) -> TextInput<'a, Message, Theme, Renderer>
 where
     Message: Clone,
-    Theme: text_input::DefaultStyle,
+    Theme: text_input::DefaultStyle + 'a,
     Renderer: core::text::Renderer,
 {
     TextInput::new(placeholder, value)
@@ -291,7 +291,7 @@ pub fn combo_box<'a, T, Message, Theme, Renderer>(
 ) -> ComboBox<'a, T, Message, Theme, Renderer>
 where
     T: std::fmt::Display + Clone,
-    Theme: combo_box::DefaultStyle,
+    Theme: combo_box::DefaultStyle + 'a,
     Renderer: core::text::Renderer,
 {
     ComboBox::new(state, placeholder, selection, on_selected)

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -170,15 +170,15 @@ where
 /// Creates a new [`Radio`].
 ///
 /// [`Radio`]: crate::Radio
-pub fn radio<Message, Theme, Renderer, V>(
+pub fn radio<'a, Message, Theme, Renderer, V>(
     label: impl Into<String>,
     value: V,
     selected: Option<V>,
     on_click: impl FnOnce(V) -> Message,
-) -> Radio<Message, Theme, Renderer>
+) -> Radio<'a, Message, Theme, Renderer>
 where
     Message: Clone,
-    Theme: radio::DefaultStyle,
+    Theme: radio::DefaultStyle + 'a,
     Renderer: core::text::Renderer,
     V: Copy + Eq,
 {

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -218,12 +218,12 @@ where
 /// Creates a new [`TextEditor`].
 ///
 /// [`TextEditor`]: crate::TextEditor
-pub fn text_editor<Message, Theme, Renderer>(
-    content: &text_editor::Content<Renderer>,
-) -> TextEditor<'_, core::text::highlighter::PlainText, Message, Theme, Renderer>
+pub fn text_editor<'a, Message, Theme, Renderer>(
+    content: &'a text_editor::Content<Renderer>,
+) -> TextEditor<'a, core::text::highlighter::PlainText, Message, Theme, Renderer>
 where
     Message: Clone,
-    Theme: text_editor::DefaultStyle,
+    Theme: text_editor::DefaultStyle + 'a,
     Renderer: core::text::Renderer,
 {
     TextEditor::new(content)

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -104,7 +104,7 @@ pub fn scrollable<'a, Message, Theme, Renderer>(
     content: impl Into<Element<'a, Message, Theme, Renderer>>,
 ) -> Scrollable<'a, Message, Theme, Renderer>
 where
-    Theme: scrollable::DefaultStyle,
+    Theme: scrollable::DefaultStyle + 'a,
     Renderer: core::Renderer,
 {
     Scrollable::new(content)

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -161,7 +161,7 @@ pub fn checkbox<'a, Message, Theme, Renderer>(
     is_checked: bool,
 ) -> Checkbox<'a, Message, Theme, Renderer>
 where
-    Theme: checkbox::DefaultStyle,
+    Theme: checkbox::DefaultStyle + 'a,
     Renderer: core::text::Renderer,
 {
     Checkbox::new(label, is_checked)

--- a/widget/src/pane_grid/content.rs
+++ b/widget/src/pane_grid/content.rs
@@ -24,7 +24,7 @@ pub struct Content<
 {
     title_bar: Option<TitleBar<'a, Message, Theme, Renderer>>,
     body: Element<'a, Message, Theme, Renderer>,
-    style: container::Style<Theme>,
+    style: container::Style<'a, Theme>,
 }
 
 impl<'a, Message, Theme, Renderer> Content<'a, Message, Theme, Renderer>
@@ -34,12 +34,12 @@ where
     /// Creates a new [`Content`] with the provided body.
     pub fn new(body: impl Into<Element<'a, Message, Theme, Renderer>>) -> Self
     where
-        Theme: container::DefaultStyle,
+        Theme: container::DefaultStyle + 'a,
     {
         Self {
             title_bar: None,
             body: body.into(),
-            style: Theme::default_style(),
+            style: Box::new(Theme::default_style),
         }
     }
 
@@ -55,9 +55,9 @@ where
     /// Sets the style of the [`Content`].
     pub fn style(
         mut self,
-        style: fn(&Theme, container::Status) -> container::Appearance,
+        style: impl Fn(&Theme, container::Status) -> container::Appearance + 'a,
     ) -> Self {
-        self.style = style.into();
+        self.style = Box::new(style);
         self
     }
 }
@@ -403,7 +403,7 @@ impl<'a, T, Message, Theme, Renderer> From<T>
     for Content<'a, Message, Theme, Renderer>
 where
     T: Into<Element<'a, Message, Theme, Renderer>>,
-    Theme: container::DefaultStyle,
+    Theme: container::DefaultStyle + 'a,
     Renderer: crate::core::Renderer,
 {
     fn from(element: T) -> Self {

--- a/widget/src/pane_grid/title_bar.rs
+++ b/widget/src/pane_grid/title_bar.rs
@@ -25,7 +25,7 @@ pub struct TitleBar<
     controls: Option<Element<'a, Message, Theme, Renderer>>,
     padding: Padding,
     always_show_controls: bool,
-    style: container::Style<Theme>,
+    style: container::Style<'a, Theme>,
 }
 
 impl<'a, Message, Theme, Renderer> TitleBar<'a, Message, Theme, Renderer>
@@ -37,14 +37,14 @@ where
         content: impl Into<Element<'a, Message, Theme, Renderer>>,
     ) -> Self
     where
-        Theme: container::DefaultStyle,
+        Theme: container::DefaultStyle + 'a,
     {
         Self {
             content: content.into(),
             controls: None,
             padding: Padding::ZERO,
             always_show_controls: false,
-            style: Theme::default_style(),
+            style: Box::new(Theme::default_style),
         }
     }
 
@@ -66,9 +66,9 @@ where
     /// Sets the style of the [`TitleBar`].
     pub fn style(
         mut self,
-        style: fn(&Theme, container::Status) -> container::Appearance,
+        style: impl Fn(&Theme, container::Status) -> container::Appearance + 'a,
     ) -> Self {
-        self.style = style.into();
+        self.style = Box::new(style);
         self
     }
 

--- a/widget/src/tooltip.rs
+++ b/widget/src/tooltip.rs
@@ -28,7 +28,7 @@ pub struct Tooltip<
     gap: f32,
     padding: f32,
     snap_within_viewport: bool,
-    style: container::Style<Theme>,
+    style: container::Style<'a, Theme>,
 }
 
 impl<'a, Message, Theme, Renderer> Tooltip<'a, Message, Theme, Renderer>
@@ -47,7 +47,7 @@ where
         position: Position,
     ) -> Self
     where
-        Theme: container::DefaultStyle,
+        Theme: container::DefaultStyle + 'a,
     {
         Tooltip {
             content: content.into(),
@@ -56,7 +56,7 @@ where
             gap: 0.0,
             padding: Self::DEFAULT_PADDING,
             snap_within_viewport: true,
-            style: Theme::default_style(),
+            style: Box::new(Theme::default_style),
         }
     }
 
@@ -81,9 +81,9 @@ where
     /// Sets the style of the [`Tooltip`].
     pub fn style(
         mut self,
-        style: fn(&Theme, container::Status) -> container::Appearance,
+        style: impl Fn(&Theme, container::Status) -> container::Appearance + 'a,
     ) -> Self {
-        self.style = style.into();
+        self.style = Box::new(style);
         self
     }
 }
@@ -239,7 +239,7 @@ where
                 positioning: self.position,
                 gap: self.gap,
                 padding: self.padding,
-                style: self.style,
+                style: &self.style,
             })))
         } else {
             None
@@ -309,7 +309,8 @@ where
     positioning: Position,
     gap: f32,
     padding: f32,
-    style: container::Style<Theme>,
+    style:
+        &'b (dyn Fn(&Theme, container::Status) -> container::Appearance + 'a),
 }
 
 impl<'a, 'b, Message, Theme, Renderer>

--- a/widget/src/vertical_slider.rs
+++ b/widget/src/vertical_slider.rs
@@ -51,7 +51,7 @@ pub struct VerticalSlider<'a, T, Message, Theme = crate::Theme> {
     on_release: Option<Message>,
     width: f32,
     height: Length,
-    style: Style<Theme>,
+    style: Style<'a, Theme>,
 }
 
 impl<'a, T, Message, Theme> VerticalSlider<'a, T, Message, Theme>
@@ -72,7 +72,7 @@ where
     ///   `Message`.
     pub fn new<F>(range: RangeInclusive<T>, value: T, on_change: F) -> Self
     where
-        Theme: DefaultStyle,
+        Theme: DefaultStyle + 'a,
         F: 'a + Fn(T) -> Message,
     {
         let value = if value >= *range.start() {
@@ -97,7 +97,7 @@ where
             on_release: None,
             width: Self::DEFAULT_WIDTH,
             height: Length::Fill,
-            style: Theme::default_style(),
+            style: Box::new(Theme::default_style),
         }
     }
 
@@ -133,8 +133,11 @@ where
     }
 
     /// Sets the style of the [`VerticalSlider`].
-    pub fn style(mut self, style: fn(&Theme, Status) -> Appearance) -> Self {
-        self.style = style.into();
+    pub fn style(
+        mut self,
+        style: impl Fn(&Theme, Status) -> Appearance + 'a,
+    ) -> Self {
+        self.style = Box::new(style);
         self
     }
 


### PR DESCRIPTION
This PR replaces the function pointers used for styling since #2312 with boxed closures. These closures can both capture and borrow application state.

We trade a bit of overhead for a lot of flexibility. No need to juggle `themer`s everywhere!