### PR TITLE
Add `Color::parse`

### DIFF
--- a/core/src/color.rs
+++ b/core/src/color.rs
@@ -88,10 +88,35 @@ impl Color {
         }
     }
 
+    /// Creates a [`Color`] from its linear RGBA components.
+    pub fn from_linear_rgba(r: f32, g: f32, b: f32, a: f32) -> Self {
+        // As described in:
+        // https://en.wikipedia.org/wiki/SRGB
+        fn gamma_component(u: f32) -> f32 {
+            if u < 0.0031308 {
+                12.92 * u
+            } else {
+                1.055 * u.powf(1.0 / 2.4) - 0.055
+            }
+        }
+
+        Self {
+            r: gamma_component(r),
+            g: gamma_component(g),
+            b: gamma_component(b),
+            a,
+        }
+    }
+
     /// Parses a [`Color`] from a hex string.
     ///
-    /// Supported formats are #rrggbb, #rrggbbaa, #rgb, and #rgba.
+    /// Supported formats are `#rrggbb`, `#rrggbbaa`, `#rgb`, and `#rgba`.
     /// The starting "#" is optional. Both uppercase and lowercase are supported.
+    ///
+    /// If you have a static color string, using the [`color!`] macro should be preferred
+    /// since it leverages hexadecimal literal notation and arithmetic directly.
+    ///
+    /// [`color!`]: crate::color!
     pub fn parse(s: &str) -> Option<Color> {
         let hex = s.strip_prefix('#').unwrap_or(s);
 
@@ -128,26 +153,6 @@ impl Color {
             ),
             _ => None?,
         })
-    }
-
-    /// Creates a [`Color`] from its linear RGBA components.
-    pub fn from_linear_rgba(r: f32, g: f32, b: f32, a: f32) -> Self {
-        // As described in:
-        // https://en.wikipedia.org/wiki/SRGB
-        fn gamma_component(u: f32) -> f32 {
-            if u < 0.0031308 {
-                12.92 * u
-            } else {
-                1.055 * u.powf(1.0 / 2.4) - 0.055
-            }
-        }
-
-        Self {
-            r: gamma_component(r),
-            g: gamma_component(g),
-            b: gamma_component(b),
-            a,
-        }
     }
 
     /// Converts the [`Color`] into its RGBA8 equivalent.

--- a/core/src/color.rs
+++ b/core/src/color.rs
@@ -1,5 +1,13 @@
 use palette::rgb::{Srgb, Srgba};
 
+#[derive(Debug, thiserror::Error)]
+/// Errors that can occur when constructing a [`Color`].
+pub enum ColorError {
+    #[error("The specified hex string is invalid. See supported formats.")]
+    /// The specified hex string is invalid. See supported formats.
+    InvalidHex,
+}
+
 /// A color in the `sRGB` color space.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub struct Color {
@@ -85,6 +93,52 @@ impl Color {
             g: f32::from(g) / 255.0,
             b: f32::from(b) / 255.0,
             a,
+        }
+    }
+
+    /// Creates a [`Color`] from a hex string. Supported formats are #rrggbb, #rrggbbaa, #rgb,
+    /// #rgba. The “#” is optional. Both uppercase and lowercase are supported.
+    pub fn from_hex(s: &str) -> Result<Color, ColorError> {
+        let hex = s.strip_prefix('#').unwrap_or(s);
+        let n_chars = hex.len();
+
+        let get_channel = |from: usize, to: usize| {
+            let num = usize::from_str_radix(&hex[from..=to], 16)
+                .map_err(|_| ColorError::InvalidHex)?
+                as f32
+                / 255.0;
+            // If we only got half a byte (one letter), expand it into a full byte (two letters)
+            Ok(if from == to { num + num * 16.0 } else { num })
+        };
+
+        if n_chars == 3 {
+            Ok(Color::from_rgb(
+                get_channel(0, 0)?,
+                get_channel(1, 1)?,
+                get_channel(2, 2)?,
+            ))
+        } else if n_chars == 6 {
+            Ok(Color::from_rgb(
+                get_channel(0, 1)?,
+                get_channel(2, 3)?,
+                get_channel(4, 5)?,
+            ))
+        } else if n_chars == 4 {
+            Ok(Color::from_rgba(
+                get_channel(0, 0)?,
+                get_channel(1, 1)?,
+                get_channel(2, 2)?,
+                get_channel(3, 3)?,
+            ))
+        } else if n_chars == 8 {
+            Ok(Color::from_rgba(
+                get_channel(0, 1)?,
+                get_channel(2, 3)?,
+                get_channel(4, 5)?,
+                get_channel(6, 7)?,
+            ))
+        } else {
+            Err(ColorError::InvalidHex)
         }
     }
 
@@ -272,5 +326,20 @@ mod tests {
         assert_relative_eq!(result.g, 0.5);
         assert_relative_eq!(result.b, 0.3);
         assert_relative_eq!(result.a, 1.0);
+    }
+
+    #[test]
+    fn from_hex() -> Result<(), ColorError> {
+        let tests = [
+            ("#ff0000", [255, 0, 0, 255]),
+            ("00ff0080", [0, 255, 0, 128]),
+            ("#F80", [255, 136, 0, 255]),
+            ("#00f1", [0, 0, 255, 17]),
+        ];
+        for (arg, expected) in tests {
+            assert_eq!(Color::from_hex(arg)?.into_rgba8(), expected);
+        }
+        assert!(Color::from_hex("invalid").is_err());
+        Ok(())
     }
 }


### PR DESCRIPTION
This function has certain advantages over creating hex colours with `color!`:
* It allows parsing of hex color strings
* It allows opacity to be specified in hex, such as `#ffffff00`
* It allows the shorthand `#fff` notation
* It has better error handling; you can, for example, do `color!(0xfafafa9)` and there won't be an error, despite the hex string being invalid

If this PR gets merged, I'll send another patch to have `color!` use `from_hex`.