### PR TITLE
Support wasm target for `download_progress`

### DIFF
--- a/examples/download_progress/Cargo.toml
+++ b/examples/download_progress/Cargo.toml
@@ -12,4 +12,4 @@ iced.features = ["tokio"]
 [dependencies.reqwest]
 version = "0.12"
 default-features = false
-features = ["rustls-tls"]
+features = ["stream", "rustls-tls"]

--- a/examples/download_progress/index.html
+++ b/examples/download_progress/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en" style="height: 100%">
+<head>
+    <meta charset="utf-8" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Download_Progress - Iced</title>
+    <base data-trunk-public-url />
+</head>
+<body style="height: 100%; margin: 0">
+<link data-trunk rel="rust" href="Cargo.toml" data-wasm-opt="z" data-bin="download_progress" />
+</body>
+</html>

--- a/examples/download_progress/src/main.rs
+++ b/examples/download_progress/src/main.rs
@@ -23,7 +23,7 @@ struct Example {
 pub enum Message {
     Add,
     Download(usize),
-    DownloadProgressed((usize, download::Progress)),
+    DownloadProgressed((usize, Result<download::Progress, download::Error>)),
 }
 
 impl Example {
@@ -114,19 +114,19 @@ impl Download {
         }
     }
 
-    pub fn progress(&mut self, new_progress: download::Progress) {
+    pub fn progress(
+        &mut self,
+        new_progress: Result<download::Progress, download::Error>,
+    ) {
         if let State::Downloading { progress } = &mut self.state {
             match new_progress {
-                download::Progress::Started => {
-                    *progress = 0.0;
+                Ok(download::Progress::Downloading { percent }) => {
+                    *progress = percent;
                 }
-                download::Progress::Advanced(percentage) => {
-                    *progress = percentage;
-                }
-                download::Progress::Finished => {
+                Ok(download::Progress::Finished) => {
                     self.state = State::Finished;
                 }
-                download::Progress::Errored => {
+                Err(_error) => {
                     self.state = State::Errored;
                 }
             }
@@ -136,7 +136,7 @@ impl Download {
     pub fn subscription(&self) -> Subscription<Message> {
         match self.state {
             State::Downloading { .. } => {
-                download::file(self.id, "https://speed.hetzner.de/100MB.bin?")
+                download::file(self.id, "https://huggingface.co/mattshumer/Reflection-Llama-3.1-70B/resolve/main/model-00001-of-00162.safetensors")
                     .map(Message::DownloadProgressed)
             }
             _ => Subscription::none(),


### PR DESCRIPTION
I think it works, but I did make some tricky modifications because
1. reqwest doesn't support `chunk` method for wasm, I have to replace chunk by stream
2. the futures generated by wasm_bindgen NO Send, so I have to pin stream

![螢幕截圖_20240502_171755](https://github.com/iced-rs/iced/assets/30007158/25a7643d-17bc-4bb8-98b2-4800eb6a8688)

