### PR TITLE
git ref readme_deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ you want to learn about a specific release, check out [the release list].
 
 [the release list]: https://github.com/iced-rs/iced/releases
 
-The majority of documentation currently follows the master branch,
-it may be suggested to use git referenced dependency in your Cargo.toml file.
+As the majority of the documentation follows the development branch,
+the latest revision of iced should be used for maximal compatibility.
 
 ```toml
 [dependencies.iced]

--- a/README.md
+++ b/README.md
@@ -79,6 +79,17 @@ you want to learn about a specific release, check out [the release list].
 
 [the release list]: https://github.com/iced-rs/iced/releases
 
+The majority of documentation currently follows the master branch,
+it may be suggested to use git referenced dependency in your Cargo.toml file.
+
+```toml
+[dependencies.iced]
+git = "https://github.com/iced-rs/iced.git"
+branch = "master"
+features = ["canvas", "tokio", "debug", "async-std", "lazy", "webgl"]
+```
+
+
 ## Overview
 
 Inspired by [The Elm Architecture], Iced expects you to split user interfaces


### PR DESCRIPTION
Hey Core Team!

Approaching Iced I found myself stumbling with getting dependencies to cooperate when using the version of Iced published to Crates.io while also referencing the current round of documentation on iced.rs.
I wasn't able to just "copy and paste" any of the examples and expect it work without coaxing.

I merely suggest a small change to the ReadMe file to include the git reference version of the Iced dependency, making users aware of their ability to reference the master branch directly in their Cargo.toml

Thanks for considering the suggestion!
James
