### PR TITLE
Add `stroke_rectangle` to `canvas::Frame`

### DIFF
--- a/graphics/src/geometry/frame.rs
+++ b/graphics/src/geometry/frame.rs
@@ -65,6 +65,17 @@ where
         self.raw.stroke(path, stroke);
     }
 
+    /// Draws the stroke of an axis-aligned rectangle with the provided style
+    /// given its top-left corner coordinate and its `Size` on the [`Frame`] .
+    pub fn stroke_rectangle<'a>(
+        &mut self,
+        top_left: Point,
+        size: Size,
+        stroke: impl Into<Stroke<'a>>,
+    ) {
+        self.raw.stroke_rectangle(top_left, size, stroke);
+    }
+
     /// Draws the characters of the given [`Text`] on the [`Frame`], filling
     /// them with the given color.
     ///
@@ -200,6 +211,12 @@ pub trait Backend: Sized {
     fn paste(&mut self, frame: Self);
 
     fn stroke<'a>(&mut self, path: &Path, stroke: impl Into<Stroke<'a>>);
+    fn stroke_rectangle<'a>(
+        &mut self,
+        top_left: Point,
+        size: Size,
+        stroke: impl Into<Stroke<'a>>,
+    );
 
     fn fill(&mut self, path: &Path, fill: impl Into<Fill>);
     fn fill_text(&mut self, text: impl Into<Text>);
@@ -248,6 +265,13 @@ impl Backend for () {
     fn paste(&mut self, _frame: Self) {}
 
     fn stroke<'a>(&mut self, _path: &Path, _stroke: impl Into<Stroke<'a>>) {}
+    fn stroke_rectangle<'a>(
+        &mut self,
+        _top_left: Point,
+        _size: Size,
+        _stroke: impl Into<Stroke<'a>>,
+    ) {
+    }
 
     fn fill(&mut self, _path: &Path, _fill: impl Into<Fill>) {}
     fn fill_text(&mut self, _text: impl Into<Text>) {}

--- a/renderer/src/fallback.rs
+++ b/renderer/src/fallback.rs
@@ -540,6 +540,19 @@ mod geometry {
             delegate!(self, frame, frame.stroke(path, stroke));
         }
 
+        fn stroke_rectangle<'a>(
+            &mut self,
+            top_left: Point,
+            size: Size,
+            stroke: impl Into<Stroke<'a>>,
+        ) {
+            delegate!(
+                self,
+                frame,
+                frame.stroke_rectangle(top_left, size, stroke)
+            );
+        }
+
         fn fill_text(&mut self, text: impl Into<Text>) {
             delegate!(self, frame, frame.fill_text(text));
         }

--- a/tiny_skia/src/geometry.rs
+++ b/tiny_skia/src/geometry.rs
@@ -168,6 +168,31 @@ impl geometry::frame::Backend for Frame {
         });
     }
 
+    fn stroke_rectangle<'a>(
+        &mut self,
+        top_left: Point,
+        size: Size,
+        stroke: impl Into<Stroke<'a>>,
+    ) {
+        let Some(path) = convert_path(&Path::rectangle(top_left, size))
+            .and_then(|path| path.transform(self.transform))
+        else {
+            return;
+        };
+
+        let stroke = stroke.into();
+        let skia_stroke = into_stroke(&stroke);
+
+        let mut paint = into_paint(stroke.style);
+        paint.shader.transform(self.transform);
+
+        self.primitives.push(Primitive::Stroke {
+            path,
+            paint,
+            stroke: skia_stroke,
+        });
+    }
+
     fn fill_text(&mut self, text: impl Into<geometry::Text>) {
         let text = text.into();
 

--- a/tiny_skia/src/geometry.rs
+++ b/tiny_skia/src/geometry.rs
@@ -174,23 +174,7 @@ impl geometry::frame::Backend for Frame {
         size: Size,
         stroke: impl Into<Stroke<'a>>,
     ) {
-        let Some(path) = convert_path(&Path::rectangle(top_left, size))
-            .and_then(|path| path.transform(self.transform))
-        else {
-            return;
-        };
-
-        let stroke = stroke.into();
-        let skia_stroke = into_stroke(&stroke);
-
-        let mut paint = into_paint(stroke.style);
-        paint.shader.transform(self.transform);
-
-        self.primitives.push(Primitive::Stroke {
-            path,
-            paint,
-            stroke: skia_stroke,
-        });
+        self.stroke(&Path::rectangle(top_left, size), stroke);
     }
 
     fn fill_text(&mut self, text: impl Into<geometry::Text>) {


### PR DESCRIPTION
This method should be able to leverage performance improvements in lyon's `tessellate_rectangle` over `tessellate_path`.

Did some quick profiling, this seems to result in a 25% reduction in frame time.