### PR TITLE
Check is_secure before a copy/cut from TextInput

### DIFF
--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -712,7 +712,7 @@ where
 
                     match key.as_ref() {
                         keyboard::Key::Character("c")
-                            if state.keyboard_modifiers.command() =>
+                            if state.keyboard_modifiers.command() && !self.is_secure =>
                         {
                             if let Some((start, end)) =
                                 state.cursor.selection(&self.value)
@@ -726,7 +726,7 @@ where
                             return event::Status::Captured;
                         }
                         keyboard::Key::Character("x")
-                            if state.keyboard_modifiers.command() =>
+                            if state.keyboard_modifiers.command() && !self.is_secure =>
                         {
                             if let Some((start, end)) =
                                 state.cursor.selection(&self.value)

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -712,7 +712,8 @@ where
 
                     match key.as_ref() {
                         keyboard::Key::Character("c")
-                            if state.keyboard_modifiers.command() && !self.is_secure =>
+                            if state.keyboard_modifiers.command()
+                                && !self.is_secure =>
                         {
                             if let Some((start, end)) =
                                 state.cursor.selection(&self.value)
@@ -726,7 +727,8 @@ where
                             return event::Status::Captured;
                         }
                         keyboard::Key::Character("x")
-                            if state.keyboard_modifiers.command() && !self.is_secure =>
+                            if state.keyboard_modifiers.command()
+                                && !self.is_secure =>
                         {
                             if let Some((start, end)) =
                                 state.cursor.selection(&self.value)


### PR DESCRIPTION
This PR adds a check for TextInput's is_secure value before copying or cutting from the field.

Fixes #2347.