### PR TITLE
Use `Iterator::size_hint` to initialize `Column` and `Row` capacity

### DIFF
--- a/widget/src/column.rs
+++ b/widget/src/column.rs
@@ -33,11 +33,18 @@ where
         Self::from_vec(Vec::new())
     }
 
+    /// Creates a [`Column`] with the given capacity.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self::from_vec(Vec::with_capacity(capacity))
+    }
+
     /// Creates a [`Column`] with the given elements.
     pub fn with_children(
         children: impl IntoIterator<Item = Element<'a, Message, Theme, Renderer>>,
     ) -> Self {
-        Self::new().extend(children)
+        let iterator = children.into_iter();
+
+        Self::with_capacity(iterator.size_hint().0).extend(iterator)
     }
 
     /// Creates a [`Column`] from an already allocated [`Vec`].

--- a/widget/src/keyed/column.rs
+++ b/widget/src/keyed/column.rs
@@ -40,16 +40,38 @@ where
 {
     /// Creates an empty [`Column`].
     pub fn new() -> Self {
-        Column {
+        Self::from_vecs(Vec::new(), Vec::new())
+    }
+
+    /// Creates a [`Column`] from already allocated [`Vec`]s.
+    ///
+    /// Keep in mind that the [`Column`] will not inspect the [`Vec`]s, which means
+    /// it won't automatically adapt to the sizing strategy of its contents.
+    ///
+    /// If any of the children have a [`Length::Fill`] strategy, you will need to
+    /// call [`Column::width`] or [`Column::height`] accordingly.
+    pub fn from_vecs(
+        keys: Vec<Key>,
+        children: Vec<Element<'a, Message, Theme, Renderer>>,
+    ) -> Self {
+        Self {
             spacing: 0.0,
             padding: Padding::ZERO,
             width: Length::Shrink,
             height: Length::Shrink,
             max_width: f32::INFINITY,
             align_items: Alignment::Start,
-            keys: Vec::new(),
-            children: Vec::new(),
+            keys,
+            children,
         }
+    }
+
+    /// Creates a [`Column`] with the given capacity.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self::from_vecs(
+            Vec::with_capacity(capacity),
+            Vec::with_capacity(capacity),
+        )
     }
 
     /// Creates a [`Column`] with the given elements.
@@ -58,9 +80,9 @@ where
             Item = (Key, Element<'a, Message, Theme, Renderer>),
         >,
     ) -> Self {
-        children
-            .into_iter()
-            .fold(Self::new(), |column, (key, child)| column.push(key, child))
+        let iterator = children.into_iter();
+
+        Self::with_capacity(iterator.size_hint().0).extend(iterator)
     }
 
     /// Sets the vertical spacing _between_ elements.
@@ -131,6 +153,18 @@ where
         } else {
             self
         }
+    }
+
+    /// Extends the [`Column`] with the given children.
+    pub fn extend(
+        self,
+        children: impl IntoIterator<
+            Item = (Key, Element<'a, Message, Theme, Renderer>),
+        >,
+    ) -> Self {
+        children
+            .into_iter()
+            .fold(self, |column, (key, child)| column.push(key, child))
     }
 }
 

--- a/widget/src/row.rs
+++ b/widget/src/row.rs
@@ -31,11 +31,18 @@ where
         Self::from_vec(Vec::new())
     }
 
+    /// Creates a [`Row`] with the given capacity.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self::from_vec(Vec::with_capacity(capacity))
+    }
+
     /// Creates a [`Row`] with the given elements.
     pub fn with_children(
         children: impl IntoIterator<Item = Element<'a, Message, Theme, Renderer>>,
     ) -> Self {
-        Self::new().extend(children)
+        let iterator = children.into_iter();
+
+        Self::with_capacity(iterator.size_hint().0).extend(iterator)
     }
 
     /// Creates a [`Row`] from an already allocated [`Vec`].


### PR DESCRIPTION
This should help containers estimate their capacity, specially when using the `column!` and `row!` macros.