### PR TITLE
Use a `StagingBelt` in `iced_wgpu` for regular buffer uploads

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,6 @@ thiserror = "1.0"
 tiny-skia = "0.11"
 tokio = "1.0"
 tracing = "0.1"
-xxhash-rust = { version = "0.8", features = ["xxh3"] }
 unicode-segmentation = "1.0"
 wasm-bindgen-futures = "0.4"
 wasm-timer = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ cosmic-text = "0.10"
 dark-light = "1.0"
 futures = "0.3"
 glam = "0.25"
-glyphon = { git = "https://github.com/hecrj/glyphon.git", rev = "6412ac86d63f048d17022fa100db7be6686db728" }
+glyphon = { git = "https://github.com/hecrj/glyphon.git", rev = "ceed55403ce53e120ce9d1fae17dcfe388726118" }
 guillotiere = "0.6"
 half = "2.2"
 image = "0.24"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ cosmic-text = "0.10"
 dark-light = "1.0"
 futures = "0.3"
 glam = "0.25"
-glyphon = "0.5"
+glyphon = { git = "https://github.com/hecrj/glyphon.git", branch = "use-staging-belt" }
 guillotiere = "0.6"
 half = "2.2"
 image = "0.24"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ cosmic-text = "0.10"
 dark-light = "1.0"
 futures = "0.3"
 glam = "0.25"
-glyphon = { git = "https://github.com/hecrj/glyphon.git", branch = "use-staging-belt" }
+glyphon = { git = "https://github.com/hecrj/glyphon.git", rev = "6412ac86d63f048d17022fa100db7be6686db728" }
 guillotiere = "0.6"
 half = "2.2"
 image = "0.24"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -21,10 +21,10 @@ log.workspace = true
 num-traits.workspace = true
 once_cell.workspace = true
 palette.workspace = true
+rustc-hash.workspace = true
 smol_str.workspace = true
 thiserror.workspace = true
 web-time.workspace = true
-xxhash-rust.workspace = true
 
 dark-light.workspace = true
 dark-light.optional = true

--- a/core/src/hasher.rs
+++ b/core/src/hasher.rs
@@ -1,7 +1,7 @@
 /// The hasher used to compare layouts.
 #[allow(missing_debug_implementations)] // Doesn't really make sense to have debug on the hasher state anyways.
 #[derive(Default)]
