### PR TITLE
Ask for explicit `Length` in `center_*` methods

### DIFF
--- a/examples/editor/src/main.rs
+++ b/examples/editor/src/main.rs
@@ -277,7 +277,7 @@ fn action<'a, Message: Clone + 'a>(
     label: &'a str,
     on_press: Option<Message>,
 ) -> Element<'a, Message> {
-    let action = button(container(content).center_x().width(30));
+    let action = button(container(content).center_x(30));
 
     if let Some(on_press) = on_press {
         tooltip(

--- a/examples/geometry/src/main.rs
+++ b/examples/geometry/src/main.rs
@@ -153,7 +153,7 @@ mod rainbow {
 }
 
 use iced::widget::{column, container, scrollable};
-use iced::Element;
+use iced::{Element, Length};
 use rainbow::rainbow;
 
 pub fn main() -> iced::Result {
@@ -176,7 +176,7 @@ fn view(_state: &()) -> Element<'_, ()> {
     .spacing(20)
     .max_width(500);
 
-    let scrollable = scrollable(container(content).center_x());
+    let scrollable = scrollable(container(content).center_x(Length::Fill));
 
-    container(scrollable).center_y().into()
+    container(scrollable).center_y(Length::Fill).into()
 }

--- a/examples/layout/src/main.rs
+++ b/examples/layout/src/main.rs
@@ -251,7 +251,7 @@ fn application<'a>() -> Element<'a, Message> {
             .align_items(Alignment::Center),
     )
     .style(container::rounded_box)
-    .center_y();
+    .center_y(Length::Fill);
 
     let content = container(
         scrollable(

--- a/examples/multi_window/src/main.rs
+++ b/examples/multi_window/src/main.rs
@@ -207,6 +207,6 @@ impl Window {
                 .align_items(Alignment::Center),
         );
 
-        container(content).center_x().width(200).into()
+        container(content).center_x(200).into()
     }
 }

--- a/examples/pane_grid/src/main.rs
+++ b/examples/pane_grid/src/main.rs
@@ -291,7 +291,10 @@ fn view_content<'a>(
     .spacing(10)
     .align_items(Alignment::Center);
 
-    container(scrollable(content)).center_y().padding(5).into()
+    container(scrollable(content))
+        .center_y(Length::Fill)
+        .padding(5)
+        .into()
 }
 
 fn view_controls<'a>(

--- a/examples/screenshot/src/main.rs
+++ b/examples/screenshot/src/main.rs
@@ -123,10 +123,9 @@ impl Example {
         };
 
         let image = container(image)
-            .center_y()
+            .center_y(Length::FillPortion(2))
             .padding(10)
-            .style(container::rounded_box)
-            .width(Length::FillPortion(2));
+            .style(container::rounded_box);
 
         let crop_origin_controls = row![
             text("X:")
@@ -211,7 +210,7 @@ impl Example {
             .spacing(40)
         };
 
-        let side_content = container(controls).center_y();
+        let side_content = container(controls).center_y(Length::Fill);
 
         let content = row![side_content, image]
             .spacing(10)

--- a/examples/slider/src/main.rs
+++ b/examples/slider/src/main.rs
@@ -1,5 +1,5 @@
 use iced::widget::{center, column, container, slider, text, vertical_slider};
-use iced::Element;
+use iced::{Element, Length};
 
 pub fn main() -> iced::Result {
     iced::run("Slider - Iced", Slider::update, Slider::view)
@@ -56,9 +56,9 @@ impl Slider {
 
         center(
             column![
-                container(v_slider).center_x(),
-                container(h_slider).center_x(),
-                container(text).center_x()
+                container(v_slider).center_x(Length::Fill),
+                container(h_slider).center_x(Length::Fill),
+                container(text).center_x(Length::Fill)
             ]
             .spacing(25),
         )

--- a/examples/svg/src/main.rs
+++ b/examples/svg/src/main.rs
@@ -45,7 +45,7 @@ impl Tiger {
                 .on_toggle(Message::ToggleColorFilter);
 
         center(
-            column![svg, container(apply_color_filter).center_x()]
+            column![svg, container(apply_color_filter).center_x(Length::Fill)]
                 .spacing(20)
                 .height(Length::Fill),
         )

--- a/examples/system_information/src/main.rs
+++ b/examples/system_information/src/main.rs
@@ -1,4 +1,4 @@
-use iced::widget::{button, column, container, text};
+use iced::widget::{button, center, column, text};
 use iced::{system, Command, Element};
 
 pub fn main() -> iced::Result {
@@ -136,6 +136,6 @@ impl Example {
             }
         };
 
-        container(content).center().into()
+        center(content).into()
     }
 }

--- a/examples/todos/src/main.rs
+++ b/examples/todos/src/main.rs
@@ -238,7 +238,10 @@ impl Todos {
                     .spacing(20)
                     .max_width(800);
 
-                scrollable(container(content).center_x().padding(40)).into()
+                scrollable(
+                    container(content).center_x(Length::Fill).padding(40),
+                )
+                .into()
             }
         }
     }

--- a/examples/tour/src/main.rs
+++ b/examples/tour/src/main.rs
@@ -76,10 +76,10 @@ impl Tour {
             } else {
                 content
             })
