### PR TITLE
add missing derive(Debug) in lib.rs docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@
 //! We start by modelling the __state__ of our application:
 //!
 //! ```
+//! #[derive(Default)]
 //! struct Counter {
 //!     // The counter value
 //!     value: i32,


### PR DESCRIPTION
The dervice(Debug) line is missing in the lib.rs. It already exists in the README.md.

This PR adds that missing line.