### PR TITLE
Add `on_scroll` handler to `mouse_area` widget

### DIFF
--- a/widget/src/mouse_area.rs
+++ b/widget/src/mouse_area.rs
@@ -1,5 +1,4 @@
 //! A container for capturing mouse events.
-
 use crate::core::event::{self, Event};
 use crate::core::layout;
 use crate::core::mouse;
@@ -123,6 +122,8 @@ impl<'a, Message, Theme, Renderer> MouseArea<'a, Message, Theme, Renderer> {
 #[derive(Default)]
 struct State {
     is_hovered: bool,
+    bounds: Rectangle,
+    cursor_position: Option<Point>,
 }
 
 impl<'a, Message, Theme, Renderer> MouseArea<'a, Message, Theme, Renderer> {
@@ -313,13 +314,17 @@ fn update<Message: Clone, Theme, Renderer>(
     cursor: mouse::Cursor,
     shell: &mut Shell<'_, Message>,
 ) -> event::Status {
-    if let Event::Mouse(mouse::Event::CursorMoved { .. })
-    | Event::Touch(touch::Event::FingerMoved { .. }) = event
-    {
-        let state: &mut State = tree.state.downcast_mut();
+    let state: &mut State = tree.state.downcast_mut();
 
+    let cursor_position = cursor.position();
+    let bounds = layout.bounds();
+
+    if state.cursor_position != cursor_position && state.bounds != bounds {
         let was_hovered = state.is_hovered;
+
         state.is_hovered = cursor.is_over(layout.bounds());
+        state.cursor_position = cursor_position;
+        state.bounds = bounds;
 
         match (
             widget.on_enter.as_ref(),

--- a/widget/src/mouse_area.rs
+++ b/widget/src/mouse_area.rs
@@ -28,7 +28,7 @@ pub struct MouseArea<
     on_middle_release: Option<Message>,
     on_scroll: Option<Box<dyn Fn(mouse::ScrollDelta) -> Message + 'a>>,
     on_enter: Option<Message>,
-    on_move: Option<Box<dyn Fn(Point) -> Message>>,
+    on_move: Option<Box<dyn Fn(Point) -> Message + 'a>>,
     on_exit: Option<Message>,
     interaction: Option<mouse::Interaction>,
 }
@@ -78,10 +78,10 @@ impl<'a, Message, Theme, Renderer> MouseArea<'a, Message, Theme, Renderer> {
 
     /// The message to emit when scroll wheel is used
     #[must_use]
-    pub fn on_scroll<F>(mut self, on_scroll: F) -> Self
-    where
-        F: Fn(mouse::ScrollDelta) -> Message + 'static,
-    {
+    pub fn on_scroll(
+        mut self,
+        on_scroll: impl Fn(mouse::ScrollDelta) -> Message + 'a,
+    ) -> Self {
         self.on_scroll = Some(Box::new(on_scroll));
         self
     }
@@ -95,11 +95,8 @@ impl<'a, Message, Theme, Renderer> MouseArea<'a, Message, Theme, Renderer> {
 
     /// The message to emit when the mouse moves in the area.
     #[must_use]
-    pub fn on_move<F>(mut self, build_message: F) -> Self
-    where
-        F: Fn(Point) -> Message + 'static,
-    {
-        self.on_move = Some(Box::new(build_message));
+    pub fn on_move(mut self, on_move: impl Fn(Point) -> Message + 'a) -> Self {
+        self.on_move = Some(Box::new(on_move));
         self
     }
 


### PR DESCRIPTION
After reading through #2375, I decided to add the ability for MouseAreas to detect scrolling. This is a very simple change, following the style of the rest of the code in the file.