-            .center_x(),
+            .center_x(Length::Fill),
         );
 
-        container(scrollable).center_y().into()
+        container(scrollable).center_y(Length::Fill).into()
     }
 }
 
@@ -669,7 +669,7 @@ fn ferris<'a>(
         .filter_method(filter_method)
         .width(width),
     )
-    .center_x()
+    .center_x(Length::Fill)
 }
 
 fn padded_button<Message: Clone>(label: &str) -> Button<'_, Message> {

--- a/widget/src/container.rs
+++ b/widget/src/container.rs
@@ -122,9 +122,6 @@ where
 
     /// Sets the [`Container`] to fill all the available space.
     ///
-    /// This can be useful to quickly position content when chained with
-    /// alignment functions—like [`center`].
-    ///
     /// Calling this method is equivalent to chaining [`fill_x`] and
     /// [`fill_y`].
     ///
@@ -159,20 +156,14 @@ where
         self
     }
 
-    /// Sets the [`Container`] to fill the available space in the horizontal axis
-    /// and centers its contents there.
-    pub fn center_x(mut self) -> Self {
-        self.width = Length::Fill;
-        self.horizontal_alignment = alignment::Horizontal::Center;
-        self
+    /// Sets the width of the [`Container`] and centers its contents horizontally.
+    pub fn center_x(self, width: impl Into<Length>) -> Self {
+        self.width(width).align_x(alignment::Horizontal::Center)
     }
 
-    /// Sets the [`Container`] to fill the available space in the vertical axis
-    /// and centers its contents there.
-    pub fn center_y(mut self) -> Self {
-        self.height = Length::Fill;
-        self.vertical_alignment = alignment::Vertical::Center;
-        self
+    /// Sets the height of the [`Container`] and centers its contents vertically.
+    pub fn center_y(self, height: impl Into<Length>) -> Self {
+        self.height(height).align_y(alignment::Vertical::Center)
     }
 
     /// Centers the contents in both the horizontal and vertical axes of the
@@ -182,8 +173,10 @@ where
     ///
     /// [`center_x`]: Self::center_x
     /// [`center_y`]: Self::center_y
-    pub fn center(self) -> Self {
-        self.center_x().center_y()
+    pub fn center(self, length: impl Into<Length>) -> Self {
+        let length = length.into();
+
+        self.center_x(length).center_y(length)
     }
 
     /// Sets whether the contents of the [`Container`] should be clipped on

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -83,9 +83,10 @@ where
 ///
 /// This is equivalent to:
 /// ```rust,no_run
+/// # use iced_widget::core::Length;
 /// # use iced_widget::Container;
 /// # fn container<A>(x: A) -> Container<'static, ()> { unreachable!() }
-/// let centered = container("Centered!").center();
+/// let centered = container("Centered!").center(Length::Fill);
 /// ```
 ///
 /// [`Container`]: crate::Container
@@ -96,7 +97,7 @@ where
     Theme: container::Catalog + 'a,
     Renderer: core::Renderer,
 {
-    container(content).fill().center()
+    container(content).center(Length::Fill)
 }
 
 /// Creates a new [`Column`] with the given children.


### PR DESCRIPTION
This removes some weird order-dependent behavior where calling `center_*` after `width` or `height` would override the set dimensions. Furthermore, it makes setting the dimensions actually explicit; since centering in a `Shrink` dimension is rarely useful.