### PR TITLE
Fix wgpu examples link in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -28,7 +28,7 @@ body:
 
         If you have any issues running any of the examples, make sure your graphics drivers are up-to-date. If the issues persist, please report them to the authors of the libraries directly!
 
-        [the `wgpu` examples]: https://github.com/gfx-rs/wgpu/tree/master/wgpu/examples
+        [the `wgpu` examples]: https://github.com/gfx-rs/wgpu/tree/trunk/examples
         [the `glow` examples]: https://github.com/grovesNL/glow/tree/main/examples
       options:
       - label: My hardware is compatible and my graphics drivers are up-to-date.


### PR DESCRIPTION
The examples have moved from `/wgpu/examples` to `/examples`, and the default branch has been renamed from `master` to `trunk`. This PR updates the `BUG-REPORT` issue template accordingly.