### PR TITLE
Introduce `auto-detect-theme` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ all-features = true
 maintenance = { status = "actively-developed" }
 
 [features]
-default = ["wgpu", "fira-sans"]
+default = ["wgpu", "fira-sans", "auto-detect-theme"]
 # Enable the `wgpu` GPU-accelerated renderer backend
 wgpu = ["iced_renderer/wgpu", "iced_widget/wgpu"]
 # Enables the `Image` widget
@@ -53,8 +53,11 @@ multi-window = ["iced_winit/multi-window"]
 advanced = []
 # Enables embedding Fira Sans as the default font on Wasm builds
 fira-sans = ["iced_renderer/fira-sans"]
+# Enables auto-detecting light/dark mode for the built-in theme
+auto-detect-theme = ["iced_core/auto-detect-theme"]
 
 [dependencies]
+iced_core.workspace = true
 iced_futures.workspace = true
 iced_renderer.workspace = true
 iced_widget.workspace = true
@@ -121,6 +124,7 @@ async-std = "1.0"
 bitflags = "2.0"
 bytemuck = { version = "1.0", features = ["derive"] }
 cosmic-text = "0.10"
+dark-light = "1.0"
 futures = "0.3"
 glam = "0.25"
 glyphon = "0.5"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,6 +10,9 @@ homepage.workspace = true
 categories.workspace = true
 keywords.workspace = true
 
+[features]
+auto-detect-theme = ["dep:dark-light"]
+
 [dependencies]
 bitflags.workspace = true
 glam.workspace = true
@@ -21,6 +24,9 @@ smol_str.workspace = true
 thiserror.workspace = true
 web-time.workspace = true
 xxhash-rust.workspace = true
+
+dark-light.workspace = true
+dark-light.optional = true
 
 [target.'cfg(windows)'.dependencies]
 raw-window-handle.workspace = true

--- a/core/src/theme.rs
+++ b/core/src/theme.rs
@@ -7,10 +7,9 @@ use std::fmt;
 use std::sync::Arc;
 
 /// A built-in theme.
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Theme {
     /// The built-in light variant.
-    #[default]
     Light,
     /// The built-in dark variant.
     Dark,
@@ -158,6 +157,28 @@ impl Theme {
             Self::Ferra => &palette::EXTENDED_FERRA,
             Self::Custom(custom) => &custom.extended,
         }
+    }
+}
+
+impl Default for Theme {
+    fn default() -> Self {
+        #[cfg(feature = "auto-detect-theme")]
+        {
+            use once_cell::sync::Lazy;
+
+            static DEFAULT: Lazy<Theme> =
+                Lazy::new(|| match dark_light::detect() {
+                    dark_light::Mode::Dark => Theme::Dark,
+                    dark_light::Mode::Light | dark_light::Mode::Default => {
+                        Theme::Light
+                    }
+                });
+
+            DEFAULT.clone()
+        }
+
+        #[cfg(not(feature = "auto-detect-theme"))]
+        Theme::Light
     }
 }
 


### PR DESCRIPTION
This PR changes the `Default` implementation of `Theme` if the `auto-detect-theme` feature is enabled to return an appropriate theme based on the dark/light mode of the OS.

The runtime should eventually react to OS theme changes—but that is quite an edge case and this simple approach gets us a lot of value already.