-pub struct Hasher(xxhash_rust::xxh3::Xxh3);
+pub struct Hasher(rustc_hash::FxHasher);
 
 impl core::hash::Hasher for Hasher {
     fn write(&mut self, bytes: &[u8]) {

--- a/graphics/Cargo.toml
+++ b/graphics/Cargo.toml
@@ -34,7 +34,6 @@ raw-window-handle.workspace = true
 rustc-hash.workspace = true
 thiserror.workspace = true
 unicode-segmentation.workspace = true
-xxhash-rust.workspace = true
 
 image.workspace = true
 image.optional = true

--- a/graphics/src/text/cache.rs
+++ b/graphics/src/text/cache.rs
@@ -2,9 +2,9 @@
 use crate::core::{Font, Size};
 use crate::text;
 
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::{FxHashMap, FxHashSet, FxHasher};
 use std::collections::hash_map;
-use std::hash::{BuildHasher, Hash, Hasher};
+use std::hash::{Hash, Hasher};
 
 /// A store of recently used sections of text.
 #[allow(missing_debug_implementations)]
@@ -13,10 +13,7 @@ pub struct Cache {
     entries: FxHashMap<KeyHash, Entry>,
     aliases: FxHashMap<KeyHash, KeyHash>,
     recently_used: FxHashSet<KeyHash>,
-    hasher: HashBuilder,
 }
-
-type HashBuilder = xxhash_rust::xxh3::Xxh3Builder;
 
 impl Cache {
     /// Creates a new empty [`Cache`].
@@ -35,7 +32,7 @@ impl Cache {
         font_system: &mut cosmic_text::FontSystem,
         key: Key<'_>,
     ) -> (KeyHash, &mut Entry) {
-        let hash = key.hash(self.hasher.build_hasher());
+        let hash = key.hash(FxHasher::default());
 
         if let Some(hash) = self.aliases.get(&hash) {
             let _ = self.recently_used.insert(*hash);
@@ -77,7 +74,7 @@ impl Cache {
             ] {
                 if key.bounds != bounds {
                     let _ = self.aliases.insert(
-                        Key { bounds, ..key }.hash(self.hasher.build_hasher()),
+                        Key { bounds, ..key }.hash(FxHasher::default()),
                         hash,
                     );
                 }

--- a/tiny_skia/Cargo.toml
+++ b/tiny_skia/Cargo.toml
@@ -25,7 +25,6 @@ log.workspace = true
 rustc-hash.workspace = true
 softbuffer.workspace = true
 tiny-skia.workspace = true
-xxhash-rust.workspace = true
 
 resvg.workspace = true
 resvg.optional = true

--- a/wgpu/src/backend.rs
+++ b/wgpu/src/backend.rs
@@ -1,3 +1,4 @@
+use crate::buffer;
 use crate::core::{Color, Size, Transformation};
 use crate::graphics::backend;
 use crate::graphics::color;
@@ -66,7 +67,9 @@ impl Backend {
             // TODO: Resize belt smartly (?)
             // It would be great if the `StagingBelt` API exposed methods
             // for introspection to detect when a resize may be worth it.
-            staging_belt: wgpu::util::StagingBelt::new(1024 * 100),
+            staging_belt: wgpu::util::StagingBelt::new(
+                buffer::MAX_WRITE_SIZE as u64,
+            ),
         }
     }
 

--- a/wgpu/src/backend.rs
+++ b/wgpu/src/backend.rs
@@ -131,7 +131,10 @@ impl Backend {
         self.image_pipeline.end_frame();
     }
 
+    /// Recalls staging memory for future uploads.
     ///
+    /// This method should be called after the command encoder
+    /// has been submitted.
     pub fn recall(&mut self) {
         self.staging_belt.recall();
     }

--- a/wgpu/src/backend.rs
+++ b/wgpu/src/backend.rs
@@ -30,6 +30,7 @@ pub struct Backend {
     pipeline_storage: pipeline::Storage,
     #[cfg(any(feature = "image", feature = "svg"))]
     image_pipeline: image::Pipeline,
+    staging_belt: wgpu::util::StagingBelt,
 }
 
 impl Backend {
@@ -61,6 +62,11 @@ impl Backend {
 
             #[cfg(any(feature = "image", feature = "svg"))]
             image_pipeline,
+
+            // TODO: Resize belt smartly (?)
+            // It would be great if the `StagingBelt` API exposed methods
+            // for introspection to detect when a resize may be worth it.
+            staging_belt: wgpu::util::StagingBelt::new(1024 * 100),
         }
     }
 
@@ -105,6 +111,8 @@ impl Backend {
             &layers,
         );
 
+        self.staging_belt.finish();
+
         self.render(
             device,
             encoder,
@@ -123,12 +131,17 @@ impl Backend {
         self.image_pipeline.end_frame();
     }
 
+    ///
+    pub fn recall(&mut self) {
+        self.staging_belt.recall();
+    }
+
     fn prepare(
         &mut self,
         device: &wgpu::Device,
         queue: &wgpu::Queue,
         format: wgpu::TextureFormat,
-        _encoder: &mut wgpu::CommandEncoder,
+        encoder: &mut wgpu::CommandEncoder,
         scale_factor: f32,
         target_size: Size<u32>,
         transformation: Transformation,
@@ -144,7 +157,8 @@ impl Backend {
             if !layer.quads.is_empty() {
                 self.quad_pipeline.prepare(
                     device,
-                    queue,
+                    encoder,
+                    &mut self.staging_belt,
                     &layer.quads,
                     transformation,
                     scale_factor,
@@ -157,7 +171,8 @@ impl Backend {
 
                 self.triangle_pipeline.prepare(
                     device,
-                    queue,
+                    encoder,
+                    &mut self.staging_belt,
                     &layer.meshes,
                     scaled,
                 );
@@ -171,8 +186,8 @@ impl Backend {
 
                     self.image_pipeline.prepare(
                         device,
-                        queue,
-                        _encoder,
+                        encoder,
+                        &mut self.staging_belt,
                         &layer.images,
                         scaled,
                         scale_factor,
@@ -184,6 +199,7 @@ impl Backend {
                 self.text_pipeline.prepare(
                     device,
                     queue,
+                    encoder,
                     &layer.text,
                     layer.bounds,
                     scale_factor,

--- a/wgpu/src/buffer.rs
+++ b/wgpu/src/buffer.rs
@@ -61,12 +61,22 @@ impl<T: bytemuck::Pod> Buffer<T> {
     /// Returns the size of the written bytes.
     pub fn write(
         &mut self,
-        queue: &wgpu::Queue,
+        device: &wgpu::Device,
+        encoder: &mut wgpu::CommandEncoder,
+        belt: &mut wgpu::util::StagingBelt,
         offset: usize,
         contents: &[T],
     ) -> usize {
         let bytes: &[u8] = bytemuck::cast_slice(contents);
-        queue.write_buffer(&self.raw, offset as u64, bytes);
+
+        belt.write_buffer(
+            encoder,
+            &self.raw,
+            offset as u64,
+            (bytes.len() as u64).try_into().expect("Non-empty write"),
+            device,
+        )
+        .copy_from_slice(bytes);
 
         self.offsets.push(offset as u64);
 

--- a/wgpu/src/image.rs
+++ b/wgpu/src/image.rs
@@ -83,21 +83,31 @@ impl Layer {
     fn prepare(
         &mut self,
         device: &wgpu::Device,
-        queue: &wgpu::Queue,
+        encoder: &mut wgpu::CommandEncoder,
+        belt: &mut wgpu::util::StagingBelt,
         nearest_instances: &[Instance],
         linear_instances: &[Instance],
         transformation: Transformation,
     ) {
-        queue.write_buffer(
+        let uniforms = Uniforms {
+            transform: transformation.into(),
+        };
+
+        let bytes = bytemuck::bytes_of(&uniforms);
+
+        belt.write_buffer(
+            encoder,
             &self.uniforms,
             0,
-            bytemuck::bytes_of(&Uniforms {
-                transform: transformation.into(),
-            }),
-        );
+            (bytes.len() as u64).try_into().expect("Sized uniforms"),
+            device,
+        )
+        .copy_from_slice(bytes);
 
-        self.nearest.upload(device, queue, nearest_instances);
-        self.linear.upload(device, queue, linear_instances);
+        self.nearest
+            .upload(device, encoder, belt, nearest_instances);
+
+        self.linear.upload(device, encoder, belt, linear_instances);
     }
 
     fn render<'a>(&'a self, render_pass: &mut wgpu::RenderPass<'a>) {
@@ -158,7 +168,8 @@ impl Data {
     fn upload(
         &mut self,
         device: &wgpu::Device,
-        queue: &wgpu::Queue,
+        encoder: &mut wgpu::CommandEncoder,
+        belt: &mut wgpu::util::StagingBelt,
         instances: &[Instance],
     ) {
         self.instance_count = instances.len();
@@ -168,7 +179,7 @@ impl Data {
         }
 
         let _ = self.instances.resize(device, instances.len());
-        let _ = self.instances.write(queue, 0, instances);
+        let _ = self.instances.write(device, encoder, belt, 0, instances);
     }
 
     fn render<'a>(&'a self, render_pass: &mut wgpu::RenderPass<'a>) {
@@ -383,8 +394,8 @@ impl Pipeline {
     pub fn prepare(
         &mut self,
         device: &wgpu::Device,
-        queue: &wgpu::Queue,
         encoder: &mut wgpu::CommandEncoder,
+        belt: &mut wgpu::util::StagingBelt,
         images: &[layer::Image],
         transformation: Transformation,
         _scale: f32,
@@ -501,7 +512,8 @@ impl Pipeline {
 
         layer.prepare(
             device,
-            queue,
+            encoder,
+            belt,
             nearest_instances,
             linear_instances,
             transformation,

--- a/wgpu/src/quad/gradient.rs
+++ b/wgpu/src/quad/gradient.rs
@@ -46,11 +46,12 @@ impl Layer {
     pub fn prepare(
         &mut self,
         device: &wgpu::Device,
-        queue: &wgpu::Queue,
+        encoder: &mut wgpu::CommandEncoder,
+        belt: &mut wgpu::util::StagingBelt,
         instances: &[Gradient],
     ) {
         let _ = self.instances.resize(device, instances.len());
-        let _ = self.instances.write(queue, 0, instances);
+        let _ = self.instances.write(device, encoder, belt, 0, instances);
 
         self.instance_count = instances.len();
     }

--- a/wgpu/src/quad/solid.rs
+++ b/wgpu/src/quad/solid.rs
@@ -40,11 +40,12 @@ impl Layer {
     pub fn prepare(
         &mut self,
         device: &wgpu::Device,
-        queue: &wgpu::Queue,
+        encoder: &mut wgpu::CommandEncoder,
+        belt: &mut wgpu::util::StagingBelt,
         instances: &[Solid],
     ) {
         let _ = self.instances.resize(device, instances.len());
-        let _ = self.instances.write(queue, 0, instances);
+        let _ = self.instances.write(device, encoder, belt, 0, instances);
 
         self.instance_count = instances.len();
     }

--- a/wgpu/src/text.rs
+++ b/wgpu/src/text.rs
@@ -53,6 +53,7 @@ impl Pipeline {
         &mut self,
         device: &wgpu::Device,
         queue: &wgpu::Queue,
+        encoder: &mut wgpu::CommandEncoder,
         sections: &[Text<'_>],
         layer_bounds: Rectangle,
         scale_factor: f32,
@@ -262,6 +263,7 @@ impl Pipeline {
         let result = renderer.prepare(
             device,
             queue,
+            encoder,
             font_system,
             &mut self.atlas,
             glyphon::Resolution {

--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -243,6 +243,7 @@ pub fn present<T: AsRef<str>>(
 
             // Submit work
             let _submission = compositor.queue.submit(Some(encoder.finish()));
+            backend.recall();
             frame.present();
 
             Ok(())


### PR DESCRIPTION
`Queue::write_buffer` seems to be allocating new buffers often, at least on Metal.

Flamegraph of `game_of_life` before:

![before](https://github.com/iced-rs/iced/assets/518289/b1514824-4cf6-4ff2-b65d-d0bf6b6642de)

Flamegraph of `game_of_life` after:

![flamegraph](https://github.com/iced-rs/iced/assets/518289/4bde5a85-19eb-4bf8-8b04-30a896cd56e8)
