### PR TITLE
Add stronger guarantee of readability/contrast for palette background/text color pairs

### DIFF
--- a/core/src/theme/palette.rs
+++ b/core/src/theme/palette.rs
@@ -612,11 +612,19 @@ fn mix(a: Color, b: Color, factor: f32) -> Color {
 
 fn readable(background: Color, text: Color) -> Color {
     if is_readable(background, text) {
-        text
-    } else if is_dark(background) {
+        return text;
+    }
+
+    let fallback = if is_dark(background) {
         Color::WHITE
     } else {
         Color::BLACK
+    };
+
+    if is_readable(background, fallback) {
+        fallback
+    } else {
+        fallback.inverse()
     }
 }
 


### PR DESCRIPTION
If we run the todo example with the SolarizedDark theme, we can see that the text color selected for display on top of a cyan background is white ('All' button):

![image](https://github.com/iced-rs/iced/assets/2389735/41c4fa18-f58d-4559-bcb5-0d9cf7ee43f7)

which [brutally fails the WCAG contrast guidelines](https://webaim.org/resources/contrastchecker/?fcolor=FFFFFF&bcolor=35C9BE).

This change guarantees that the text color passes the test, and [passes the guidelines](https://webaim.org/resources/contrastchecker/?fcolor=000000&bcolor=35C9BE) by selecting black text for the example in question.