### PR TITLE
Hide internal `Task` constructors

### DIFF
--- a/runtime/src/clipboard.rs
+++ b/runtime/src/clipboard.rs
@@ -1,7 +1,7 @@
 //! Access the clipboard.
 use crate::core::clipboard::Kind;
 use crate::futures::futures::channel::oneshot;
-use crate::Task;
+use crate::task::{self, Task};
 
 /// A clipboard action to be performed by some [`Task`].
 ///
@@ -27,7 +27,7 @@ pub enum Action {
 
 /// Read the current contents of the clipboard.
 pub fn read() -> Task<Option<String>> {
-    Task::oneshot(|channel| {
+    task::oneshot(|channel| {
         crate::Action::Clipboard(Action::Read {
             target: Kind::Standard,
             channel,
@@ -37,7 +37,7 @@ pub fn read() -> Task<Option<String>> {
 
 /// Read the current contents of the primary clipboard.
 pub fn read_primary() -> Task<Option<String>> {
-    Task::oneshot(|channel| {
+    task::oneshot(|channel| {
         crate::Action::Clipboard(Action::Read {
             target: Kind::Primary,
             channel,
@@ -47,7 +47,7 @@ pub fn read_primary() -> Task<Option<String>> {
 
 /// Write the given contents to the clipboard.
 pub fn write<T>(contents: String) -> Task<T> {
-    Task::effect(crate::Action::Clipboard(Action::Write {
+    task::effect(crate::Action::Clipboard(Action::Write {
         target: Kind::Standard,
         contents,
     }))
@@ -55,7 +55,7 @@ pub fn write<T>(contents: String) -> Task<T> {
 
 /// Write the given contents to the primary clipboard.
 pub fn write_primary<Message>(contents: String) -> Task<Message> {
-    Task::effect(crate::Action::Clipboard(Action::Write {
+    task::effect(crate::Action::Clipboard(Action::Write {
         target: Kind::Primary,
         contents,
     }))

--- a/runtime/src/font.rs
+++ b/runtime/src/font.rs
@@ -1,5 +1,6 @@
 //! Load and use fonts.
-use crate::{Action, Task};
+use crate::task::{self, Task};
+use crate::Action;
 use std::borrow::Cow;
 
 /// An error while loading a font.
@@ -8,7 +9,7 @@ pub enum Error {}
 
 /// Load a font from its bytes.
 pub fn load(bytes: impl Into<Cow<'static, [u8]>>) -> Task<Result<(), Error>> {
-    Task::oneshot(|channel| Action::LoadFont {
+    task::oneshot(|channel| Action::LoadFont {
         bytes: bytes.into(),
         channel,
     })

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -15,13 +15,12 @@ pub mod keyboard;
 pub mod overlay;
 pub mod program;
 pub mod system;
+pub mod task;
 pub mod user_interface;
 pub mod window;
 
 #[cfg(feature = "multi-window")]
 pub mod multi_window;
-
-mod task;
 
 // We disable debug capabilities on release builds unless the `debug` feature
 // is explicitly enabled.
@@ -127,5 +126,5 @@ where
 /// This will normally close any application windows and
 /// terminate the runtime loop.
 pub fn exit<T>() -> Task<T> {
-    Task::effect(Action::Exit)
+    task::effect(Action::Exit)
 }

--- a/runtime/src/window.rs
+++ b/runtime/src/window.rs
@@ -11,7 +11,7 @@ use crate::core::{Point, Size};
 use crate::futures::event;
 use crate::futures::futures::channel::oneshot;
 use crate::futures::Subscription;
-use crate::Task;
+use crate::task::{self, Task};
 
 pub use raw_window_handle;
 
@@ -210,99 +210,99 @@ pub fn close_requests() -> Subscription<Id> {
 pub fn open(settings: Settings) -> Task<Id> {
     let id = Id::unique();
 
-    Task::oneshot(|channel| {
+    task::oneshot(|channel| {
         crate::Action::Window(Action::Open(id, settings, channel))
     })
 }
 
 /// Closes the window with `id`.
 pub fn close<T>(id: Id) -> Task<T> {
-    Task::effect(crate::Action::Window(Action::Close(id)))
+    task::effect(crate::Action::Window(Action::Close(id)))
 }
 
 /// Gets the window [`Id`] of the oldest window.
 pub fn get_oldest() -> Task<Option<Id>> {
-    Task::oneshot(|channel| crate::Action::Window(Action::GetOldest(channel)))
+    task::oneshot(|channel| crate::Action::Window(Action::GetOldest(channel)))
 }
 
 /// Gets the window [`Id`] of the latest window.
 pub fn get_latest() -> Task<Option<Id>> {
-    Task::oneshot(|channel| crate::Action::Window(Action::GetLatest(channel)))
+    task::oneshot(|channel| crate::Action::Window(Action::GetLatest(channel)))
 }
 
 /// Begins dragging the window while the left mouse button is held.
 pub fn drag<T>(id: Id) -> Task<T> {
-    Task::effect(crate::Action::Window(Action::Drag(id)))
+    task::effect(crate::Action::Window(Action::Drag(id)))
 }
 
 /// Resizes the window to the given logical dimensions.
 pub fn resize<T>(id: Id, new_size: Size) -> Task<T> {
-    Task::effect(crate::Action::Window(Action::Resize(id, new_size)))
+    task::effect(crate::Action::Window(Action::Resize(id, new_size)))
 }
 
 /// Get the window's size in logical dimensions.
 pub fn get_size(id: Id) -> Task<Size> {
-    Task::oneshot(move |channel| {
+    task::oneshot(move |channel| {
         crate::Action::Window(Action::GetSize(id, channel))
     })
 }
 
 /// Gets the maximized state of the window with the given [`Id`].
 pub fn get_maximized(id: Id) -> Task<bool> {
-    Task::oneshot(move |channel| {
+    task::oneshot(move |channel| {
         crate::Action::Window(Action::GetMaximized(id, channel))
     })
 }
 
 /// Maximizes the window.
 pub fn maximize<T>(id: Id, maximized: bool) -> Task<T> {
-    Task::effect(crate::Action::Window(Action::Maximize(id, maximized)))
+    task::effect(crate::Action::Window(Action::Maximize(id, maximized)))
 }
 
 /// Gets the minimized state of the window with the given [`Id`].
 pub fn get_minimized(id: Id) -> Task<Option<bool>> {
-    Task::oneshot(move |channel| {
+    task::oneshot(move |channel| {
         crate::Action::Window(Action::GetMinimized(id, channel))
     })
 }
 
 /// Minimizes the window.
 pub fn minimize<T>(id: Id, minimized: bool) -> Task<T> {
-    Task::effect(crate::Action::Window(Action::Minimize(id, minimized)))
+    task::effect(crate::Action::Window(Action::Minimize(id, minimized)))
 }
 
 /// Gets the position in logical coordinates of the window with the given [`Id`].
 pub fn get_position(id: Id) -> Task<Option<Point>> {
-    Task::oneshot(move |channel| {
+    task::oneshot(move |channel| {
         crate::Action::Window(Action::GetPosition(id, channel))
     })
 }
 
 /// Moves the window to the given logical coordinates.
 pub fn move_to<T>(id: Id, position: Point) -> Task<T> {
-    Task::effect(crate::Action::Window(Action::Move(id, position)))
+    task::effect(crate::Action::Window(Action::Move(id, position)))
 }
 
 /// Changes the [`Mode`] of the window.
 pub fn change_mode<T>(id: Id, mode: Mode) -> Task<T> {
-    Task::effect(crate::Action::Window(Action::ChangeMode(id, mode)))
+    task::effect(crate::Action::Window(Action::ChangeMode(id, mode)))
 }
 
 /// Gets the current [`Mode`] of the window.
 pub fn get_mode(id: Id) -> Task<Mode> {
-    Task::oneshot(move |channel| {
+    task::oneshot(move |channel| {
         crate::Action::Window(Action::GetMode(id, channel))
     })
 }
 
 /// Toggles the window to maximized or back.
 pub fn toggle_maximize<T>(id: Id) -> Task<T> {
-    Task::effect(crate::Action::Window(Action::ToggleMaximize(id)))
+    task::effect(crate::Action::Window(Action::ToggleMaximize(id)))
 }
 
 /// Toggles the window decorations.
 pub fn toggle_decorations<T>(id: Id) -> Task<T> {
-    Task::effect(crate::Action::Window(Action::ToggleDecorations(id)))
+    task::effect(crate::Action::Window(Action::ToggleDecorations(id)))
 }
 
 /// Request user attention to the window. This has no effect if the application
@@ -315,7 +315,7 @@ pub fn request_user_attention<T>(
     id: Id,
     user_attention: Option<UserAttention>,
 ) -> Task<T> {
-    Task::effect(crate::Action::Window(Action::RequestUserAttention(
+    task::effect(crate::Action::Window(Action::RequestUserAttention(
         id,
         user_attention,
     )))
@@ -328,32 +328,32 @@ pub fn request_user_attention<T>(
 /// you are certain that's what the user wants. Focus stealing can cause an extremely disruptive
 /// user experience.
 pub fn gain_focus<T>(id: Id) -> Task<T> {
-    Task::effect(crate::Action::Window(Action::GainFocus(id)))
+    task::effect(crate::Action::Window(Action::GainFocus(id)))
 }
 
 /// Changes the window [`Level`].
 pub fn change_level<T>(id: Id, level: Level) -> Task<T> {
-    Task::effect(crate::Action::Window(Action::ChangeLevel(id, level)))
+    task::effect(crate::Action::Window(Action::ChangeLevel(id, level)))
 }
 
 /// Show the [system menu] at cursor position.
 ///
 /// [system menu]: https://en.wikipedia.org/wiki/Common_menus_in_Microsoft_Windows#System_menu
 pub fn show_system_menu<T>(id: Id) -> Task<T> {
-    Task::effect(crate::Action::Window(Action::ShowSystemMenu(id)))
+    task::effect(crate::Action::Window(Action::ShowSystemMenu(id)))
 }
 
 /// Gets an identifier unique to the window, provided by the underlying windowing system. This is
 /// not to be confused with [`Id`].
 pub fn get_raw_id<Message>(id: Id) -> Task<u64> {
-    Task::oneshot(|channel| {
+    task::oneshot(|channel| {
         crate::Action::Window(Action::GetRawId(id, channel))
     })
 }
 
 /// Changes the [`Icon`] of the window.
 pub fn change_icon<T>(id: Id, icon: Icon) -> Task<T> {
-    Task::effect(crate::Action::Window(Action::ChangeIcon(id, icon)))
+    task::effect(crate::Action::Window(Action::ChangeIcon(id, icon)))
 }
 
 /// Runs the given callback with the native window handle for the window with the given id.
@@ -366,7 +366,7 @@ pub fn run_with_handle<T>(
 where
     T: Send + 'static,
 {
-    Task::oneshot(move |channel| {
+    task::oneshot(move |channel| {
         crate::Action::Window(Action::RunWithHandle(
             id,
             Box::new(move |handle| {
@@ -378,7 +378,7 @@ where
 
 /// Captures a [`Screenshot`] from the window.
 pub fn screenshot(id: Id) -> Task<Screenshot> {
-    Task::oneshot(move |channel| {
+    task::oneshot(move |channel| {
         crate::Action::Window(Action::Screenshot(id, channel))
     })
 }

--- a/widget/src/container.rs
+++ b/widget/src/container.rs
@@ -13,7 +13,7 @@ use crate::core::{
     Padding, Pixels, Point, Rectangle, Shadow, Shell, Size, Theme, Vector,
     Widget,
 };
-use crate::runtime::Task;
+use crate::runtime::task::{self, Task};
 
 /// An element decorating some content.
 ///
@@ -538,7 +538,7 @@ pub fn visible_bounds(id: Id) -> Task<Option<Rectangle>> {
         }
     }
 
-    Task::widget(VisibleBounds {
+    task::widget(VisibleBounds {
         target: id.into(),
         depth: 0,
         scrollables: Vec::new(),

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -12,7 +12,8 @@ use crate::pick_list::{self, PickList};
 use crate::progress_bar::{self, ProgressBar};
 use crate::radio::{self, Radio};
 use crate::rule::{self, Rule};
-use crate::runtime::{Action, Task};
+use crate::runtime::task::{self, Task};
+use crate::runtime::Action;
 use crate::scrollable::{self, Scrollable};
 use crate::slider::{self, Slider};
 use crate::text::{self, Text};
@@ -930,12 +931,12 @@ where
 
 /// Focuses the previous focusable widget.
 pub fn focus_previous<T>() -> Task<T> {
-    Task::effect(Action::widget(operation::focusable::focus_previous()))
+    task::effect(Action::widget(operation::focusable::focus_previous()))
 }
 
 /// Focuses the next focusable widget.
 pub fn focus_next<T>() -> Task<T> {
-    Task::effect(Action::widget(operation::focusable::focus_next()))
+    task::effect(Action::widget(operation::focusable::focus_next()))
 }
 
 /// A container intercepting mouse events.

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -15,7 +15,8 @@ use crate::core::{
     self, Background, Border, Clipboard, Color, Element, Layout, Length,
     Pixels, Point, Rectangle, Shell, Size, Theme, Vector, Widget,
 };
-use crate::runtime::{Action, Task};
+use crate::runtime::task::{self, Task};
+use crate::runtime::Action;
 
 pub use operation::scrollable::{AbsoluteOffset, RelativeOffset};
 
@@ -955,13 +956,13 @@ impl From<Id> for widget::Id {
 /// Produces a [`Task`] that snaps the [`Scrollable`] with the given [`Id`]
 /// to the provided `percentage` along the x & y axis.
 pub fn snap_to<T>(id: Id, offset: RelativeOffset) -> Task<T> {
-    Task::effect(Action::widget(operation::scrollable::snap_to(id.0, offset)))
+    task::effect(Action::widget(operation::scrollable::snap_to(id.0, offset)))
 }
 
 /// Produces a [`Task`] that scrolls the [`Scrollable`] with the given [`Id`]
 /// to the provided [`AbsoluteOffset`] along the x & y axis.
 pub fn scroll_to<T>(id: Id, offset: AbsoluteOffset) -> Task<T> {
-    Task::effect(Action::widget(operation::scrollable::scroll_to(
+    task::effect(Action::widget(operation::scrollable::scroll_to(
         id.0, offset,
     )))
 }

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -30,7 +30,8 @@ use crate::core::{
     Background, Border, Color, Element, Layout, Length, Padding, Pixels, Point,
     Rectangle, Shell, Size, Theme, Vector, Widget,
 };
-use crate::runtime::{Action, Task};
+use crate::runtime::task::{self, Task};
+use crate::runtime::Action;
 
 /// A field that can be filled with text.
 ///
@@ -1142,13 +1143,13 @@ impl From<Id> for widget::Id {
 
 /// Produces a [`Task`] that focuses the [`TextInput`] with the given [`Id`].
 pub fn focus<T>(id: Id) -> Task<T> {
-    Task::effect(Action::widget(operation::focusable::focus(id.0)))
+    task::effect(Action::widget(operation::focusable::focus(id.0)))
 }
 
 /// Produces a [`Task`] that moves the cursor of the [`TextInput`] with the given [`Id`] to the
 /// end.
 pub fn move_cursor_to_end<T>(id: Id) -> Task<T> {
-    Task::effect(Action::widget(operation::text_input::move_cursor_to_end(
+    task::effect(Action::widget(operation::text_input::move_cursor_to_end(
         id.0,
     )))
 }
@@ -1156,7 +1157,7 @@ pub fn move_cursor_to_end<T>(id: Id) -> Task<T> {
 /// Produces a [`Task`] that moves the cursor of the [`TextInput`] with the given [`Id`] to the
 /// front.
 pub fn move_cursor_to_front<T>(id: Id) -> Task<T> {
-    Task::effect(Action::widget(operation::text_input::move_cursor_to_front(
+    task::effect(Action::widget(operation::text_input::move_cursor_to_front(
         id.0,
     )))
 }
@@ -1164,14 +1165,14 @@ pub fn move_cursor_to_front<T>(id: Id) -> Task<T> {
 /// Produces a [`Task`] that moves the cursor of the [`TextInput`] with the given [`Id`] to the
 /// provided position.
 pub fn move_cursor_to<T>(id: Id, position: usize) -> Task<T> {
-    Task::effect(Action::widget(operation::text_input::move_cursor_to(
+    task::effect(Action::widget(operation::text_input::move_cursor_to(
         id.0, position,
     )))
 }
 
 /// Produces a [`Task`] that selects all the content of the [`TextInput`] with the given [`Id`].
 pub fn select_all<T>(id: Id) -> Task<T> {
-    Task::effect(Action::widget(operation::text_input::select_all(id.0)))
+    task::effect(Action::widget(operation::text_input::select_all(id.0)))
 }
 
 /// The state of a [`TextInput`].

--- a/winit/src/program.rs
+++ b/winit/src/program.rs
@@ -203,7 +203,7 @@ where
 
     let (program, task) = runtime.enter(|| P::new(flags));
 
-    if let Some(stream) = task.into_stream() {
+    if let Some(stream) = runtime::task::into_stream(task) {
         runtime.run(stream);
     }
 
@@ -1114,7 +1114,7 @@ fn update<P: Program, E: Executor>(
         let task = runtime.enter(|| program.update(message));
         debug.update_finished();
 
-        if let Some(stream) = task.into_stream() {
+        if let Some(stream) = runtime::task::into_stream(task) {
             runtime.run(stream);
         }
     }

--- a/winit/src/system.rs
+++ b/winit/src/system.rs
@@ -5,7 +5,7 @@ use crate::runtime::{self, Task};
 
 /// Query for available system information.
 pub fn fetch_information() -> Task<Information> {
-    Task::oneshot(|channel| {
+    runtime::task::oneshot(|channel| {
         runtime::Action::System(Action::QueryInformation(channel))
     })
 }


### PR DESCRIPTION
This PR converts the private constructors of a `Task` into free functions inside the `task` module.

This way, we can expose the `Task` type publicly without necessarily exposing its internal constructors to users.
