### PR TITLE
Fix `clock` example doesn't get the correct local time under unix system

### DIFF
--- a/examples/clock/Cargo.toml
+++ b/examples/clock/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 [dependencies]
 iced.workspace = true
 iced.features = ["canvas", "tokio", "debug"]
-chrono = { version = "0.4", features = [ "clock" ] }
+chrono = "0.4"
 tracing-subscriber = "0.3"

--- a/examples/clock/Cargo.toml
+++ b/examples/clock/Cargo.toml
@@ -8,6 +8,5 @@ publish = false
 [dependencies]
 iced.workspace = true
 iced.features = ["canvas", "tokio", "debug"]
-
-time = { version = "0.3", features = ["local-offset"] }
+chrono = { version = "0.4", features = [ "clock" ] }
 tracing-subscriber = "0.3"


### PR DESCRIPTION
There is a long-standing problem (https://github.com/time-rs/time/issues/293) that has not yet been solved by time-rs 

Switch to chrono as it seemed to solve the problem (https://github.com/chronotope/chrono/pull/677)
