### PR TITLE
Remove extra Download struct from dowload_progress example

### DIFF
--- a/examples/download_progress/src/download.rs
+++ b/examples/download_progress/src/download.rs
@@ -12,12 +12,6 @@ pub fn file<I: 'static + Hash + Copy + Send + Sync, T: ToString>(
     })
 }
 
-#[derive(Debug, Hash, Clone)]
-pub struct Download<I> {
-    id: I,
-    url: String,
-}
-
 async fn download<I: Copy>(id: I, state: State) -> ((I, Progress), State) {
     match state {
         State::Ready(url) => {


### PR DESCRIPTION
I've just noticed that on the `download_progress` example there is an extra `Download` struct on the `download.rs` file that is not being used. For some reason, `rust_analyzer` doesn't give any warnings not even clippy. But that struct has no references to it.

I guess that it might have first been created to be used to pass the `id` and `url` from `main` to the `download::file` function, but then it ended up passing both parameters instead.

I don't know why didn't `rust_analyzer` pick this up before, but I tried running the example without it and it runs just fine. So might as well remove it so people don't confuse it with the actual `Download` struct that is created on the `main.rs` file.
