### PR TITLE
add `Command::dispatch` as a shortcut for `Command::perform` without action

### DIFF
--- a/runtime/src/command.rs
+++ b/runtime/src/command.rs
@@ -41,6 +41,14 @@ impl<T> Command<T> {
         Self::single(Action::Widget(Box::new(operation)))
     }
 
+    /// Dispatches message without action
+    pub fn dispatch(message: T) -> Self
+    where
+        T: 'static + MaybeSend,
+    {
+        Command::single(Action::Future(Box::pin(std::future::ready(message))))
+    }
+
     /// Creates a [`Command`] that performs the action of the given future.
     pub fn perform<A>(
         future: impl Future<Output = A> + 'static + MaybeSend,


### PR DESCRIPTION
This function is useful when you want to send event without state. I did not find other way to do it with current api other than `Command::perform(async {}, |_| Message::MyMessage)` which is inconvenient and creates a useless extra future.

New api is `Command::dispatch(Message::MyMessage)` where

```rust
enum Message {
    MyMessage,
}
```