### PR TITLE
`Program` API

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ that can be incremented and decremented using two buttons.
 We start by modelling the __state__ of our application:
 
 ```rust
+#[derive(Default)]
 struct Counter {
-    // The counter value
     value: i32,
 }
 ```
@@ -110,8 +110,8 @@ the button presses. These interactions are our __messages__:
 ```rust
 #[derive(Debug, Clone, Copy)]
 pub enum Message {
-    IncrementPressed,
-    DecrementPressed,
+    Increment,
+    Decrement,
 }
 ```
 
@@ -126,15 +126,15 @@ impl Counter {
         // We use a column: a simple vertical layout
         column![
             // The increment button. We tell it to produce an
-            // `IncrementPressed` message when pressed
-            button("+").on_press(Message::IncrementPressed),
+            // `Increment` message when pressed
+            button("+").on_press(Message::Increment),
 
             // We show the value of the counter here
             text(self.value).size(50),
 
             // The decrement button. We tell it to produce a
-            // `DecrementPressed` message when pressed
-            button("-").on_press(Message::DecrementPressed),
+            // `Decrement` message when pressed
+            button("-").on_press(Message::Decrement),
         ]
     }
 }
@@ -160,8 +160,15 @@ impl Counter {
 }
 ```
 
-And that's everything! We just wrote a whole user interface. Iced is now able
-to:
+And that's everything! We just wrote a whole user interface. Let's run it:
+
+```rust
+fn main() -> iced::Result {
+    iced::run("A cool counter", Counter::update, Counter::view)
+}
+```
+
+Iced will automatically:
 
   1. Take the result of our __view logic__ and layout its widgets.
   1. Process events from our system and produce __messages__ for our

--- a/core/src/angle.rs
+++ b/core/src/angle.rs
@@ -7,6 +7,18 @@ use std::ops::{Add, AddAssign, Div, Mul, RangeInclusive, Sub, SubAssign};
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
 pub struct Degrees(pub f32);
 
+impl PartialEq<f32> for Degrees {
+    fn eq(&self, other: &f32) -> bool {
+        self.0.eq(other)
+    }
+}
+
+impl PartialOrd<f32> for Degrees {
+    fn partial_cmp(&self, other: &f32) -> Option<std::cmp::Ordering> {
+        self.0.partial_cmp(other)
+    }
+}
+
 /// Radians
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
 pub struct Radians(pub f32);
@@ -138,5 +150,17 @@ impl Div for Radians {
 
     fn div(self, rhs: Self) -> Self::Output {
         Self(self.0 / rhs.0)
+    }
+}
+
+impl PartialEq<f32> for Radians {
+    fn eq(&self, other: &f32) -> bool {
+        self.0.eq(other)
+    }
+}
+
+impl PartialOrd<f32> for Radians {
+    fn partial_cmp(&self, other: &f32) -> Option<std::cmp::Ordering> {
+        self.0.partial_cmp(other)
     }
 }

--- a/examples/arc/src/main.rs
+++ b/examples/arc/src/main.rs
@@ -7,8 +7,7 @@ use iced::widget::canvas::{
 use iced::{Element, Length, Point, Rectangle, Renderer, Subscription, Theme};
 
 pub fn main() -> iced::Result {
-    iced::sandbox(Arc::update, Arc::view)
-        .title("Arc - Iced")
+    iced::sandbox("Arc - Iced", Arc::update, Arc::view)
         .subscription(Arc::subscription)
         .theme(|_| Theme::Dark)
         .antialiased()

--- a/examples/arc/src/main.rs
+++ b/examples/arc/src/main.rs
@@ -1,20 +1,18 @@
 use std::{f32::consts::PI, time::Instant};
 
-use iced::executor;
 use iced::mouse;
 use iced::widget::canvas::{
     self, stroke, Cache, Canvas, Geometry, Path, Stroke,
 };
-use iced::{
-    Application, Command, Element, Length, Point, Rectangle, Renderer,
-    Settings, Subscription, Theme,
-};
+use iced::{Element, Length, Point, Rectangle, Renderer, Subscription, Theme};
 
 pub fn main() -> iced::Result {
-    Arc::run(Settings {
-        antialiasing: true,
-        ..Settings::default()
-    })
+    iced::sandbox(Arc::update, Arc::view)
+        .title("Arc - Iced")
+        .subscription(Arc::subscription)
+        .theme(|_| Theme::Dark)
+        .antialiased()
+        .run()
 }
 
 struct Arc {
@@ -27,30 +25,9 @@ enum Message {
     Tick,
 }
 
-impl Application for Arc {
-    type Executor = executor::Default;
-    type Message = Message;
-    type Theme = Theme;
-    type Flags = ();
-
-    fn new(_flags: ()) -> (Self, Command<Message>) {
-        (
-            Arc {
-                start: Instant::now(),
-                cache: Cache::default(),
-            },
-            Command::none(),
-        )
-    }
-
-    fn title(&self) -> String {
-        String::from("Arc - Iced")
-    }
-
-    fn update(&mut self, _: Message) -> Command<Message> {
+impl Arc {
+    fn update(&mut self, _: Message) {
         self.cache.clear();
-
-        Command::none()
     }
 
     fn view(&self) -> Element<Message> {
@@ -60,13 +37,18 @@ impl Application for Arc {
             .into()
     }
 
-    fn theme(&self) -> Theme {
-        Theme::Dark
-    }
-
     fn subscription(&self) -> Subscription<Message> {
         iced::time::every(std::time::Duration::from_millis(10))
             .map(|_| Message::Tick)
+    }
+}
+
+impl Default for Arc {
+    fn default() -> Self {
+        Arc {
+            start: Instant::now(),
+            cache: Cache::default(),
+        }
     }
 }
 

--- a/examples/bezier_tool/src/main.rs
+++ b/examples/bezier_tool/src/main.rs
@@ -1,12 +1,12 @@
 //! This example showcases an interactive `Canvas` for drawing Bézier curves.
 use iced::widget::{button, column, text};
-use iced::{Alignment, Element, Length, Sandbox, Settings};
+use iced::{Alignment, Element, Length};
 
 pub fn main() -> iced::Result {
-    Example::run(Settings {
-        antialiasing: true,
-        ..Settings::default()
-    })
+    iced::sandbox(Example::update, Example::view)
+        .title("Bezier tool - Iced")
+        .antialiased()
+        .run()
 }
 
 #[derive(Default)]
@@ -21,17 +21,7 @@ enum Message {
     Clear,
 }
 
-impl Sandbox for Example {
-    type Message = Message;
-
-    fn new() -> Self {
-        Example::default()
-    }
-
-    fn title(&self) -> String {
-        String::from("Bezier tool - Iced")
-    }
-
+impl Example {
     fn update(&mut self, message: Message) {
         match message {
             Message::AddCurve(curve) => {

--- a/examples/bezier_tool/src/main.rs
+++ b/examples/bezier_tool/src/main.rs
@@ -3,8 +3,7 @@ use iced::widget::{button, column, text};
 use iced::{Alignment, Element, Length};
 
 pub fn main() -> iced::Result {
-    iced::sandbox(Example::update, Example::view)
-        .title("Bezier tool - Iced")
+    iced::sandbox("Bezier Tool - Iced", Example::update, Example::view)
         .antialiased()
         .run()
 }

--- a/examples/checkbox/src/main.rs
+++ b/examples/checkbox/src/main.rs
@@ -5,7 +5,7 @@ const ICON_FONT: Font = Font::with_name("icons");
 
 pub fn main() -> iced::Result {
     iced::sandbox("Checkbox - Iced", Example::update, Example::view)
-        .fonts([include_bytes!("../fonts/icons.ttf").as_slice().into()])
+        .font(include_bytes!("../fonts/icons.ttf").as_slice())
         .run()
 }
 

--- a/examples/checkbox/src/main.rs
+++ b/examples/checkbox/src/main.rs
@@ -1,12 +1,13 @@
-use iced::executor;
-use iced::font::{self, Font};
 use iced::widget::{checkbox, column, container, row, text};
-use iced::{Application, Command, Element, Length, Settings, Theme};
+use iced::{Element, Font, Length};
 
 const ICON_FONT: Font = Font::with_name("icons");
 
 pub fn main() -> iced::Result {
-    Example::run(Settings::default())
+    iced::sandbox(Example::update, Example::view)
+        .title("Checkbox - Iced")
+        .fonts([include_bytes!("../fonts/icons.ttf").as_slice().into()])
+        .run()
 }
 
 #[derive(Default)]
@@ -21,28 +22,10 @@ enum Message {
     DefaultToggled(bool),
     CustomToggled(bool),
     StyledToggled(bool),
-    FontLoaded(Result<(), font::Error>),
 }
 
-impl Application for Example {
-    type Message = Message;
-    type Flags = ();
-    type Executor = executor::Default;
-    type Theme = Theme;
-
-    fn new(_flags: Self::Flags) -> (Self, Command<Message>) {
-        (
-            Self::default(),
-            font::load(include_bytes!("../fonts/icons.ttf").as_slice())
-                .map(Message::FontLoaded),
-        )
-    }
-
-    fn title(&self) -> String {
-        String::from("Checkbox - Iced")
-    }
-
-    fn update(&mut self, message: Message) -> Command<Message> {
+impl Example {
+    fn update(&mut self, message: Message) {
         match message {
             Message::DefaultToggled(default) => {
                 self.default = default;
@@ -53,10 +36,7 @@ impl Application for Example {
             Message::CustomToggled(custom) => {
                 self.custom = custom;
             }
-            Message::FontLoaded(_) => (),
         }
-
-        Command::none()
     }
 
     fn view(&self) -> Element<Message> {

--- a/examples/checkbox/src/main.rs
+++ b/examples/checkbox/src/main.rs
@@ -4,8 +4,7 @@ use iced::{Element, Font, Length};
 const ICON_FONT: Font = Font::with_name("icons");
 
 pub fn main() -> iced::Result {
-    iced::sandbox(Example::update, Example::view)
-        .title("Checkbox - Iced")
+    iced::sandbox("Checkbox - Iced", Example::update, Example::view)
         .fonts([include_bytes!("../fonts/icons.ttf").as_slice().into()])
         .run()
 }

--- a/examples/clock/src/main.rs
+++ b/examples/clock/src/main.rs
@@ -1,17 +1,17 @@
-use iced::executor;
 use iced::mouse;
 use iced::widget::canvas::{stroke, Cache, Geometry, LineCap, Path, Stroke};
 use iced::widget::{canvas, container};
 use iced::{
-    Application, Command, Element, Length, Point, Rectangle, Renderer,
-    Settings, Subscription, Theme, Vector,
+    Element, Length, Point, Rectangle, Renderer, Subscription, Theme, Vector,
 };
 
 pub fn main() -> iced::Result {
-    Clock::run(Settings {
-        antialiasing: true,
-        ..Settings::default()
-    })
+    iced::sandbox(Clock::update, Clock::view)
+        .title("Clock - Iced")
+        .subscription(Clock::subscription)
+        .theme(Clock::theme)
+        .antialiased()
+        .run()
 }
 
 struct Clock {
@@ -24,28 +24,8 @@ enum Message {
     Tick(time::OffsetDateTime),
 }
 
-impl Application for Clock {
-    type Executor = executor::Default;
-    type Message = Message;
-    type Theme = Theme;
-    type Flags = ();
-
-    fn new(_flags: ()) -> (Self, Command<Message>) {
-        (
-            Clock {
-                now: time::OffsetDateTime::now_local()
-                    .unwrap_or_else(|_| time::OffsetDateTime::now_utc()),
-                clock: Cache::default(),
-            },
-            Command::none(),
-        )
-    }
-
-    fn title(&self) -> String {
-        String::from("Clock - Iced")
-    }
-
-    fn update(&mut self, message: Message) -> Command<Message> {
+impl Clock {
+    fn update(&mut self, message: Message) {
         match message {
             Message::Tick(local_time) => {
                 let now = local_time;
@@ -56,8 +36,6 @@ impl Application for Clock {
                 }
             }
         }
-
-        Command::none()
     }
 
     fn view(&self) -> Element<Message> {
@@ -82,7 +60,18 @@ impl Application for Clock {
     }
 
     fn theme(&self) -> Theme {
-        Theme::TokyoNight
+        Theme::ALL[(self.now.unix_timestamp() as usize / 60) % Theme::ALL.len()]
+            .clone()
+    }
+}
+
+impl Default for Clock {
+    fn default() -> Self {
+        Self {
+            now: time::OffsetDateTime::now_local()
+                .unwrap_or_else(|_| time::OffsetDateTime::now_utc()),
+            clock: Cache::default(),
+        }
     }
 }
 

--- a/examples/clock/src/main.rs
+++ b/examples/clock/src/main.rs
@@ -1,8 +1,10 @@
+use iced::alignment;
 use iced::mouse;
 use iced::widget::canvas::{stroke, Cache, Geometry, LineCap, Path, Stroke};
 use iced::widget::{canvas, container};
 use iced::{
-    Element, Length, Point, Rectangle, Renderer, Subscription, Theme, Vector,
+    Degrees, Element, Font, Length, Point, Rectangle, Renderer, Subscription,
+    Theme, Vector,
 };
 
 pub fn main() -> iced::Result {
@@ -133,8 +135,31 @@ impl<Message> canvas::Program<Message> for Clock {
             });
 
             frame.with_save(|frame| {
-                frame.rotate(hand_rotation(self.now.second(), 60));
+                let rotation = hand_rotation(self.now.second(), 60);
+
+                frame.rotate(rotation);
                 frame.stroke(&long_hand, thin_stroke());
+
+                let rotate_factor = if rotation < 180.0 { 1.0 } else { -1.0 };
+
+                frame.rotate(Degrees(-90.0 * rotate_factor));
+                frame.fill_text(canvas::Text {
+                    content: theme.to_string(),
+                    size: 15.into(),
+                    position: Point::new(
+                        (0.8 * radius - 8.0) * rotate_factor,
+                        -8.0,
+                    ),
+                    color: palette.primary.weak.text,
+                    horizontal_alignment: if rotate_factor > 0.0 {
+                        alignment::Horizontal::Right
+                    } else {
+                        alignment::Horizontal::Left
+                    },
+                    vertical_alignment: alignment::Vertical::Bottom,
+                    font: Font::MONOSPACE,
+                    ..canvas::Text::default()
+                });
             });
         });
 
@@ -142,8 +167,8 @@ impl<Message> canvas::Program<Message> for Clock {
     }
 }
 
-fn hand_rotation(n: u8, total: u8) -> f32 {
+fn hand_rotation(n: u8, total: u8) -> Degrees {
     let turns = n as f32 / total as f32;
 
-    2.0 * std::f32::consts::PI * turns
+    Degrees(360.0 * turns)
 }

--- a/examples/clock/src/main.rs
+++ b/examples/clock/src/main.rs
@@ -6,8 +6,7 @@ use iced::{
 };
 
 pub fn main() -> iced::Result {
-    iced::sandbox(Clock::update, Clock::view)
-        .title("Clock - Iced")
+    iced::sandbox("Clock - Iced", Clock::update, Clock::view)
         .subscription(Clock::subscription)
         .theme(Clock::theme)
         .antialiased()

--- a/examples/color_palette/src/main.rs
+++ b/examples/color_palette/src/main.rs
@@ -3,8 +3,8 @@ use iced::mouse;
 use iced::widget::canvas::{self, Canvas, Frame, Geometry, Path};
 use iced::widget::{column, row, text, Slider};
 use iced::{
-    Color, Element, Font, Length, Pixels, Point, Rectangle, Renderer, Sandbox,
-    Settings, Size, Vector,
+    Color, Element, Font, Length, Pixels, Point, Rectangle, Renderer, Size,
+    Vector,
 };
 use palette::{
     self, convert::FromColor, rgb::Rgb, Darken, Hsl, Lighten, ShiftHue,
@@ -13,11 +13,12 @@ use std::marker::PhantomData;
 use std::ops::RangeInclusive;
 
 pub fn main() -> iced::Result {
-    ColorPalette::run(Settings {
-        antialiasing: true,
-        default_font: Font::MONOSPACE,
-        ..Settings::default()
-    })
+    iced::sandbox(ColorPalette::update, ColorPalette::view)
+        .theme(ColorPalette::theme)
+        .title("Color Palette - Iced")
+        .default_font(Font::MONOSPACE)
+        .antialiased()
+        .run()
 }
 
 #[derive(Default)]
@@ -41,17 +42,7 @@ pub enum Message {
     LchColorChanged(palette::Lch),
 }
 
-impl Sandbox for ColorPalette {
-    type Message = Message;
-
-    fn new() -> Self {
-        Self::default()
-    }
-
-    fn title(&self) -> String {
-        String::from("Color palette - Iced")
-    }
-
+impl ColorPalette {
     fn update(&mut self, message: Message) {
         let srgb = match message {
             Message::RgbColorChanged(rgb) => Rgb::from(rgb),

--- a/examples/color_palette/src/main.rs
+++ b/examples/color_palette/src/main.rs
@@ -13,12 +13,15 @@ use std::marker::PhantomData;
 use std::ops::RangeInclusive;
 
 pub fn main() -> iced::Result {
-    iced::sandbox(ColorPalette::update, ColorPalette::view)
-        .theme(ColorPalette::theme)
-        .title("Color Palette - Iced")
-        .default_font(Font::MONOSPACE)
-        .antialiased()
-        .run()
+    iced::sandbox(
+        "Color Palette - Iced",
+        ColorPalette::update,
+        ColorPalette::view,
+    )
+    .theme(ColorPalette::theme)
+    .default_font(Font::MONOSPACE)
+    .antialiased()
+    .run()
 }
 
 #[derive(Default)]

--- a/examples/combo_box/src/main.rs
+++ b/examples/combo_box/src/main.rs
@@ -1,10 +1,10 @@
 use iced::widget::{
     column, combo_box, container, scrollable, text, vertical_space,
 };
-use iced::{Alignment, Element, Length, Sandbox, Settings};
+use iced::{Alignment, Element, Length};
 
 pub fn main() -> iced::Result {
-    Example::run(Settings::default())
+    iced::run("Combo Box - Iced", Example::update, Example::view)
 }
 
 struct Example {
@@ -20,19 +20,13 @@ enum Message {
     Closed,
 }
 
-impl Sandbox for Example {
-    type Message = Message;
-
+impl Example {
     fn new() -> Self {
         Self {
             languages: combo_box::State::new(Language::ALL.to_vec()),
             selected_language: None,
             text: String::new(),
         }
-    }
-
-    fn title(&self) -> String {
-        String::from("Combo box - Iced")
     }
 
     fn update(&mut self, message: Message) {
@@ -80,6 +74,12 @@ impl Sandbox for Example {
             .center_x()
             .center_y()
             .into()
+    }
+}
+
+impl Default for Example {
+    fn default() -> Self {
+        Example::new()
     }
 }
 

--- a/examples/component/src/main.rs
+++ b/examples/component/src/main.rs
@@ -1,10 +1,10 @@
 use iced::widget::container;
-use iced::{Element, Length, Sandbox, Settings};
+use iced::{Element, Length};
 
 use numeric_input::numeric_input;
 
 pub fn main() -> iced::Result {
-    Component::run(Settings::default())
+    iced::run("Component - Iced", Component::update, Component::view)
 }
 
 #[derive(Default)]
@@ -17,17 +17,7 @@ enum Message {
     NumericInputChanged(Option<u32>),
 }
 
-impl Sandbox for Component {
-    type Message = Message;
-
-    fn new() -> Self {
-        Self::default()
-    }
-
-    fn title(&self) -> String {
-        String::from("Component - Iced")
-    }
-
+impl Component {
     fn update(&mut self, message: Message) {
         match message {
             Message::NumericInputChanged(value) => {

--- a/examples/counter/src/main.rs
+++ b/examples/counter/src/main.rs
@@ -1,50 +1,40 @@
-use iced::widget::{button, column, text};
-use iced::{Alignment, Element, Sandbox, Settings};
+use iced::widget::{button, column, text, Column};
+use iced::Alignment;
 
 pub fn main() -> iced::Result {
-    Counter::run(Settings::default())
+    iced::run("A cool counter", Counter::update, Counter::view)
 }
 
+#[derive(Default)]
 struct Counter {
-    value: i32,
+    value: i64,
 }
 
 #[derive(Debug, Clone, Copy)]
 enum Message {
-    IncrementPressed,
-    DecrementPressed,
+    Increment,
+    Decrement,
 }
 
-impl Sandbox for Counter {
-    type Message = Message;
-
-    fn new() -> Self {
-        Self { value: 0 }
-    }
-
-    fn title(&self) -> String {
-        String::from("Counter - Iced")
-    }
-
+impl Counter {
     fn update(&mut self, message: Message) {
         match message {
-            Message::IncrementPressed => {
+            Message::Increment => {
                 self.value += 1;
             }
-            Message::DecrementPressed => {
+            Message::Decrement => {
                 self.value -= 1;
             }
         }
     }
 
-    fn view(&self) -> Element<Message> {
+    fn view(&self) -> Column<Message> {
         column![
-            button("Increment").on_press(Message::IncrementPressed),
+            button("Increment").on_press(Message::Increment),
             text(self.value).size(50),
-            button("Decrement").on_press(Message::DecrementPressed)
+            button("Decrement").on_press(Message::Decrement)
         ]
         .padding(20)
         .align_items(Alignment::Center)
-        .into()
     }
 }

--- a/examples/custom_quad/src/main.rs
+++ b/examples/custom_quad/src/main.rs
@@ -82,12 +82,10 @@ mod quad {
 }
 
 use iced::widget::{column, container, slider, text};
-use iced::{
-    Alignment, Color, Element, Length, Sandbox, Settings, Shadow, Vector,
-};
+use iced::{Alignment, Color, Element, Length, Shadow, Vector};
 
 pub fn main() -> iced::Result {
-    Example::run(Settings::default())
+    iced::run("Custom Quad - Iced", Example::update, Example::view)
 }
 
 struct Example {
@@ -109,9 +107,7 @@ enum Message {
     ShadowBlurRadiusChanged(f32),
 }
 
-impl Sandbox for Example {
-    type Message = Message;
-
+impl Example {
     fn new() -> Self {
         Self {
             radius: [50.0; 4],
@@ -122,10 +118,6 @@ impl Sandbox for Example {
                 blur_radius: 16.0,
             },
         }
-    }
-
-    fn title(&self) -> String {
-        String::from("Custom widget - Iced")
     }
 
     fn update(&mut self, message: Message) {
@@ -201,5 +193,11 @@ impl Sandbox for Example {
             .center_x()
             .center_y()
             .into()
+    }
+}
+
+impl Default for Example {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/examples/custom_shader/src/main.rs
+++ b/examples/custom_shader/src/main.rs
@@ -9,9 +9,8 @@ use iced::window;
 use iced::{Alignment, Color, Element, Length, Subscription};
 
 fn main() -> iced::Result {
-    iced::sandbox(IcedCubes::update, IcedCubes::view)
+    iced::sandbox("Custom Shader - Iced", IcedCubes::update, IcedCubes::view)
         .subscription(IcedCubes::subscription)
-        .title("Custom Shader - Iced")
         .run()
 }
 

--- a/examples/custom_shader/src/main.rs
+++ b/examples/custom_shader/src/main.rs
@@ -2,18 +2,17 @@ mod scene;
 
 use scene::Scene;
 
-use iced::executor;
 use iced::time::Instant;
 use iced::widget::shader::wgpu;
 use iced::widget::{checkbox, column, container, row, shader, slider, text};
 use iced::window;
-use iced::{
-    Alignment, Application, Color, Command, Element, Length, Subscription,
-    Theme,
-};
+use iced::{Alignment, Color, Element, Length, Subscription};
 
 fn main() -> iced::Result {
-    IcedCubes::run(iced::Settings::default())
+    iced::sandbox(IcedCubes::update, IcedCubes::view)
+        .subscription(IcedCubes::subscription)
+        .title("Custom Shader - Iced")
+        .run()
 }
 
 struct IcedCubes {
@@ -30,27 +29,15 @@ enum Message {
     LightColorChanged(Color),
 }
 
-impl Application for IcedCubes {
-    type Executor = executor::Default;
-    type Message = Message;
-    type Theme = Theme;
-    type Flags = ();
-
-    fn new(_flags: Self::Flags) -> (Self, Command<Self::Message>) {
-        (
-            Self {
-                start: Instant::now(),
-                scene: Scene::new(),
-            },
-            Command::none(),
-        )
+impl IcedCubes {
+    fn new() -> Self {
+        Self {
+            start: Instant::now(),
+            scene: Scene::new(),
+        }
     }
 
-    fn title(&self) -> String {
-        "Iced Cubes".to_string()
-    }
-
-    fn update(&mut self, message: Self::Message) -> Command<Self::Message> {
+    fn update(&mut self, message: Message) {
         match message {
             Message::CubeAmountChanged(amount) => {
                 self.scene.change_amount(amount);
@@ -68,11 +55,9 @@ impl Application for IcedCubes {
                 self.scene.light_color = color;
             }
         }
-
-        Command::none()
     }
 
-    fn view(&self) -> Element<'_, Self::Message> {
+    fn view(&self) -> Element<'_, Message> {
         let top_controls = row![
             control(
                 "Amount",
@@ -147,8 +132,14 @@ impl Application for IcedCubes {
             .into()
     }
 
-    fn subscription(&self) -> Subscription<Self::Message> {
+    fn subscription(&self) -> Subscription<Message> {
         window::frames().map(Message::Tick)
+    }
+}
+
+impl Default for IcedCubes {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/examples/custom_widget/src/main.rs
+++ b/examples/custom_widget/src/main.rs
@@ -83,10 +83,10 @@ mod circle {
 
 use circle::circle;
 use iced::widget::{column, container, slider, text};
-use iced::{Alignment, Element, Length, Sandbox, Settings};
+use iced::{Alignment, Element, Length};
 
 pub fn main() -> iced::Result {
-    Example::run(Settings::default())
+    iced::run("Custom Widget - Iced", Example::update, Example::view)
 }
 
 struct Example {
@@ -98,15 +98,9 @@ enum Message {
     RadiusChanged(f32),
 }
 
-impl Sandbox for Example {
-    type Message = Message;
-
+impl Example {
     fn new() -> Self {
         Example { radius: 50.0 }
-    }
-
-    fn title(&self) -> String {
-        String::from("Custom widget - Iced")
     }
 
     fn update(&mut self, message: Message) {
@@ -134,5 +128,11 @@ impl Sandbox for Example {
             .center_x()
             .center_y()
             .into()
+    }
+}
+
+impl Default for Example {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/examples/download_progress/src/main.rs
+++ b/examples/download_progress/src/main.rs
@@ -1,14 +1,13 @@
-use iced::executor;
-use iced::widget::{button, column, container, progress_bar, text, Column};
-use iced::{
-    Alignment, Application, Command, Element, Length, Settings, Subscription,
-    Theme,
-};
-
 mod download;
 
+use iced::widget::{button, column, container, progress_bar, text, Column};
+use iced::{Alignment, Element, Length, Subscription};
+
 pub fn main() -> iced::Result {
-    Example::run(Settings::default())
+    iced::sandbox(Example::update, Example::view)
+        .subscription(Example::subscription)
+        .title("Download Progress - Iced")
+        .run()
 }
 
 #[derive(Debug)]
@@ -24,27 +23,15 @@ pub enum Message {
     DownloadProgressed((usize, download::Progress)),
 }
 
-impl Application for Example {
-    type Message = Message;
-    type Theme = Theme;
-    type Executor = executor::Default;
-    type Flags = ();
-
-    fn new(_flags: ()) -> (Example, Command<Message>) {
-        (
-            Example {
-                downloads: vec![Download::new(0)],
-                last_id: 0,
-            },
-            Command::none(),
-        )
+impl Example {
+    fn new() -> Self {
+        Self {
+            downloads: vec![Download::new(0)],
+            last_id: 0,
+        }
     }
 
-    fn title(&self) -> String {
-        String::from("Download progress - Iced")
-    }
-
-    fn update(&mut self, message: Message) -> Command<Message> {
+    fn update(&mut self, message: Message) {
         match message {
             Message::Add => {
                 self.last_id += 1;
@@ -63,9 +50,7 @@ impl Application for Example {
                     download.progress(progress);
                 }
             }
-        };
-
-        Command::none()
+        }
     }
 
     fn subscription(&self) -> Subscription<Message> {
@@ -90,6 +75,12 @@ impl Application for Example {
             .center_y()
             .padding(20)
             .into()
+    }
+}
+
+impl Default for Example {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/examples/download_progress/src/main.rs
+++ b/examples/download_progress/src/main.rs
@@ -4,9 +4,8 @@ use iced::widget::{button, column, container, progress_bar, text, Column};
 use iced::{Alignment, Element, Length, Subscription};
 
 pub fn main() -> iced::Result {
-    iced::sandbox(Example::update, Example::view)
+    iced::sandbox("Download Progress - Iced", Example::update, Example::view)
         .subscription(Example::subscription)
-        .title("Download Progress - Iced")
         .run()
 }
 

--- a/examples/events/src/main.rs
+++ b/examples/events/src/main.rs
@@ -1,21 +1,15 @@
 use iced::alignment;
 use iced::event::{self, Event};
-use iced::executor;
 use iced::widget::{button, checkbox, container, text, Column};
 use iced::window;
-use iced::{
-    Alignment, Application, Command, Element, Length, Settings, Subscription,
-    Theme,
-};
+use iced::{Alignment, Command, Element, Length, Subscription};
 
 pub fn main() -> iced::Result {
-    Events::run(Settings {
-        window: window::Settings {
-            exit_on_close_request: false,
-            ..window::Settings::default()
-        },
-        ..Settings::default()
-    })
+    iced::application(Events::new, Events::update, Events::view)
+        .title("Events - Iced")
+        .subscription(Events::subscription)
+        .ignore_close_request()
+        .run()
 }
 
 #[derive(Debug, Default)]
@@ -31,18 +25,9 @@ enum Message {
     Exit,
 }
 
-impl Application for Events {
-    type Message = Message;
-    type Theme = Theme;
-    type Executor = executor::Default;
-    type Flags = ();
-
-    fn new(_flags: ()) -> (Events, Command<Message>) {
+impl Events {
+    fn new() -> (Events, Command<Message>) {
         (Events::default(), Command::none())
-    }
-
-    fn title(&self) -> String {
-        String::from("Events - Iced")
     }
 
     fn update(&mut self, message: Message) -> Command<Message> {

--- a/examples/events/src/main.rs
+++ b/examples/events/src/main.rs
@@ -5,8 +5,7 @@ use iced::window;
 use iced::{Alignment, Command, Element, Length, Subscription};
 
 pub fn main() -> iced::Result {
-    iced::application(Events::new, Events::update, Events::view)
-        .title("Events - Iced")
+    iced::application("Events - Iced", Events::update, Events::view)
         .subscription(Events::subscription)
         .ignore_close_request()
         .run()
@@ -26,10 +25,6 @@ enum Message {
 }
 
 impl Events {
-    fn new() -> (Events, Command<Message>) {
-        (Events::default(), Command::none())
-    }
-
     fn update(&mut self, message: Message) -> Command<Message> {
         match message {
             Message::EventOccurred(event) if self.enabled => {

--- a/examples/exit/src/main.rs
+++ b/examples/exit/src/main.rs
@@ -3,9 +3,7 @@ use iced::window;
 use iced::{Alignment, Command, Element, Length};
 
 pub fn main() -> iced::Result {
-    iced::application(Exit::new, Exit::update, Exit::view)
-        .title("Exit - Iced")
-        .run()
+    iced::application("Exit - Iced", Exit::update, Exit::view).run()
 }
 
 #[derive(Default)]
@@ -20,10 +18,6 @@ enum Message {
 }
 
 impl Exit {
-    fn new() -> (Self, Command<Message>) {
-        (Self::default(), Command::none())
-    }
-
     fn update(&mut self, message: Message) -> Command<Message> {
         match message {
             Message::Confirm => window::close(window::Id::MAIN),

--- a/examples/exit/src/main.rs
+++ b/examples/exit/src/main.rs
@@ -1,10 +1,11 @@
-use iced::executor;
 use iced::widget::{button, column, container};
 use iced::window;
-use iced::{Alignment, Application, Command, Element, Length, Settings, Theme};
+use iced::{Alignment, Command, Element, Length};
 
 pub fn main() -> iced::Result {
-    Exit::run(Settings::default())
+    iced::application(Exit::new, Exit::update, Exit::view)
+        .title("Exit - Iced")
+        .run()
 }
 
 #[derive(Default)]
@@ -18,18 +19,9 @@ enum Message {
     Exit,
 }
 
-impl Application for Exit {
-    type Executor = executor::Default;
-    type Message = Message;
-    type Theme = Theme;
-    type Flags = ();
-
-    fn new(_flags: ()) -> (Self, Command<Message>) {
+impl Exit {
+    fn new() -> (Self, Command<Message>) {
         (Self::default(), Command::none())
-    }
-
-    fn title(&self) -> String {
-        String::from("Exit - Iced")
     }
 
     fn update(&mut self, message: Message) -> Command<Message> {

--- a/examples/geometry/src/main.rs
+++ b/examples/geometry/src/main.rs
@@ -147,51 +147,35 @@ mod rainbow {
 }
 
 use iced::widget::{column, container, scrollable};
-use iced::{Element, Length, Sandbox, Settings};
+use iced::{Element, Length};
 use rainbow::rainbow;
 
 pub fn main() -> iced::Result {
-    Example::run(Settings::default())
+    iced::run("Custom 2D Geometry - Iced", |_, _| {}, view)
 }
 
-struct Example;
-
-impl Sandbox for Example {
-    type Message = ();
-
-    fn new() -> Self {
-        Self
-    }
-
-    fn title(&self) -> String {
-        String::from("Custom 2D geometry - Iced")
-    }
-
-    fn update(&mut self, _: ()) {}
-
-    fn view(&self) -> Element<()> {
-        let content = column![
-            rainbow(),
-            "In this example we draw a custom widget Rainbow, using \
+fn view(_state: &()) -> Element<'_, ()> {
+    let content = column![
+        rainbow(),
+        "In this example we draw a custom widget Rainbow, using \
                  the Mesh2D primitive. This primitive supplies a list of \
                  triangles, expressed as vertices and indices.",
-            "Move your cursor over it, and see the center vertex \
+        "Move your cursor over it, and see the center vertex \
                  follow you!",
-            "Every Vertex2D defines its own color. You could use the \
+        "Every Vertex2D defines its own color. You could use the \
                  Mesh2D primitive to render virtually any two-dimensional \
                  geometry for your widget.",
-        ]
-        .padding(20)
-        .spacing(20)
-        .max_width(500);
+    ]
+    .padding(20)
+    .spacing(20)
+    .max_width(500);
 
-        let scrollable =
-            scrollable(container(content).width(Length::Fill).center_x());
+    let scrollable =
+        scrollable(container(content).width(Length::Fill).center_x());
 
-        container(scrollable)
-            .width(Length::Fill)
-            .height(Length::Fill)
-            .center_y()
-            .into()
-    }
+    container(scrollable)
+        .width(Length::Fill)
+        .height(Length::Fill)
+        .center_y()
+        .into()
 }

--- a/examples/layout/src/main.rs
+++ b/examples/layout/src/main.rs
@@ -1,4 +1,3 @@
-use iced::executor;
 use iced::keyboard;
 use iced::mouse;
 use iced::widget::{
@@ -6,15 +5,19 @@ use iced::widget::{
     row, scrollable, text,
 };
 use iced::{
-    color, Alignment, Application, Command, Element, Font, Length, Point,
-    Rectangle, Renderer, Settings, Subscription, Theme,
+    color, Alignment, Element, Font, Length, Point, Rectangle, Renderer,
+    Subscription, Theme,
 };
 
 pub fn main() -> iced::Result {
-    Layout::run(Settings::default())
+    iced::sandbox(Layout::update, Layout::view)
+        .title(Layout::title)
+        .subscription(Layout::subscription)
+        .theme(Layout::theme)
+        .run()
 }
 
-#[derive(Debug)]
+#[derive(Default, Debug)]
 struct Layout {
     example: Example,
     explain: bool,
@@ -29,28 +32,12 @@ enum Message {
     ThemeSelected(Theme),
 }
 
-impl Application for Layout {
-    type Message = Message;
-    type Theme = Theme;
-    type Executor = executor::Default;
-    type Flags = ();
-
-    fn new(_flags: Self::Flags) -> (Self, Command<Message>) {
-        (
-            Self {
-                example: Example::default(),
-                explain: false,
-                theme: Theme::Light,
-            },
-            Command::none(),
-        )
-    }
-
+impl Layout {
     fn title(&self) -> String {
         format!("{} - Layout - Iced", self.example.title)
     }
 
-    fn update(&mut self, message: Self::Message) -> Command<Message> {
+    fn update(&mut self, message: Message) {
         match message {
             Message::Next => {
                 self.example = self.example.next();
@@ -65,8 +52,6 @@ impl Application for Layout {
                 self.theme = theme;
             }
         }
-
-        Command::none()
     }
 
     fn subscription(&self) -> Subscription<Message> {

--- a/examples/layout/src/main.rs
+++ b/examples/layout/src/main.rs
@@ -10,8 +10,7 @@ use iced::{
 };
 
 pub fn main() -> iced::Result {
-    iced::sandbox(Layout::update, Layout::view)
-        .title(Layout::title)
+    iced::sandbox(Layout::title, Layout::update, Layout::view)
         .subscription(Layout::subscription)
         .theme(Layout::theme)
         .run()

--- a/examples/lazy/src/main.rs
+++ b/examples/lazy/src/main.rs
@@ -2,13 +2,13 @@ use iced::widget::{
     button, column, horizontal_space, lazy, pick_list, row, scrollable, text,
     text_input,
 };
-use iced::{Element, Length, Sandbox, Settings};
+use iced::{Element, Length};
 
 use std::collections::HashSet;
 use std::hash::Hash;
 
 pub fn main() -> iced::Result {
-    App::run(Settings::default())
+    iced::run("Lazy - Iced", App::update, App::view)
 }
 
 struct App {
@@ -120,17 +120,7 @@ enum Message {
     ItemColorChanged(Item, Color),
 }
 
-impl Sandbox for App {
-    type Message = Message;
-
-    fn new() -> Self {
-        Self::default()
-    }
-
-    fn title(&self) -> String {
-        String::from("Lazy - Iced")
-    }
-
+impl App {
     fn update(&mut self, message: Message) {
         match message {
             Message::InputChanged(input) => {

--- a/examples/loading_spinners/src/main.rs
+++ b/examples/loading_spinners/src/main.rs
@@ -11,10 +11,13 @@ use circular::Circular;
 use linear::Linear;
 
 pub fn main() -> iced::Result {
-    iced::sandbox(LoadingSpinners::update, LoadingSpinners::view)
-        .title("Loading Spinners - Iced")
-        .antialiased()
-        .run()
+    iced::sandbox(
+        "Loading Spinners - Iced",
+        LoadingSpinners::update,
+        LoadingSpinners::view,
+    )
+    .antialiased()
+    .run()
 }
 
 struct LoadingSpinners {

--- a/examples/loading_spinners/src/main.rs
+++ b/examples/loading_spinners/src/main.rs
@@ -1,6 +1,5 @@
-use iced::executor;
 use iced::widget::{column, container, row, slider, text};
-use iced::{Application, Command, Element, Length, Settings, Theme};
+use iced::{Element, Length};
 
 use std::time::Duration;
 
@@ -12,22 +11,14 @@ use circular::Circular;
 use linear::Linear;
 
 pub fn main() -> iced::Result {
-    LoadingSpinners::run(Settings {
-        antialiasing: true,
-        ..Default::default()
-    })
+    iced::sandbox(LoadingSpinners::update, LoadingSpinners::view)
+        .title("Loading Spinners - Iced")
+        .antialiased()
+        .run()
 }
 
 struct LoadingSpinners {
     cycle_duration: f32,
-}
-
-impl Default for LoadingSpinners {
-    fn default() -> Self {
-        Self {
-            cycle_duration: 2.0,
-        }
-    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -35,28 +26,13 @@ enum Message {
     CycleDurationChanged(f32),
 }
 
-impl Application for LoadingSpinners {
-    type Message = Message;
-    type Flags = ();
-    type Executor = executor::Default;
-    type Theme = Theme;
-
-    fn new(_flags: Self::Flags) -> (Self, Command<Message>) {
-        (Self::default(), Command::none())
-    }
-
-    fn title(&self) -> String {
-        String::from("Loading Spinners - Iced")
-    }
-
-    fn update(&mut self, message: Message) -> Command<Message> {
+impl LoadingSpinners {
+    fn update(&mut self, message: Message) {
         match message {
             Message::CycleDurationChanged(duration) => {
                 self.cycle_duration = duration;
             }
         }
-
-        Command::none()
     }
 
     fn view(&self) -> Element<Message> {
@@ -113,5 +89,13 @@ impl Application for LoadingSpinners {
         .center_x()
         .center_y()
         .into()
+    }
+}
+
+impl Default for LoadingSpinners {
+    fn default() -> Self {
+        Self {
+            cycle_duration: 2.0,
+        }
     }
 }

--- a/examples/loupe/src/main.rs
+++ b/examples/loupe/src/main.rs
@@ -1,39 +1,30 @@
 use iced::widget::{button, column, container, text};
-use iced::{Alignment, Element, Length, Sandbox, Settings};
+use iced::{Alignment, Element, Length};
 
 use loupe::loupe;
 
 pub fn main() -> iced::Result {
-    Counter::run(Settings::default())
+    iced::run("Loupe - Iced", Loupe::update, Loupe::view)
 }
 
-struct Counter {
-    value: i32,
+#[derive(Default)]
+struct Loupe {
+    value: i64,
 }
 
 #[derive(Debug, Clone, Copy)]
 enum Message {
-    IncrementPressed,
-    DecrementPressed,
+    Increment,
+    Decrement,
 }
 
-impl Sandbox for Counter {
-    type Message = Message;
-
-    fn new() -> Self {
-        Self { value: 0 }
-    }
-
-    fn title(&self) -> String {
-        String::from("Counter - Iced")
-    }
-
+impl Loupe {
     fn update(&mut self, message: Message) {
         match message {
-            Message::IncrementPressed => {
+            Message::Increment => {
                 self.value += 1;
             }
-            Message::DecrementPressed => {
+            Message::Decrement => {
                 self.value -= 1;
             }
         }
@@ -43,9 +34,9 @@ impl Sandbox for Counter {
         container(loupe(
             3.0,
             column![
-                button("Increment").on_press(Message::IncrementPressed),
+                button("Increment").on_press(Message::Increment),
                 text(self.value).size(50),
-                button("Decrement").on_press(Message::DecrementPressed)
+                button("Decrement").on_press(Message::Decrement)
             ]
             .padding(20)
             .align_items(Alignment::Center),

--- a/examples/multitouch/src/main.rs
+++ b/examples/multitouch/src/main.rs
@@ -13,8 +13,7 @@ use std::collections::HashMap;
 pub fn main() -> iced::Result {
     tracing_subscriber::fmt::init();
 
-    iced::sandbox(Multitouch::update, Multitouch::view)
-        .title("Multitouch - Iced")
+    iced::sandbox("Multitouch - Iced", Multitouch::update, Multitouch::view)
         .antialiased()
         .centered()
         .run()

--- a/examples/pane_grid/src/main.rs
+++ b/examples/pane_grid/src/main.rs
@@ -1,17 +1,16 @@
 use iced::alignment::{self, Alignment};
-use iced::executor;
 use iced::keyboard;
 use iced::widget::pane_grid::{self, PaneGrid};
 use iced::widget::{
     button, column, container, responsive, row, scrollable, text,
 };
-use iced::{
-    Application, Color, Command, Element, Length, Settings, Size, Subscription,
-    Theme,
-};
+use iced::{Color, Element, Length, Size, Subscription};
 
 pub fn main() -> iced::Result {
-    Example::run(Settings::default())
+    iced::sandbox(Example::update, Example::view)
+        .subscription(Example::subscription)
+        .title("Pane Grid - Iced")
+        .run()
 }
 
 struct Example {
@@ -35,30 +34,18 @@ enum Message {
     CloseFocused,
 }
 
-impl Application for Example {
-    type Message = Message;
-    type Theme = Theme;
-    type Executor = executor::Default;
-    type Flags = ();
-
-    fn new(_flags: ()) -> (Self, Command<Message>) {
+impl Example {
+    fn new() -> Self {
         let (panes, _) = pane_grid::State::new(Pane::new(0));
 
-        (
-            Example {
-                panes,
-                panes_created: 1,
-                focus: None,
-            },
-            Command::none(),
-        )
+        Example {
+            panes,
+            panes_created: 1,
+            focus: None,
+        }
     }
 
-    fn title(&self) -> String {
-        String::from("Pane grid - Iced")
-    }
-
-    fn update(&mut self, message: Message) -> Command<Message> {
+    fn update(&mut self, message: Message) {
         match message {
             Message::Split(axis, pane) => {
                 let result =
@@ -132,8 +119,6 @@ impl Application for Example {
                 }
             }
         }
-
-        Command::none()
     }
 
     fn subscription(&self) -> Subscription<Message> {
@@ -206,6 +191,12 @@ impl Application for Example {
             .height(Length::Fill)
             .padding(10)
             .into()
+    }
+}
+
+impl Default for Example {
+    fn default() -> Self {
+        Example::new()
     }
 }
 

--- a/examples/pane_grid/src/main.rs
+++ b/examples/pane_grid/src/main.rs
@@ -7,9 +7,8 @@ use iced::widget::{
 use iced::{Color, Element, Length, Size, Subscription};
 
 pub fn main() -> iced::Result {
-    iced::sandbox(Example::update, Example::view)
+    iced::sandbox("Pane Grid - Iced", Example::update, Example::view)
         .subscription(Example::subscription)
-        .title("Pane Grid - Iced")
         .run()
 }
 

--- a/examples/pick_list/src/main.rs
+++ b/examples/pick_list/src/main.rs
@@ -1,8 +1,8 @@
 use iced::widget::{column, pick_list, scrollable, vertical_space};
-use iced::{Alignment, Element, Length, Sandbox, Settings};
+use iced::{Alignment, Element, Length};
 
 pub fn main() -> iced::Result {
-    Example::run(Settings::default())
+    iced::run("Pick List - Iced", Example::update, Example::view)
 }
 
 #[derive(Default)]
@@ -15,17 +15,7 @@ enum Message {
     LanguageSelected(Language),
 }
 
-impl Sandbox for Example {
-    type Message = Message;
-
-    fn new() -> Self {
-        Self::default()
-    }
-
-    fn title(&self) -> String {
-        String::from("Pick list - Iced")
-    }
-
+impl Example {
     fn update(&mut self, message: Message) {
         match message {
             Message::LanguageSelected(language) => {

--- a/examples/pokedex/src/main.rs
+++ b/examples/pokedex/src/main.rs
@@ -4,7 +4,7 @@ use iced::{Alignment, Command, Element, Length};
 
 pub fn main() -> iced::Result {
     iced::application(Pokedex::title, Pokedex::update, Pokedex::view)
-        .load(Pokedex::load)
+        .load(Pokedex::search)
         .run()
 }
 
@@ -25,7 +25,7 @@ enum Message {
 }
 
 impl Pokedex {
-    fn load() -> Command<Message> {
+    fn search() -> Command<Message> {
         Command::perform(Pokemon::search(), Message::PokemonFound)
     }
 
@@ -56,7 +56,7 @@ impl Pokedex {
                 _ => {
                     *self = Pokedex::Loading;
 
-                    Command::perform(Pokemon::search(), Message::PokemonFound)
+                    Self::search()
                 }
             },
         }

--- a/examples/pokedex/src/main.rs
+++ b/examples/pokedex/src/main.rs
@@ -1,9 +1,11 @@
 use iced::futures;
 use iced::widget::{self, column, container, image, row, text};
-use iced::{Alignment, Application, Command, Element, Length, Settings, Theme};
+use iced::{Alignment, Command, Element, Length};
 
 pub fn main() -> iced::Result {
-    Pokedex::run(Settings::default())
+    iced::application(Pokedex::new, Pokedex::update, Pokedex::view)
+        .title(Pokedex::title)
+        .run()
 }
 
 #[derive(Debug)]
@@ -19,13 +21,8 @@ enum Message {
     Search,
 }
 
-impl Application for Pokedex {
-    type Message = Message;
-    type Theme = Theme;
-    type Executor = iced::executor::Default;
-    type Flags = ();
-
-    fn new(_flags: ()) -> (Pokedex, Command<Message>) {
+impl Pokedex {
+    fn new() -> (Self, Command<Message>) {
         (
             Pokedex::Loading,
             Command::perform(Pokemon::search(), Message::PokemonFound),

--- a/examples/pokedex/src/main.rs
+++ b/examples/pokedex/src/main.rs
@@ -3,15 +3,18 @@ use iced::widget::{self, column, container, image, row, text};
 use iced::{Alignment, Command, Element, Length};
 
 pub fn main() -> iced::Result {
-    iced::application(Pokedex::new, Pokedex::update, Pokedex::view)
-        .title(Pokedex::title)
+    iced::application(Pokedex::title, Pokedex::update, Pokedex::view)
+        .load(Pokedex::load)
         .run()
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 enum Pokedex {
+    #[default]
     Loading,
-    Loaded { pokemon: Pokemon },
+    Loaded {
+        pokemon: Pokemon,
+    },
     Errored,
 }
 
@@ -22,11 +25,8 @@ enum Message {
 }
 
 impl Pokedex {
-    fn new() -> (Self, Command<Message>) {
-        (
-            Pokedex::Loading,
-            Command::perform(Pokemon::search(), Message::PokemonFound),
-        )
+    fn load() -> Command<Message> {
+        Command::perform(Pokemon::search(), Message::PokemonFound)
     }
 
     fn title(&self) -> String {

--- a/examples/progress_bar/src/main.rs
+++ b/examples/progress_bar/src/main.rs
@@ -1,8 +1,8 @@
 use iced::widget::{column, progress_bar, slider};
-use iced::{Element, Sandbox, Settings};
+use iced::Element;
 
 pub fn main() -> iced::Result {
-    Progress::run(Settings::default())
+    iced::run("Progress Bar - Iced", Progress::update, Progress::view)
 }
 
 #[derive(Default)]
@@ -15,17 +15,7 @@ enum Message {
     SliderChanged(f32),
 }
 
-impl Sandbox for Progress {
-    type Message = Message;
-
-    fn new() -> Self {
-        Self::default()
-    }
-
-    fn title(&self) -> String {
-        String::from("A simple Progressbar")
-    }
-
+impl Progress {
     fn update(&mut self, message: Message) {
         match message {
             Message::SliderChanged(x) => self.value = x,

--- a/examples/qr_code/src/main.rs
+++ b/examples/qr_code/src/main.rs
@@ -4,10 +4,13 @@ use iced::widget::{
 use iced::{Alignment, Element, Length, Theme};
 
 pub fn main() -> iced::Result {
-    iced::sandbox(QRGenerator::update, QRGenerator::view)
-        .title("QR Code Generator - Iced")
-        .theme(QRGenerator::theme)
-        .run()
+    iced::sandbox(
+        "QR Code Generator - Iced",
+        QRGenerator::update,
+        QRGenerator::view,
+    )
+    .theme(QRGenerator::theme)
+    .run()
 }
 
 #[derive(Default)]

--- a/examples/qr_code/src/main.rs
+++ b/examples/qr_code/src/main.rs
@@ -1,10 +1,13 @@
 use iced::widget::{
     column, container, pick_list, qr_code, row, text, text_input,
 };
-use iced::{Alignment, Element, Length, Sandbox, Settings, Theme};
+use iced::{Alignment, Element, Length, Theme};
 
 pub fn main() -> iced::Result {
-    QRGenerator::run(Settings::default())
+    iced::sandbox(QRGenerator::update, QRGenerator::view)
+        .title("QR Code Generator - Iced")
+        .theme(QRGenerator::theme)
+        .run()
 }
 
 #[derive(Default)]
@@ -20,17 +23,7 @@ enum Message {
     ThemeChanged(Theme),
 }
 
-impl Sandbox for QRGenerator {
-    type Message = Message;
-
-    fn new() -> Self {
-        QRGenerator::default()
-    }
-
-    fn title(&self) -> String {
-        String::from("QR Code Generator - Iced")
-    }
-
+impl QRGenerator {
     fn update(&mut self, message: Message) {
         match message {
             Message::DataChanged(mut data) => {

--- a/examples/screenshot/src/main.rs
+++ b/examples/screenshot/src/main.rs
@@ -1,12 +1,10 @@
 use iced::alignment;
-use iced::executor;
 use iced::keyboard;
 use iced::widget::{button, column, container, image, row, text, text_input};
 use iced::window;
 use iced::window::screenshot::{self, Screenshot};
 use iced::{
-    Alignment, Application, Command, ContentFit, Element, Length, Rectangle,
-    Subscription, Theme,
+    Alignment, Command, ContentFit, Element, Length, Rectangle, Subscription,
 };
 
 use ::image as img;
@@ -15,7 +13,10 @@ use ::image::ColorType;
 fn main() -> iced::Result {
     tracing_subscriber::fmt::init();
 
-    Example::run(iced::Settings::default())
+    iced::application(Example::new, Example::update, Example::view)
+        .subscription(Example::subscription)
+        .title("Screenshot - Iced")
+        .run()
 }
 
 struct Example {
@@ -42,13 +43,8 @@ enum Message {
     HeightInputChanged(Option<u32>),
 }
 
-impl Application for Example {
-    type Executor = executor::Default;
-    type Message = Message;
-    type Theme = Theme;
-    type Flags = ();
-
-    fn new(_flags: Self::Flags) -> (Self, Command<Self::Message>) {
+impl Example {
+    fn new() -> (Self, Command<Message>) {
         (
             Example {
                 screenshot: None,
@@ -64,11 +60,7 @@ impl Application for Example {
         )
     }
 
-    fn title(&self) -> String {
-        "Screenshot".to_string()
-    }
-
-    fn update(&mut self, message: Self::Message) -> Command<Self::Message> {
+    fn update(&mut self, message: Message) -> Command<Message> {
         match message {
             Message::Screenshot => {
                 return iced::window::screenshot(
@@ -130,7 +122,7 @@ impl Application for Example {
         Command::none()
     }
 
-    fn view(&self) -> Element<'_, Self::Message> {
+    fn view(&self) -> Element<'_, Message> {
         let image: Element<Message> = if let Some(screenshot) = &self.screenshot
         {
             image(image::Handle::from_pixels(
@@ -259,7 +251,7 @@ impl Application for Example {
             .into()
     }
 
-    fn subscription(&self) -> Subscription<Self::Message> {
+    fn subscription(&self) -> Subscription<Message> {
         use keyboard::key;
 
         keyboard::on_key_press(|key, _modifiers| {

--- a/examples/screenshot/src/main.rs
+++ b/examples/screenshot/src/main.rs
@@ -13,12 +13,12 @@ use ::image::ColorType;
 fn main() -> iced::Result {
     tracing_subscriber::fmt::init();
 
-    iced::application(Example::new, Example::update, Example::view)
+    iced::application("Screenshot - Iced", Example::update, Example::view)
         .subscription(Example::subscription)
-        .title("Screenshot - Iced")
         .run()
 }
 
+#[derive(Default)]
 struct Example {
     screenshot: Option<Screenshot>,
     saved_png_path: Option<Result<String, PngError>>,
@@ -44,22 +44,6 @@ enum Message {
 }
 
 impl Example {
-    fn new() -> (Self, Command<Message>) {
-        (
-            Example {
-                screenshot: None,
-                saved_png_path: None,
-                png_saving: false,
-                crop_error: None,
-                x_input_value: None,
-                y_input_value: None,
-                width_input_value: None,
-                height_input_value: None,
-            },
-            Command::none(),
-        )
-    }
-
     fn update(&mut self, message: Message) -> Command<Message> {
         match message {
             Message::Screenshot => {

--- a/examples/scrollable/src/main.rs
+++ b/examples/scrollable/src/main.rs
@@ -1,20 +1,23 @@
-use iced::executor;
 use iced::widget::scrollable::Properties;
 use iced::widget::{
     button, column, container, horizontal_space, progress_bar, radio, row,
     scrollable, slider, text, vertical_space, Scrollable,
 };
-use iced::{
-    Alignment, Application, Border, Color, Command, Element, Length, Settings,
-    Theme,
-};
+use iced::{Alignment, Border, Color, Command, Element, Length, Theme};
 
 use once_cell::sync::Lazy;
 
 static SCROLLABLE_ID: Lazy<scrollable::Id> = Lazy::new(scrollable::Id::unique);
 
 pub fn main() -> iced::Result {
-    ScrollableDemo::run(Settings::default())
+    iced::application(
+        ScrollableDemo::new,
+        ScrollableDemo::update,
+        ScrollableDemo::view,
+    )
+    .theme(ScrollableDemo::theme)
+    .title("Scrollable - Iced")
+    .run()
 }
 
 struct ScrollableDemo {
@@ -45,13 +48,8 @@ enum Message {
     Scrolled(scrollable::Viewport),
 }
 
-impl Application for ScrollableDemo {
-    type Executor = executor::Default;
-    type Message = Message;
-    type Theme = Theme;
-    type Flags = ();
-
-    fn new(_flags: Self::Flags) -> (Self, Command<Message>) {
+impl ScrollableDemo {
+    fn new() -> (Self, Command<Message>) {
         (
             ScrollableDemo {
                 scrollable_direction: Direction::Vertical,
@@ -63,10 +61,6 @@ impl Application for ScrollableDemo {
             },
             Command::none(),
         )
-    }
-
-    fn title(&self) -> String {
-        String::from("Scrollable - Iced")
     }
 
     fn update(&mut self, message: Message) -> Command<Message> {
@@ -340,7 +334,7 @@ impl Application for ScrollableDemo {
         container(content).padding(20).center_x().center_y().into()
     }
 
-    fn theme(&self) -> Self::Theme {
+    fn theme(&self) -> Theme {
         Theme::Dark
     }
 }

--- a/examples/scrollable/src/main.rs
+++ b/examples/scrollable/src/main.rs
@@ -11,12 +11,11 @@ static SCROLLABLE_ID: Lazy<scrollable::Id> = Lazy::new(scrollable::Id::unique);
 
 pub fn main() -> iced::Result {
     iced::application(
-        ScrollableDemo::new,
+        "Scrollable - Iced",
         ScrollableDemo::update,
         ScrollableDemo::view,
     )
     .theme(ScrollableDemo::theme)
-    .title("Scrollable - Iced")
     .run()
 }
 
@@ -49,18 +48,15 @@ enum Message {
 }
 
 impl ScrollableDemo {
-    fn new() -> (Self, Command<Message>) {
-        (
-            ScrollableDemo {
-                scrollable_direction: Direction::Vertical,
-                scrollbar_width: 10,
-                scrollbar_margin: 0,
-                scroller_width: 10,
-                current_scroll_offset: scrollable::RelativeOffset::START,
-                alignment: scrollable::Alignment::Start,
-            },
-            Command::none(),
-        )
+    fn new() -> Self {
+        ScrollableDemo {
+            scrollable_direction: Direction::Vertical,
+            scrollbar_width: 10,
+            scrollbar_margin: 0,
+            scroller_width: 10,
+            current_scroll_offset: scrollable::RelativeOffset::START,
+            alignment: scrollable::Alignment::Start,
+        }
     }
 
     fn update(&mut self, message: Message) -> Command<Message> {
@@ -336,6 +332,12 @@ impl ScrollableDemo {
 
     fn theme(&self) -> Theme {
         Theme::Dark
+    }
+}
+
+impl Default for ScrollableDemo {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/examples/sierpinski_triangle/src/main.rs
+++ b/examples/sierpinski_triangle/src/main.rs
@@ -8,10 +8,13 @@ use rand::Rng;
 use std::fmt::Debug;
 
 fn main() -> iced::Result {
-    iced::sandbox(SierpinskiEmulator::update, SierpinskiEmulator::view)
-        .title("Sierpinski Triangle - Iced")
-        .antialiased()
-        .run()
+    iced::sandbox(
+        "Sierpinski Triangle - Iced",
+        SierpinskiEmulator::update,
+        SierpinskiEmulator::view,
+    )
+    .antialiased()
+    .run()
 }
 
 #[derive(Debug, Default)]

--- a/examples/sierpinski_triangle/src/main.rs
+++ b/examples/sierpinski_triangle/src/main.rs
@@ -1,25 +1,20 @@
-use std::fmt::Debug;
-
-use iced::executor;
 use iced::mouse;
 use iced::widget::canvas::event::{self, Event};
 use iced::widget::canvas::{self, Canvas};
 use iced::widget::{column, row, slider, text};
-use iced::{
-    Application, Color, Command, Length, Point, Rectangle, Renderer, Settings,
-    Size, Theme,
-};
+use iced::{Color, Length, Point, Rectangle, Renderer, Size, Theme};
 
 use rand::Rng;
+use std::fmt::Debug;
 
 fn main() -> iced::Result {
-    SierpinskiEmulator::run(Settings {
-        antialiasing: true,
-        ..Settings::default()
-    })
+    iced::sandbox(SierpinskiEmulator::update, SierpinskiEmulator::view)
+        .title("Sierpinski Triangle - Iced")
+        .antialiased()
+        .run()
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 struct SierpinskiEmulator {
     graph: SierpinskiGraph,
 }
@@ -31,27 +26,8 @@ pub enum Message {
     PointRemoved,
 }
 
-impl Application for SierpinskiEmulator {
-    type Executor = executor::Default;
-    type Message = Message;
-    type Theme = Theme;
-    type Flags = ();
-
-    fn new(_flags: Self::Flags) -> (Self, iced::Command<Self::Message>) {
-        let emulator = SierpinskiEmulator {
-            graph: SierpinskiGraph::new(),
-        };
-        (emulator, Command::none())
-    }
-
-    fn title(&self) -> String {
-        "Sierpinski Triangle Emulator".to_string()
-    }
-
-    fn update(
-        &mut self,
-        message: Self::Message,
-    ) -> iced::Command<Self::Message> {
+impl SierpinskiEmulator {
+    fn update(&mut self, message: Message) {
         match message {
             Message::IterationSet(cur_iter) => {
                 self.graph.iteration = cur_iter;
@@ -67,11 +43,9 @@ impl Application for SierpinskiEmulator {
         }
 
         self.graph.redraw();
-
-        Command::none()
     }
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<'_, Message> {
         column![
             Canvas::new(&self.graph)
                 .width(Length::Fill)
@@ -167,10 +141,6 @@ impl canvas::Program<Message> for SierpinskiGraph {
 }
 
 impl SierpinskiGraph {
-    fn new() -> SierpinskiGraph {
-        SierpinskiGraph::default()
-    }
-
     fn redraw(&mut self) {
         self.cache.clear();
     }

--- a/examples/slider/src/main.rs
+++ b/examples/slider/src/main.rs
@@ -1,8 +1,8 @@
 use iced::widget::{column, container, slider, text, vertical_slider};
-use iced::{Element, Length, Sandbox, Settings};
+use iced::{Element, Length};
 
 pub fn main() -> iced::Result {
-    Slider::run(Settings::default())
+    iced::run("Slider - Iced", Slider::update, Slider::view)
 }
 
 #[derive(Debug, Clone)]
@@ -17,20 +17,14 @@ pub struct Slider {
     shift_step: u8,
 }
 
-impl Sandbox for Slider {
-    type Message = Message;
-
-    fn new() -> Slider {
+impl Slider {
+    fn new() -> Self {
         Slider {
             value: 50,
             default: 50,
             step: 5,
             shift_step: 1,
         }
-    }
-
-    fn title(&self) -> String {
-        String::from("Slider - Iced")
     }
 
     fn update(&mut self, message: Message) {
@@ -73,5 +67,11 @@ impl Sandbox for Slider {
         .center_x()
         .center_y()
         .into()
+    }
+}
+
+impl Default for Slider {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/examples/solar_system/src/main.rs
+++ b/examples/solar_system/src/main.rs
@@ -22,11 +22,14 @@ use std::time::Instant;
 pub fn main() -> iced::Result {
     tracing_subscriber::fmt::init();
 
-    iced::sandbox(SolarSystem::update, SolarSystem::view)
-        .subscription(SolarSystem::subscription)
-        .theme(SolarSystem::theme)
-        .title("Solar System - Iced")
-        .run()
+    iced::sandbox(
+        "Solar System - Iced",
+        SolarSystem::update,
+        SolarSystem::view,
+    )
+    .subscription(SolarSystem::subscription)
+    .theme(SolarSystem::theme)
+    .run()
 }
 
 #[derive(Default)]

--- a/examples/solar_system/src/main.rs
+++ b/examples/solar_system/src/main.rs
@@ -6,8 +6,6 @@
 //! Inspired by the example found in the MDN docs[1].
 //!
 //! [1]: https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Basic_animations#An_animated_solar_system
-use iced::application;
-use iced::executor;
 use iced::mouse;
 use iced::widget::canvas;
 use iced::widget::canvas::gradient;
@@ -15,8 +13,8 @@ use iced::widget::canvas::stroke::{self, Stroke};
 use iced::widget::canvas::Path;
 use iced::window;
 use iced::{
-    Application, Color, Command, Element, Length, Point, Rectangle, Renderer,
-    Settings, Size, Subscription, Theme, Vector,
+    Color, Element, Length, Point, Rectangle, Renderer, Size, Subscription,
+    Theme, Vector,
 };
 
 use std::time::Instant;
@@ -24,12 +22,14 @@ use std::time::Instant;
 pub fn main() -> iced::Result {
     tracing_subscriber::fmt::init();
 
-    SolarSystem::run(Settings {
-        antialiasing: true,
-        ..Settings::default()
-    })
+    iced::sandbox(SolarSystem::update, SolarSystem::view)
+        .subscription(SolarSystem::subscription)
+        .theme(SolarSystem::theme)
+        .title("Solar System - Iced")
+        .run()
 }
 
+#[derive(Default)]
 struct SolarSystem {
     state: State,
 }
@@ -39,33 +39,13 @@ enum Message {
     Tick(Instant),
 }
 
-impl Application for SolarSystem {
-    type Executor = executor::Default;
-    type Message = Message;
-    type Theme = Theme;
-    type Flags = ();
-
-    fn new(_flags: ()) -> (Self, Command<Message>) {
-        (
-            SolarSystem {
-                state: State::new(),
-            },
-            Command::none(),
-        )
-    }
-
-    fn title(&self) -> String {
-        String::from("Solar system - Iced")
-    }
-
-    fn update(&mut self, message: Message) -> Command<Message> {
+impl SolarSystem {
+    fn update(&mut self, message: Message) {
         match message {
             Message::Tick(instant) => {
                 self.state.update(instant);
             }
         }
-
-        Command::none()
     }
 
     fn view(&self) -> Element<Message> {
@@ -76,14 +56,7 @@ impl Application for SolarSystem {
     }
 
     fn theme(&self) -> Theme {
-        Theme::Dark
-    }
-
-    fn style(&self, _theme: &Theme) -> application::Appearance {
-        application::Appearance {
-            background_color: Color::BLACK,
-            text_color: Color::WHITE,
-        }
+        Theme::Moonfly
     }
 
     fn subscription(&self) -> Subscription<Message> {
@@ -222,5 +195,11 @@ impl<Message> canvas::Program<Message> for State {
         });
 
         vec![background, system]
+    }
+}
+
+impl Default for State {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/examples/stopwatch/src/main.rs
+++ b/examples/stopwatch/src/main.rs
@@ -1,27 +1,32 @@
 use iced::alignment;
-use iced::executor;
 use iced::keyboard;
 use iced::time;
 use iced::widget::{button, column, container, row, text};
-use iced::{
-    Alignment, Application, Command, Element, Length, Settings, Subscription,
-    Theme,
-};
+use iced::{Alignment, Element, Length, Subscription, Theme};
 
 use std::time::{Duration, Instant};
 
 pub fn main() -> iced::Result {
-    Stopwatch::run(Settings::default())
+    iced::sandbox(Stopwatch::update, Stopwatch::view)
+        .subscription(Stopwatch::subscription)
+        .theme(Stopwatch::theme)
+        .title("Stopwatch - Iced")
+        .run()
 }
 
+#[derive(Default)]
 struct Stopwatch {
     duration: Duration,
     state: State,
 }
 
+#[derive(Default)]
 enum State {
+    #[default]
     Idle,
-    Ticking { last_tick: Instant },
+    Ticking {
+        last_tick: Instant,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -31,27 +36,8 @@ enum Message {
     Tick(Instant),
 }
 
-impl Application for Stopwatch {
-    type Message = Message;
-    type Theme = Theme;
-    type Executor = executor::Default;
-    type Flags = ();
-
-    fn new(_flags: ()) -> (Stopwatch, Command<Message>) {
-        (
-            Stopwatch {
-                duration: Duration::default(),
-                state: State::Idle,
-            },
-            Command::none(),
-        )
-    }
-
-    fn title(&self) -> String {
-        String::from("Stopwatch - Iced")
-    }
-
-    fn update(&mut self, message: Message) -> Command<Message> {
+impl Stopwatch {
+    fn update(&mut self, message: Message) {
         match message {
             Message::Toggle => match self.state {
                 State::Idle => {
@@ -73,8 +59,6 @@ impl Application for Stopwatch {
                 self.duration = Duration::default();
             }
         }
-
-        Command::none()
     }
 
     fn subscription(&self) -> Subscription<Message> {

--- a/examples/stopwatch/src/main.rs
+++ b/examples/stopwatch/src/main.rs
@@ -7,10 +7,9 @@ use iced::{Alignment, Element, Length, Subscription, Theme};
 use std::time::{Duration, Instant};
 
 pub fn main() -> iced::Result {
-    iced::sandbox(Stopwatch::update, Stopwatch::view)
+    iced::sandbox("Stopwatch - Iced", Stopwatch::update, Stopwatch::view)
         .subscription(Stopwatch::subscription)
         .theme(Stopwatch::theme)
-        .title("Stopwatch - Iced")
         .run()
 }
 

--- a/examples/styling/src/main.rs
+++ b/examples/styling/src/main.rs
@@ -3,10 +3,13 @@ use iced::widget::{
     progress_bar, row, scrollable, slider, text, text_input, toggler,
     vertical_rule, vertical_space,
 };
-use iced::{Alignment, Element, Length, Sandbox, Settings, Theme};
+use iced::{Alignment, Element, Length, Theme};
 
 pub fn main() -> iced::Result {
-    Styling::run(Settings::default())
+    iced::sandbox(Styling::update, Styling::view)
+        .theme(Styling::theme)
+        .title("Styling - Iced")
+        .run()
 }
 
 #[derive(Default)]
@@ -28,17 +31,7 @@ enum Message {
     TogglerToggled(bool),
 }
 
-impl Sandbox for Styling {
-    type Message = Message;
-
-    fn new() -> Self {
-        Styling::default()
-    }
-
-    fn title(&self) -> String {
-        String::from("Styling - Iced")
-    }
-
+impl Styling {
     fn update(&mut self, message: Message) {
         match message {
             Message::ThemeChanged(theme) => {

--- a/examples/styling/src/main.rs
+++ b/examples/styling/src/main.rs
@@ -6,9 +6,8 @@ use iced::widget::{
 use iced::{Alignment, Element, Length, Theme};
 
 pub fn main() -> iced::Result {
-    iced::sandbox(Styling::update, Styling::view)
+    iced::sandbox("Styling - Iced", Styling::update, Styling::view)
         .theme(Styling::theme)
-        .title("Styling - Iced")
         .run()
 }
 

--- a/examples/svg/src/main.rs
+++ b/examples/svg/src/main.rs
@@ -1,8 +1,8 @@
 use iced::widget::{checkbox, column, container, svg};
-use iced::{color, Element, Length, Sandbox, Settings};
+use iced::{color, Element, Length};
 
 pub fn main() -> iced::Result {
-    Tiger::run(Settings::default())
+    iced::run("SVG - Iced", Tiger::update, Tiger::view)
 }
 
 #[derive(Debug, Default)]
@@ -15,18 +15,8 @@ pub enum Message {
     ToggleColorFilter(bool),
 }
 
-impl Sandbox for Tiger {
-    type Message = Message;
-
-    fn new() -> Self {
-        Tiger::default()
-    }
-
-    fn title(&self) -> String {
-        String::from("SVG - Iced")
-    }
-
-    fn update(&mut self, message: Self::Message) {
+impl Tiger {
+    fn update(&mut self, message: Message) {
         match message {
             Message::ToggleColorFilter(apply_color_filter) => {
                 self.apply_color_filter = apply_color_filter;
@@ -34,7 +24,7 @@ impl Sandbox for Tiger {
         }
     }
 
-    fn view(&self) -> Element<Self::Message> {
+    fn view(&self) -> Element<Message> {
         let handle = svg::Handle::from_path(format!(
             "{}/resources/tiger.svg",
             env!("CARGO_MANIFEST_DIR")

--- a/examples/system_information/src/main.rs
+++ b/examples/system_information/src/main.rs
@@ -1,18 +1,23 @@
 use iced::widget::{button, column, container, text};
 use iced::{system, Command, Element, Length};
 
-use bytesize::ByteSize;
-
 pub fn main() -> iced::Result {
-    iced::application(Example::new, Example::update, Example::view)
-        .title("System Information - Iced")
-        .run()
+    iced::application(
+        "System Information - Iced",
+        Example::update,
+        Example::view,
+    )
+    .run()
 }
 
+#[derive(Default)]
 #[allow(clippy::large_enum_variant)]
 enum Example {
+    #[default]
     Loading,
-    Loaded { information: system::Information },
+    Loaded {
+        information: system::Information,
+    },
 }
 
 #[derive(Clone, Debug)]
@@ -23,13 +28,6 @@ enum Message {
 }
 
 impl Example {
-    fn new() -> (Self, Command<Message>) {
-        (
-            Self::Loading,
-            system::fetch_information(Message::InformationReceived),
-        )
-    }
-
     fn update(&mut self, message: Message) -> Command<Message> {
         match message {
             Message::Refresh => {
@@ -46,6 +44,8 @@ impl Example {
     }
 
     fn view(&self) -> Element<Message> {
+        use bytesize::ByteSize;
+
         let content: Element<_> = match self {
             Example::Loading => text("Loading...").size(40).into(),
             Example::Loaded { information } => {

--- a/examples/system_information/src/main.rs
+++ b/examples/system_information/src/main.rs
@@ -1,12 +1,12 @@
 use iced::widget::{button, column, container, text};
-use iced::{
-    executor, system, Application, Command, Element, Length, Settings, Theme,
-};
+use iced::{system, Command, Element, Length};
 
 use bytesize::ByteSize;
 
 pub fn main() -> iced::Result {
-    Example::run(Settings::default())
+    iced::application(Example::new, Example::update, Example::view)
+        .title("System Information - Iced")
+        .run()
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -22,21 +22,12 @@ enum Message {
     Refresh,
 }
 
-impl Application for Example {
-    type Message = Message;
-    type Theme = Theme;
-    type Executor = executor::Default;
-    type Flags = ();
-
-    fn new(_flags: ()) -> (Self, Command<Message>) {
+impl Example {
+    fn new() -> (Self, Command<Message>) {
         (
             Self::Loading,
             system::fetch_information(Message::InformationReceived),
         )
-    }
-
-    fn title(&self) -> String {
-        String::from("System Information - Iced")
     }
 
     fn update(&mut self, message: Message) -> Command<Message> {

--- a/examples/tooltip/src/main.rs
+++ b/examples/tooltip/src/main.rs
@@ -1,12 +1,13 @@
 use iced::widget::tooltip::Position;
 use iced::widget::{button, container, tooltip};
-use iced::{Element, Length, Sandbox, Settings};
+use iced::{Element, Length};
 
 pub fn main() -> iced::Result {
-    Example::run(Settings::default())
+    iced::run("Tooltip - Iced", Tooltip::update, Tooltip::view)
 }
 
-struct Example {
+#[derive(Default)]
+struct Tooltip {
     position: Position,
 }
 
@@ -15,28 +16,16 @@ enum Message {
     ChangePosition,
 }
 
-impl Sandbox for Example {
-    type Message = Message;
-
-    fn new() -> Self {
-        Self {
-            position: Position::Bottom,
-        }
-    }
-
-    fn title(&self) -> String {
-        String::from("Tooltip - Iced")
-    }
-
+impl Tooltip {
     fn update(&mut self, message: Message) {
         match message {
             Message::ChangePosition => {
                 let position = match &self.position {
-                    Position::FollowCursor => Position::Top,
                     Position::Top => Position::Bottom,
                     Position::Bottom => Position::Left,
                     Position::Left => Position::Right,
                     Position::Right => Position::FollowCursor,
+                    Position::FollowCursor => Position::Top,
                 };
 
                 self.position = position;

--- a/examples/tour/src/main.rs
+++ b/examples/tour/src/main.rs
@@ -16,8 +16,7 @@ pub fn main() -> iced::Result {
     #[cfg(not(target_arch = "wasm32"))]
     tracing_subscriber::fmt::init();
 
-    iced::sandbox(Tour::update, Tour::view)
-        .title(Tour::title)
+    iced::sandbox(Tour::title, Tour::update, Tour::view)
         .centered()
         .run()
 }

--- a/examples/tour/src/main.rs
+++ b/examples/tour/src/main.rs
@@ -4,7 +4,7 @@ use iced::widget::{
     scrollable, slider, text, text_input, toggler, vertical_space,
 };
 use iced::widget::{Button, Column, Container, Slider};
-use iced::{Color, Element, Font, Length, Pixels, Sandbox, Settings};
+use iced::{Color, Element, Font, Length, Pixels};
 
 pub fn main() -> iced::Result {
     #[cfg(target_arch = "wasm32")]
@@ -16,7 +16,10 @@ pub fn main() -> iced::Result {
     #[cfg(not(target_arch = "wasm32"))]
     tracing_subscriber::fmt::init();
 
-    Tour::run(Settings::default())
+    iced::sandbox(Tour::update, Tour::view)
+        .title(Tour::title)
+        .centered()
+        .run()
 }
 
 pub struct Tour {
@@ -24,11 +27,9 @@ pub struct Tour {
     debug: bool,
 }
 
-impl Sandbox for Tour {
-    type Message = Message;
-
-    fn new() -> Tour {
-        Tour {
+impl Tour {
+    fn new() -> Self {
+        Self {
             steps: Steps::new(),
             debug: false,
         }
@@ -87,6 +88,12 @@ impl Sandbox for Tour {
         );
 
         container(scrollable).height(Length::Fill).center_y().into()
+    }
+}
+
+impl Default for Tour {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/examples/url_handler/src/main.rs
+++ b/examples/url_handler/src/main.rs
@@ -1,12 +1,12 @@
 use iced::event::{self, Event};
-use iced::executor;
 use iced::widget::{container, text};
-use iced::{
-    Application, Command, Element, Length, Settings, Subscription, Theme,
-};
+use iced::{Element, Length, Subscription};
 
 pub fn main() -> iced::Result {
-    App::run(Settings::default())
+    iced::sandbox(App::update, App::view)
+        .subscription(App::subscription)
+        .title("URL Handler - Iced")
+        .run()
 }
 
 #[derive(Debug, Default)]
@@ -19,21 +19,8 @@ enum Message {
     EventOccurred(Event),
 }
 
-impl Application for App {
-    type Message = Message;
-    type Theme = Theme;
-    type Executor = executor::Default;
-    type Flags = ();
-
-    fn new(_flags: ()) -> (App, Command<Message>) {
-        (App::default(), Command::none())
-    }
-
-    fn title(&self) -> String {
-        String::from("Url - Iced")
-    }
-
-    fn update(&mut self, message: Message) -> Command<Message> {
+impl App {
+    fn update(&mut self, message: Message) {
         match message {
             Message::EventOccurred(event) => {
                 if let Event::PlatformSpecific(
@@ -45,9 +32,7 @@ impl Application for App {
                     self.url = Some(url);
                 }
             }
-        };
-
-        Command::none()
+        }
     }
 
     fn subscription(&self) -> Subscription<Message> {

--- a/examples/url_handler/src/main.rs
+++ b/examples/url_handler/src/main.rs
@@ -3,9 +3,8 @@ use iced::widget::{container, text};
 use iced::{Element, Length, Subscription};
 
 pub fn main() -> iced::Result {
-    iced::sandbox(App::update, App::view)
+    iced::sandbox("URL Handler - Iced", App::update, App::view)
         .subscription(App::subscription)
-        .title("URL Handler - Iced")
         .run()
 }
 

--- a/examples/vectorial_text/src/main.rs
+++ b/examples/vectorial_text/src/main.rs
@@ -3,18 +3,17 @@ use iced::mouse;
 use iced::widget::{
     canvas, checkbox, column, horizontal_space, row, slider, text,
 };
-use iced::{
-    Element, Length, Point, Rectangle, Renderer, Sandbox, Settings, Theme,
-    Vector,
-};
+use iced::{Element, Length, Point, Rectangle, Renderer, Theme, Vector};
 
 pub fn main() -> iced::Result {
-    VectorialText::run(Settings {
-        antialiasing: true,
-        ..Settings::default()
-    })
+    iced::sandbox(VectorialText::update, VectorialText::view)
+        .theme(|_| Theme::Dark)
+        .title("Vectorial Text - Iced")
+        .antialiased()
+        .run()
 }
 
+#[derive(Default)]
 struct VectorialText {
     state: State,
 }
@@ -27,19 +26,7 @@ enum Message {
     ToggleJapanese(bool),
 }
 
-impl Sandbox for VectorialText {
-    type Message = Message;
-
-    fn new() -> Self {
-        Self {
-            state: State::new(),
-        }
-    }
-
-    fn title(&self) -> String {
-        String::from("Vectorial Text - Iced")
-    }
-
+impl VectorialText {
     fn update(&mut self, message: Message) {
         match message {
             Message::SizeChanged(size) => {
@@ -106,10 +93,6 @@ impl Sandbox for VectorialText {
         .padding(20)
         .into()
     }
-
-    fn theme(&self) -> Theme {
-        Theme::Dark
-    }
 }
 
 struct State {
@@ -168,5 +151,11 @@ impl<Message> canvas::Program<Message> for State {
         });
 
         vec![geometry]
+    }
+}
+
+impl Default for State {
+    fn default() -> Self {
+        State::new()
     }
 }

--- a/examples/vectorial_text/src/main.rs
+++ b/examples/vectorial_text/src/main.rs
@@ -6,11 +6,14 @@ use iced::widget::{
 use iced::{Element, Length, Point, Rectangle, Renderer, Theme, Vector};
 
 pub fn main() -> iced::Result {
-    iced::sandbox(VectorialText::update, VectorialText::view)
-        .theme(|_| Theme::Dark)
-        .title("Vectorial Text - Iced")
-        .antialiased()
-        .run()
+    iced::sandbox(
+        "Vectorial Text - Iced",
+        VectorialText::update,
+        VectorialText::view,
+    )
+    .theme(|_| Theme::Dark)
+    .antialiased()
+    .run()
 }
 
 #[derive(Default)]

--- a/renderer/src/geometry.rs
+++ b/renderer/src/geometry.rs
@@ -2,7 +2,7 @@ mod cache;
 
 pub use cache::Cache;
 
-use crate::core::{Point, Rectangle, Size, Transformation, Vector};
+use crate::core::{Point, Radians, Rectangle, Size, Transformation, Vector};
 use crate::graphics::geometry::{Fill, Path, Stroke, Text};
 use crate::Renderer;
 
@@ -184,7 +184,7 @@ impl Frame {
 
     /// Applies a rotation in radians to the current transform of the [`Frame`].
     #[inline]
-    pub fn rotate(&mut self, angle: f32) {
+    pub fn rotate(&mut self, angle: impl Into<Radians>) {
         delegate!(self, frame, frame.rotate(angle));
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -370,7 +370,7 @@ where
     State: Default + 'static,
     Message: std::fmt::Debug + Send + 'static,
 {
-    sandbox(update, view).title(title).run()
+    sandbox(title, update, view).run()
 }
 
 #[doc(inline)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,6 +175,7 @@ mod error;
 mod sandbox;
 
 pub mod application;
+pub mod program;
 pub mod settings;
 pub mod time;
 pub mod window;
@@ -308,6 +309,7 @@ pub use error::Error;
 pub use event::Event;
 pub use executor::Executor;
 pub use font::Font;
+pub use program::Program;
 pub use renderer::Renderer;
 pub use sandbox::Sandbox;
 pub use settings::Settings;
@@ -327,3 +329,49 @@ pub type Element<
 ///
 /// [`Application`]: crate::Application
 pub type Result = std::result::Result<(), Error>;
+
+/// Runs a basic iced application with default [`Settings`] given
+///   - its window title,
+///   - its update logic,
+///   - and its view logic.
+///
+/// # Example
+/// ```no_run
+/// use iced::widget::{button, column, text, Column};
+///
+/// pub fn main() -> iced::Result {
+///     iced::run("A counter", update, view)
+/// }
+///
+/// #[derive(Debug, Clone)]
+/// enum Message {
+///     Increment,
+/// }
+///
+/// fn update(value: &mut u64, message: Message) {
+///     match message {
+///         Message::Increment => *value += 1,
+///     }
+/// }
+///
+/// fn view(value: &u64) -> Column<Message> {
+///     column![
+///         text(value),
+///         button("+").on_press(Message::Increment),
+///     ]
+/// }
+/// ```
+pub fn run<State, Message>(
+    title: &'static str,
+    update: impl Fn(&mut State, Message) + 'static,
+    view: impl for<'a> program::View<'a, State, Message> + 'static,
+) -> Result
+where
+    State: Default + 'static,
+    Message: std::fmt::Debug + Send + 'static,
+{
+    sandbox(update, view).title(title).run()
+}
+
+#[doc(inline)]
+pub use program::{application, sandbox};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -362,7 +362,7 @@ pub type Result = std::result::Result<(), Error>;
 /// }
 /// ```
 pub fn run<State, Message>(
-    title: &'static str,
+    title: impl program::Title<State> + 'static,
     update: impl Fn(&mut State, Message) + 'static,
     view: impl for<'a> program::View<'a, State, Message> + 'static,
 ) -> Result

