### PR TITLE
fix: unstuck event loop while mouse is held down and a user event occurs

### DIFF
--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -289,7 +289,8 @@ where
                         | winit::event::WindowEvent::Moved(_),
                     ..
                 }
-            ) {
+            ) || matches!(event, winit::event::Event::UserEvent(_))
+            {
                 process_event(event, event_loop);
                 process_event(winit::event::Event::AboutToWait, event_loop);
             } else {


### PR DESCRIPTION
TL,DR: See https://github.com/iced-rs/iced/issues/2323

Right now, there is a workaround due to a limitation of winit regarding the processing and waiting for events on windows. 
If you hold down your left mouse button on the title bar of your window, all events come to a hold unless you move the window or let got of your mouse button. 
To be able to still process events while holding down your mouse button, this fix/workaround addition was created. 