### PR TITLE
feat: animations for default widgets

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -32,7 +32,7 @@ web-time.workspace = true
 
 dark-light.workspace = true
 dark-light.optional = true
-lilt = "0.5.0"
+lilt = "0.6.0"
 
 [dev-dependencies]
 approx = "0.5"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -32,6 +32,7 @@ web-time.workspace = true
 
 dark-light.workspace = true
 dark-light.optional = true
+lilt = "0.5.0"
 
 [dev-dependencies]
 approx = "0.5"

--- a/core/src/animations.rs
+++ b/core/src/animations.rs
@@ -1,0 +1,50 @@
+//! Helpers for internal animations for a [`Widget`], mainly for style transitions.
+
+/// The duration and enabled state of an animation.
+#[derive(Debug, Clone)]
+pub struct AnimationDuration {
+    /// Duration, in milliseconds, for the animation.
+    duration_ms: f32,
+    /// If disabled, transition is instantaneous.
+    enabled: bool,
+}
+
+impl AnimationDuration {
+    /// Create a [`AnimationDuration`] with the given duration in milliseconds.
+    pub fn new(duration_ms: f32) -> Self {
+        Self {
+            duration_ms,
+            enabled: true,
+        }
+    }
+
+    /// Get the duration, in milliseconds, of the animation.
+    /// If `enabled` is set to `false`, duration is 0.0.
+    pub fn get(&self) -> f32 {
+        if self.enabled {
+            self.duration_ms
+        } else {
+            0.
+        }
+    }
+
+    /// Set the duration, in milliseconds, of the animation.
+    pub fn set(&mut self, duration_ms: f32) {
+        self.duration_ms = duration_ms;
+    }
+
+    /// Disable the animation, making it instantaneous.
+    pub fn disable(&mut self) {
+        self.enabled = false;
+    }
+
+    /// Enable the animation.
+    pub fn enable(&mut self) {
+        self.enabled = true;
+    }
+
+    /// Is the animation enabled
+    pub fn enabled(&self) -> bool {
+        self.enabled
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -10,6 +10,7 @@
     html_logo_url = "https://raw.githubusercontent.com/iced-rs/iced/9ab6923e943f784985e9ef9ca28b10278297225d/docs/logo.svg"
 )]
 pub mod alignment;
+pub mod animations;
 pub mod border;
 pub mod clipboard;
 pub mod event;

--- a/core/src/theme/palette.rs
+++ b/core/src/theme/palette.rs
@@ -594,7 +594,8 @@ fn lighten(color: Color, amount: f32) -> Color {
     from_hsl(hsl)
 }
 
