### PR TITLE
Add disabled state to `toggler` widget

### DIFF
--- a/examples/editor/src/main.rs
+++ b/examples/editor/src/main.rs
@@ -150,11 +150,8 @@ impl Editor {
                 self.is_dirty.then_some(Message::SaveFile)
             ),
             horizontal_space(),
-            toggler(
-                Some("Word Wrap"),
-                self.word_wrap,
-                Message::WordWrapToggled
-            ),
+            toggler(Some("Word Wrap"), self.word_wrap)
+                .on_toggle(Message::WordWrapToggled),
             pick_list(
                 highlighter::Theme::ALL,
                 Some(self.theme),

--- a/examples/editor/src/main.rs
+++ b/examples/editor/src/main.rs
@@ -150,7 +150,8 @@ impl Editor {
                 self.is_dirty.then_some(Message::SaveFile)
             ),
             horizontal_space(),
-            toggler(Some("Word Wrap"), self.word_wrap)
+            toggler(self.word_wrap)
+                .label("Word Wrap")
                 .on_toggle(Message::WordWrapToggled),
             pick_list(
                 highlighter::Theme::ALL,

--- a/examples/styling/src/main.rs
+++ b/examples/styling/src/main.rs
@@ -77,7 +77,8 @@ impl Styling {
         let checkbox = checkbox("Check me!", self.checkbox_value)
             .on_toggle(Message::CheckboxToggled);
 
-        let toggler = toggler(Some("Toggle me!"), self.toggler_value)
+        let toggler = toggler(self.toggler_value)
+            .label("Toggle me!")
             .on_toggle(Message::TogglerToggled)
             .spacing(10);
 

--- a/examples/styling/src/main.rs
+++ b/examples/styling/src/main.rs
@@ -77,12 +77,9 @@ impl Styling {
         let checkbox = checkbox("Check me!", self.checkbox_value)
             .on_toggle(Message::CheckboxToggled);
 
-        let toggler = toggler(
-            Some("Toggle me!"),
-            self.toggler_value,
-            Message::TogglerToggled,
-        )
-        .spacing(10);
+        let toggler = toggler(Some("Toggle me!"), self.toggler_value)
+            .on_toggle(Message::TogglerToggled)
+            .spacing(10);
 
         let content = column![
             choose_theme,

--- a/examples/tour/src/main.rs
+++ b/examples/tour/src/main.rs
@@ -358,7 +358,8 @@ impl Tour {
             .push("A toggler is mostly used to enable or disable something.")
             .push(
                 Container::new(
-                    toggler(Some("Toggle me to continue..."), self.toggler)
+                    toggler(self.toggler)
+                        .label("Toggle me to continue...")
                         .on_toggle(Message::TogglerChanged),
                 )
                 .padding([0, 40]),

--- a/examples/tour/src/main.rs
+++ b/examples/tour/src/main.rs
@@ -357,11 +357,10 @@ impl Tour {
         Self::container("Toggler")
             .push("A toggler is mostly used to enable or disable something.")
             .push(
-                Container::new(toggler(
-                    Some("Toggle me to continue..."),
-                    self.toggler,
-                    Message::TogglerChanged,
-                ))
+                Container::new(
+                    toggler(Some("Toggle me to continue..."), self.toggler)
+                        .on_toggle(Message::TogglerChanged),
+                )
                 .padding([0, 40]),
             )
     }

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -769,13 +769,12 @@ where
 pub fn toggler<'a, Message, Theme, Renderer>(
     label: Option<impl text::IntoFragment<'a>>,
     is_checked: bool,
-    f: impl Fn(bool) -> Message + 'a,
 ) -> Toggler<'a, Message, Theme, Renderer>
 where
     Theme: toggler::Catalog + 'a,
     Renderer: core::text::Renderer,
 {
-    Toggler::new(label, is_checked, f)
+    Toggler::new(label, is_checked)
 }
 
 /// Creates a new [`TextInput`].

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -767,14 +767,13 @@ where
 ///
 /// [`Toggler`]: crate::Toggler
 pub fn toggler<'a, Message, Theme, Renderer>(
-    label: Option<impl text::IntoFragment<'a>>,
     is_checked: bool,
 ) -> Toggler<'a, Message, Theme, Renderer>
 where
     Theme: toggler::Catalog + 'a,
     Renderer: core::text::Renderer,
 {
-    Toggler::new(label, is_checked)
+    Toggler::new(is_checked)
 }
 
 /// Creates a new [`TextInput`].

--- a/widget/src/toggler.rs
+++ b/widget/src/toggler.rs
@@ -26,7 +26,8 @@ use crate::core::{
 ///
 /// let is_toggled = true;
 ///
-/// Toggler::new(Some("Toggle me!"), is_toggled)
+/// Toggler::new(is_toggled)
+///     .label("Toggle me!")
 ///     .on_toggle(Message::TogglerToggled);
 /// ```
 #[allow(missing_debug_implementations)]
@@ -70,14 +71,11 @@ where
     ///   * a function that will be called when the [`Toggler`] is toggled. It
     ///     will receive the new state of the [`Toggler`] and must produce a
     ///     `Message`.
-    pub fn new(
-        label: Option<impl text::IntoFragment<'a>>,
-        is_toggled: bool,
-    ) -> Self {
+    pub fn new(is_toggled: bool) -> Self {
         Toggler {
             is_toggled,
             on_toggle: None,
-            label: label.map(text::IntoFragment::into_fragment),
+            label: None,
             width: Length::Shrink,
             size: Self::DEFAULT_SIZE,
             text_size: None,
@@ -89,6 +87,12 @@ where
             font: None,
             class: Theme::default(),
         }
+    }
+
+    /// Sets the label of the [`Toggler`].
+    pub fn label(mut self, label: impl text::IntoFragment<'a>) -> Self {
+        self.label = Some(label.into_fragment());
+        self
     }
 
     /// Sets the message that should be produced when a user toggles


### PR DESCRIPTION
#### Requirement
In our [pigg app](https://github.com/andrewdavidmackenzie/pigg), we encountered a scenario where it was necessary to disable the toggler based on user interactions. This functionality was crucial to ensure better control and flexibility within the app's user interface.
![pigg](https://github.com/iced-rs/iced/assets/104441812/2979f7da-94b7-4ec2-8040-33874a8d41ab)


#### Implementation
To address this need, I implemented the disable feature for the Toggler widget in Iced. When disabled, the toggler prevents any interaction, thereby enhancing the overall user experience by providing more control over the UI components.

I have also incorporated this feature into the Tour example of Iced to showcase its functionality and usage.
![tour](https://github.com/iced-rs/iced/assets/104441812/8efe5461-10fa-419a-adc8-7df744d4c669)

Your feedback and suggestions for further improvements are highly appreciated!