### PR TITLE
implement From<String> for Element

### DIFF
--- a/core/src/widget/text.rs
+++ b/core/src/widget/text.rs
@@ -329,6 +329,27 @@ where
     }
 }
 
+impl<'a, Theme, Renderer> From<String> for Text<'a, Theme, Renderer>
+where
+    Theme: Catalog + 'a,
+    Renderer: text::Renderer,
+{
+    fn from(content: String) -> Self {
+        Self::new(content)
+    }
+}
+
+impl<'a, Message, Theme, Renderer> From<String>
+    for Element<'a, Message, Theme, Renderer>
+where
+    Theme: Catalog + 'a,
+    Renderer: text::Renderer + 'a,
+{
+    fn from(content: String) -> Self {
+        Text::from(content).into()
+    }
+}
+
 /// The appearance of some text.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct Style {


### PR DESCRIPTION
This PR adds a `From<String>` implemenation for Element. 

This works:
```rs
widget::button("")
```
This did not work:
```rs
widget::button(String::new())
```
You needed this:
```rs
widget::button(widget::text(String::new()))
```

This PR makes it a lot less redundant if you want have `format!` generated text in a button. 