### PR TITLE
Render border above active progress for progress_bar widget.

### DIFF
--- a/widget/src/progress_bar.rs
+++ b/widget/src/progress_bar.rs
@@ -152,21 +152,13 @@ where
                         width: active_progress_width,
                         ..bounds
                     },
-                    border: border::rounded(style.border.radius),
+                    border: Border {
+                        color: Color::TRANSPARENT,
+                        ..style.border
+                    },
                     ..renderer::Quad::default()
                 },
                 style.bar,
-            );
-        }
-
-        if style.border.color != Color::TRANSPARENT {
-            renderer.fill_quad(
-                renderer::Quad {
-                    bounds: Rectangle { ..bounds },
-                    border: style.border,
-                    ..renderer::Quad::default()
-                },
-                Color::TRANSPARENT,
             );
         }
     }

--- a/widget/src/progress_bar.rs
+++ b/widget/src/progress_bar.rs
@@ -139,10 +139,7 @@ where
         renderer.fill_quad(
             renderer::Quad {
                 bounds: Rectangle { ..bounds },
-                border: Border {
-                    color: Color::TRANSPARENT,
-                    ..style.border
-                },
+                border: style.border,
                 ..renderer::Quad::default()
             },
             style.background,

--- a/widget/src/progress_bar.rs
+++ b/widget/src/progress_bar.rs
@@ -5,7 +5,8 @@ use crate::core::mouse;
 use crate::core::renderer;
 use crate::core::widget::Tree;
 use crate::core::{
-    self, Background, Element, Layout, Length, Rectangle, Size, Theme, Widget,
+    self, Background, Color, Element, Layout, Length, Rectangle, Size, Theme,
+    Widget,
 };
 
 use std::ops::RangeInclusive;
@@ -138,7 +139,10 @@ where
         renderer.fill_quad(
             renderer::Quad {
                 bounds: Rectangle { ..bounds },
-                border: style.border,
+                border: Border {
+                    color: Color::TRANSPARENT,
+                    ..style.border
+                },
                 ..renderer::Quad::default()
             },
             style.background,
@@ -155,6 +159,17 @@ where
                     ..renderer::Quad::default()
                 },
                 style.bar,
+            );
+        }
+
+        if style.border.color != Color::TRANSPARENT {
+            renderer.fill_quad(
+                renderer::Quad {
+                    bounds: Rectangle { ..bounds },
+                    border: style.border,
+                    ..renderer::Quad::default()
+                },
+                Color::TRANSPARENT,
             );
         }
     }


### PR DESCRIPTION
Before:
![Screenshot 2024-05-18 140250](https://github.com/iced-rs/iced/assets/40839054/969d6356-5080-42aa-b9ab-467313335295)

After:
![Screenshot 2024-05-18 140125](https://github.com/iced-rs/iced/assets/40839054/60a4d7d5-5c14-48b1-b1a4-1219a89e7edc)
