### PR TITLE
Add `override_redirect` for X11 windows

### DIFF
--- a/core/src/window/settings/linux.rs
+++ b/core/src/window/settings/linux.rs
@@ -8,4 +8,10 @@ pub struct PlatformSpecific {
     /// As a best practice, it is suggested to select an application id that match
     /// the basename of the application’s .desktop file.
     pub application_id: String,
+
+    /// Whether bypass the window manager mapping for x11 windows
+    ///
+    /// This flag is particularly useful for creating UI elements that need precise
+    /// positioning and immediate display without window manager interference.
+    pub override_redirect: bool,
 }

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -105,10 +105,14 @@ pub fn window_attributes(
         {
             use winit::platform::x11::WindowAttributesExtX11;
 
-            attributes = attributes.with_name(
-                &settings.platform_specific.application_id,
-                &settings.platform_specific.application_id,
-            );
+            attributes = attributes
+                .with_override_redirect(
+                    settings.platform_specific.override_redirect,
+                )
+                .with_name(
+                    &settings.platform_specific.application_id,
+                    &settings.platform_specific.application_id,
+                );
         }
         #[cfg(feature = "wayland")]
         {


### PR DESCRIPTION
This commit add the `override_redirect` boolean field to the `PlatformSpecific` struct . This is a X11-specific flag allow bypassing window manager mapping for precise positioning of windows.
It's particularly useful for creating Application launchers (like [rofi](https://github.com/davatorium/rofi/blob/75ae2a41f01b77c2123ec773d193fa686a8ef6d9/source/view.c#L1146)) and Custom overlay UIs (e.g., notification apps, screen capture tools)