### PR TITLE
Allow checking whether a `TextEditor` is focused

### DIFF
--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -319,7 +319,9 @@ where
     }
 }
 
-struct State<Highlighter: text::Highlighter> {
+/// The state of a [`TextEditor`].
+#[derive(Debug)]
+pub struct State<Highlighter: text::Highlighter> {
     is_focused: bool,
     last_click: Option<mouse::Click>,
     drag_click: Option<mouse::click::Kind>,
@@ -327,6 +329,13 @@ struct State<Highlighter: text::Highlighter> {
     highlighter: RefCell<Highlighter>,
     highlighter_settings: Highlighter::Settings,
     highlighter_format_address: usize,
+}
+
+impl<Highlighter: text::Highlighter> State<Highlighter> {
+    /// Returns whether the [`TextEditor`] is currently focused or not.
+    pub fn is_focused(&self) -> bool {
+        self.is_focused
+    }
 }
 
 impl<'a, Highlighter, Message, Theme, Renderer> Widget<Message, Theme, Renderer>


### PR DESCRIPTION
My use case is that I have a widget for wrapping `TextInput` and handling undo/redo shortcuts if the widget is focused. I'd like to do the same for `TextEditor`, but it doesn't currently expose a way to check for focus. I added an `is_focused` method, like the one that `TextInput` has.

I tested both of these checks with these changes:

* `tree.state.downcast_ref::<iced::widget::text_editor::State<iced::advanced::text::highlighter::PlainText>>().is_focused()`
* `tree.state.downcast_ref::<iced::widget::text_editor::State<iced::highlighter::Highlighter>>().is_focused()`