### PR TITLE
Don't consume unused scroll events

### DIFF
--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -964,55 +964,55 @@ pub fn scroll_to<Message: 'static>(
     Command::widget(operation::scrollable::scroll_to(id.0, offset))
 }
 
-/ Returns [`true`] if the viewport actually changed.
- fn notify_on_scroll<Message>(
-     state: &mut State,
-     on_scroll: &Option<Box<dyn Fn(Viewport) -> Message + '_>>,
-     bounds: Rectangle,
-     content_bounds: Rectangle,
-     shell: &mut Shell<'_, Message>,
- ) -> bool {
-     if content_bounds.width <= bounds.width
-         && content_bounds.height <= bounds.height
-     {
-         return false;
-     }
+/// Returns [`true`] if the viewport actually changed.
+fn notify_on_scroll<Message>(
+    state: &mut State,
+    on_scroll: &Option<Box<dyn Fn(Viewport) -> Message + '_>>,
+    bounds: Rectangle,
+    content_bounds: Rectangle,
+    shell: &mut Shell<'_, Message>,
+) -> bool {
+    if content_bounds.width <= bounds.width
+        && content_bounds.height <= bounds.height
+    {
+        return false;
+    }
 
-     let viewport = Viewport {
-         offset_x: state.offset_x,
-         offset_y: state.offset_y,
-         bounds,
-         content_bounds,
-     };
+    let viewport = Viewport {
+        offset_x: state.offset_x,
+        offset_y: state.offset_y,
+        bounds,
+        content_bounds,
+    };
 
-     // Don't publish redundant viewports to shell
-     if let Some(last_notified) = state.last_notified {
-         let last_relative_offset = last_notified.relative_offset();
-         let current_relative_offset = viewport.relative_offset();
+    // Don't publish redundant viewports to shell
+    if let Some(last_notified) = state.last_notified {
+        let last_relative_offset = last_notified.relative_offset();
+        let current_relative_offset = viewport.relative_offset();
 
-         let last_absolute_offset = last_notified.absolute_offset();
-         let current_absolute_offset = viewport.absolute_offset();
+        let last_absolute_offset = last_notified.absolute_offset();
+        let current_absolute_offset = viewport.absolute_offset();
 
-         let unchanged = |a: f32, b: f32| {
-             (a - b).abs() <= f32::EPSILON || (a.is_nan() && b.is_nan())
-         };
+        let unchanged = |a: f32, b: f32| {
+            (a - b).abs() <= f32::EPSILON || (a.is_nan() && b.is_nan())
+        };
 
-         if unchanged(last_relative_offset.x, current_relative_offset.x)
-             && unchanged(last_relative_offset.y, current_relative_offset.y)
-             && unchanged(last_absolute_offset.x, current_absolute_offset.x)
-             && unchanged(last_absolute_offset.y, current_absolute_offset.y)
-         {
-             return false;
-         }
-     }
+        if unchanged(last_relative_offset.x, current_relative_offset.x)
+            && unchanged(last_relative_offset.y, current_relative_offset.y)
+            && unchanged(last_absolute_offset.x, current_absolute_offset.x)
+            && unchanged(last_absolute_offset.y, current_absolute_offset.y)
+        {
+            return false;
+        }
+    }
 
-     if let Some(on_scroll) = on_scroll {
-         shell.publish(on_scroll(viewport));
-     }
-     state.last_notified = Some(viewport);
+    if let Some(on_scroll) = on_scroll {
+        shell.publish(on_scroll(viewport));
+    }
+    state.last_notified = Some(viewport);
 
-     true
- }
+    true
+}
 
 #[derive(Debug, Clone, Copy)]
 struct State {

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -484,7 +484,7 @@ where
                                 Some(cursor_position);
 
                             // TODO: bubble up touch movements if not consumed.
-                            _ = notify_on_scroll(
+                            let _ = notify_on_scroll(
                                 state,
                                 &self.on_scroll,
                                 bounds,
@@ -519,7 +519,7 @@ where
                             content_bounds,
                         );
 
-                        _ = notify_on_scroll(
+                        let _ = notify_on_scroll(
                             state,
                             &self.on_scroll,
                             bounds,
@@ -557,7 +557,7 @@ where
 
                         state.y_scroller_grabbed_at = Some(scroller_grabbed_at);
 
-                        _ = notify_on_scroll(
+                        let _ = notify_on_scroll(
                             state,
                             &self.on_scroll,
                             bounds,
@@ -590,7 +590,7 @@ where
                             content_bounds,
                         );
 
-                        _ = notify_on_scroll(
+                        let _ = notify_on_scroll(
                             state,
                             &self.on_scroll,
                             bounds,
@@ -628,7 +628,7 @@ where
 
                         state.x_scroller_grabbed_at = Some(scroller_grabbed_at);
 
-                        _ = notify_on_scroll(
+                        let _ = notify_on_scroll(
                             state,
                             &self.on_scroll,
                             bounds,


### PR DESCRIPTION
If the viewport of a scrollable is not changed by an event, it did not consume it. This updates the code to reflect that.

(This means that scrollables can be nested and scroll the parent scrollable if an end is reached, and that horizontal scrollables can be put in vertical ones with no issue)

This is _not_ mutually exclusive with #2381, but that would need some sort of heuristic to determine whether a scroll was active recently.