-fn deviate(color: Color, amount: f32) -> Color {
+/// Lighten dark colors and darken light ones by the specefied amount.
+pub fn deviate(color: Color, amount: f32) -> Color {
     if is_dark(color) {
         lighten(color, amount)
     } else {

--- a/core/src/theme/palette.rs
+++ b/core/src/theme/palette.rs
@@ -602,7 +602,8 @@ fn deviate(color: Color, amount: f32) -> Color {
     }
 }
 
-fn mix(a: Color, b: Color, factor: f32) -> Color {
+/// Mix with another color with the given ratio (from 0 to 1)
+pub fn mix(a: Color, b: Color, factor: f32) -> Color {
     let a_lin = Rgb::from(a).into_linear();
     let b_lin = Rgb::from(b).into_linear();
 

--- a/core/src/widget/operation.rs
+++ b/core/src/widget/operation.rs
@@ -37,6 +37,7 @@ pub trait Operation<T>: Send {
         _state: &mut dyn Scrollable,
         _id: Option<&Id>,
         _bounds: Rectangle,
+        _content_bounds: Rectangle,
         _translation: Vector,
     ) {
     }
@@ -127,9 +128,16 @@ where
                     state: &mut dyn Scrollable,
                     id: Option<&Id>,
                     bounds: Rectangle,
+                    content_bounds: Rectangle,
                     translation: Vector,
                 ) {
-                    self.operation.scrollable(state, id, bounds, translation);
+                    self.operation.scrollable(
+                        state,
+                        id,
+                        bounds,
+                        content_bounds,
+                        translation,
+                    );
                 }
 
                 fn focusable(
@@ -170,9 +178,16 @@ where
             state: &mut dyn Scrollable,
             id: Option<&Id>,
             bounds: Rectangle,
+            content_bounds: Rectangle,
             translation: Vector,
         ) {
-            self.operation.scrollable(state, id, bounds, translation);
+            self.operation.scrollable(
+                state,
+                id,
+                bounds,
+                content_bounds,
+                translation,
+            );
         }
 
         fn text_input(&mut self, state: &mut dyn TextInput, id: Option<&Id>) {

--- a/core/src/widget/operation/scrollable.rs
+++ b/core/src/widget/operation/scrollable.rs
@@ -8,7 +8,12 @@ pub trait Scrollable {
     fn snap_to(&mut self, offset: RelativeOffset);
 
     /// Scroll the widget to the given [`AbsoluteOffset`] along the horizontal & vertical axis.
-    fn scroll_to(&mut self, offset: AbsoluteOffset);
+    fn scroll_to(
+        &mut self,
+        offset: AbsoluteOffset,
+        bounds: Rectangle,
+        content_bounds: Rectangle,
+    );
 }
 
 /// Produces an [`Operation`] that snaps the widget with the given [`Id`] to
@@ -34,6 +39,7 @@ pub fn snap_to<T>(target: Id, offset: RelativeOffset) -> impl Operation<T> {
             state: &mut dyn Scrollable,
             id: Option<&Id>,
             _bounds: Rectangle,
+            _content_bounds: Rectangle,
             _translation: Vector,
         ) {
             if Some(&self.target) == id {
@@ -67,11 +73,12 @@ pub fn scroll_to<T>(target: Id, offset: AbsoluteOffset) -> impl Operation<T> {
             &mut self,
             state: &mut dyn Scrollable,
             id: Option<&Id>,
-            _bounds: Rectangle,
+            bounds: Rectangle,
+            content_bounds: Rectangle,
             _translation: Vector,
         ) {
             if Some(&self.target) == id {
-                state.scroll_to(self.offset);
+                state.scroll_to(self.offset, bounds, content_bounds);
             }
         }
     }

--- a/examples/animations/Cargo.toml
+++ b/examples/animations/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "animations"
+version = "0.1.0"
+authors = ["LazyTanuki"]
+edition = "2021"
+publish = false
+
+[dependencies]
+iced = { path = "../..", features = ["debug"] }

--- a/examples/animations/Cargo.toml
+++ b/examples/animations/Cargo.toml
@@ -7,3 +7,4 @@ publish = false
 
 [dependencies]
 iced = { path = "../..", features = ["debug"] }
+once_cell.workspace = true

--- a/examples/animations/README.md
+++ b/examples/animations/README.md
@@ -1,0 +1,12 @@
+# Animations
+
+An application to showcase Iced widgets that have default animations.
+
+The __[`main`]__ file contains all the code of the example.
+
+You can run it with `cargo run`:
+```
+cargo run --package animations
+```
+
+[`main`]: src/main.rs

--- a/examples/animations/src/main.rs
+++ b/examples/animations/src/main.rs
@@ -1,0 +1,107 @@
+use iced::{
+    widget::{
+        button, checkbox, column, container, radio, row, text_input, Toggler,
+    },
+    Element,
+};
+
+pub fn main() -> iced::Result {
+    iced::run("Animated widgets", Animations::update, Animations::view)
+}
+
+#[derive(Default)]
+struct Animations {
+    _animation_multiplier: i32,
+    radio1: Option<usize>,
+    radio2: Option<usize>,
+    input_text: String,
+    toggled: bool,
+    checked: bool,
+    animations_disabled: bool,
+}
+
+#[derive(Debug, Clone)]
+enum Message {
+    ButtonPressed,
+    RadioPressed(usize),
+    TextSubmitted,
+    TextChanged(String),
+    Toggle(bool),
+    Check(bool),
+    DisableAnimations(bool),
+}
+
+impl Animations {
+    fn update(&mut self, message: Message) {
+        match message {
+            Message::RadioPressed(i) => match i {
+                1 => {
+                    self.radio1 = Some(1);
+                    self.radio2 = None;
+                }
+                2 => {
+                    self.radio2 = Some(2);
+                    self.radio1 = None;
+                }
+                _ => {}
+            },
+            Message::TextChanged(txt) => {
+                self.input_text = txt;
+            }
+            Message::Toggle(t) => self.toggled = t,
+            Message::TextSubmitted | Message::ButtonPressed => {}
+            Message::Check(c) => self.checked = c,
+            Message::DisableAnimations(b) => self.animations_disabled = b,
+        }
+    }
+
+    fn view(&self) -> Element<Message> {
+        column![
+            text_input("Insert some text here...", &self.input_text)
+                .on_submit(Message::TextSubmitted)
+                .on_input(Message::TextChanged),
+            row![
+                button("Primary")
+                    .on_press(Message::ButtonPressed)
+                    .style(button::primary)
+                    .set_animations_enabled(!self.animations_disabled),
+                button("Secondary")
+                    .on_press(Message::ButtonPressed)
+                    .style(button::secondary)
+                    .set_animations_enabled(!self.animations_disabled),
+                button("Success")
+                    .on_press(Message::ButtonPressed)
+                    .style(button::success)
+                    .set_animations_enabled(!self.animations_disabled),
+                button("Danger")
+                    .on_press(Message::ButtonPressed)
+                    .style(button::danger)
+                    .set_animations_enabled(!self.animations_disabled),
+                container(Toggler::new(
+                    Some("Disable buttons animations".into()),
+                    self.animations_disabled,
+                    Message::DisableAnimations,
+                ))
+                .padding(5)
+            ],
+            button("Text")
+                .on_press(Message::ButtonPressed)
+                .style(button::text),
+            radio("Click me 1", 1, self.radio1, |i| {
+                Message::RadioPressed(i)
+            }),
+            radio("Click me 2", 2, self.radio2, |i| {
+                Message::RadioPressed(i)
+            }),
+            checkbox("Check me", self.checked)
+                .on_toggle(|t| { Message::Check(t) }),
+            Toggler::new(Some("Toggle me".into()), self.toggled, |t| {
+                Message::Toggle(t)
+            }),
+        ]
+        .spacing(10)
+        .padding(50)
+        .max_width(800)
+        .into()
+    }
+}

--- a/examples/animations/src/main.rs
+++ b/examples/animations/src/main.rs
@@ -1,19 +1,21 @@
 use iced::{
     widget::{
-        button, checkbox, column, container, radio, row, text_input, Toggler,
+        button, checkbox, column, container, row, scrollable, text, text_input,
+        Toggler,
     },
-    Element,
+    Element, Length, Task, Theme,
 };
+use once_cell::sync::Lazy;
+use std::fmt::Write;
 
 pub fn main() -> iced::Result {
-    iced::run("Animated widgets", Animations::update, Animations::view)
+    iced::application("Animated widgets", Animations::update, Animations::view)
+        .theme(Animations::theme)
+        .run()
 }
 
 #[derive(Default)]
 struct Animations {
-    _animation_multiplier: i32,
-    radio1: Option<usize>,
-    radio2: Option<usize>,
     input_text: String,
     toggled: bool,
     checked: bool,
@@ -23,35 +25,54 @@ struct Animations {
 #[derive(Debug, Clone)]
 enum Message {
     ButtonPressed,
-    RadioPressed(usize),
     TextSubmitted,
     TextChanged(String),
     Toggle(bool),
     Check(bool),
     DisableAnimations(bool),
+    GoToStart,
+    GoToEnd,
 }
 
+static SCROLLABLE_TEXT: Lazy<String> = Lazy::new(|| {
+    (0..50).fold(String::new(), |mut output, i| {
+        let _ = writeln!(
+            output,
+            "This is a long text string to test the scrollbar: {i}\n"
+        );
+        output
+    })
+});
+static SCROLLABLE_ID: Lazy<scrollable::Id> = Lazy::new(scrollable::Id::unique);
+
 impl Animations {
-    fn update(&mut self, message: Message) {
+    fn update(&mut self, message: Message) -> Task<Message> {
         match message {
-            Message::RadioPressed(i) => match i {
-                1 => {
-                    self.radio1 = Some(1);
-                    self.radio2 = None;
-                }
-                2 => {
-                    self.radio2 = Some(2);
-                    self.radio1 = None;
-                }
-                _ => {}
-            },
             Message::TextChanged(txt) => {
                 self.input_text = txt;
+                Task::none()
             }
-            Message::Toggle(t) => self.toggled = t,
-            Message::TextSubmitted | Message::ButtonPressed => {}
-            Message::Check(c) => self.checked = c,
-            Message::DisableAnimations(b) => self.animations_disabled = b,
+            Message::Toggle(t) => {
+                self.toggled = t;
+                Task::none()
+            }
+            Message::TextSubmitted | Message::ButtonPressed => Task::none(),
+            Message::Check(c) => {
+                self.checked = c;
+                Task::none()
+            }
+            Message::DisableAnimations(b) => {
+                self.animations_disabled = b;
+                Task::none()
+            }
+            Message::GoToStart => scrollable::snap_to(
+                SCROLLABLE_ID.clone(),
+                scrollable::RelativeOffset::START,
+            ),
+            Message::GoToEnd => scrollable::snap_to(
+                SCROLLABLE_ID.clone(),
+                scrollable::RelativeOffset::END,
+            ),
         }
     }
 
@@ -87,21 +108,29 @@ impl Animations {
             button("Text")
                 .on_press(Message::ButtonPressed)
                 .style(button::text),
-            radio("Click me 1", 1, self.radio1, |i| {
-                Message::RadioPressed(i)
-            }),
-            radio("Click me 2", 2, self.radio2, |i| {
-                Message::RadioPressed(i)
-            }),
             checkbox("Check me", self.checked)
                 .on_toggle(|t| { Message::Check(t) }),
             Toggler::new(Some("Toggle me".into()), self.toggled, |t| {
                 Message::Toggle(t)
             }),
+            scrollable(
+                container(column![
+                    button("Go to end").on_press(Message::GoToEnd),
+                    text(SCROLLABLE_TEXT.as_str()),
+                    button("Go to start").on_press(Message::GoToStart)
+                ])
+                .width(Length::Fill)
+                .padding(5)
+            )
+            .id(SCROLLABLE_ID.clone())
         ]
         .spacing(10)
         .padding(50)
         .max_width(800)
         .into()
+    }
+
+    fn theme(&self) -> Theme {
+        Theme::Light
     }
 }

--- a/widget/Cargo.toml
+++ b/widget/Cargo.toml
@@ -53,4 +53,4 @@ iced_highlighter.optional = true
 url.workspace = true
 url.optional = true
 
-lilt = "0.5.0"
+lilt = "0.6.0"

--- a/widget/Cargo.toml
+++ b/widget/Cargo.toml
@@ -52,3 +52,5 @@ iced_highlighter.optional = true
 
 url.workspace = true
 url.optional = true
+
+lilt = "0.5.0"

--- a/widget/src/button.rs
+++ b/widget/src/button.rs
@@ -9,7 +9,7 @@ use crate::core::layout;
 use crate::core::mouse;
 use crate::core::overlay;
 use crate::core::renderer;
-use crate::core::theme::palette::{self, mix};
+use crate::core::theme::palette::{self, deviate};
 use crate::core::touch;
 use crate::core::widget::tree::{self, Tree};
 use crate::core::widget::Operation;
@@ -102,7 +102,7 @@ where
             padding: DEFAULT_PADDING,
             clip: false,
             class: Theme::default(),
-            animation_forward_duration: AnimationDuration::new(50.),
+            animation_forward_duration: AnimationDuration::new(75.),
             animation_backward_duration: AnimationDuration::new(200.),
         }
     }
@@ -691,30 +691,24 @@ impl Catalog for Theme {
 
 /// Mix the base with the hover color according to the [`Button`] state.
 #[inline(always)]
-fn status_style(
-    status: Status,
-    base: palette::Pair,
-    hover_color: Color,
-) -> Style {
+fn status_style(status: Status, base: palette::Pair) -> Style {
     match status {
         Status::Active => styled(base),
         Status::Pressed {
             animation_progress: progress,
         } => Style {
-            background: Some(Background::Color(mix(
+            background: Some(Background::Color(deviate(
                 base.color,
-                hover_color,
-                progress,
+                progress * 0.2,
             ))),
             ..styled(base)
         },
         Status::Hovered {
             animation_progress: progress,
         } => Style {
-            background: Some(Background::Color(mix(
+            background: Some(Background::Color(deviate(
                 base.color,
-                hover_color,
-                progress,
+                progress * 0.2,
             ))),
             ..styled(base)
         },
@@ -726,36 +720,32 @@ fn status_style(
 pub fn primary(theme: &Theme, status: Status) -> Style {
     let palette = theme.extended_palette();
     let base = palette.primary.strong;
-    let hover_color = palette.primary.base.color;
 
-    status_style(status, base, hover_color)
+    status_style(status, base)
 }
 
 /// A secondary button; denoting a complementary action.
 pub fn secondary(theme: &Theme, status: Status) -> Style {
     let palette = theme.extended_palette();
     let base = palette.secondary.base;
-    let hover_color = palette.secondary.strong.color;
 
-    status_style(status, base, hover_color)
+    status_style(status, base)
 }
 
 /// A success button; denoting a good outcome.
 pub fn success(theme: &Theme, status: Status) -> Style {
     let palette = theme.extended_palette();
     let base = palette.success.base;
-    let hover_color = palette.success.strong.color;
 
-    status_style(status, base, hover_color)
+    status_style(status, base)
 }
 
 /// A danger button; denoting a destructive action.
 pub fn danger(theme: &Theme, status: Status) -> Style {
     let palette = theme.extended_palette();
     let base = palette.danger.base;
-    let hover_color = palette.danger.strong.color;
 
-    status_style(status, base, hover_color)
+    status_style(status, base)
 }
 
 /// A text button; useful for links.

--- a/widget/src/button.rs
+++ b/widget/src/button.rs
@@ -1,14 +1,19 @@
 //! Allow your users to perform actions by pressing a button.
+use lilt::{Animated, FloatRepresentable};
+use std::time::Instant;
+
+use crate::core::animations::AnimationDuration;
 use crate::core::border::{self, Border};
 use crate::core::event::{self, Event};
 use crate::core::layout;
 use crate::core::mouse;
 use crate::core::overlay;
 use crate::core::renderer;
-use crate::core::theme::palette;
+use crate::core::theme::palette::{self, mix};
 use crate::core::touch;
 use crate::core::widget::tree::{self, Tree};
 use crate::core::widget::Operation;
+use crate::core::window;
 use crate::core::{
     Background, Clipboard, Color, Element, Layout, Length, Padding, Rectangle,
     Shadow, Shell, Size, Theme, Vector, Widget,
@@ -59,6 +64,8 @@ where
     padding: Padding,
     clip: bool,
     class: Theme::Class<'a>,
+    animation_forward_duration: AnimationDuration,
+    animation_backward_duration: AnimationDuration,
 }
 
 enum OnPress<'a, Message> {
@@ -95,6 +102,8 @@ where
             padding: DEFAULT_PADDING,
             clip: false,
             class: Theme::default(),
+            animation_forward_duration: AnimationDuration::new(50.),
+            animation_backward_duration: AnimationDuration::new(200.),
         }
     }
 
@@ -173,11 +182,66 @@ where
         self.class = class.into();
         self
     }
+
+    /// Sets the [`AnimationDuration`] forward duration (in milliseconds) of the [`Button`].
+    pub fn animation_forward_duration(
+        mut self,
+        animation_duration_ms: f32,
+    ) -> Self {
+        self.animation_forward_duration.set(animation_duration_ms);
+        self
+    }
+
+    /// Sets the [`AnimationDuration`] backward duration (in milliseconds) of the [`Button`].
+    pub fn animation_backward_duration(
+        mut self,
+        animation_duration_ms: f32,
+    ) -> Self {
+        self.animation_backward_duration.set(animation_duration_ms);
+        self
+    }
+
+    /// Enables or disables [`AnimationDuration`] transition on [`Pressed`] and [`Hover`] states.
+    pub fn set_animations_enabled(mut self, enable: bool) -> Self {
+        if enable {
+            self.animation_forward_duration.enable();
+            self.animation_backward_duration.enable();
+        } else {
+            self.animation_forward_duration.disable();
+            self.animation_backward_duration.disable();
+        }
+        self
+    }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone)]
 struct State {
     is_pressed: bool,
+    style_animation: Animated<AnimationTarget, Instant>,
+}
+
+impl State {
+    /// This check is meant to fix cases when we get a tainted state from another
+    /// ['Button'] widget by finding impossible cases.
+    fn is_animation_state_tainted(
+        &self,
+        animate_value: f32,
+        is_mouse_over: bool,
+    ) -> bool {
+        if !is_mouse_over {
+            match self.style_animation.value {
+                AnimationTarget::Hovered => {
+                    animate_value == AnimationTarget::Pressed.float_value()
+                }
+                AnimationTarget::Pressed => {
+                    animate_value == AnimationTarget::Hovered.float_value()
+                }
+                AnimationTarget::Active => false,
+            }
+        } else {
+            false
+        }
+    }
 }
 
 impl<'a, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
@@ -192,7 +256,15 @@ where
     }
 
     fn state(&self) -> tree::State {
-        tree::State::new(State::default())
+        // The animations start backwards so that it can do its first transition by switching to forward
+        let state = State {
+            style_animation: Animated::new(AnimationTarget::Active)
+                .duration(self.animation_forward_duration.get())
+                .asymmetric_duration(self.animation_backward_duration.get())
+                .easing(lilt::Easing::Linear),
+            is_pressed: false,
+        };
+        tree::State::new(state)
     }
 
     fn children(&self) -> Vec<Tree> {
@@ -282,7 +354,18 @@ where
                         let state = tree.state.downcast_mut::<State>();
 
                         state.is_pressed = true;
-
+                        if self.animation_forward_duration.enabled() {
+                            state.style_animation.transition(
+                                AnimationTarget::Pressed,
+                                Instant::now(),
+                            );
+                        } else {
+                            state.style_animation.transition_instantaneous(
+                                AnimationTarget::Pressed,
+                                Instant::now(),
+                            );
+                        }
+                        shell.request_redraw(window::RedrawRequest::NextFrame);
                         return event::Status::Captured;
                     }
                 }
@@ -292,15 +375,36 @@ where
                 if let Some(on_press) = self.on_press.as_ref().map(OnPress::get)
                 {
                     let state = tree.state.downcast_mut::<State>();
+                    let bounds = layout.bounds();
+                    let is_mouse_over = cursor.is_over(bounds);
 
                     if state.is_pressed {
                         state.is_pressed = false;
-
-                        let bounds = layout.bounds();
-
-                        if cursor.is_over(bounds) {
+                        if is_mouse_over {
+                            if self.animation_backward_duration.enabled() {
+                                state.style_animation.transition(
+                                    AnimationTarget::Hovered,
+                                    Instant::now(),
+                                );
+                            } else {
+                                state.style_animation.transition_instantaneous(
+                                    AnimationTarget::Hovered,
+                                    Instant::now(),
+                                );
+                            }
                             shell.publish(on_press);
+                        } else if self.animation_backward_duration.enabled() {
+                            state.style_animation.transition(
+                                AnimationTarget::Active,
+                                Instant::now(),
+                            );
+                        } else {
+                            state.style_animation.transition_instantaneous(
+                                AnimationTarget::Hovered,
+                                Instant::now(),
+                            );
                         }
+                        shell.request_redraw(window::RedrawRequest::NextFrame);
 
                         return event::Status::Captured;
                     }
@@ -310,6 +414,44 @@ where
                 let state = tree.state.downcast_mut::<State>();
 
                 state.is_pressed = false;
+            }
+            Event::Window(window::Event::RedrawRequested(now)) => {
+                let state = tree.state.downcast_mut::<State>();
+                let bounds = layout.bounds();
+                let is_mouse_over = cursor.is_over(bounds);
+                let animated_value = state
+                    .style_animation
+                    .animate(|target| target.float_value(), now);
+
+                // Reset animation on tainted state
+                if state
+                    .is_animation_state_tainted(animated_value, is_mouse_over)
+                {
+                    state
+                        .style_animation
+                        .transition_instantaneous(AnimationTarget::Active, now);
+                }
+
+                if state.style_animation.in_progress(now) {
+                    shell.request_redraw(window::RedrawRequest::NextFrame);
+                }
+            }
+            Event::Mouse(mouse::Event::CursorMoved { position: _ }) => {
+                let state = tree.state.downcast_mut::<State>();
+                let bounds = layout.bounds();
+                let is_mouse_over = cursor.is_over(bounds);
+                let style_animation = &mut state.style_animation;
+                if !state.is_pressed
+                    && hover_animation_on_cursor_move(
+                        is_mouse_over,
+                        style_animation,
+                        Instant::now(),
+                        &self.animation_forward_duration,
+                        &self.animation_backward_duration,
+                    )
+                {
+                    shell.request_redraw(window::RedrawRequest::NextFrame);
+                }
             }
             _ => {}
         }
@@ -333,16 +475,29 @@ where
 
         let status = if self.on_press.is_none() {
             Status::Disabled
-        } else if is_mouse_over {
-            let state = tree.state.downcast_ref::<State>();
-
-            if state.is_pressed {
-                Status::Pressed
-            } else {
-                Status::Hovered
-            }
         } else {
-            Status::Active
+            let state = tree.state.downcast_ref::<State>();
+            if is_mouse_over
+                || state.is_pressed
+                || state.style_animation.in_progress(Instant::now())
+            {
+                let now = Instant::now();
+                if state.is_pressed {
+                    Status::Pressed {
+                        animation_progress: state
+                            .style_animation
+                            .animate(|target| target.float_value(), now),
+                    }
+                } else {
+                    Status::Hovered {
+                        animation_progress: state
+                            .style_animation
+                            .animate(|target| target.float_value(), now),
+                    }
+                }
+            } else {
+                Status::Active
+            }
         };
 
         let style = theme.style(&self.class, status);
@@ -436,16 +591,41 @@ pub(crate) const DEFAULT_PADDING: Padding = Padding {
 };
 
 /// The possible status of a [`Button`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Status {
     /// The [`Button`] can be pressed.
     Active,
-    /// The [`Button`] can be pressed and it is being hovered.
-    Hovered,
-    /// The [`Button`] is being pressed.
-    Pressed,
+    /// The [`Button`] can be pressed and it is being hovered
+    Hovered {
+        /// Current progress of the [`AnimationTime`] transition
+        animation_progress: f32,
+    },
+    /// The [`Button`] is being pressed
+    Pressed {
+        /// Current progress of the [`AnimationTime`] transition
+        animation_progress: f32,
+    },
     /// The [`Button`] cannot be pressed.
     Disabled,
+}
+
+/// The [`AnimationTarget`] represents, through its ['FloatRepresentable`]
+/// implementation the ratio of color mixing between the base and hover colors.
+#[derive(Debug, Clone)]
+enum AnimationTarget {
+    Active,
+    Hovered,
+    Pressed,
+}
+
+impl FloatRepresentable for AnimationTarget {
+    fn float_value(&self) -> f32 {
+        match self {
+            AnimationTarget::Active => 0.0,
+            AnimationTarget::Hovered => 0.5,
+            AnimationTarget::Pressed => 1.0,
+        }
+    }
 }
 
 /// The style of a button.
@@ -509,64 +689,73 @@ impl Catalog for Theme {
     }
 }
 
+/// Mix the base with the hover color according to the [`Button`] state.
+#[inline(always)]
+fn status_style(
+    status: Status,
+    base: palette::Pair,
+    hover_color: Color,
+) -> Style {
+    match status {
+        Status::Active => styled(base),
+        Status::Pressed {
+            animation_progress: progress,
+        } => Style {
+            background: Some(Background::Color(mix(
+                base.color,
+                hover_color,
+                progress,
+            ))),
+            ..styled(base)
+        },
+        Status::Hovered {
+            animation_progress: progress,
+        } => Style {
+            background: Some(Background::Color(mix(
+                base.color,
+                hover_color,
+                progress,
+            ))),
+            ..styled(base)
+        },
+        Status::Disabled => disabled(styled(base)),
+    }
+}
+
 /// A primary button; denoting a main action.
 pub fn primary(theme: &Theme, status: Status) -> Style {
     let palette = theme.extended_palette();
-    let base = styled(palette.primary.strong);
+    let base = palette.primary.strong;
+    let hover_color = palette.primary.base.color;
 
-    match status {
-        Status::Active | Status::Pressed => base,
-        Status::Hovered => Style {
-            background: Some(Background::Color(palette.primary.base.color)),
-            ..base
-        },
-        Status::Disabled => disabled(base),
-    }
+    status_style(status, base, hover_color)
 }
 
 /// A secondary button; denoting a complementary action.
 pub fn secondary(theme: &Theme, status: Status) -> Style {
     let palette = theme.extended_palette();
-    let base = styled(palette.secondary.base);
+    let base = palette.secondary.base;
+    let hover_color = palette.secondary.strong.color;
 
-    match status {
-        Status::Active | Status::Pressed => base,
-        Status::Hovered => Style {
-            background: Some(Background::Color(palette.secondary.strong.color)),
-            ..base
-        },
-        Status::Disabled => disabled(base),
-    }
+    status_style(status, base, hover_color)
 }
 
 /// A success button; denoting a good outcome.
 pub fn success(theme: &Theme, status: Status) -> Style {
     let palette = theme.extended_palette();
-    let base = styled(palette.success.base);
+    let base = palette.success.base;
+    let hover_color = palette.success.strong.color;
 
-    match status {
-        Status::Active | Status::Pressed => base,
-        Status::Hovered => Style {
-            background: Some(Background::Color(palette.success.strong.color)),
-            ..base
-        },
-        Status::Disabled => disabled(base),
-    }
+    status_style(status, base, hover_color)
 }
 
 /// A danger button; denoting a destructive action.
 pub fn danger(theme: &Theme, status: Status) -> Style {
     let palette = theme.extended_palette();
-    let base = styled(palette.danger.base);
+    let base = palette.danger.base;
+    let hover_color = palette.danger.strong.color;
 
-    match status {
-        Status::Active | Status::Pressed => base,
-        Status::Hovered => Style {
-            background: Some(Background::Color(palette.danger.strong.color)),
-            ..base
-        },
-        Status::Disabled => disabled(base),
-    }
+    status_style(status, base, hover_color)
 }
 
 /// A text button; useful for links.
@@ -579,9 +768,25 @@ pub fn text(theme: &Theme, status: Status) -> Style {
     };
 
     match status {
-        Status::Active | Status::Pressed => base,
-        Status::Hovered => Style {
-            text_color: palette.background.base.text.scale_alpha(0.8),
+        Status::Active => base,
+        Status::Pressed {
+            animation_progress: progress,
+        } => Style {
+            text_color: palette
+                .background
+                .base
+                .text
+                .scale_alpha(0.8 + 0.2 * progress),
+            ..base
+        },
+        Status::Hovered {
+            animation_progress: progress,
+        } => Style {
+            text_color: palette
+                .background
+                .base
+                .text
+                .scale_alpha(1.0 - 0.2 * progress),
             ..base
         },
         Status::Disabled => disabled(base),
@@ -604,5 +809,42 @@ fn disabled(style: Style) -> Style {
             .map(|background| background.scale_alpha(0.5)),
         text_color: style.text_color.scale_alpha(0.5),
         ..style
+    }
+}
+
+/// Update an animation for a hover effect when the cursor moves
+fn hover_animation_on_cursor_move(
+    is_mouse_over: bool,
+    style_animation: &mut Animated<AnimationTarget, Instant>,
+    now: Instant,
+    forward_animation_duration: &AnimationDuration,
+    backward_animation_duration: &AnimationDuration,
+) -> bool {
+    if is_mouse_over {
+        if !style_animation.in_progress(now) {
+            if forward_animation_duration.enabled() {
+                style_animation.transition(AnimationTarget::Hovered, now);
+            } else {
+                style_animation
+                    .transition_instantaneous(AnimationTarget::Hovered, now);
+            }
+        }
+        true
+    } else {
+        // Change the animation's "direction" if it's still going back
+        // to the "Active" state
+        if matches!(style_animation.value, AnimationTarget::Hovered)
+            || matches!(style_animation.value, AnimationTarget::Pressed)
+        {
+            if backward_animation_duration.enabled() {
+                style_animation.transition(AnimationTarget::Active, now);
+            } else {
+                style_animation
+                    .transition_instantaneous(AnimationTarget::Active, now);
+            }
+            true
+        } else {
+            false
+        }
     }
 }

--- a/widget/src/button.rs
+++ b/widget/src/button.rs
@@ -611,7 +611,7 @@ pub enum Status {
 
 /// The [`AnimationTarget`] represents, through its ['FloatRepresentable`]
 /// implementation the ratio of color mixing between the base and hover colors.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 enum AnimationTarget {
     Active,
     Hovered,

--- a/widget/src/container.rs
+++ b/widget/src/container.rs
@@ -460,6 +460,7 @@ pub fn visible_bounds(id: Id) -> Task<Option<Rectangle>> {
             _state: &mut dyn widget::operation::Scrollable,
             _id: Option<&widget::Id>,
             bounds: Rectangle,
+            _content_bounds: Rectangle,
             translation: Vector,
         ) {
             match self.scrollables.last() {

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -11,14 +11,19 @@ use crate::core::touch;
 use crate::core::widget;
 use crate::core::widget::operation::{self, Operation};
 use crate::core::widget::tree::{self, Tree};
+use crate::core::window;
 use crate::core::{
     self, Background, Clipboard, Color, Element, Layout, Length, Padding,
     Pixels, Point, Rectangle, Shell, Size, Theme, Vector, Widget,
 };
-use crate::runtime::task::{self, Task};
-use crate::runtime::Action;
-
+use crate::runtime::{
+    task::{self, Task},
+    Action,
+};
+use lilt::Animated;
+use lilt::Easing::EaseOut;
 pub use operation::scrollable::{AbsoluteOffset, RelativeOffset};
+use std::time::Instant;
 
 /// A widget that can vertically display an infinite amount of content with a
 /// scrollbar.
@@ -39,6 +44,7 @@ pub struct Scrollable<
     content: Element<'a, Message, Theme, Renderer>,
     on_scroll: Option<Box<dyn Fn(Viewport) -> Message + 'a>>,
     class: Theme::Class<'a>,
+    animation_duration_ms: f32,
 }
 
 impl<'a, Message, Theme, Renderer> Scrollable<'a, Message, Theme, Renderer>
@@ -58,6 +64,7 @@ where
             content: content.into(),
             on_scroll: None,
             class: Theme::default(),
+            animation_duration_ms: 200.,
         }
         .validate()
     }
@@ -327,7 +334,7 @@ where
     }
 
     fn state(&self) -> tree::State {
-        tree::State::new(State::new())
+        tree::State::new(State::new(self.animation_duration_ms))
     }
 
     fn children(&self) -> Vec<Tree> {
@@ -472,10 +479,14 @@ where
                             return event::Status::Ignored;
                         };
 
-                        state.scroll_y_to(scrollbar.scroll_percentage_y(
-                            scroller_grabbed_at,
-                            cursor_position,
-                        ));
+                        state.scroll_y_to(
+                            scrollbar.scroll_percentage_y(
+                                scroller_grabbed_at,
+                                cursor_position,
+                            ),
+                            true,
+                        );
+                        shell.request_redraw(window::RedrawRequest::NextFrame);
 
                         let _ = notify_on_scroll(
                             state,
@@ -504,10 +515,14 @@ where
                         scrollbars.grab_y_scroller(cursor_position),
                         scrollbars.y,
                     ) {
-                        state.scroll_y_to(scrollbar.scroll_percentage_y(
-                            scroller_grabbed_at,
-                            cursor_position,
-                        ));
+                        state.scroll_y_to(
+                            scrollbar.scroll_percentage_y(
+                                scroller_grabbed_at,
+                                cursor_position,
+                            ),
+                            false,
+                        );
+                        shell.request_redraw(window::RedrawRequest::NextFrame);
 
                         state.y_scroller_grabbed_at = Some(scroller_grabbed_at);
 
@@ -535,10 +550,14 @@ where
                     };
 
                     if let Some(scrollbar) = scrollbars.x {
-                        state.scroll_x_to(scrollbar.scroll_percentage_x(
-                            scroller_grabbed_at,
-                            cursor_position,
-                        ));
+                        state.scroll_x_to(
+                            scrollbar.scroll_percentage_x(
+                                scroller_grabbed_at,
+                                cursor_position,
+                            ),
+                            true,
+                        );
+                        shell.request_redraw(window::RedrawRequest::NextFrame);
 
                         let _ = notify_on_scroll(
                             state,
@@ -567,10 +586,14 @@ where
                         scrollbars.grab_x_scroller(cursor_position),
                         scrollbars.x,
                     ) {
-                        state.scroll_x_to(scrollbar.scroll_percentage_x(
-                            scroller_grabbed_at,
-                            cursor_position,
-                        ));
+                        state.scroll_x_to(
+                            scrollbar.scroll_percentage_x(
+                                scroller_grabbed_at,
+                                cursor_position,
+                            ),
+                            false,
+                        );
+                        shell.request_redraw(window::RedrawRequest::NextFrame);
 
                         state.x_scroller_grabbed_at = Some(scroller_grabbed_at);
 
@@ -675,6 +698,7 @@ where
                 };
 
                 state.scroll(delta, self.direction, bounds, content_bounds);
+                shell.request_redraw(window::RedrawRequest::NextFrame);
 
                 event_status = if notify_on_scroll(
                     state,
@@ -720,6 +744,9 @@ where
                                 bounds,
                                 content_bounds,
                             );
+                            shell.request_redraw(
+                                window::RedrawRequest::NextFrame,
+                            );
 
                             state.scroll_area_touched_at =
                                 Some(cursor_position);
@@ -738,6 +765,13 @@ where
                 }
 
                 event_status = event::Status::Captured;
+            }
+            Event::Window(window::Event::RedrawRequested(now)) => {
+                if state.x_animation.in_progress(now)
+                    || state.y_animation.in_progress(now)
+                {
+                    shell.request_redraw(window::RedrawRequest::NextFrame);
+                }
             }
             _ => {}
         }
@@ -1115,7 +1149,7 @@ fn notify_on_scroll<Message>(
     true
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 struct State {
     scroll_area_touched_at: Option<Point>,
     offset_y_relative: f32,
@@ -1124,20 +1158,8 @@ struct State {
     x_scroller_grabbed_at: Option<f32>,
     keyboard_modifiers: keyboard::Modifiers,
     last_notified: Option<Viewport>,
-}
-
-impl Default for State {
-    fn default() -> Self {
-        Self {
-            scroll_area_touched_at: None,
-            offset_y_relative: 0.0,
-            y_scroller_grabbed_at: None,
-            offset_x_relative: 0.0,
-            x_scroller_grabbed_at: None,
-            keyboard_modifiers: keyboard::Modifiers::default(),
-            last_notified: None,
-        }
-    }
+    y_animation: Animated<f32, Instant>,
+    x_animation: Animated<f32, Instant>,
 }
 
 impl operation::Scrollable for State {
@@ -1254,8 +1276,22 @@ impl Viewport {
 
 impl State {
     /// Creates a new [`State`] with the scrollbar(s) at the beginning.
-    pub fn new() -> Self {
-        State::default()
+    pub fn new(animation_duration_ms: f32) -> Self {
+        Self {
+            scroll_area_touched_at: None,
+            offset_y_relative: 0.0,
+            y_scroller_grabbed_at: None,
+            offset_x_relative: 0.0,
+            x_scroller_grabbed_at: None,
+            keyboard_modifiers: keyboard::Modifiers::default(),
+            last_notified: None,
+            y_animation: Animated::new(0.0)
+                .easing(EaseOut)
+                .duration(animation_duration_ms),
+            x_animation: Animated::new(0.0)
+                .easing(EaseOut)
+                .duration(animation_duration_ms),
+        }
     }
 
     /// Apply a scrolling offset to the current [`State`], given the bounds of
@@ -1287,6 +1323,7 @@ impl State {
             align(vertical_alignment, delta.y),
         );
 
+        let now = Instant::now();
         if bounds.height < content_bounds.height {
             self.offset_y_relative =
                 ((Offset::Relative(self.offset_y_relative)
@@ -1294,6 +1331,7 @@ impl State {
                     - delta.y)
                     .clamp(0.0, content_bounds.height - bounds.height))
                     / (content_bounds.height - bounds.height);
+            self.y_animation.transition(self.offset_y_relative, now);
         }
 
         if bounds.width < content_bounds.width {
@@ -1303,6 +1341,7 @@ impl State {
                     - delta.x)
                     .clamp(0.0, content_bounds.width - bounds.width))
                     / (content_bounds.width - bounds.width);
+            self.x_animation.transition(self.offset_x_relative, now);
         }
     }
 
@@ -1310,22 +1349,43 @@ impl State {
     ///
     /// `0` represents scrollbar at the beginning, while `1` represents scrollbar at
     /// the end.
-    pub fn scroll_y_to(&mut self, percentage: f32) {
-        self.offset_y_relative = percentage.clamp(0.0, 1.0);
+    ///
+    /// When `instantaneous` is set to `true`, the transition uses no animation.
+    pub fn scroll_y_to(&mut self, percentage: f32, instantaneous: bool) {
+        let percentage = percentage.clamp(0.0, 1.0);
+        self.offset_y_relative = percentage;
+        if instantaneous {
+            self.y_animation
+                .transition_instantaneous(percentage, Instant::now());
+        } else {
+            self.y_animation.transition(percentage, Instant::now());
+        }
     }
 
     /// Scrolls the [`Scrollable`] to a relative amount along the x axis.
     ///
     /// `0` represents scrollbar at the beginning, while `1` represents scrollbar at
     /// the end.
-    pub fn scroll_x_to(&mut self, percentage: f32) {
-        self.offset_x_relative = percentage.clamp(0.0, 1.0);
+    ///
+    /// When `instantaneous` is set to `true`, the transition uses no animation.
+    pub fn scroll_x_to(&mut self, percentage: f32, instantaneous: bool) {
+        let percentage = percentage.clamp(0.0, 1.0);
+        self.offset_x_relative = percentage;
+        if instantaneous {
+            self.x_animation
+                .transition_instantaneous(percentage, Instant::now());
+        } else {
+            self.x_animation.transition(percentage, Instant::now());
+        }
     }
 
     /// Snaps the scroll position to a [`RelativeOffset`].
     pub fn snap_to(&mut self, offset: RelativeOffset) {
+        let now = Instant::now();
         self.offset_x_relative = offset.x.clamp(0.0, 1.0);
         self.offset_y_relative = offset.y.clamp(0.0, 1.0);
+        self.x_animation.transition(self.offset_x_relative, now);
+        self.y_animation.transition(self.offset_y_relative, now);
     }
 
     /// Scroll to the provided [`AbsoluteOffset`].
@@ -1335,10 +1395,15 @@ impl State {
         bounds: Rectangle,
         content_bounds: Rectangle,
     ) {
+        let now = Instant::now();
         self.offset_x_relative = Offset::Absolute(offset.x.max(0.0))
-            .relative(bounds.width, content_bounds.width);
+            .relative(bounds.width, content_bounds.width)
+            .clamp(0.0, 1.0);
         self.offset_y_relative = Offset::Absolute(offset.y.max(0.0))
-            .relative(bounds.height, content_bounds.height);
+            .relative(bounds.height, content_bounds.height)
+            .clamp(0.0, 1.0);
+        self.x_animation.transition(self.offset_x_relative, now);
+        self.y_animation.transition(self.offset_y_relative, now);
     }
 
     /// Returns the scrolling translation of the [`State`], given a [`Direction`],
@@ -1351,7 +1416,10 @@ impl State {
     ) -> Vector {
         Vector::new(
             if let Some(horizontal) = direction.horizontal() {
-                Offset::Relative(self.offset_x_relative).translation(
+                Offset::Relative(
+                    self.x_animation.animate(|target| target, Instant::now()),
+                )
+                .translation(
                     bounds.width,
                     content_bounds.width,
                     horizontal.alignment,
@@ -1360,7 +1428,10 @@ impl State {
                 0.0
             },
             if let Some(vertical) = direction.vertical() {
-                Offset::Relative(self.offset_y_relative).translation(
+                Offset::Relative(
+                    self.y_animation.animate(|target| target, Instant::now()),
+                )
+                .translation(
                     bounds.height,
                     content_bounds.height,
                     vertical.alignment,

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -421,6 +421,7 @@ where
             state,
             self.id.as_ref().map(|id| &id.0),
             bounds,
+            content_bounds,
             translation,
         );
 
@@ -1144,8 +1145,13 @@ impl operation::Scrollable for State {
         State::snap_to(self, offset);
     }
 
-    fn scroll_to(&mut self, offset: AbsoluteOffset) {
-        State::scroll_to(self, offset);
+    fn scroll_to(
+        &mut self,
+        offset: AbsoluteOffset,
+        bounds: Rectangle,
+        content_bounds: Rectangle,
+    ) {
+        State::scroll_to(self, offset, bounds, content_bounds);
     }
 }
 
@@ -1323,17 +1329,16 @@ impl State {
     }
 
     /// Scroll to the provided [`AbsoluteOffset`].
-    pub fn scroll_to(&mut self, offset: AbsoluteOffset) {
-        // TODO: do we have cases where `self.last_notified` is `None`?
-        if let Some(viewport) = self.last_notified {
-            self.offset_x_relative = Offset::Absolute(offset.x.max(0.0))
-                .relative(viewport.bounds.width, viewport.content_bounds.width);
-            self.offset_y_relative = Offset::Absolute(offset.y.max(0.0))
-                .relative(
-                    viewport.bounds.height,
-                    viewport.content_bounds.height,
-                );
-        }
+    pub fn scroll_to(
+        &mut self,
+        offset: AbsoluteOffset,
+        bounds: Rectangle,
+        content_bounds: Rectangle,
+    ) {
+        self.offset_x_relative = Offset::Absolute(offset.x.max(0.0))
+            .relative(bounds.width, content_bounds.width);
+        self.offset_y_relative = Offset::Absolute(offset.y.max(0.0))
+            .relative(bounds.height, content_bounds.height);
     }
 
     /// Returns the scrolling translation of the [`State`], given a [`Direction`],

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -99,7 +99,7 @@ pub enum CursorAnimationType {
 
 /// The [`AnimationTarget`] represents, through its ['FloatRepresentable`]
 /// implementation the ratio of opacity of the cursor during it's blink effect.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 enum AnimationTarget {
     Shown,
     Hidden,

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -21,6 +21,7 @@ use crate::core::keyboard::key;
 use crate::core::layout;
 use crate::core::mouse::{self, click};
 use crate::core::renderer;
+use crate::core::text::paragraph::Plain;
 use crate::core::text::{self, paragraph, Text};
 use crate::core::time::Instant;
 use crate::core::touch;
@@ -1207,9 +1208,9 @@ impl<P: text::Paragraph> Default for State<P> {
     fn default() -> Self {
         Self {
             cursor_animation: cursor_animation(CursorAnimationType::default()),
-            value: Default::default(),
-            placeholder: Default::default(),
-            icon: Default::default(),
+            value: Plain::default(),
+            placeholder: Plain::default(),
+            icon: Plain::default(),
             is_focused: false,
             is_dragging: false,
             is_pasting: None,

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -7,6 +7,8 @@ mod value;
 pub mod cursor;
 
 pub use cursor::Cursor;
+use iced_runtime::keyboard::Modifiers;
+use lilt::{Animated, FloatRepresentable};
 pub use value::Value;
 
 use editor::Editor;
@@ -19,9 +21,8 @@ use crate::core::keyboard::key;
 use crate::core::layout;
 use crate::core::mouse::{self, click};
 use crate::core::renderer;
-use crate::core::text::paragraph;
-use crate::core::text::{self, Text};
-use crate::core::time::{Duration, Instant};
+use crate::core::text::{self, paragraph, Text};
+use crate::core::time::Instant;
 use crate::core::touch;
 use crate::core::widget;
 use crate::core::widget::operation::{self, Operation};
@@ -33,6 +34,8 @@ use crate::core::{
 };
 use crate::runtime::task::{self, Task};
 use crate::runtime::Action;
+
+use self::cursor::CursorAnimation;
 
 /// A field that can be filled with text.
 ///
@@ -79,6 +82,35 @@ pub struct TextInput<
     on_submit: Option<Message>,
     icon: Option<Icon<Renderer::Font>>,
     class: Theme::Class<'a>,
+    cursor_animation_type: CursorAnimationType,
+    cursor_animation_style: CursorAnimation,
+}
+
+/// Type of animation for the ['TextInput'] cursor.
+#[derive(Debug, Clone, Copy, Default)]
+pub enum CursorAnimationType {
+    /// The cursor fades.
+    #[default]
+    Fade,
+    /// The cursor blinks.
+    Blink,
+}
+
+/// The [`AnimationTarget`] represents, through its ['FloatRepresentable`]
+/// implementation the ratio of opacity of the cursor during it's blink effect.
+#[derive(Debug, Clone)]
+enum AnimationTarget {
+    Shown,
+    Hidden,
+}
+
+impl FloatRepresentable for AnimationTarget {
+    fn float_value(&self) -> f32 {
+        match self {
+            AnimationTarget::Shown => 1.0,
+            AnimationTarget::Hidden => 0.0,
+        }
+    }
 }
 
 /// The default [`Padding`] of a [`TextInput`].
@@ -108,6 +140,8 @@ where
             on_submit: None,
             icon: None,
             class: Theme::default(),
+            cursor_animation_style: CursorAnimation::default(),
+            cursor_animation_type: CursorAnimationType::Fade,
         }
     }
 
@@ -308,6 +342,15 @@ where
         }
     }
 
+    /// Sets the animation style of the [`Cursor`].
+    pub fn set_cursor_animation_style(
+        mut self,
+        cursor_animation_style: CursorAnimation,
+    ) -> Self {
+        self.cursor_animation_style = cursor_animation_style;
+        self
+    }
+
     /// Draws the [`TextInput`] with the given [`Renderer`], overriding its
     /// [`Value`] if provided.
     ///
@@ -338,7 +381,7 @@ where
 
         let status = if is_disabled {
             Status::Disabled
-        } else if state.is_focused() {
+        } else if state.is_focused {
             Status::Focused
         } else if is_mouse_over {
             Status::Hovered
@@ -370,11 +413,7 @@ where
 
         let text = value.to_string();
 
-        let (cursor, offset, is_selecting) = if let Some(focus) = state
-            .is_focused
-            .as_ref()
-            .filter(|focus| focus.is_window_focused)
-        {
+        let (cursor, offset, is_selecting) = if state.is_focused {
             match state.cursor.state(value) {
                 cursor::State::Index(position) => {
                     let (text_value_width, offset) =
@@ -384,29 +423,22 @@ where
                             position,
                         );
 
-                    let is_cursor_visible = ((focus.now - focus.updated_at)
-                        .as_millis()
-                        / CURSOR_BLINK_INTERVAL_MILLIS)
-                        % 2
-                        == 0;
-
-                    let cursor = if is_cursor_visible {
-                        Some((
-                            renderer::Quad {
-                                bounds: Rectangle {
-                                    x: (text_bounds.x + text_value_width)
-                                        .floor(),
-                                    y: text_bounds.y,
-                                    width: 1.0,
-                                    height: text_bounds.height,
-                                },
-                                ..renderer::Quad::default()
+                    let mut cursor_color = style.value;
+                    cursor_color.a = state
+                        .cursor_animation
+                        .animate(|target| target.float_value(), Instant::now());
+                    let cursor = Some((
+                        renderer::Quad {
+                            bounds: Rectangle {
+                                x: text_bounds.x + text_value_width,
+                                y: text_bounds.y,
+                                width: 1.0,
+                                height: text_bounds.height,
                             },
-                            style.value,
-                        ))
-                    } else {
-                        None
-                    };
+                            ..renderer::Quad::default()
+                        },
+                        cursor_color,
+                    ));
 
                     (cursor, offset, false)
                 }
@@ -492,6 +524,13 @@ where
             draw(renderer, text_bounds);
         }
     }
+
+    fn reset_cursor(&self, state: &mut State<Renderer::Paragraph>) {
+        {
+            state.cursor_animation =
+                cursor_animation(self.cursor_animation_type);
+        };
+    }
 }
 
 impl<'a, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
@@ -515,7 +554,7 @@ where
         // Unfocus text input if it becomes disabled
         if self.on_input.is_none() {
             state.last_click = None;
-            state.is_focused = None;
+            state.is_focused = false;
             state.is_pasting = None;
             state.is_dragging = false;
         }
@@ -584,19 +623,7 @@ where
                     None
                 };
 
-                state.is_focused = if click_position.is_some() {
-                    state.is_focused.or_else(|| {
-                        let now = Instant::now();
-
-                        Some(Focus {
-                            updated_at: now,
-                            now,
-                            is_window_focused: true,
-                        })
-                    })
-                } else {
-                    None
-                };
+                state.is_focused = click_position.is_some();
 
                 if let Some(cursor_position) = click_position {
                     let text_layout = layout.children().next().unwrap();
@@ -705,13 +732,15 @@ where
             }) => {
                 let state = state::<Renderer>(tree);
 
-                if let Some(focus) = &mut state.is_focused {
+                if state.is_focused {
+                    self.reset_cursor(state);
+                }
+                if state.is_focused {
                     let Some(on_input) = &self.on_input else {
                         return event::Status::Ignored;
                     };
 
                     let modifiers = state.keyboard_modifiers;
-                    focus.updated_at = Instant::now();
 
                     match key.as_ref() {
                         keyboard::Key::Character("c")
@@ -813,7 +842,7 @@ where
                             let message = (on_input)(editor.contents());
                             shell.publish(message);
 
-                            focus.updated_at = Instant::now();
+                            self.reset_cursor(state);
 
                             update_cache(state, &self.value);
 
@@ -957,7 +986,7 @@ where
                             }
                         }
                         keyboard::Key::Named(key::Named::Escape) => {
-                            state.is_focused = None;
+                            state.is_focused = false;
                             state.is_dragging = false;
                             state.is_pasting = None;
 
@@ -980,7 +1009,7 @@ where
             Event::Keyboard(keyboard::Event::KeyReleased { key, .. }) => {
                 let state = state::<Renderer>(tree);
 
-                if state.is_focused.is_some() {
+                if state.is_focused {
                     match key.as_ref() {
                         keyboard::Key::Character("v") => {
                             state.is_pasting = None;
@@ -1007,38 +1036,20 @@ where
             }
             Event::Window(window::Event::Unfocused) => {
                 let state = state::<Renderer>(tree);
-
-                if let Some(focus) = &mut state.is_focused {
-                    focus.is_window_focused = false;
-                }
+                state.is_focused = false;
             }
             Event::Window(window::Event::Focused) => {
                 let state = state::<Renderer>(tree);
 
-                if let Some(focus) = &mut state.is_focused {
-                    focus.is_window_focused = true;
-                    focus.updated_at = Instant::now();
-
+                if state.is_focused {
                     shell.request_redraw(window::RedrawRequest::NextFrame);
                 }
             }
-            Event::Window(window::Event::RedrawRequested(now)) => {
+            Event::Window(window::Event::RedrawRequested(_now)) => {
                 let state = state::<Renderer>(tree);
 
-                if let Some(focus) = &mut state.is_focused {
-                    if focus.is_window_focused {
-                        focus.now = now;
-
-                        let millis_until_redraw = CURSOR_BLINK_INTERVAL_MILLIS
-                            - (now - focus.updated_at).as_millis()
-                                % CURSOR_BLINK_INTERVAL_MILLIS;
-
-                        shell.request_redraw(window::RedrawRequest::At(
-                            now + Duration::from_millis(
-                                millis_until_redraw as u64,
-                            ),
-                        ));
-                    }
+                if state.is_focused {
+                    shell.request_redraw(window::RedrawRequest::NextFrame);
                 }
             }
             _ => {}
@@ -1177,31 +1188,72 @@ pub fn select_all<T>(id: Id) -> Task<T> {
 }
 
 /// The state of a [`TextInput`].
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub struct State<P: text::Paragraph> {
     value: paragraph::Plain<P>,
     placeholder: paragraph::Plain<P>,
     icon: paragraph::Plain<P>,
-    is_focused: Option<Focus>,
+    is_focused: bool,
     is_dragging: bool,
     is_pasting: Option<Value>,
     last_click: Option<mouse::Click>,
     cursor: Cursor,
     keyboard_modifiers: keyboard::Modifiers,
+    cursor_animation: Animated<AnimationTarget, Instant>,
     // TODO: Add stateful horizontal scrolling offset
+}
+
+impl<P: text::Paragraph> Default for State<P> {
+    fn default() -> Self {
+        Self {
+            cursor_animation: cursor_animation(CursorAnimationType::default()),
+            value: Default::default(),
+            placeholder: Default::default(),
+            icon: Default::default(),
+            is_focused: false,
+            is_dragging: false,
+            is_pasting: None,
+            last_click: None,
+            cursor: Cursor::default(),
+            keyboard_modifiers: Modifiers::default(),
+        }
+    }
+}
+
+fn cursor_animation(
+    animation_type: CursorAnimationType,
+) -> Animated<AnimationTarget, Instant> {
+    Animated::new(AnimationTarget::Shown)
+        .duration(CURSOR_BLINK_INTERVAL_MILLIS)
+        .repeat_forever()
+        .auto_reverse()
+        .auto_start(AnimationTarget::Hidden, Instant::now())
+        .delay(CURSOR_BLINK_PAUSE_MILLIS)
+        .easing(cursor_blink_easing(animation_type))
+        .asymmetric_easing(cursor_blink_easing(animation_type))
+}
+
+fn cursor_blink_easing(animation_type: CursorAnimationType) -> lilt::Easing {
+    match animation_type {
+        CursorAnimationType::Fade => lilt::Easing::Custom(|x| {
+            if x < 0.3 {
+                0.0
+            } else if x > 0.9 {
+                1.0
+            } else {
+                (x - 0.3) / (0.9 - 0.3)
+            }
+        }),
+        CursorAnimationType::Blink => {
+            lilt::Easing::Custom(|x| if x < 0.5 { 0.0 } else { 1.0 })
+        }
+    }
 }
 
 fn state<Renderer: text::Renderer>(
     tree: &mut Tree,
 ) -> &mut State<Renderer::Paragraph> {
     tree.state.downcast_mut::<State<Renderer::Paragraph>>()
-}
-
-#[derive(Debug, Clone, Copy)]
-struct Focus {
-    updated_at: Instant,
-    now: Instant,
-    is_window_focused: bool,
 }
 
 impl<P: text::Paragraph> State<P> {
@@ -1211,23 +1263,24 @@ impl<P: text::Paragraph> State<P> {
     }
 
     /// Creates a new [`State`], representing a focused [`TextInput`].
-    pub fn focused() -> Self {
+    pub fn focused(cursor_animation_type: CursorAnimationType) -> Self {
         Self {
             value: paragraph::Plain::default(),
             placeholder: paragraph::Plain::default(),
             icon: paragraph::Plain::default(),
-            is_focused: None,
+            is_focused: false,
             is_dragging: false,
             is_pasting: None,
             last_click: None,
             cursor: Cursor::default(),
             keyboard_modifiers: keyboard::Modifiers::default(),
+            cursor_animation: cursor_animation(cursor_animation_type),
         }
     }
 
     /// Returns whether the [`TextInput`] is currently focused or not.
     pub fn is_focused(&self) -> bool {
-        self.is_focused.is_some()
+        self.is_focused
     }
 
     /// Returns the [`Cursor`] of the [`TextInput`].
@@ -1237,20 +1290,13 @@ impl<P: text::Paragraph> State<P> {
 
     /// Focuses the [`TextInput`].
     pub fn focus(&mut self) {
-        let now = Instant::now();
-
-        self.is_focused = Some(Focus {
-            updated_at: now,
-            now,
-            is_window_focused: true,
-        });
-
+        self.is_focused = true;
         self.move_cursor_to_end();
     }
 
     /// Unfocuses the [`TextInput`].
     pub fn unfocus(&mut self) {
-        self.is_focused = None;
+        self.is_focused = false;
     }
 
     /// Moves the [`Cursor`] of the [`TextInput`] to the front of the input text.
@@ -1311,7 +1357,7 @@ fn offset<P: text::Paragraph>(
     value: &Value,
     state: &State<P>,
 ) -> f32 {
-    if state.is_focused() {
+    if state.is_focused {
         let cursor = state.cursor();
 
         let focus_position = match cursor.state(value) {
@@ -1400,7 +1446,8 @@ fn replace_paragraph<Renderer>(
     });
 }
 
-const CURSOR_BLINK_INTERVAL_MILLIS: u128 = 500;
+const CURSOR_BLINK_INTERVAL_MILLIS: f32 = 600.0;
+const CURSOR_BLINK_PAUSE_MILLIS: f32 = 250.0;
 
 /// The possible status of a [`TextInput`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/widget/src/text_input/cursor.rs
+++ b/widget/src/text_input/cursor.rs
@@ -7,6 +7,16 @@ pub struct Cursor {
     state: State,
 }
 
+/// The animation styles for the [`Cursor`].
+#[derive(Debug, Clone, Copy, Default)]
+pub enum CursorAnimation {
+    /// Blink the cursor (visible then not visible in a loop)
+    Blink,
+    /// Fade from visible to invisible in a loop
+    #[default]
+    Fade,
+}
+
 /// The state of a [`Cursor`].
 #[derive(Debug, Copy, Clone)]
 pub enum State {


### PR DESCRIPTION
Hi!

This PR is the continuation / replacement of my previous work in #1855 which needed a heavy rebase as well as improvements for some edge cases.

This PR implements internal animations for some default widgets. The goal here is to make Iced applications appear smooth when hovering / clicking things, without breaking the API.
This heavily uses the frame subscription API as well as the brand new [lilt crate](https://crates.io/crates/lilt) (thanks @ejjonny !)


https://github.com/iced-rs/iced/assets/43273245/b9290c84-2571-4add-b083-84c5cb210db3

# Motivation

In many other toolkits out there, such as GTK, app developers can make GUIs without needing to handle widget animations by themselves, which makes for a better coding experience and a coherent ecosystem.

# Implementation

Animations are added to the widgets `State`, which use `lilt::Animated<...>` values that are then interpolated in the `draw()` function to render animated frames.
Animations are triggered by specific events, such as cursor movements.
The frame subscription API is used to request redraws until the animations are completed.

Widgets that have got animations are:
- **buttons**: hover and click style transitions

	I have had to make a kind of opinionated decision here. As of now, hovering a `Button` with the mouse transitions its color to a lighter/darker version for dark/light base colors, and pressing the `Button` reverts that effect back to the base color. However, this isn't very well suited to animations, as it makes the transition go from base to hover (hover), hover to base (pressed), then base to hover (release mouse button), then back from hover to base when not hovering it. On quick movements, it looks a bit odd. What other toolkits out there have been doing is a bit more linear: on a dark base color, hovering lightens it, pressing lightens it more, and so that there isn't too much back and forth between different variations.

	Also, buttons feature an asymmetric animation. The transition from idle to hovered is quicker than the one back to idle. That way, when moving the cursor rapidly between multiple widgets, you still get the feedback of the widgets "lighting" up when the cursor flies over them, and then you get a slower, smooth transition back to their idle state. Otherwise, having long animations would prevent the hover effects from being visible on fast cursor movements, and animations fast enough for it would feel too fast for the "back to idle" transition.
- **text input cursor**: cursor fades in and out when idle, but remains visible while typing
- **togglers**
- **checkboxes**
- **scrollables**: scrolling using the mouse wheel and clicking on the scrollbar follows an eased-out trajectory, whereas scrolling by grabbing the scrollbar remains instantaneous.

	To make the code simpler and the diff shorter, I've to do a bit of refactoring there. All offsets are now stored as relative offsets, but absolute offsets are still passed in arguments when necessary, only to be converted back to relative offsets (outside `draw()`).


This PR is divided in separate commits for an easier reviewing.

# Caveats

Due to the stateless nature of the widgets, I've encountered some edge cases where a widget would use what I call a "tainted" state in the code. For instance, in the `tour` example, the first checkbox of a page will share the same state as the first checkbox of the page that follows (first one of its kind in the state tree map). This can lead to the new checkbox already having an ongoing animation when being rendered for the first time. I've added checks to detect and fix "tainted" states, they are pretty straightforward, but I did not find a better way to handle this.

# What's next

If and when this PR lands, some more widgets can receive animations. However, the most important step that I intend to implement is a global animation speed multiplier, so that users can set it according to their preferences in the COSMIC desktop, for instance. It could also include some other user settings, such as animation styles for different widgets and so on.

Thanks for reading this!
