### PR TITLE
Suggestion: scrollable::scroll_by operation

### DIFF
--- a/core/src/element.rs
+++ b/core/src/element.rs
@@ -338,9 +338,10 @@ where
                 state: &mut dyn widget::operation::Scrollable,
                 id: Option<&widget::Id>,
                 bounds: Rectangle,
+                content_bounds: Rectangle,
                 translation: Vector,
             ) {
-                self.operation.scrollable(state, id, bounds, translation);
+                self.operation.scrollable(state, id, bounds, content_bounds, translation);
             }
 
             fn text_input(

--- a/core/src/overlay/element.rs
+++ b/core/src/overlay/element.rs
@@ -179,9 +179,10 @@ where
                 state: &mut dyn widget::operation::Scrollable,
                 id: Option<&widget::Id>,
                 bounds: Rectangle,
+                content_bounds: Rectangle,
                 translation: Vector,
             ) {
-                self.operation.scrollable(state, id, bounds, translation);
+                self.operation.scrollable(state, id, bounds, content_bounds, translation);
             }
 
             fn text_input(

--- a/core/src/widget/operation.rs
+++ b/core/src/widget/operation.rs
@@ -37,6 +37,7 @@ pub trait Operation<T> {
         _state: &mut dyn Scrollable,
         _id: Option<&Id>,
         _bounds: Rectangle,
+        _content_bounds: Rectangle,
         _translation: Vector,
     ) {
     }
@@ -127,9 +128,10 @@ where
                     state: &mut dyn Scrollable,
                     id: Option<&Id>,
                     bounds: Rectangle,
+                    content_bounds: Rectangle,
                     translation: Vector,
                 ) {
-                    self.operation.scrollable(state, id, bounds, translation);
+                    self.operation.scrollable(state, id, bounds, content_bounds, translation);
                 }
 
                 fn focusable(
@@ -170,9 +172,10 @@ where
             state: &mut dyn Scrollable,
             id: Option<&Id>,
             bounds: Rectangle,
+            content_bounds: Rectangle,
             translation: Vector,
         ) {
-            self.operation.scrollable(state, id, bounds, translation);
+            self.operation.scrollable(state, id, bounds, content_bounds, translation);
         }
 
         fn text_input(&mut self, state: &mut dyn TextInput, id: Option<&Id>) {

--- a/core/src/widget/operation/scrollable.rs
+++ b/core/src/widget/operation/scrollable.rs
@@ -9,6 +9,9 @@ pub trait Scrollable {
 
     /// Scroll the widget to the given [`AbsoluteOffset`] along the horizontal & vertical axis.
     fn scroll_to(&mut self, offset: AbsoluteOffset);
+
+    /// Scroll the widget by the given [`AbsoluteOffset`] along the horizontal & vertical axis.
+    fn scroll_by(&mut self, offset: AbsoluteOffset, bounds: Rectangle, content_bounds: Rectangle);
 }
 
 /// Produces an [`Operation`] that snaps the widget with the given [`Id`] to
@@ -34,6 +37,7 @@ pub fn snap_to<T>(target: Id, offset: RelativeOffset) -> impl Operation<T> {
             state: &mut dyn Scrollable,
             id: Option<&Id>,
             _bounds: Rectangle,
+            _content_bounds: Rectangle,
             _translation: Vector,
         ) {
             if Some(&self.target) == id {
@@ -68,6 +72,7 @@ pub fn scroll_to<T>(target: Id, offset: AbsoluteOffset) -> impl Operation<T> {
             state: &mut dyn Scrollable,
             id: Option<&Id>,
             _bounds: Rectangle,
+            _content_bounds: Rectangle,
             _translation: Vector,
         ) {
             if Some(&self.target) == id {
@@ -77,6 +82,41 @@ pub fn scroll_to<T>(target: Id, offset: AbsoluteOffset) -> impl Operation<T> {
     }
 
     ScrollTo { target, offset }
+}
+
+/// Produces an [`Operation`] that scrolls the widget with the given [`Id`] by
+/// the provided [`AbsoluteOffset`].
+pub fn scroll_by<T>(target: Id, offset: AbsoluteOffset) -> impl Operation<T> {
+    struct ScrollBy {
+        target: Id,
+        offset: AbsoluteOffset,
+    }
+
+    impl<T> Operation<T> for ScrollBy {
+        fn container(
+            &mut self,
+            _id: Option<&Id>,
+            _bounds: Rectangle,
+            operate_on_children: &mut dyn FnMut(&mut dyn Operation<T>),
+        ) {
+            operate_on_children(self);
+        }
+
+        fn scrollable(
+            &mut self,
+            state: &mut dyn Scrollable,
+            id: Option<&Id>,
+            bounds: Rectangle,
+            content_bounds: Rectangle,
+            _translation: Vector,
+        ) {
+            if Some(&self.target) == id {
+                state.scroll_by(self.offset, bounds, content_bounds);
+            }
+        }
+    }
+
+    ScrollBy { target, offset }
 }
 
 /// The amount of absolute offset in each direction of a [`Scrollable`].

--- a/widget/src/container.rs
+++ b/widget/src/container.rs
@@ -480,6 +480,7 @@ pub fn visible_bounds(id: Id) -> Command<Option<Rectangle>> {
             _state: &mut dyn widget::operation::Scrollable,
             _id: Option<&widget::Id>,
             bounds: Rectangle,
+            _content_bounds: Rectangle,
             translation: Vector,
         ) {
             match self.scrollables.last() {

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -309,6 +309,7 @@ where
             state,
             self.id.as_ref().map(|id| &id.0),
             bounds,
+            content_bounds,
             translation,
         );
 
@@ -970,6 +971,15 @@ pub fn scroll_to<Message: 'static>(
     Command::widget(operation::scrollable::scroll_to(id.0, offset))
 }
 
+/// Produces a [`Command`] that scrolls the [`Scrollable`] with the given [`Id`]
+/// by the provided [`AbsoluteOffset`] along the x & y axis.
+pub fn scroll_by<Message: 'static>(
+    id: Id,
+    offset: AbsoluteOffset,
+) -> Command<Message> {
+    Command::widget(operation::scrollable::scroll_by(id.0, offset))
+}
+
 /// Returns [`true`] if the viewport actually changed.
 fn notify_on_scroll<Message>(
     state: &mut State,
@@ -1052,6 +1062,10 @@ impl operation::Scrollable for State {
 
     fn scroll_to(&mut self, offset: AbsoluteOffset) {
         State::scroll_to(self, offset);
+    }
+
+    fn scroll_by(&mut self, offset: AbsoluteOffset, bounds: Rectangle, content_bounds: Rectangle) {
+        State::scroll_by(self, offset, bounds, content_bounds);
     }
 }
 
@@ -1235,6 +1249,31 @@ impl State {
     pub fn scroll_to(&mut self, offset: AbsoluteOffset) {
         self.offset_x = Offset::Absolute(offset.x.max(0.0));
         self.offset_y = Offset::Absolute(offset.y.max(0.0));
+    }
+
+    /// Scroll by the provided [`AbsoluteOffset`].
+    pub fn scroll_by(
+        &mut self,
+        offset: AbsoluteOffset,
+        bounds: Rectangle,
+        content_bounds: Rectangle,
+    ) {
+        self.offset_x = match self.offset_x {
+            Offset::Absolute(v) => Offset::Absolute((v + offset.x).max(0.0).min(
+                content_bounds.width - bounds.width
+            )),
+            rel => Offset::Absolute(
+                (rel.absolute(bounds.width, content_bounds.width) + offset.x).max(0.0)
+            ),
+        };
+        self.offset_y = match self.offset_y {
+            Offset::Absolute(v) => Offset::Absolute((v + offset.y).max(0.0).min(
+                content_bounds.height - bounds.height
+            )),
+            rel => Offset::Absolute(
+                (rel.absolute(bounds.height, content_bounds.height) + offset.y).max(0.0)
+            ),
+        };
     }
 
     /// Unsnaps the current scroll position, if snapped, given the bounds of the


### PR DESCRIPTION
This new operation scrolls an scrollable an absolute amount from their current position, in contrast to `scroll_to` that scrolls to an absolute position.

I'm not entirely convinced my implementation is good, I just hacked away until it worked. Suggestions welcome.

My use case for this is that I want to scroll a scrollable with the keyboard, using custom keys, and by custom amounts of pixels. The content bounds are required in case the new AbsoluteOffset needs to be applied on top of a RelativeOffset.