### PR TITLE
Support wasm target for `clock` example

### DIFF
--- a/examples/clock/Cargo.toml
+++ b/examples/clock/Cargo.toml
@@ -6,7 +6,15 @@ edition = "2021"
 publish = false
 
 [dependencies]
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 iced.workspace = true
 iced.features = ["canvas", "tokio", "debug"]
 chrono = { version = "0.4", features = [ "clock" ] }
 tracing-subscriber = "0.3"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+iced.workspace = true
+iced.features = ["webgl", "canvas", "tokio", "debug"]
+chrono = { version = "0.4", features = [ "clock", "wasmbind" ] }
+instant = { version = "0.1", features = [ "wasm-bindgen" ] }
+

--- a/examples/clock/index.html
+++ b/examples/clock/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en" style="height: 100%">
+<head>
+    <meta charset="utf-8" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Clock - Iced</title>
+    <base data-trunk-public-url />
+</head>
+<body style="height: 100%; margin: 0">
+<link data-trunk rel="rust" href="Cargo.toml" data-wasm-opt="z" data-bin="clock" />
+</body>
+</html>

--- a/examples/clock/src/main.rs
+++ b/examples/clock/src/main.rs
@@ -11,6 +11,7 @@ use chrono as time;
 use time::Timelike;
 
 pub fn main() -> iced::Result {
+    #[cfg(not(target_arch = "wasm32"))]
     tracing_subscriber::fmt::init();
 
     iced::program("Clock - Iced", Clock::update, Clock::view)


### PR DESCRIPTION
base on #2421

Fix the env loading problem by enabling `wasm-bindgen` feature with `instant`

problem : it failed on firefox
log : https://gist.github.com/skygrango/6561e1a77a147c664f62ab2fef248a74
```bash
<wgpu::backend::wgpu_core::ContextWgpuCore as wgpu::context::Context>::device_create_render_pipeline::he39460428393c56b http://127.0.0.1:8080/clock-c25483e98ad88e58_bg.wasm:4833636
<T as wgpu::context::DynContext>::device_create_render_pipeline::h77fdafe577d5f84d http://127.0.0.1:8080/clock-c25483e98ad88e58_bg.wasm:17303843`
```

I don't know how to fix it, maybe something wrong with `widget/canvas`


it almost work on chrome, except for drawing text
![螢幕截圖_20240503_142518-1](https://github.com/iced-rs/iced/assets/30007158/a3e4fffb-af26-4d5f-a86c-a74c180a4820)

