### PR TITLE
Reuse `glyphon::Pipeline` state in `iced_wgpu`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,7 @@ cosmic-text = "0.10"
 dark-light = "1.0"
 futures = "0.3"
 glam = "0.25"
-glyphon = { git = "https://github.com/hecrj/glyphon.git", rev = "ceed55403ce53e120ce9d1fae17dcfe388726118" }
+glyphon = { git = "https://github.com/hecrj/glyphon.git", rev = "cd66a24859cf30b0b8cabf06256dacad362ed44a" }
 guillotiere = "0.6"
 half = "2.2"
 image = "0.24"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,7 @@ cosmic-text = "0.10"
 dark-light = "1.0"
 futures = "0.3"
 glam = "0.25"
-glyphon = { git = "https://github.com/hecrj/glyphon.git", rev = "cd66a24859cf30b0b8cabf06256dacad362ed44a" }
+glyphon = { git = "https://github.com/hecrj/glyphon.git", rev = "f410f3ab4fc7b484003684881124cb0ee7ef2e01" }
 guillotiere = "0.6"
 half = "2.2"
 image = "0.24"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,7 @@ cosmic-text = "0.10"
 dark-light = "1.0"
 futures = "0.3"
 glam = "0.25"
-glyphon = { git = "https://github.com/hecrj/glyphon.git", rev = "f410f3ab4fc7b484003684881124cb0ee7ef2e01" }
+glyphon = { git = "https://github.com/hecrj/glyphon.git", rev = "f07e7bab705e69d39a5e6e52c73039a93c4552f8" }
 guillotiere = "0.6"
 half = "2.2"
 image = "0.24"

--- a/wgpu/src/text.rs
+++ b/wgpu/src/text.rs
@@ -115,6 +115,7 @@ impl Storage {
         queue: &wgpu::Queue,
         encoder: &mut wgpu::CommandEncoder,
         format: wgpu::TextureFormat,
+        pipeline: &glyphon::Pipeline,
         cache: &Cache,
         new_transformation: Transformation,
         bounds: Rectangle,
@@ -131,7 +132,7 @@ impl Storage {
 
             Group {
                 atlas: glyphon::TextAtlas::with_color_mode(
-                    device, queue, format, COLOR_MODE,
+                    device, queue, pipeline, format, COLOR_MODE,
                 ),
                 version: 0,
                 should_trim: false,
@@ -259,6 +260,7 @@ impl Storage {
 
 #[allow(missing_debug_implementations)]
 pub struct Pipeline {
+    state: glyphon::Pipeline,
     format: wgpu::TextureFormat,
     atlas: glyphon::TextAtlas,
     renderers: Vec<glyphon::TextRenderer>,
@@ -272,12 +274,16 @@ impl Pipeline {
         queue: &wgpu::Queue,
         format: wgpu::TextureFormat,
     ) -> Self {
+        let state = glyphon::Pipeline::new(device);
+        let atlas = glyphon::TextAtlas::with_color_mode(
+            device, queue, &state, format, COLOR_MODE,
+        );
+
         Pipeline {
+            state,
             format,
             renderers: Vec::new(),
-            atlas: glyphon::TextAtlas::with_color_mode(
-                device, queue, format, COLOR_MODE,
-            ),
+            atlas,
             prepare_layer: 0,
             cache: BufferCache::new(),
         }
@@ -343,6 +349,7 @@ impl Pipeline {
                         queue,
                         encoder,
                         self.format,
+                        &self.state,
                         cache,
                         layer_transformation * *transformation,
                         layer_bounds * layer_transformation,

--- a/wgpu/src/text.rs
+++ b/wgpu/src/text.rs
@@ -116,7 +116,7 @@ impl Storage {
         viewport: &glyphon::Viewport,
         encoder: &mut wgpu::CommandEncoder,
         format: wgpu::TextureFormat,
-        pipeline: &glyphon::Pipeline,
+        state: &glyphon::Cache,
         cache: &Cache,
         new_transformation: Transformation,
         bounds: Rectangle,
@@ -132,7 +132,7 @@ impl Storage {
 
             Group {
                 atlas: glyphon::TextAtlas::with_color_mode(
-                    device, queue, pipeline, format, COLOR_MODE,
+                    device, queue, state, format, COLOR_MODE,
                 ),
                 version: 0,
                 should_trim: false,
@@ -274,7 +274,7 @@ impl Viewport {
 
 #[allow(missing_debug_implementations)]
 pub struct Pipeline {
-    state: glyphon::Pipeline,
+    state: glyphon::Cache,
     format: wgpu::TextureFormat,
     atlas: glyphon::TextAtlas,
     renderers: Vec<glyphon::TextRenderer>,
@@ -288,7 +288,7 @@ impl Pipeline {
         queue: &wgpu::Queue,
         format: wgpu::TextureFormat,
     ) -> Self {
-        let state = glyphon::Pipeline::new(device);
+        let state = glyphon::Cache::new(device);
         let atlas = glyphon::TextAtlas::with_color_mode(
             device, queue, &state, format, COLOR_MODE,
         );


### PR DESCRIPTION
This should improve potential frame drops when drawing a bunch of `canvas::Cache` for the first time at once.

Relies on https://github.com/grovesNL/glyphon/pull/95 and https://github.com/grovesNL/glyphon/pull/96.
