### PR TITLE
Utilize bytes::Bytes for images

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,8 +136,8 @@ iced_winit = { version = "0.13.0-dev", path = "winit" }
 
 async-std = "1.0"
 bitflags = "2.0"
-bytes = "1.6"
 bytemuck = { version = "1.0", features = ["derive"] }
+bytes = "1.6"
 cosmic-text = "0.10"
 dark-light = "1.0"
 futures = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,7 @@ iced_winit = { version = "0.13.0-dev", path = "winit" }
 
 async-std = "1.0"
 bitflags = "2.0"
+bytes = "1.6"
 bytemuck = { version = "1.0", features = ["derive"] }
 cosmic-text = "0.10"
 dark-light = "1.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -19,6 +19,7 @@ advanced = []
 
 [dependencies]
 bitflags.workspace = true
+bytes.workspace = true
 glam.workspace = true
 log.workspace = true
 num-traits.workspace = true

--- a/core/src/image.rs
+++ b/core/src/image.rs
@@ -4,90 +4,12 @@ pub use bytes::Bytes;
 use crate::{Rectangle, Size};
 
 use rustc_hash::FxHasher;
-use std::hash::{Hash, Hasher as _};
+use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
 
 /// A handle of some image data.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Handle {
-    id: u64,
-    data: Data,
-}
-
-impl Handle {
-    /// Creates an image [`Handle`] pointing to the image of the given path.
-    ///
-    /// Makes an educated guess about the image format by examining the data in the file.
-    pub fn from_path<T: Into<PathBuf>>(path: T) -> Handle {
-        Self::from_data(Data::Path(path.into()))
-    }
-
-    /// Creates an image [`Handle`] containing the image pixels directly. This
-    /// function expects the input data to be provided as a `Vec<u8>` of RGBA
-    /// pixels.
-    ///
-    /// This is useful if you have already decoded your image.
-    pub fn from_pixels(
-        width: u32,
-        height: u32,
-        pixels: impl Into<Bytes>,
-    ) -> Handle {
-        Self::from_data(Data::Rgba {
-            width,
-            height,
-            pixels: pixels.into(),
-        })
-    }
-
-    /// Creates an image [`Handle`] containing the image data directly.
-    ///
-    /// Makes an educated guess about the image format by examining the given data.
-    ///
-    /// This is useful if you already have your image loaded in-memory, maybe
-    /// because you downloaded or generated it procedurally.
-    pub fn from_memory(bytes: impl Into<Bytes>) -> Handle {
-        Self::from_data(Data::Bytes(bytes.into()))
-    }
-
-    fn from_data(data: Data) -> Handle {
-        let mut hasher = FxHasher::default();
-        data.hash(&mut hasher);
-
-        Handle {
-            id: hasher.finish(),
-            data,
-        }
-    }
-
-    /// Returns the unique identifier of the [`Handle`].
-    pub fn id(&self) -> u64 {
-        self.id
-    }
-
-    /// Returns a reference to the image [`Data`].
-    pub fn data(&self) -> &Data {
-        &self.data
-    }
-}
-
-impl<T> From<T> for Handle
-where
-    T: Into<PathBuf>,
-{
-    fn from(path: T) -> Handle {
-        Handle::from_path(path.into())
-    }
-}
-
-impl Hash for Handle {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.id.hash(state);
-    }
-}
-
-/// The data of a raster image.
-#[derive(Clone, PartialEq, Eq, Hash)]
-pub enum Data {
+#[derive(Clone, PartialEq, Eq)]
+pub enum Handle {
     /// File data
     Path(PathBuf),
 
@@ -105,12 +27,75 @@ pub enum Data {
     },
 }
 
-impl std::fmt::Debug for Data {
+impl Handle {
+    /// Creates an image [`Handle`] pointing to the image of the given path.
+    ///
+    /// Makes an educated guess about the image format by examining the data in the file.
+    pub fn from_path<T: Into<PathBuf>>(path: T) -> Handle {
+        Self::Path(path.into())
+    }
+
+    /// Creates an image [`Handle`] containing the image pixels directly. This
+    /// function expects the input data to be provided as a `Vec<u8>` of RGBA
+    /// pixels.
+    ///
+    /// This is useful if you have already decoded your image.
+    pub fn from_pixels(
+        width: u32,
+        height: u32,
+        pixels: impl Into<Bytes>,
+    ) -> Handle {
+        Self::Rgba {
+            width,
+            height,
+            pixels: pixels.into(),
+        }
+    }
+
+    /// Creates an image [`Handle`] containing the image data directly.
+    ///
+    /// Makes an educated guess about the image format by examining the given data.
+    ///
+    /// This is useful if you already have your image loaded in-memory, maybe
+    /// because you downloaded or generated it procedurally.
+    pub fn from_memory(bytes: impl Into<Bytes>) -> Handle {
+        Self::Bytes(bytes.into())
+    }
+
+    /// Returns the unique identifier of the [`Handle`].
+    pub fn id(&self) -> u64 {
+        let mut hasher = FxHasher::default();
+        self.hash(&mut hasher);
+
+        hasher.finish()
+    }
+}
+
+impl Hash for Handle {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self {
+            Self::Path(path) => path.hash(state),
+            Self::Bytes(bytes) => bytes.as_ptr().hash(state),
+            Self::Rgba { pixels, .. } => pixels.as_ptr().hash(state),
+        }
+    }
+}
+
+impl<T> From<T> for Handle
+where
+    T: Into<PathBuf>,
+{
+    fn from(path: T) -> Handle {
+        Handle::from_path(path.into())
+    }
+}
+
+impl std::fmt::Debug for Handle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Data::Path(path) => write!(f, "Path({path:?})"),
-            Data::Bytes(_) => write!(f, "Bytes(...)"),
-            Data::Rgba { width, height, .. } => {
+            Self::Path(path) => write!(f, "Path({path:?})"),
+            Self::Bytes(_) => write!(f, "Bytes(...)"),
+            Self::Rgba { width, height, .. } => {
                 write!(f, "Pixels({width} * {height})")
             }
         }

--- a/core/src/image.rs
+++ b/core/src/image.rs
@@ -29,7 +29,7 @@ pub enum Handle {
     ///
     /// Use [`from_rgba`] to create this variant.
     ///
-    /// [`from_rgba`]: Self::from_bytes
+    /// [`from_rgba`]: Self::from_rgba
     Rgba {
         /// The id of this handle.
         id: Id,

--- a/examples/pokedex/src/main.rs
+++ b/examples/pokedex/src/main.rs
@@ -188,7 +188,7 @@ impl Pokemon {
         {
             let bytes = reqwest::get(&url).await?.bytes().await?;
 
-            Ok(image::Handle::from_memory(bytes))
+            Ok(image::Handle::from_bytes(bytes))
         }
 
         #[cfg(target_arch = "wasm32")]

--- a/examples/screenshot/src/main.rs
+++ b/examples/screenshot/src/main.rs
@@ -109,7 +109,7 @@ impl Example {
     fn view(&self) -> Element<'_, Message> {
         let image: Element<Message> = if let Some(screenshot) = &self.screenshot
         {
-            image(image::Handle::from_pixels(
+            image(image::Handle::from_rgba(
                 screenshot.size.width,
                 screenshot.size.height,
                 screenshot.clone(),

--- a/graphics/src/image.rs
+++ b/graphics/src/image.rs
@@ -102,7 +102,7 @@ pub fn load(
     }
 
     let (width, height, pixels) = match handle {
-        image::Handle::Path(path) => {
+        image::Handle::Path(_, path) => {
             let image = ::image::open(path)?;
 
             let operation = std::fs::File::open(path)
@@ -119,7 +119,7 @@ pub fn load(
                 image::Bytes::from(rgba.into_raw()),
             )
         }
-        image::Handle::Bytes(bytes) => {
+        image::Handle::Bytes(_, bytes) => {
             let image = ::image::load_from_memory(bytes)?;
             let operation =
                 Operation::from_exif(&mut std::io::Cursor::new(bytes))
@@ -138,6 +138,7 @@ pub fn load(
             width,
             height,
             pixels,
+            ..
         } => (*width, *height, pixels.clone()),
     };
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -18,6 +18,7 @@ debug = []
 multi-window = []
 
 [dependencies]
+bytes.workspace = true
 iced_core.workspace = true
 iced_futures.workspace = true
 iced_futures.features = ["thread-pool"]

--- a/runtime/src/window/screenshot.rs
+++ b/runtime/src/window/screenshot.rs
@@ -80,9 +80,9 @@ impl AsRef<[u8]> for Screenshot {
     }
 }
 
-impl Into<Bytes> for Screenshot {
-    fn into(self) -> Bytes {
-        self.bytes
+impl From<Screenshot> for Bytes {
+    fn from(screenshot: Screenshot) -> Self {
+        screenshot.bytes
     }
 }
 

--- a/runtime/src/window/screenshot.rs
+++ b/runtime/src/window/screenshot.rs
@@ -1,8 +1,8 @@
 //! Take screenshots of a window.
 use crate::core::{Rectangle, Size};
 
+use bytes::Bytes;
 use std::fmt::{Debug, Formatter};
-use std::sync::Arc;
 
 /// Data of a screenshot, captured with `window::screenshot()`.
 ///
@@ -10,7 +10,7 @@ use std::sync::Arc;
 #[derive(Clone)]
 pub struct Screenshot {
     /// The bytes of the [`Screenshot`].
-    pub bytes: Arc<Vec<u8>>,
+    pub bytes: Bytes,
     /// The size of the [`Screenshot`].
     pub size: Size<u32>,
 }
@@ -28,9 +28,9 @@ impl Debug for Screenshot {
 
 impl Screenshot {
     /// Creates a new [`Screenshot`].
-    pub fn new(bytes: Vec<u8>, size: Size<u32>) -> Self {
+    pub fn new(bytes: impl Into<Bytes>, size: Size<u32>) -> Self {
         Self {
-            bytes: Arc::new(bytes),
+            bytes: bytes.into(),
             size,
         }
     }
@@ -68,7 +68,7 @@ impl Screenshot {
         );
 
         Ok(Self {
-            bytes: Arc::new(chopped),
+            bytes: Bytes::from(chopped),
             size: Size::new(region.width, region.height),
         })
     }
@@ -77,6 +77,12 @@ impl Screenshot {
 impl AsRef<[u8]> for Screenshot {
     fn as_ref(&self) -> &[u8] {
         &self.bytes
+    }
+}
+
+impl Into<Bytes> for Screenshot {
+    fn into(self) -> Bytes {
+        self.bytes
     }
 }
 

--- a/tiny_skia/src/raster.rs
+++ b/tiny_skia/src/raster.rs
@@ -71,8 +71,8 @@ impl Pipeline {
 
 #[derive(Debug, Default)]
 struct Cache {
-    entries: FxHashMap<u64, Option<Entry>>,
-    hits: FxHashSet<u64>,
+    entries: FxHashMap<raster::Id, Option<Entry>>,
+    hits: FxHashSet<raster::Id>,
 }
 
 impl Cache {

--- a/tiny_skia/src/raster.rs
+++ b/tiny_skia/src/raster.rs
@@ -83,7 +83,7 @@ impl Cache {
         let id = handle.id();
 
         if let hash_map::Entry::Vacant(entry) = self.entries.entry(id) {
-            let image = graphics::image::load(handle).ok()?.into_rgba8();
+            let image = graphics::image::load(handle).ok()?;
 
             let mut buffer =
                 vec![0u32; image.width() as usize * image.height() as usize];

--- a/wgpu/src/image/raster.rs
+++ b/wgpu/src/image/raster.rs
@@ -10,7 +10,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 #[derive(Debug)]
 pub enum Memory {
     /// Image data on host
-    Host(image_rs::ImageBuffer<image_rs::Rgba<u8>, Vec<u8>>),
+    Host(image_rs::ImageBuffer<image_rs::Rgba<u8>, image::Bytes>),
     /// Storage entry
     Device(atlas::Entry),
     /// Image not found
@@ -51,7 +51,7 @@ impl Cache {
         }
 
         let memory = match graphics::image::load(handle) {
-            Ok(image) => Memory::Host(image.to_rgba8()),
+            Ok(image) => Memory::Host(image),
             Err(image_rs::error::ImageError::IoError(_)) => Memory::NotFound,
             Err(_) => Memory::Invalid,
         };

--- a/wgpu/src/image/raster.rs
+++ b/wgpu/src/image/raster.rs
@@ -38,8 +38,8 @@ impl Memory {
 /// Caches image raster data
 #[derive(Debug, Default)]
 pub struct Cache {
-    map: FxHashMap<u64, Memory>,
-    hits: FxHashSet<u64>,
+    map: FxHashMap<image::Id, Memory>,
+    hits: FxHashSet<image::Id>,
     should_trim: bool,
 }
 

--- a/widget/src/image.rs
+++ b/widget/src/image.rs
@@ -11,8 +11,6 @@ use crate::core::{
     ContentFit, Element, Layout, Length, Rectangle, Size, Vector, Widget,
 };
 
-use std::hash::Hash;
-
 pub use image::{FilterMethod, Handle};
 
 /// Creates a new [`Viewer`] with the given image `Handle`.
@@ -128,7 +126,7 @@ pub fn draw<Renderer, Handle>(
     filter_method: FilterMethod,
 ) where
     Renderer: image::Renderer<Handle = Handle>,
-    Handle: Clone + Hash,
+    Handle: Clone,
 {
     let Size { width, height } = renderer.measure_image(handle);
     let image_size = Size::new(width as f32, height as f32);
@@ -167,7 +165,7 @@ impl<Message, Theme, Renderer, Handle> Widget<Message, Theme, Renderer>
     for Image<Handle>
 where
     Renderer: image::Renderer<Handle = Handle>,
-    Handle: Clone + Hash,
+    Handle: Clone,
 {
     fn size(&self) -> Size<Length> {
         Size {
@@ -216,7 +214,7 @@ impl<'a, Message, Theme, Renderer, Handle> From<Image<Handle>>
     for Element<'a, Message, Theme, Renderer>
 where
     Renderer: image::Renderer<Handle = Handle>,
-    Handle: Clone + Hash + 'a,
+    Handle: Clone + 'a,
 {
     fn from(image: Image<Handle>) -> Element<'a, Message, Theme, Renderer> {
         Element::new(image)

--- a/widget/src/image/viewer.rs
+++ b/widget/src/image/viewer.rs
@@ -10,8 +10,6 @@ use crate::core::{
     Vector, Widget,
 };
 
-use std::hash::Hash;
-
 /// A frame that displays an image with the ability to zoom in/out and pan.
 #[allow(missing_debug_implementations)]
 pub struct Viewer<Handle> {
@@ -94,7 +92,7 @@ impl<Message, Theme, Renderer, Handle> Widget<Message, Theme, Renderer>
     for Viewer<Handle>
 where
     Renderer: image::Renderer<Handle = Handle>,
-    Handle: Clone + Hash,
+    Handle: Clone,
 {
     fn tag(&self) -> tree::Tag {
         tree::Tag::of::<State>()
@@ -401,7 +399,7 @@ impl<'a, Message, Theme, Renderer, Handle> From<Viewer<Handle>>
 where
     Renderer: 'a + image::Renderer<Handle = Handle>,
     Message: 'a,
-    Handle: Clone + Hash + 'a,
+    Handle: Clone + 'a,
 {
     fn from(viewer: Viewer<Handle>) -> Element<'a, Message, Theme, Renderer> {
         Element::new(viewer)


### PR DESCRIPTION
This PR is to replace image::Bytes with bytes::Bytes as it's more optimized/feature rich and is basically a drop in replacement. 