### PR TITLE
Fix: grabbing `image::Viewer` from outside the widget

### DIFF
--- a/widget/src/image/viewer.rs
+++ b/widget/src/image/viewer.rs
@@ -216,7 +216,7 @@ where
                 event::Status::Captured
             }
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) => {
-                let Some(cursor_position) = cursor.position() else {
+                let Some(cursor_position) = cursor.position_over(bounds) else {
                     return event::Status::Ignored;
                 };
 


### PR DESCRIPTION
#1998 fixed out of bounds scrolling, but I noticed that *grabbing* the image from anywhere was still possible.