### PR TITLE
Use generic `Content` in `Text` to avoid reallocation in `fill_text`

### DIFF
--- a/core/src/renderer/null.rs
+++ b/core/src/renderer/null.rs
@@ -67,7 +67,7 @@ impl text::Renderer for () {
 
     fn fill_text(
         &mut self,
-        _paragraph: Text<'_, Self::Font>,
+        _paragraph: Text,
         _position: Point,
         _color: Color,
         _clip_bounds: Rectangle,
@@ -78,11 +78,11 @@ impl text::Renderer for () {
 impl text::Paragraph for () {
     type Font = Font;
 
-    fn with_text(_text: Text<'_, Self::Font>) -> Self {}
+    fn with_text(_text: Text<&str>) -> Self {}
 
     fn resize(&mut self, _new_bounds: Size) {}
 
-    fn compare(&self, _text: Text<'_, Self::Font>) -> text::Difference {
+    fn compare(&self, _text: Text<&str>) -> text::Difference {
         text::Difference::None
     }
 

--- a/core/src/text.rs
+++ b/core/src/text.rs
@@ -16,9 +16,9 @@ use std::hash::{Hash, Hasher};
 
 /// A paragraph.
 #[derive(Debug, Clone, Copy)]
-pub struct Text<'a, Font> {
+pub struct Text<Content = String, Font = crate::Font> {
     /// The content of the paragraph.
-    pub content: &'a str,
+    pub content: Content,
 
     /// The bounds of the paragraph.
     pub bounds: Size,
@@ -219,7 +219,7 @@ pub trait Renderer: crate::Renderer {
     /// [`Color`].
     fn fill_text(
         &mut self,
-        text: Text<'_, Self::Font>,
+        text: Text<String, Self::Font>,
         position: Point,
         color: Color,
         clip_bounds: Rectangle,

--- a/core/src/text/paragraph.rs
+++ b/core/src/text/paragraph.rs
@@ -8,14 +8,14 @@ pub trait Paragraph: Sized + Default {
     type Font: Copy + PartialEq;
 
     /// Creates a new [`Paragraph`] laid out with the given [`Text`].
-    fn with_text(text: Text<'_, Self::Font>) -> Self;
+    fn with_text(text: Text<&str, Self::Font>) -> Self;
 
     /// Lays out the [`Paragraph`] with some new boundaries.
     fn resize(&mut self, new_bounds: Size);
 
     /// Compares the [`Paragraph`] with some desired [`Text`] and returns the
     /// [`Difference`].
-    fn compare(&self, text: Text<'_, Self::Font>) -> Difference;
+    fn compare(&self, text: Text<&str, Self::Font>) -> Difference;
 
     /// Returns the horizontal alignment of the [`Paragraph`].
     fn horizontal_alignment(&self) -> alignment::Horizontal;
@@ -35,7 +35,7 @@ pub trait Paragraph: Sized + Default {
     fn grapheme_position(&self, line: usize, index: usize) -> Option<Point>;
 
     /// Updates the [`Paragraph`] to match the given [`Text`], if needed.
-    fn update(&mut self, text: Text<'_, Self::Font>) {
+    fn update(&mut self, text: Text<&str, Self::Font>) {
         match self.compare(text) {
             Difference::None => {}
             Difference::Bounds => {

--- a/graphics/src/renderer.rs
+++ b/graphics/src/renderer.rs
@@ -163,13 +163,13 @@ where
 
     fn fill_text(
         &mut self,
-        text: Text<'_, Self::Font>,
+        text: Text,
         position: Point,
         color: Color,
         clip_bounds: Rectangle,
     ) {
         self.primitives.push(Primitive::Text {
-            content: text.content.to_string(),
+            content: text.content,
             bounds: Rectangle::new(position, text.bounds),
             size: text.size,
             line_height: text.line_height,

--- a/graphics/src/text/paragraph.rs
+++ b/graphics/src/text/paragraph.rs
@@ -61,7 +61,7 @@ impl Paragraph {
 impl core::text::Paragraph for Paragraph {
     type Font = Font;
 
-    fn with_text(text: Text<'_, Font>) -> Self {
+    fn with_text(text: Text<&str>) -> Self {
         log::trace!("Allocating paragraph: {}", text.content);
 
         let mut font_system =
@@ -146,7 +146,7 @@ impl core::text::Paragraph for Paragraph {
         }
     }
 
-    fn compare(&self, text: Text<'_, Font>) -> core::text::Difference {
+    fn compare(&self, text: Text<&str>) -> core::text::Difference {
         let font_system = text::font_system().read().expect("Read font system");
         let paragraph = self.internal();
         let metrics = paragraph.buffer.metrics();

--- a/renderer/src/fallback.rs
+++ b/renderer/src/fallback.rs
@@ -115,7 +115,7 @@ where
 
     fn fill_text(
         &mut self,
-        text: core::Text<'_, Self::Font>,
+        text: core::Text<String, Self::Font>,
         position: Point,
         color: Color,
         clip_bounds: Rectangle,

--- a/widget/src/checkbox.rs
+++ b/widget/src/checkbox.rs
@@ -340,7 +340,7 @@ where
             if self.is_checked {
                 renderer.fill_text(
                     text::Text {
-                        content: &code_point.to_string(),
+                        content: code_point.to_string(),
                         font: *font,
                         size,
                         line_height: *line_height,

--- a/widget/src/overlay/menu.rs
+++ b/widget/src/overlay/menu.rs
@@ -526,7 +526,7 @@ where
 
             renderer.fill_text(
                 Text {
-                    content: &option.to_string(),
+                    content: option.to_string(),
                     bounds: Size::new(f32::INFINITY, bounds.height),
                     size: text_size,
                     line_height: self.text_line_height,

--- a/widget/src/pick_list.rs
+++ b/widget/src/pick_list.rs
@@ -479,7 +479,7 @@ where
 
             renderer.fill_text(
                 Text {
-                    content: &code_point.to_string(),
+                    content: code_point.to_string(),
                     size,
                     line_height,
                     font,
@@ -502,7 +502,7 @@ where
 
         let label = selected.map(ToString::to_string);
 
-        if let Some(label) = label.as_deref().or(self.placeholder.as_deref()) {
+        if let Some(label) = label.or_else(|| self.placeholder.clone()) {
             let text_size =
                 self.text_size.unwrap_or_else(|| renderer.default_size());
 

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -232,7 +232,7 @@ where
         let placeholder_text = Text {
             font,
             line_height: self.line_height,
-            content: &self.placeholder,
+            content: self.placeholder.as_str(),
             bounds: Size::new(f32::INFINITY, text_bounds.height),
             size: text_size,
             horizontal_alignment: alignment::Horizontal::Left,
@@ -251,9 +251,11 @@ where
         });
 
         if let Some(icon) = &self.icon {
+            let mut content = [0; 4];
+
             let icon_text = Text {
                 line_height: self.line_height,
-                content: &icon.code_point.to_string(),
+                content: icon.code_point.encode_utf8(&mut content) as &_,
                 font: icon.font,
                 size: icon.size.unwrap_or_else(|| renderer.default_size()),
                 bounds: Size::new(f32::INFINITY, text_bounds.height),


### PR DESCRIPTION
`Renderer::fill_text` asks for a `&str` just to turn it into a `String`... Amazing.

Let's get rid of that, shall we?
