### PR TITLE
Add `resize_events` subscription to `window` module

### DIFF
--- a/core/src/window/event.rs
+++ b/core/src/window/event.rs
@@ -23,20 +23,10 @@ pub enum Event {
     Closed,
 
     /// A window was moved.
-    Moved {
-        /// The new logical x location of the window
-        x: i32,
-        /// The new logical y location of the window
-        y: i32,
-    },
+    Moved(Point),
 
     /// A window was resized.
-    Resized {
-        /// The new logical width of the window
-        width: u32,
-        /// The new logical height of the window
-        height: u32,
-    },
+    Resized(Size),
 
     /// A window redraw was requested.
     ///

--- a/runtime/src/window.rs
+++ b/runtime/src/window.rs
@@ -194,6 +194,17 @@ pub fn close_events() -> Subscription<Id> {
     })
 }
 
+/// Subscribes to all [`Event::Resized`] occurrences in the running application.
+pub fn resize_events() -> Subscription<(Id, Size)> {
+    event::listen_with(|event, _status, id| {
+        if let crate::core::Event::Window(Event::Resized(size)) = event {
+            Some((id, size))
+        } else {
+            None
+        }
+    })
+}
+
 /// Subscribes to all [`Event::CloseRequested`] occurences in the running application.
 pub fn close_requests() -> Subscription<Id> {
     event::listen_with(|event, _status, id| {

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -132,10 +132,10 @@ pub fn window_event(
         WindowEvent::Resized(new_size) => {
             let logical_size = new_size.to_logical(scale_factor);
 
-            Some(Event::Window(window::Event::Resized {
+            Some(Event::Window(window::Event::Resized(Size {
                 width: logical_size.width,
                 height: logical_size.height,
-            }))
+            })))
         }
         WindowEvent::CloseRequested => {
             Some(Event::Window(window::Event::CloseRequested))
@@ -277,7 +277,7 @@ pub fn window_event(
             let winit::dpi::LogicalPosition { x, y } =
                 position.to_logical(scale_factor);
 
-            Some(Event::Window(window::Event::Moved { x, y }))
+            Some(Event::Window(window::Event::Moved(Point::new(x, y))))
         }
         _ => None,
     }


### PR DESCRIPTION
Also use `f32` for the new sizes and positions of a window, since they are logical coordinates.