### PR TITLE
Fix(infinite list): move visible elements when an update occurs offscreen before them

### DIFF
--- a/widget/src/list.rs
+++ b/widget/src/list.rs
@@ -189,6 +189,20 @@ where
                                     layout
                                         .move_to_mut((0.0, state.offsets[*i]));
                                 }
+                            } else if let Some(first_visible) =
+                                state.visible_layouts.first()
+                            {
+                                let first_visible_index = first_visible.0;
+                                if original < first_visible_index {
+                                    for (i, layout, _) in
+                                        &mut state.visible_layouts[..]
+                                    {
+                                        layout.move_to_mut((
+                                            0.0,
+                                            state.offsets[*i],
+                                        ));
+                                    }
+                                }
                             }
 
                             state.size.height += height_difference;


### PR DESCRIPTION
This fix is related to a bug on the branch `feature/list-widget-reloaded`:
- When there is a `Change::Update` on an element that isn't visible it wasn't moving the layouts, however when that element is before the ones visible they need to be moved or else they will be on the wrong position if there was a height change.
- TODO: maybe all this layout moving and offset calculation logic should only be run if `height_difference` was different than 0. Since when it is 0 it changes nothing. Sometimes this update changes are only value updates that don't change the height, so there is no point in doing it in those cases.

I was going to tell you about this on Discord but since you weren't online I thought there was no harm in doing this PR anyway since I had already made the fix and tried it. Feel free to make your own fix if you prefer.