--- a/src/program.rs
+++ b/src/program.rs
@@ -107,7 +107,7 @@ where
         type Theme = crate::Theme;
         type Executor = iced_futures::backend::null::Executor;
 
-        fn new(&self) -> (Self::State, Command<Self::Message>) {
+        fn build(&self) -> (Self::State, Command<Self::Message>) {
             (State::default(), Command::none())
         }
 
@@ -176,7 +176,7 @@ where
         type Theme = crate::Theme;
         type Executor = executor::Default;
 
-        fn new(&self) -> (Self::State, Command<Self::Message>) {
+        fn build(&self) -> (Self::State, Command<Self::Message>) {
             (self.new)()
         }
 
@@ -240,7 +240,7 @@ impl<P: Definition> Program<P> {
             type Executor = P::Executor;
 
             fn new(program: Self::Flags) -> (Self, Command<Self::Message>) {
-                let (state, command) = P::new(&program);
+                let (state, command) = P::build(&program);
 
                 (Self { program, state }, command)
             }
@@ -414,7 +414,7 @@ pub trait Definition: Sized {
     /// The executor of the program.
     type Executor: Executor;
 
-    fn new(&self) -> (Self::State, Command<Self::Message>);
+    fn build(&self) -> (Self::State, Command<Self::Message>);
 
     fn update(
         &self,
@@ -462,8 +462,8 @@ fn with_title<P: Definition>(
         type Theme = P::Theme;
         type Executor = P::Executor;
 
-        fn new(&self) -> (Self::State, Command<Self::Message>) {
-            self.program.new()
+        fn build(&self) -> (Self::State, Command<Self::Message>) {
+            self.program.build()
         }
 
         fn title(&self, state: &Self::State) -> String {
@@ -525,8 +525,8 @@ fn with_subscription<P: Definition>(
             (self.subscription)(state)
         }
 
-        fn new(&self) -> (Self::State, Command<Self::Message>) {
-            self.program.new()
+        fn build(&self) -> (Self::State, Command<Self::Message>) {
+            self.program.build()
         }
 
         fn update(
@@ -581,8 +581,8 @@ fn with_theme<P: Definition>(
             (self.theme)(state)
         }
 
-        fn new(&self) -> (Self::State, Command<Self::Message>) {
-            self.program.new()
+        fn build(&self) -> (Self::State, Command<Self::Message>) {
+            self.program.build()
         }
 
         fn title(&self, state: &Self::State) -> String {

--- a/src/program.rs
+++ b/src/program.rs
@@ -312,18 +312,10 @@ impl<P: Definition> Program<P> {
         }
     }
 
-    /// Sets the fonts that will be loaded at the start of the [`Program`].
-    pub fn fonts(
-        self,
-        fonts: impl IntoIterator<Item = Cow<'static, [u8]>>,
-    ) -> Self {
-        Self {
-            settings: Settings {
-                fonts: fonts.into_iter().collect(),
-                ..self.settings
-            },
-            ..self
-        }
+    /// Adds a font to the list of fonts that will be loaded at the start of the [`Program`].
+    pub fn font(mut self, font: impl Into<Cow<'static, [u8]>>) -> Self {
+        self.settings.fonts.push(font.into());
+        self
     }
 
     /// Sets the [`window::Settings::position`] to [`window::Position::Centered`] in the [`Program`].

--- a/src/program.rs
+++ b/src/program.rs
@@ -355,7 +355,7 @@ impl<P: Definition> Program<P> {
     }
 
     /// Sets the [`Title`] of the [`Program`].
-    pub fn title(
+    pub(crate) fn title(
         self,
         title: impl Title<P::State>,
     ) -> Program<

--- a/src/program.rs
+++ b/src/program.rs
@@ -1,0 +1,669 @@
+//! Create iced applications out of simple functions.
+//!
+//! You can use this API to create and run iced applications
+//! step by step—without coupling your logic to a trait
+//! or a specific type.
+//!
+//! This API is meant to be a more convenient—although less
+//! powerful—alternative to the [`Sandbox`] and [`Application`] traits.
+//!
+//! [`Sandbox`]: crate::Sandbox
+//!
+//! # Example
+//! ```no_run
+//! use iced::widget::{button, column, text, Column};
+//! use iced::Theme;
+//!
+//! pub fn main() -> iced::Result {
+//!     iced::sandbox(update, view)
+//!         .title("A counter")
+//!         .theme(|_| Theme::Dark)
+//!         .centered()
+//!         .run()
+//! }
+//!
+//! #[derive(Debug, Clone)]
+//! enum Message {
+//!     Increment,
+//! }
+//!
+//! fn update(value: &mut u64, message: Message) {
+//!     match message {
+//!         Message::Increment => *value += 1,
+//!     }
+//! }
+//!
+//! fn view(value: &u64) -> Column<Message> {
+//!     column![
+//!         text(value),
+//!         button("+").on_press(Message::Increment),
+//!     ]
+//! }
+//! ```
+use crate::application::{self, Application};
+use crate::executor::{self, Executor};
+use crate::window;
+use crate::{Command, Element, Font, Result, Settings, Subscription};
+
+use std::borrow::Cow;
+
+/// Creates the most basic kind of [`Program`] from some update and view logic.
+///
+/// # Example
+/// ```no_run
+/// use iced::widget::{button, column, text, Column};
+///
+/// pub fn main() -> iced::Result {
+///     iced::sandbox(update, view).title("A counter").run()
+/// }
+///
+/// #[derive(Debug, Clone)]
+/// enum Message {
+///     Increment,
+/// }
+///
+/// fn update(value: &mut u64, message: Message) {
+///     match message {
+///         Message::Increment => *value += 1,
+///     }
+/// }
+///
+/// fn view(value: &u64) -> Column<Message> {
+///     column![
+///         text(value),
+///         button("+").on_press(Message::Increment),
+///     ]
+/// }
+/// ```
+pub fn sandbox<State, Message>(
+    update: impl Fn(&mut State, Message),
+    view: impl for<'a> self::View<'a, State, Message>,
+) -> Program<
+    impl Definition<State = State, Message = Message, Theme = crate::Theme>,
+>
+where
+    State: Default + 'static,
+    Message: Send + std::fmt::Debug,
+{
+    use std::marker::PhantomData;
+
+    struct Sandbox<State, Message, Update, View> {
+        update: Update,
+        view: View,
+        _state: PhantomData<State>,
+        _message: PhantomData<Message>,
+    }
+
+    impl<State, Message, Update, View> Definition
+        for Sandbox<State, Message, Update, View>
+    where
+        State: Default + 'static,
+        Message: Send + std::fmt::Debug,
+        Update: Fn(&mut State, Message),
+        View: for<'a> self::View<'a, State, Message>,
+    {
+        type State = State;
+        type Message = Message;
+        type Theme = crate::Theme;
+        type Executor = iced_futures::backend::null::Executor;
+
+        fn new(&self) -> (Self::State, Command<Self::Message>) {
+            (State::default(), Command::none())
+        }
+
+        fn update(
+            &self,
+            state: &mut Self::State,
+            message: Self::Message,
+        ) -> Command<Self::Message> {
+            (self.update)(state, message);
+
+            Command::none()
+        }
+
+        fn view<'a>(
+            &self,
+            state: &'a Self::State,
+        ) -> Element<'a, Self::Message, Self::Theme> {
+            self.view.view(state).into()
+        }
+    }
+
+    Program {
+        raw: Sandbox {
+            update,
+            view,
+            _state: PhantomData,
+            _message: PhantomData,
+        },
+        settings: Settings::default(),
+    }
+}
+
+/// Creates a [`Program`] that can leverage the [`Command`] API for
+/// concurrent operations.
+pub fn application<State, Message>(
+    new: impl Fn() -> (State, Command<Message>),
+    update: impl Fn(&mut State, Message) -> Command<Message>,
+    view: impl for<'a> self::View<'a, State, Message>,
+) -> Program<
+    impl Definition<State = State, Message = Message, Theme = crate::Theme>,
+>
+where
+    State: 'static,
+    Message: Send + std::fmt::Debug,
+{
+    use std::marker::PhantomData;
+
+    struct Application<State, Message, New, Update, View> {
+        new: New,
+        update: Update,
+        view: View,
+        _state: PhantomData<State>,
+        _message: PhantomData<Message>,
+    }
+
+    impl<State, Message, New, Update, View> Definition
+        for Application<State, Message, New, Update, View>
+    where
+        Message: Send + std::fmt::Debug,
+        New: Fn() -> (State, Command<Message>),
+        Update: Fn(&mut State, Message) -> Command<Message>,
+        View: for<'a> self::View<'a, State, Message>,
+    {
+        type State = State;
+        type Message = Message;
+        type Theme = crate::Theme;
+        type Executor = executor::Default;
+
+        fn new(&self) -> (Self::State, Command<Self::Message>) {
+            (self.new)()
+        }
+
+        fn update(
+            &self,
+            state: &mut Self::State,
+            message: Self::Message,
+        ) -> Command<Self::Message> {
+            (self.update)(state, message)
+        }
+
+        fn view<'a>(
+            &self,
+            state: &'a Self::State,
+        ) -> Element<'a, Self::Message, Self::Theme> {
+            self.view.view(state).into()
+        }
+    }
+
+    Program {
+        raw: Application {
+            new,
+            update,
+            view,
+            _state: PhantomData,
+            _message: PhantomData,
+        },
+        settings: Settings::default(),
+    }
+}
+
+/// A fully functioning and configured iced application.
+///
+/// It can be [`run`]!
+///
+/// Create one with either the [`sandbox`] or [`application`] helpers.
+///
+/// [`run`]: Program::run
+/// [`application`]: self::application()
+#[derive(Debug)]
+pub struct Program<P: Definition> {
+    raw: P,
+    settings: Settings,
+}
+
+impl<P: Definition> Program<P> {
+    /// Runs the [`Program`].
+    pub fn run(self) -> Result
+    where
+        Self: 'static,
+    {
+        struct Instance<P: Definition> {
+            program: P,
+            state: P::State,
+        }
+
+        impl<P: Definition> Application for Instance<P> {
+            type Message = P::Message;
+            type Theme = P::Theme;
+            type Flags = P;
+            type Executor = P::Executor;
+
+            fn new(program: Self::Flags) -> (Self, Command<Self::Message>) {
+                let (state, command) = P::new(&program);
+
+                (Self { program, state }, command)
+            }
+
+            fn title(&self) -> String {
+                self.program.title(&self.state)
+            }
+
+            fn update(
+                &mut self,
+                message: Self::Message,
+            ) -> Command<Self::Message> {
+                self.program.update(&mut self.state, message)
+            }
+
+            fn view(
+                &self,
+            ) -> crate::Element<'_, Self::Message, Self::Theme, crate::Renderer>
+            {
+                self.program.view(&self.state)
+            }
+
+            fn theme(&self) -> Self::Theme {
+                self.program.theme(&self.state)
+            }
+
+            fn subscription(&self) -> Subscription<Self::Message> {
+                self.program.subscription(&self.state)
+            }
+        }
+
+        let Self { raw, settings } = self;
+
+        Instance::run(Settings {
+            flags: raw,
+            id: settings.id,
+            window: settings.window,
+            fonts: settings.fonts,
+            default_font: settings.default_font,
+            default_text_size: settings.default_text_size,
+            antialiasing: settings.antialiasing,
+        })
+    }
+
+    /// Sets the [`Settings`] that will be used to run the [`Program`].
+    pub fn settings(self, settings: Settings) -> Self {
+        Self { settings, ..self }
+    }
+
+    /// Toggles the [`Settings::antialiasing`] to `true` for the [`Program`].
+    pub fn antialiased(self) -> Self {
+        Self {
+            settings: Settings {
+                antialiasing: true,
+                ..self.settings
+            },
+            ..self
+        }
+    }
+
+    /// Sets the default [`Font`] of the [`Program`].
+    pub fn default_font(self, default_font: Font) -> Self {
+        Self {
+            settings: Settings {
+                default_font,
+                ..self.settings
+            },
+            ..self
+        }
+    }
+
+    /// Sets the fonts that will be loaded at the start of the [`Program`].
+    pub fn fonts(
+        self,
+        fonts: impl IntoIterator<Item = Cow<'static, [u8]>>,
+    ) -> Self {
+        Self {
+            settings: Settings {
+                fonts: fonts.into_iter().collect(),
+                ..self.settings
+            },
+            ..self
+        }
+    }
+
+    /// Sets the [`window::Settings::position`] to [`window::Position::Centered`] in the [`Program`].
+    pub fn centered(self) -> Self {
+        Self {
+            settings: Settings {
+                window: window::Settings {
+                    position: window::Position::Centered,
+                    ..self.settings.window
+                },
+                ..self.settings
+            },
+            ..self
+        }
+    }
+
+    /// Sets the [`window::Settings::exit_on_close_request`] to `false` in the [`Program`].
+    pub fn ignore_close_request(self) -> Self {
+        Self {
+            settings: Settings {
+                window: window::Settings {
+                    exit_on_close_request: false,
+                    ..self.settings.window
+                },
+                ..self.settings
+            },
+            ..self
+        }
+    }
+
+    /// Sets the [`Title`] of the [`Program`].
+    pub fn title(
+        self,
+        title: impl Title<P::State>,
+    ) -> Program<
+        impl Definition<State = P::State, Message = P::Message, Theme = P::Theme>,
+    > {
+        Program {
+            raw: with_title(self.raw, title),
+            settings: self.settings,
+        }
+    }
+
+    /// Sets the subscription logic of the [`Program`].
+    pub fn subscription(
+        self,
+        f: impl Fn(&P::State) -> Subscription<P::Message>,
+    ) -> Program<
+        impl Definition<State = P::State, Message = P::Message, Theme = P::Theme>,
+    > {
+        Program {
+            raw: with_subscription(self.raw, f),
+            settings: self.settings,
+        }
+    }
+
+    /// Sets the theme logic of the [`Program`].
+    pub fn theme(
+        self,
+        f: impl Fn(&P::State) -> P::Theme,
+    ) -> Program<
+        impl Definition<State = P::State, Message = P::Message, Theme = P::Theme>,
+    > {
+        Program {
+            raw: with_theme(self.raw, f),
+            settings: self.settings,
+        }
+    }
+}
+
+/// The internal definition of a [`Program`].
+///
+/// You should not need to implement this trait directly. Instead, use the
+/// helper functions available in the [`program`] module and the [`Program`] struct.
+///
+/// [`program`]: crate::program
+#[allow(missing_docs)]
+pub trait Definition: Sized {
+    /// The state of the program.
+    type State;
+
+    /// The message of the program.
+    type Message: Send + std::fmt::Debug;
+
+    /// The theme of the program.
+    type Theme: Default + application::DefaultStyle;
+
+    /// The executor of the program.
+    type Executor: Executor;
+
+    fn new(&self) -> (Self::State, Command<Self::Message>);
+
+    fn update(
+        &self,
+        state: &mut Self::State,
+        message: Self::Message,
+    ) -> Command<Self::Message>;
+
+    fn view<'a>(
+        &self,
+        state: &'a Self::State,
+    ) -> Element<'a, Self::Message, Self::Theme>;
+
+    fn title(&self, _state: &Self::State) -> String {
+        String::from("A cool iced application!")
+    }
+
+    fn subscription(
+        &self,
+        _state: &Self::State,
+    ) -> Subscription<Self::Message> {
+        Subscription::none()
+    }
+
+    fn theme(&self, _state: &Self::State) -> Self::Theme {
+        Self::Theme::default()
+    }
+}
+
+fn with_title<P: Definition>(
+    program: P,
+    title: impl Title<P::State>,
+) -> impl Definition<State = P::State, Message = P::Message, Theme = P::Theme> {
+    struct WithTitle<P, Title> {
+        program: P,
+        title: Title,
+    }
+
+    impl<P, Title> Definition for WithTitle<P, Title>
+    where
+        P: Definition,
+        Title: self::Title<P::State>,
+    {
+        type State = P::State;
+        type Message = P::Message;
+        type Theme = P::Theme;
+        type Executor = P::Executor;
+
+        fn new(&self) -> (Self::State, Command<Self::Message>) {
+            self.program.new()
+        }
+
+        fn title(&self, state: &Self::State) -> String {
+            self.title.title(state)
+        }
+
+        fn update(
+            &self,
+            state: &mut Self::State,
+            message: Self::Message,
+        ) -> Command<Self::Message> {
+            self.program.update(state, message)
+        }
+
+        fn view<'a>(
+            &self,
+            state: &'a Self::State,
+        ) -> Element<'a, Self::Message, Self::Theme> {
+            self.program.view(state)
+        }
+
+        fn theme(&self, state: &Self::State) -> Self::Theme {
+            self.program.theme(state)
+        }
+
+        fn subscription(
+            &self,
+            state: &Self::State,
+        ) -> Subscription<Self::Message> {
+            self.program.subscription(state)
+        }
+    }
+
+    WithTitle { program, title }
+}
+
+fn with_subscription<P: Definition>(
+    program: P,
+    f: impl Fn(&P::State) -> Subscription<P::Message>,
+) -> impl Definition<State = P::State, Message = P::Message, Theme = P::Theme> {
+    struct WithSubscription<P, F> {
+        program: P,
+        subscription: F,
+    }
+
+    impl<P: Definition, F> Definition for WithSubscription<P, F>
+    where
+        F: Fn(&P::State) -> Subscription<P::Message>,
+    {
+        type State = P::State;
+        type Message = P::Message;
+        type Theme = P::Theme;
+        type Executor = executor::Default;
+
+        fn subscription(
+            &self,
+            state: &Self::State,
+        ) -> Subscription<Self::Message> {
+            (self.subscription)(state)
+        }
+
+        fn new(&self) -> (Self::State, Command<Self::Message>) {
+            self.program.new()
+        }
+
+        fn update(
+            &self,
+            state: &mut Self::State,
+            message: Self::Message,
+        ) -> Command<Self::Message> {
+            self.program.update(state, message)
+        }
+
+        fn view<'a>(
+            &self,
+            state: &'a Self::State,
+        ) -> Element<'a, Self::Message, Self::Theme> {
+            self.program.view(state)
+        }
+
+        fn title(&self, state: &Self::State) -> String {
+            self.program.title(state)
+        }
+
+        fn theme(&self, state: &Self::State) -> Self::Theme {
+            self.program.theme(state)
+        }
+    }
+
+    WithSubscription {
+        program,
+        subscription: f,
+    }
+}
+
+fn with_theme<P: Definition>(
+    program: P,
+    f: impl Fn(&P::State) -> P::Theme,
+) -> impl Definition<State = P::State, Message = P::Message, Theme = P::Theme> {
+    struct WithTheme<P, F> {
+        program: P,
+        theme: F,
+    }
+
+    impl<P: Definition, F> Definition for WithTheme<P, F>
+    where
+        F: Fn(&P::State) -> P::Theme,
+    {
+        type State = P::State;
+        type Message = P::Message;
+        type Theme = P::Theme;
+        type Executor = P::Executor;
+
+        fn theme(&self, state: &Self::State) -> Self::Theme {
+            (self.theme)(state)
+        }
+
+        fn new(&self) -> (Self::State, Command<Self::Message>) {
+            self.program.new()
+        }
+
+        fn title(&self, state: &Self::State) -> String {
+            self.program.title(state)
+        }
+
+        fn update(
+            &self,
+            state: &mut Self::State,
+            message: Self::Message,
+        ) -> Command<Self::Message> {
+            self.program.update(state, message)
+        }
+
+        fn view<'a>(
+            &self,
+            state: &'a Self::State,
+        ) -> Element<'a, Self::Message, Self::Theme> {
+            self.program.view(state)
+        }
+
+        fn subscription(
+            &self,
+            state: &Self::State,
+        ) -> Subscription<Self::Message> {
+            self.program.subscription(state)
+        }
+    }
+
+    WithTheme { program, theme: f }
+}
+
+/// The title logic of some [`Program`].
+///
+/// This trait is implemented both for `&static str` and
+/// any closure `Fn(&State) -> String`.
+///
+/// You can use any of these in [`Program::title`].
+pub trait Title<State> {
+    /// Produces the title of the [`Program`].
+    fn title(&self, state: &State) -> String;
+}
+
+impl<State> Title<State> for &'static str {
+    fn title(&self, _state: &State) -> String {
+        self.to_string()
+    }
+}
+
+impl<T, State> Title<State> for T
+where
+    T: Fn(&State) -> String,
+{
+    fn title(&self, state: &State) -> String {
+        self(state)
+    }
+}
+
+/// The view logic of some [`Program`].
+///
+/// This trait allows [`sandbox`] and [`application`] to
+/// take any closure that returns any `Into<Element<'_, Message>>`.
+///
+/// [`application`]: self::application()
+pub trait View<'a, State, Message> {
+    /// The widget returned by the view logic.
+    type Widget: Into<Element<'a, Message>>;
+
+    /// Produces the widget of the [`Program`].
+    fn view(&self, state: &'a State) -> Self::Widget;
+}
+
+impl<'a, T, State, Message, Widget> View<'a, State, Message> for T
+where
+    T: Fn(&'a State) -> Widget,
+    State: 'static,
+    Widget: Into<Element<'a, Message>>,
+{
+    type Widget = Widget;
+
+    fn view(&self, state: &'a State) -> Self::Widget {
+        self(state)
+    }
+}

--- a/src/program.rs
+++ b/src/program.rs
@@ -15,8 +15,7 @@
 //! use iced::Theme;
 //!
 //! pub fn main() -> iced::Result {
-//!     iced::sandbox(update, view)
-//!         .title("A counter")
+//!     iced::sandbox("A counter", update, view)
 //!         .theme(|_| Theme::Dark)
 //!         .centered()
 //!         .run()
@@ -54,7 +53,7 @@ use std::borrow::Cow;
 /// use iced::widget::{button, column, text, Column};
 ///
 /// pub fn main() -> iced::Result {
-///     iced::sandbox(update, view).title("A counter").run()
+///     iced::sandbox("A counter", update, view).run()
 /// }
 ///
 /// #[derive(Debug, Clone)]
@@ -76,6 +75,7 @@ use std::borrow::Cow;
 /// }
 /// ```
 pub fn sandbox<State, Message>(
+    title: impl Title<State>,
     update: impl Fn(&mut State, Message),
     view: impl for<'a> self::View<'a, State, Message>,
 ) -> Program<
@@ -138,6 +138,7 @@ where
         },
         settings: Settings::default(),
     }
