### PR TITLE
Fix some `text_editor` quirks

### DIFF
--- a/graphics/src/text/editor.rs
+++ b/graphics/src/text/editor.rs
@@ -456,10 +456,14 @@ impl editor::Editor for Editor {
                 }
             }
             Action::Scroll { lines } => {
-                editor.action(
-                    font_system.raw(),
-                    cosmic_text::Action::Scroll { lines },
-                );
+                let (_, height) = editor.buffer().size();
+
+                if height < i32::MAX as f32 {
+                    editor.action(
+                        font_system.raw(),
+                        cosmic_text::Action::Scroll { lines },
+                    );
+                }
             }
         }
 

--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -569,23 +569,27 @@ where
         if state.is_focused {
             match internal.editor.cursor() {
                 Cursor::Caret(position) => {
-                    let position = position + translation;
+                    let cursor =
+                        Rectangle::new(
+                            position + translation,
+                            Size::new(
+                                1.0,
+                                self.line_height
+                                    .to_absolute(self.text_size.unwrap_or_else(
+                                        || renderer.default_size(),
+                                    ))
+                                    .into(),
+                            ),
+                        );
 
-                    if bounds.contains(position) {
+                    if let Some(clipped_cursor) = bounds.intersection(&cursor) {
                         renderer.fill_quad(
                             renderer::Quad {
                                 bounds: Rectangle {
-                                    x: position.x.floor(),
-                                    y: position.y,
-                                    width: 1.0,
-                                    height: self
-                                        .line_height
-                                        .to_absolute(
-                                            self.text_size.unwrap_or_else(
-                                                || renderer.default_size(),
-                                            ),
-                                        )
-                                        .into(),
+                                    x: clipped_cursor.x.floor(),
+                                    y: clipped_cursor.y,
+                                    width: clipped_cursor.width,
+                                    height: clipped_cursor.height,
                                 },
                                 ..renderer::Quad::default()
                             },


### PR DESCRIPTION
This PR fixes an addition with overflow when scrolling a `text_editor` widget inside a `scrollable` and an edge case where the caret could be rendered outside of bounds after scrolling.
