### PR TITLE
Introduce `stream::try_channel` helper

### DIFF
--- a/futures/src/stream.rs
+++ b/futures/src/stream.rs
@@ -23,3 +23,24 @@ where
 
     stream::select(receiver, runner)
 }
+
+/// Creates a new [`Stream`] that produces the items sent from a [`Future`]
+/// that can fail to the [`mpsc::Sender`] provided to the closure.
+pub fn try_channel<T, E, F>(
+    size: usize,
+    f: impl FnOnce(mpsc::Sender<T>) -> F,
+) -> impl Stream<Item = Result<T, E>>
+where
+    F: Future<Output = Result<(), E>>,
+{
+    let (sender, receiver) = mpsc::channel(size);
+
+    let runner = stream::once(f(sender)).filter_map(|result| async {
+        match result {
+            Ok(()) => None,
+            Err(error) => Some(Err(error)),
+        }
+    });
+
+    stream::select(receiver.map(Ok), runner)
+}


### PR DESCRIPTION
This PR introduces a `try_channel` helper to the `stream` module. It is analogous to the `channel` helper, but the `Future` returns a `Result`—useful when your futures can error fatally.