### PR TITLE
`hover` widget

### DIFF
--- a/examples/bezier_tool/src/main.rs
+++ b/examples/bezier_tool/src/main.rs
@@ -1,6 +1,6 @@
 //! This example showcases an interactive `Canvas` for drawing Bézier curves.
 use iced::alignment;
-use iced::widget::{button, container, stack};
+use iced::widget::{button, container, horizontal_space, hover};
 use iced::{Element, Length, Theme};
 
 pub fn main() -> iced::Result {
@@ -37,17 +37,21 @@ impl Example {
     }
 
     fn view(&self) -> Element<Message> {
-        container(stack![
+        container(hover(
             self.bezier.view(&self.curves).map(Message::AddCurve),
-            container(
-                button("Clear")
-                    .style(button::danger)
-                    .on_press(Message::Clear)
-            )
-            .padding(10)
-            .width(Length::Fill)
-            .align_x(alignment::Horizontal::Right),
-        ])
+            if self.curves.is_empty() {
+                container(horizontal_space())
+            } else {
+                container(
+                    button("Clear")
+                        .style(button::danger)
+                        .on_press(Message::Clear),
+                )
+                .padding(10)
+                .width(Length::Fill)
+                .align_x(alignment::Horizontal::Right)
+            },
+        ))
         .padding(20)
         .into()
     }

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -434,7 +434,14 @@ where
             let mut children = layout.children().zip(&mut tree.children);
             let (base_layout, base_tree) = children.next().unwrap();
 
-            let top_status = if cursor.is_over(layout.bounds()) {
+            let top_status = if matches!(
+                event,
+                Event::Mouse(
+                    mouse::Event::CursorMoved { .. }
+                        | mouse::Event::ButtonReleased(_)
+                )
+            ) || cursor.is_over(layout.bounds())
+            {
                 let (top_layout, top_tree) = children.next().unwrap();
 
                 self.top.as_widget_mut().on_event(

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -375,29 +375,32 @@ where
             cursor: mouse::Cursor,
             viewport: &Rectangle,
         ) {
-            let mut children = layout.children().zip(&tree.children);
+            if let Some(bounds) = layout.bounds().intersection(viewport) {
+                let mut children = layout.children().zip(&tree.children);
 
-            let (base_layout, base_tree) = children.next().unwrap();
+                let (base_layout, base_tree) = children.next().unwrap();
 
-            self.base.as_widget().draw(
-                base_tree,
-                renderer,
-                theme,
-                style,
-                base_layout,
-                cursor,
-                viewport,
-            );
+                self.base.as_widget().draw(
+                    base_tree,
+                    renderer,
+                    theme,
+                    style,
+                    base_layout,
+                    cursor,
+                    viewport,
+                );
 
-            if cursor.is_over(layout.bounds()) || self.is_top_overlay_active {
-                let (top_layout, top_tree) = children.next().unwrap();
+                if cursor.is_over(layout.bounds()) || self.is_top_overlay_active
+                {
+                    let (top_layout, top_tree) = children.next().unwrap();
 
-                renderer.with_layer(layout.bounds(), |renderer| {
-                    self.top.as_widget().draw(
-                        top_tree, renderer, theme, style, top_layout, cursor,
-                        viewport,
-                    );
-                });
+                    renderer.with_layer(bounds, |renderer| {
+                        self.top.as_widget().draw(
+                            top_tree, renderer, theme, style, top_layout,
+                            cursor, viewport,
+                        );
+                    });
+                }
             }
         }
 

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -294,6 +294,8 @@ where
 ///
 /// This works analogously to a [`stack`], but it will only display the layer on top
 /// when the cursor is over the base. It can be useful for removing visual clutter.
+///
+/// [`stack`]: stack()
 pub fn hover<'a, Message, Theme, Renderer>(
     base: impl Into<Element<'a, Message, Theme, Renderer>>,
     top: impl Into<Element<'a, Message, Theme, Renderer>>,


### PR DESCRIPTION
This PR introduces a simple widget helper that can be used to display a widget on top of another one, only when the base one is hovered. Useful for removing visual clutter!