### PR TITLE
Target `#iced` container by default on Wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,4 +158,4 @@ web-time = "0.2"
 wgpu = "0.19"
 winapi = "0.3"
 window_clipboard = "0.4.1"
-winit = { git = "https://github.com/iced-rs/winit.git", rev = "b91e39ece2c0d378c3b80da7f3ab50e17bb798a5" }
+winit = { git = "https://github.com/iced-rs/winit.git", rev = "592bd152f6d5786fae7d918532d7db752c0d164f" }

--- a/core/src/window/settings/wasm.rs
+++ b/core/src/window/settings/wasm.rs
@@ -1,11 +1,21 @@
 //! Platform specific settings for WebAssembly.
 
 /// The platform specific window settings of an application.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PlatformSpecific {
     /// The identifier of a DOM element that will be replaced with the
     /// application.
     ///
     /// If set to `None`, the application will be appended to the HTML body.
+    ///
+    /// By default, it is set to `"iced"`.
     pub target: Option<String>,
+}
+
+impl Default for PlatformSpecific {
+    fn default() -> Self {
+        Self {
+            target: Some(String::from("iced")),
+        }
+    }
 }


### PR DESCRIPTION
This PR changes the default behavior when running an `iced` application on Wasm.

Instead of always appending to the `body`, the runtime will look for an element with the `#iced` identifier and replace it with the application `canvas`.

This is convenient to initialize an `iced` application with default settings without having to establish communication between Javascript and Wasm.

Additionally, this PR updates our `winit` fork; which includes an important bugfix for initializing mutliple applications in the same web document.