### PR TITLE
Update `cosmic-text`, `glyphon`, `wgpu`, and unpin `web-sys`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,11 +137,11 @@ iced_winit = { version = "0.13.0-dev", path = "winit" }
 async-std = "1.0"
 bitflags = "2.0"
 bytemuck = { version = "1.0", features = ["derive"] }
-cosmic-text = "0.10"
+cosmic-text = "0.11"
 dark-light = "1.0"
 futures = "0.3"
 glam = "0.25"
-glyphon = { git = "https://github.com/hecrj/glyphon.git", rev = "ceed55403ce53e120ce9d1fae17dcfe388726118" }
+glyphon = { git = "https://github.com/hecrj/glyphon.git", rev = "670140e2a1482a1ad3607dead44c40d8261ba582" }
 guillotiere = "0.6"
 half = "2.2"
 image = "0.24"
@@ -170,9 +170,9 @@ tracing = "0.1"
 unicode-segmentation = "1.0"
 wasm-bindgen-futures = "0.4"
 wasm-timer = "0.2"
-web-sys = "=0.3.67"
+web-sys = "0.3"
 web-time = "0.2"
-wgpu = "0.19"
+wgpu = "0.20"
 winapi = "0.3"
 window_clipboard = "0.4.1"
 winit = { git = "https://github.com/iced-rs/winit.git", rev = "592bd152f6d5786fae7d918532d7db752c0d164f" }

--- a/graphics/src/geometry/text.rs
+++ b/graphics/src/geometry/text.rs
@@ -52,6 +52,7 @@ impl Text {
             self.size.0,
             f32::MAX,
             cosmic_text::Wrap::None,
+            None
         );
 
         let translation_x = match self.horizontal_alignment {

--- a/graphics/src/text.rs
+++ b/graphics/src/text.rs
@@ -20,7 +20,7 @@ use std::sync::{Arc, RwLock, Weak};
 
 /// A text primitive.
 #[derive(Debug, Clone, PartialEq)]
-pub enum Text {
+pub enum Text<'buffer> {
     /// A paragraph.
     #[allow(missing_docs)]
     Paragraph {
@@ -33,7 +33,7 @@ pub enum Text {
     /// An editor.
     #[allow(missing_docs)]
     Editor {
-        editor: editor::Weak,
+        editor: editor::Weak<'buffer>,
         position: Point,
         color: Color,
         clip_bounds: Rectangle,
@@ -70,7 +70,7 @@ pub enum Text {
     },
 }
 
-impl Text {
+impl Text<'_> {
     /// Returns the visible bounds of the [`Text`].
     pub fn visible_bounds(&self) -> Option<Rectangle> {
         let (bounds, horizontal_alignment, vertical_alignment) = match self {

--- a/wgpu/src/color.rs
+++ b/wgpu/src/color.rs
@@ -77,11 +77,13 @@ pub fn convert(
             vertex: wgpu::VertexState {
                 module: &shader,
                 entry_point: "vs_main",
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
                 buffers: &[],
             },
             fragment: Some(wgpu::FragmentState {
                 module: &shader,
                 entry_point: "fs_main",
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
                 targets: &[Some(wgpu::ColorTargetState {
                     format,
                     blend: Some(wgpu::BlendState {

--- a/wgpu/src/quad/gradient.rs
+++ b/wgpu/src/quad/gradient.rs
@@ -125,6 +125,7 @@ impl Pipeline {
                     vertex: wgpu::VertexState {
                         module: &shader,
                         entry_point: "gradient_vs_main",
+                        compilation_options: wgpu::PipelineCompilationOptions::default(),
                         buffers: &[wgpu::VertexBufferLayout {
                             array_stride: std::mem::size_of::<Gradient>()
                                 as u64,
@@ -156,6 +157,7 @@ impl Pipeline {
                     fragment: Some(wgpu::FragmentState {
                         module: &shader,
                         entry_point: "gradient_fs_main",
+                        compilation_options: wgpu::PipelineCompilationOptions::default(),
                         targets: &quad::color_target_state(format),
                     }),
                     primitive: wgpu::PrimitiveState {

--- a/wgpu/src/quad/solid.rs
+++ b/wgpu/src/quad/solid.rs
@@ -90,6 +90,7 @@ impl Pipeline {
                 vertex: wgpu::VertexState {
                     module: &shader,
                     entry_point: "solid_vs_main",
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
                     buffers: &[wgpu::VertexBufferLayout {
                         array_stride: std::mem::size_of::<Solid>() as u64,
                         step_mode: wgpu::VertexStepMode::Instance,
@@ -118,6 +119,7 @@ impl Pipeline {
                 fragment: Some(wgpu::FragmentState {
                     module: &shader,
                     entry_point: "solid_fs_main",
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
                     targets: &quad::color_target_state(format),
                 }),
                 primitive: wgpu::PrimitiveState {

--- a/wgpu/src/triangle.rs
+++ b/wgpu/src/triangle.rs
@@ -745,6 +745,7 @@ mod solid {
                         vertex: wgpu::VertexState {
                             module: &shader,
                             entry_point: "solid_vs_main",
+                            compilation_options: wgpu::PipelineCompilationOptions::default(),
                             buffers: &[wgpu::VertexBufferLayout {
                                 array_stride: std::mem::size_of::<
                                     mesh::SolidVertex2D,
@@ -763,6 +764,7 @@ mod solid {
                         fragment: Some(wgpu::FragmentState {
                             module: &shader,
                             entry_point: "solid_fs_main",
+                            compilation_options: wgpu::PipelineCompilationOptions::default(),
                             targets: &[Some(triangle::fragment_target(format))],
                         }),
                         primitive: triangle::primitive_state(),
@@ -913,6 +915,7 @@ mod gradient {
                     vertex: wgpu::VertexState {
                         module: &shader,
                         entry_point: "gradient_vs_main",
+                        compilation_options: wgpu::PipelineCompilationOptions::default(),
                         buffers: &[wgpu::VertexBufferLayout {
                             array_stride: std::mem::size_of::<
                                 mesh::GradientVertex2D,
@@ -940,6 +943,7 @@ mod gradient {
                     fragment: Some(wgpu::FragmentState {
                         module: &shader,
                         entry_point: "gradient_fs_main",
+                        compilation_options: wgpu::PipelineCompilationOptions::default(),
                         targets: &[Some(triangle::fragment_target(format))],
                     }),
                     primitive: triangle::primitive_state(),

--- a/wgpu/src/triangle/msaa.rs
+++ b/wgpu/src/triangle/msaa.rs
@@ -111,11 +111,13 @@ impl Blit {
                 vertex: wgpu::VertexState {
                     module: &shader,
                     entry_point: "vs_main",
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
                     buffers: &[],
                 },
                 fragment: Some(wgpu::FragmentState {
                     module: &shader,
                     entry_point: "fs_main",
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
                     targets: &[Some(wgpu::ColorTargetState {
                         format,
                         blend: Some(


### PR DESCRIPTION
Updates `cosmic-text` to `0.11`, which allows `wgpu` to be updated to `0.20`, which should allow `web-sys` to be unpinned from version `0.3.67`