### PR TITLE
Add viewport scale to screenshot data

### DIFF
--- a/runtime/src/window/screenshot.rs
+++ b/runtime/src/window/screenshot.rs
@@ -11,16 +11,20 @@ use std::fmt::{Debug, Formatter};
 pub struct Screenshot {
     /// The bytes of the [`Screenshot`].
     pub bytes: Bytes,
-    /// The size of the [`Screenshot`].
+    /// The size of the [`Screenshot`] in physical pixels.
     pub size: Size<u32>,
+    /// The scale factor of the [`Screenshot`]. This can be useful when converting between widget
+    /// bounds (which are in logical pixels) to crop screenshots.
+    pub scale_factor: f64,
 }
 
 impl Debug for Screenshot {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Screenshot: {{ \n bytes: {}\n size: {:?} }}",
+            "Screenshot: {{ \n bytes: {}\n scale: {}\n size: {:?} }}",
             self.bytes.len(),
+            self.scale_factor,
             self.size
         )
     }
@@ -28,10 +32,15 @@ impl Debug for Screenshot {
 
 impl Screenshot {
     /// Creates a new [`Screenshot`].
-    pub fn new(bytes: impl Into<Bytes>, size: Size<u32>) -> Self {
+    pub fn new(
+        bytes: impl Into<Bytes>,
+        size: Size<u32>,
+        scale_factor: f64,
+    ) -> Self {
         Self {
             bytes: bytes.into(),
             size,
+            scale_factor,
         }
     }
 
@@ -70,6 +79,7 @@ impl Screenshot {
         Ok(Self {
             bytes: Bytes::from(chopped),
             size: Size::new(region.width, region.height),
+            scale_factor: self.scale_factor,
         })
     }
 }

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -1066,6 +1066,7 @@ pub fn run_command<A, C, E>(
                     proxy.send(tag(window::Screenshot::new(
                         bytes,
                         state.physical_size(),
+                        state.viewport().scale_factor(),
                     )));
                 }
             },

--- a/winit/src/multi_window.rs
+++ b/winit/src/multi_window.rs
@@ -1239,6 +1239,7 @@ fn run_command<A, C, E>(
                         proxy.send(tag(window::Screenshot::new(
                             bytes,
                             window.state.physical_size(),
+                            window.state.viewport().scale_factor(),
                         )));
                     }
                 }


### PR DESCRIPTION
Addresses [this](https://github.com/iced-rs/iced/pull/1971#issuecomment-1652724543), which I thought I already merged 😅 

Fixes:
- When using the widget bounds operation, the bounds are returned in logical pixels
- When using the screenshot command, the screenshot is taken in physical pixels
- When cropping a screenshot, we need to know the scale factor of the viewport to properly screenshot an individual widget