### PR TITLE
Abortable `Task`

### DIFF
--- a/runtime/src/task.rs
+++ b/runtime/src/task.rs
@@ -55,24 +55,6 @@ impl<T> Task<T> {
         Self::stream(stream.map(f))
     }
 
-    /// Creates a new [`Task`] that runs the given [`Future`] and produces
-    /// its output.
-    pub fn future(future: impl Future<Output = T> + MaybeSend + 'static) -> Self
-    where
-        T: 'static,
-    {
-        Self::stream(stream::once(future))
-    }
-
-    /// Creates a new [`Task`] that runs the given [`Stream`] and produces
-    /// each of its items.
-    pub fn stream(stream: impl Stream<Item = T> + MaybeSend + 'static) -> Self
-    where
-        T: 'static,
-    {
-        Self(Some(boxed_stream(stream.map(Action::Output))))
-    }
-
     /// Combines the given tasks and produces a single [`Task`] that will run all of them
     /// in parallel.
     pub fn batch(tasks: impl IntoIterator<Item = Self>) -> Self
@@ -175,6 +157,24 @@ impl<T> Task<T> {
                 .filter_map(future::ready),
             ))),
         }
+    }
+
+    /// Creates a new [`Task`] that runs the given [`Future`] and produces
+    /// its output.
+    pub fn future(future: impl Future<Output = T> + MaybeSend + 'static) -> Self
+    where
+        T: 'static,
+    {
+        Self::stream(stream::once(future))
+    }
+
+    /// Creates a new [`Task`] that runs the given [`Stream`] and produces
+    /// each of its items.
+    pub fn stream(stream: impl Stream<Item = T> + MaybeSend + 'static) -> Self
+    where
+        T: 'static,
+    {
+        Self(Some(boxed_stream(stream.map(Action::Output))))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,8 +202,13 @@ pub use crate::core::{
     Length, Padding, Pixels, Point, Radians, Rectangle, Rotation, Shadow, Size,
     Theme, Transformation, Vector,
 };
-pub use crate::runtime::{exit, Task};
+pub use crate::runtime::exit;
 pub use iced_futures::Subscription;
+
+pub mod task {
+    //! Create runtime tasks.
+    pub use crate::runtime::task::{Handle, Task};
+}
 
 pub mod clipboard {
     //! Access the clipboard.
@@ -309,6 +314,7 @@ pub use executor::Executor;
 pub use font::Font;
 pub use renderer::Renderer;
 pub use settings::Settings;
+pub use task::Task;
 
 #[doc(inline)]
 pub use application::application;


### PR DESCRIPTION
This PR introduces the `Task::abortable` method, which returns a `task::Handle` that can be used to easily cancel a `Task` that has already been handled to the runtime.

This is useful for long-running tasks that are not well-suited to become subscriptions (i.e. may eventually finish on their own) and that may need to be canceled by the user, like downloading a file (yes, this means our `download_progress` example is outdated).