+    .title(title)
 }
 
 /// Creates a [`Program`] that can leverage the [`Command`] API for

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -6,7 +6,7 @@ use std::borrow::Cow;
 
 /// The settings of an application.
 #[derive(Debug, Clone)]
-pub struct Settings<Flags> {
+pub struct Settings<Flags = ()> {
     /// The identifier of the application.
     ///
     /// If provided, this identifier may be used to identify the application or

--- a/tiny_skia/src/geometry.rs
+++ b/tiny_skia/src/geometry.rs
@@ -1,5 +1,7 @@
 use crate::core::text::LineHeight;
-use crate::core::{Pixels, Point, Rectangle, Size, Transformation, Vector};
+use crate::core::{
+    Pixels, Point, Radians, Rectangle, Size, Transformation, Vector,
+};
 use crate::graphics::geometry::fill::{self, Fill};
 use crate::graphics::geometry::stroke::{self, Stroke};
 use crate::graphics::geometry::{Path, Style, Text};
@@ -192,10 +194,10 @@ impl Frame {
             self.transform.pre_translate(translation.x, translation.y);
     }
 
-    pub fn rotate(&mut self, angle: f32) {
-        self.transform = self
-            .transform
-            .pre_concat(tiny_skia::Transform::from_rotate(angle.to_degrees()));
+    pub fn rotate(&mut self, angle: impl Into<Radians>) {
+        self.transform = self.transform.pre_concat(
+            tiny_skia::Transform::from_rotate(angle.into().0.to_degrees()),
+        );
     }
 
     pub fn scale(&mut self, scale: impl Into<f32>) {

--- a/wgpu/src/geometry.rs
+++ b/wgpu/src/geometry.rs
@@ -1,6 +1,8 @@
 //! Build and draw geometry.
 use crate::core::text::LineHeight;
-use crate::core::{Pixels, Point, Rectangle, Size, Transformation, Vector};
+use crate::core::{
+    Pixels, Point, Radians, Rectangle, Size, Transformation, Vector,
+};
 use crate::graphics::color;
 use crate::graphics::geometry::fill::{self, Fill};
 use crate::graphics::geometry::{
@@ -475,12 +477,12 @@ impl Frame {
 
     /// Applies a rotation in radians to the current transform of the [`Frame`].
     #[inline]
-    pub fn rotate(&mut self, angle: f32) {
+    pub fn rotate(&mut self, angle: impl Into<Radians>) {
         self.transforms.current.0 = self
             .transforms
             .current
             .0
-            .pre_rotate(lyon::math::Angle::radians(angle));
+            .pre_rotate(lyon::math::Angle::radians(angle.into().0));
     }
 
     /// Applies a uniform scaling to the current transform of the [`Frame`].

--- a/widget/src/tooltip.rs
+++ b/widget/src/tooltip.rs
@@ -273,11 +273,10 @@ where
 }
 
 /// The position of the tooltip. Defaults to following the cursor.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum Position {
-    /// The tooltip will follow the cursor.
-    FollowCursor,
     /// The tooltip will appear on the top of the widget.
+    #[default]
     Top,
     /// The tooltip will appear on the bottom of the widget.
     Bottom,
@@ -285,6 +284,8 @@ pub enum Position {
     Left,
     /// The tooltip will appear on the right of the widget.
     Right,
+    /// The tooltip will follow the cursor.
+    FollowCursor,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Default)]


### PR DESCRIPTION
This PR introduces a new `Program` API as a more convenient—although less powerful—alternative to the `Sandbox` and `Application` traits.

The main motivation is lowering the learning curve and entry barrier of the library. Specifically, `Application` has a lot of moving parts (e.g. `Flags`, `Executor`, `Theme`, `subscription`, etc.)

# The `run` Function
There is a new `run` function in the root module that can be used to easily run basic applications, like the classic counter:

```rust
use iced::widget::{button, column, text, Column};

pub fn main() -> iced::Result {
    iced::run("A counter", update, view)
}

#[derive(Debug, Clone)]
enum Message {
    Increment,
}

fn update(value: &mut u64, message: Message) {
    match message {
        Message::Increment => *value += 1,
    }
}

fn view(value: &u64) -> Column<Message> {
    column![
        text(value),
        button("+").on_press(Message::Increment),
    ]
}
```

# The `Program` API
The `Program` API can be used to create and run iced applications step by step—without coupling your logic to a trait or a specific type.

For instance, here is the new `main` function of the `clock` example:

```rust
pub fn main() -> iced::Result {
    iced::sandbox("Clock - Iced", Clock::update, Clock::view)
        .subscription(Clock::subscription)
        .theme(Clock::theme)
        .antialiased()
        .run()
}
```