### PR TITLE
Add `SpecificWith` variant to `window::Position`

### DIFF
--- a/core/src/window/position.rs
+++ b/core/src/window/position.rs
@@ -1,4 +1,4 @@
-use crate::Point;
+use crate::{Point, Size};
 
 /// The position of a window in a given screen.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -15,6 +15,12 @@ pub enum Position {
     /// at (0, 0) you would have to set the position to
     /// `(PADDING_X, PADDING_Y)`.
     Specific(Point),
+    /// Like [`Specific`], but the window is positioned with the specific coordinates returned by the function.
+    ///
+    /// The function receives the window size and the monitor's resolution as input.
+    ///
+    /// [`Specific`]: Self::Specific
+    SpecificWith(fn(Size, Size) -> Point),
 }
 
 impl Default for Position {

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -323,6 +323,35 @@ pub fn position(
                 y: f64::from(position.y),
             }))
         }
+        window::Position::SpecificWith(to_position) => {
+            if let Some(monitor) = monitor {
+                let start = monitor.position();
+
+                let resolution: winit::dpi::LogicalSize<f32> =
+                    monitor.size().to_logical(monitor.scale_factor());
+
+                let position = to_position(
+                    size,
+                    Size::new(resolution.width, resolution.height),
+                );
+
+                let centered: winit::dpi::PhysicalPosition<i32> =
+                    winit::dpi::LogicalPosition {
+                        x: position.x,
+                        y: position.y,
+                    }
+                    .to_physical(monitor.scale_factor());
+
+                Some(winit::dpi::Position::Physical(
+                    winit::dpi::PhysicalPosition {
+                        x: start.x + centered.x,
+                        y: start.y + centered.y,
+                    },
+                ))
+            } else {
+                None
+            }
+        }
         window::Position::Centered => {
             if let Some(monitor) = monitor {
                 let start = monitor.position();


### PR DESCRIPTION
This PR introduces a `SpecificWith` variant to the `window::Position` enum.

It works analogously to the `Specific` variant but it takes a function pointer instead. This function will be called with the window size and the monitor's resolution—effectively allowing relative positioning inside a monitor's bounds.
