### PR TITLE
Implement Copy on Fill and Stroke

### DIFF
--- a/graphics/src/geometry/fill.rs
+++ b/graphics/src/geometry/fill.rs
@@ -7,7 +7,7 @@ use crate::core::Color;
 use crate::gradient::{self, Gradient};
 
 /// The style used to fill geometry.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct Fill {
     /// The color or gradient of the fill.
     ///

--- a/graphics/src/geometry/stroke.rs
+++ b/graphics/src/geometry/stroke.rs
@@ -6,7 +6,7 @@ pub use crate::geometry::Style;
 use iced_core::Color;
 
 /// The style of a stroke.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct Stroke<'a> {
     /// The color or gradient of the stroke.
     ///

--- a/graphics/src/geometry/style.rs
+++ b/graphics/src/geometry/style.rs
@@ -2,7 +2,7 @@ use crate::core::Color;
 use crate::geometry::Gradient;
 
 /// The coloring style of some drawing.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Style {
     /// A solid [`Color`].
     Solid(Color),

--- a/graphics/src/gradient.rs
+++ b/graphics/src/gradient.rs
@@ -9,7 +9,7 @@ use bytemuck::{Pod, Zeroable};
 use half::f16;
 use std::cmp::Ordering;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 /// A fill which linearly interpolates colors along a direction.
 ///
 /// For a gradient which can be used as a fill for a background of a widget, see [`crate::core::Gradient`].


### PR DESCRIPTION
In general, would it not be better to have functions such as `fill_rectangle` take `&Fill` to prevent unnecessary copies, especially when drawing the same item over and over?