### PR TITLE
`rich_text` and `markdown` widgets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ svg = ["iced_widget/svg"]
 canvas = ["iced_widget/canvas"]
 # Enables the `QRCode` widget
 qr_code = ["iced_widget/qr_code"]
+# Enables the `markdown` widget
+markdown = ["iced_widget/markdown"]
 # Enables lazy widgets
 lazy = ["iced_widget/lazy"]
 # Enables a debug view in native platforms (press F12)
@@ -51,7 +53,7 @@ web-colors = ["iced_renderer/web-colors"]
 # Enables the WebGL backend, replacing WebGPU
 webgl = ["iced_renderer/webgl"]
 # Enables the syntax `highlighter` module
-highlighter = ["iced_highlighter"]
+highlighter = ["iced_highlighter", "iced_widget/highlighter"]
 # Enables experimental multi-window support.
 multi-window = ["iced_winit/multi-window"]
 # Enables the advanced module
@@ -155,6 +157,7 @@ num-traits = "0.2"
 once_cell = "1.0"
 ouroboros = "0.18"
 palette = "0.7"
+pulldown-cmark = "0.11"
 qrcode = { version = "0.13", default-features = false }
 raw-window-handle = "0.6"
 resvg = "0.42"

--- a/core/src/renderer/null.rs
+++ b/core/src/renderer/null.rs
@@ -77,6 +77,11 @@ impl text::Paragraph for () {
 
     fn with_text(_text: Text<&str>) -> Self {}
 
+    fn with_spans(
+        _text: Text<&[text::Span<'_, Self::Font>], Self::Font>,
+    ) -> Self {
+    }
+
     fn resize(&mut self, _new_bounds: Size) {}
 
     fn compare(&self, _text: Text<()>) -> text::Difference {

--- a/core/src/renderer/null.rs
+++ b/core/src/renderer/null.rs
@@ -79,7 +79,7 @@ impl text::Paragraph for () {
 
     fn resize(&mut self, _new_bounds: Size) {}
 
-    fn compare(&self, _text: Text<&str>) -> text::Difference {
+    fn compare(&self, _text: Text<()>) -> text::Difference {
         text::Difference::None
     }
 

--- a/core/src/text.rs
+++ b/core/src/text.rs
@@ -1,8 +1,7 @@
 //! Draw and interact with text.
-mod paragraph;
-
 pub mod editor;
 pub mod highlighter;
+pub mod paragraph;
 
 pub use editor::Editor;
 pub use highlighter::Highlighter;

--- a/core/src/text.rs
+++ b/core/src/text.rs
@@ -267,9 +267,21 @@ impl<'a, Font> Span<'a, Font> {
         self
     }
 
+    /// Sets the font of the [`Span`], if any.
+    pub fn font_maybe(mut self, font: Option<impl Into<Font>>) -> Self {
+        self.font = font.map(Into::into);
+        self
+    }
+
     /// Sets the [`Color`] of the [`Span`].
     pub fn color(mut self, color: impl Into<Color>) -> Self {
         self.color = Some(color.into());
+        self
+    }
+
+    /// Sets the [`Color`] of the [`Span`], if any.
+    pub fn color_maybe(mut self, color: Option<impl Into<Color>>) -> Self {
+        self.color = color.map(Into::into);
         self
     }
 

--- a/core/src/text/paragraph.rs
+++ b/core/src/text/paragraph.rs
@@ -1,6 +1,6 @@
 //! Draw paragraphs.
 use crate::alignment;
-use crate::text::{Difference, Hit, Text};
+use crate::text::{Difference, Hit, Span, Text};
 use crate::{Point, Size};
 
 /// A text paragraph.
@@ -10,6 +10,9 @@ pub trait Paragraph: Sized + Default {
 
     /// Creates a new [`Paragraph`] laid out with the given [`Text`].
     fn with_text(text: Text<&str, Self::Font>) -> Self;
+
+    /// Creates a new [`Paragraph`] laid out with the given [`Text`].
+    fn with_spans(text: Text<&[Span<'_, Self::Font>], Self::Font>) -> Self;
 
     /// Lays out the [`Paragraph`] with some new boundaries.
     fn resize(&mut self, new_bounds: Size);

--- a/core/src/widget/text.rs
+++ b/core/src/widget/text.rs
@@ -3,7 +3,8 @@ use crate::alignment;
 use crate::layout;
 use crate::mouse;
 use crate::renderer;
-use crate::text::{self, Paragraph};
+use crate::text;
+use crate::text::paragraph::{self, Paragraph};
 use crate::widget::tree::{self, Tree};
 use crate::{
     Color, Element, Layout, Length, Pixels, Point, Rectangle, Size, Theme,
@@ -155,7 +156,7 @@ where
 
 /// The internal state of a [`Text`] widget.
 #[derive(Debug, Default)]
-pub struct State<P: Paragraph>(P);
+pub struct State<P: Paragraph>(paragraph::Plain<P>);
 
 impl<'a, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
     for Text<'a, Theme, Renderer>
@@ -168,7 +169,9 @@ where
     }
 
     fn state(&self) -> tree::State {
-        tree::State::new(State(Renderer::Paragraph::default()))
+        tree::State::new(State::<Renderer::Paragraph>(
+            paragraph::Plain::default(),
+        ))
     }
 
     fn size(&self) -> Size<Length> {
@@ -294,7 +297,7 @@ pub fn draw<Renderer>(
     };
 
     renderer.fill_paragraph(
-        paragraph,
+        paragraph.raw(),
         Point::new(x, y),
         appearance.color.unwrap_or(style.text_color),
         *viewport,

--- a/examples/editor/src/main.rs
+++ b/examples/editor/src/main.rs
@@ -189,7 +189,7 @@ impl Editor {
                 .highlight::<Highlighter>(
                     highlighter::Settings {
                         theme: self.theme,
-                        extension: self
+                        token: self
                             .file
                             .as_deref()
                             .and_then(Path::extension)

--- a/examples/markdown/Cargo.toml
+++ b/examples/markdown/Cargo.toml
@@ -7,6 +7,4 @@ publish = false
 
 [dependencies]
 iced.workspace = true
-iced.features = ["highlighter", "debug"]
-
-pulldown-cmark = "0.11"
+iced.features = ["markdown", "highlighter", "debug"]

--- a/examples/markdown/Cargo.toml
+++ b/examples/markdown/Cargo.toml
@@ -7,6 +7,6 @@ publish = false
 
 [dependencies]
 iced.workspace = true
-iced.features = ["debug"]
+iced.features = ["highlighter", "debug"]
 
 pulldown-cmark = "0.11"

--- a/examples/markdown/Cargo.toml
+++ b/examples/markdown/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "markdown"
+version = "0.1.0"
+authors = ["Héctor Ramón Jiménez <hector0193@gmail.com>"]
+edition = "2021"
+publish = false
+
+[dependencies]
+iced.workspace = true
+iced.features = ["debug"]
+
+pulldown-cmark = "0.11"

--- a/examples/markdown/overview.md
+++ b/examples/markdown/overview.md
@@ -1,0 +1,102 @@
+# Overview
+
+Inspired by [The Elm Architecture], Iced expects you to split user interfaces
+into four different concepts:
+
+* __State__ — the state of your application
+* __Messages__ — user interactions or meaningful events that you care
+  about
+* __View logic__ — a way to display your __state__ as widgets that
+  may produce __messages__ on user interaction
+* __Update logic__ — a way to react to __messages__ and update your
+  __state__
+
+We can build something to see how this works! Let's say we want a simple counter
+that can be incremented and decremented using two buttons.
+
+We start by modelling the __state__ of our application:
+
+```rust
+#[derive(Default)]
+struct Counter {
+    value: i32,
+}
+```
+
+Next, we need to define the possible user interactions of our counter:
+the button presses. These interactions are our __messages__:
+
+```rust
+#[derive(Debug, Clone, Copy)]
+pub enum Message {
+    Increment,
+    Decrement,
+}
+```
+
+Now, let's show the actual counter by putting it all together in our
+__view logic__:
+
+```rust
+use iced::widget::{button, column, text, Column};
+
+impl Counter {
+    pub fn view(&self) -> Column<Message> {
+        // We use a column: a simple vertical layout
+        column![
+            // The increment button. We tell it to produce an
+            // `Increment` message when pressed
+            button("+").on_press(Message::Increment),
+
+            // We show the value of the counter here
+            text(self.value).size(50),
+
+            // The decrement button. We tell it to produce a
+            // `Decrement` message when pressed
+            button("-").on_press(Message::Decrement),
+        ]
+    }
+}
+```
+
+Finally, we need to be able to react to any produced __messages__ and change our
+__state__ accordingly in our __update logic__:
+
+```rust
+impl Counter {
+    // ...
+
+    pub fn update(&mut self, message: Message) {
+        match message {
+            Message::Increment => {
+                self.value += 1;
+            }
+            Message::Decrement => {
+                self.value -= 1;
+            }
+        }
+    }
+}
+```
+
+And that's everything! We just wrote a whole user interface. Let's run it:
+
+```rust
+fn main() -> iced::Result {
+    iced::run("A cool counter", Counter::update, Counter::view)
+}
+```
+
+Iced will automatically:
+
+  1. Take the result of our __view logic__ and layout its widgets.
+  1. Process events from our system and produce __messages__ for our
+     __update logic__.
+  1. Draw the resulting user interface.
+
+Read the [book], the [documentation], and the [examples] to learn more!
+
+[book]: https://book.iced.rs/
+[documentation]: https://docs.rs/iced/
+[examples]: https://github.com/iced-rs/iced/tree/master/examples#examples
+[The Elm Architecture]: https://guide.elm-lang.org/architecture/

--- a/examples/markdown/src/main.rs
+++ b/examples/markdown/src/main.rs
@@ -1,7 +1,4 @@
-use iced::widget::{
-    self, column, container, rich_text, row, scrollable, span, text,
-    text_editor,
-};
+use iced::widget::{self, markdown, row, scrollable, text_editor};
 use iced::{Element, Fill, Font, Task, Theme};
 
 pub fn main() -> iced::Result {
@@ -12,7 +9,7 @@ pub fn main() -> iced::Result {
 
 struct Markdown {
     content: text_editor::Content,
-    items: Vec<Item>,
+    items: Vec<markdown::Item>,
     theme: Theme,
 }
 
@@ -30,7 +27,8 @@ impl Markdown {
         (
             Self {
                 content: text_editor::Content::with_text(INITIAL_CONTENT),
-                items: parse(INITIAL_CONTENT, &theme).collect(),
+                items: markdown::parse(INITIAL_CONTENT, theme.palette())
+                    .collect(),
                 theme,
             },
             widget::focus_next(),
@@ -44,8 +42,11 @@ impl Markdown {
                 self.content.perform(action);
 
                 if is_edit {
-                    self.items =
-                        parse(&self.content.text(), &self.theme).collect();
+                    self.items = markdown::parse(
+                        &self.content.text(),
+                        self.theme.palette(),
+                    )
+                    .collect();
                 }
             }
         }
@@ -69,211 +70,4 @@ impl Markdown {
     fn theme(&self) -> Theme {
         Theme::TokyoNight
     }
-}
-
-fn markdown<'a>(
-    items: impl IntoIterator<Item = &'a Item>,
-) -> Element<'a, Message> {
-    use iced::padding;
-
-    let blocks = items.into_iter().enumerate().map(|(i, item)| match item {
-        Item::Heading(heading) => container(rich_text(heading))
-            .padding(padding::top(if i > 0 { 8 } else { 0 }))
-            .into(),
-        Item::Paragraph(paragraph) => rich_text(paragraph).into(),
-        Item::List { start: None, items } => column(
-            items
-                .iter()
-                .map(|item| row!["•", rich_text(item)].spacing(10).into()),
-        )
-        .spacing(10)
-        .into(),
-        Item::List {
-            start: Some(start),
-            items,
-        } => column(items.iter().enumerate().map(|(i, item)| {
-            row![text!("{}.", i as u64 + *start), rich_text(item)]
-                .spacing(10)
-                .into()
-        }))
-        .spacing(10)
-        .into(),
-        Item::CodeBlock(code) => {
-            container(rich_text(code).font(Font::MONOSPACE).size(12))
-                .width(Fill)
-                .padding(10)
-                .style(container::rounded_box)
-                .into()
-        }
-    });
-
-    column(blocks).width(Fill).spacing(16).into()
-}
-
-#[derive(Debug, Clone)]
-enum Item {
-    Heading(Vec<text::Span<'static>>),
-    Paragraph(Vec<text::Span<'static>>),
-    CodeBlock(Vec<text::Span<'static>>),
-    List {
-        start: Option<u64>,
-        items: Vec<Vec<text::Span<'static>>>,
-    },
-}
-
-fn parse<'a>(
-    markdown: &'a str,
-    theme: &'a Theme,
-) -> impl Iterator<Item = Item> + 'a {
-    use iced::font;
-    use iced::highlighter::{self, Highlighter};
-    use text::Highlighter as _;
-
-    let mut spans = Vec::new();
-    let mut heading = None;
-    let mut strong = false;
-    let mut emphasis = false;
-    let mut link = false;
-    let mut list = Vec::new();
-    let mut list_start = None;
-    let mut highlighter = None;
-
-    let parser = pulldown_cmark::Parser::new(markdown);
-
-    // We want to keep the `spans` capacity
-    #[allow(clippy::drain_collect)]
-    parser.filter_map(move |event| match event {
-        pulldown_cmark::Event::Start(tag) => match tag {
-            pulldown_cmark::Tag::Heading { level, .. } => {
-                heading = Some(level);
-                None
-            }
-            pulldown_cmark::Tag::Strong => {
-                strong = true;
-                None
-            }
-            pulldown_cmark::Tag::Emphasis => {
-                emphasis = true;
-                None
-            }
-            pulldown_cmark::Tag::Link { .. } => {
-                link = true;
-                None
-            }
-            pulldown_cmark::Tag::List(first_item) => {
-                list_start = first_item;
-                None
-            }
-            pulldown_cmark::Tag::CodeBlock(
-                pulldown_cmark::CodeBlockKind::Fenced(language),
-            ) => {
-                highlighter = Some(Highlighter::new(&highlighter::Settings {
-                    theme: highlighter::Theme::Base16Ocean,
-                    token: language.to_string(),
-                }));
-
-                None
-            }
-            _ => None,
-        },
-        pulldown_cmark::Event::End(tag) => match tag {
-            pulldown_cmark::TagEnd::Heading(_) => {
-                heading = None;
-                Some(Item::Heading(spans.drain(..).collect()))
-            }
-            pulldown_cmark::TagEnd::Emphasis => {
-                emphasis = false;
-                None
-            }
-            pulldown_cmark::TagEnd::Strong => {
-                strong = false;
-                None
-            }
-            pulldown_cmark::TagEnd::Link => {
-                link = false;
-                None
-            }
-            pulldown_cmark::TagEnd::Paragraph => {
-                Some(Item::Paragraph(spans.drain(..).collect()))
-            }
-            pulldown_cmark::TagEnd::List(_) => Some(Item::List {
-                start: list_start,
-                items: list.drain(..).collect(),
-            }),
-            pulldown_cmark::TagEnd::Item => {
-                list.push(spans.drain(..).collect());
-                None
-            }
-            pulldown_cmark::TagEnd::CodeBlock => {
-                highlighter = None;
-                Some(Item::CodeBlock(spans.drain(..).collect()))
-            }
-            _ => None,
-        },
-        pulldown_cmark::Event::Text(text) => {
-            if let Some(highlighter) = &mut highlighter {
-                for (range, highlight) in
-                    highlighter.highlight_line(text.as_ref())
-                {
-                    let span = span(text[range].to_owned())
-                        .color_maybe(highlight.color())
-                        .font_maybe(highlight.font());
-
-                    spans.push(span);
-                }
-            } else {
-                let span = span(text.into_string());
-
-                let span = match heading {
-                    None => span,
-                    Some(heading) => span.size(match heading {
-                        pulldown_cmark::HeadingLevel::H1 => 32,
-                        pulldown_cmark::HeadingLevel::H2 => 28,
-                        pulldown_cmark::HeadingLevel::H3 => 24,
-                        pulldown_cmark::HeadingLevel::H4 => 20,
-                        pulldown_cmark::HeadingLevel::H5 => 16,
-                        pulldown_cmark::HeadingLevel::H6 => 16,
-                    }),
-                };
-
-                let span = if strong || emphasis {
-                    span.font(Font {
-                        weight: if strong {
-                            font::Weight::Bold
-                        } else {
-                            font::Weight::Normal
-                        },
-                        style: if emphasis {
-                            font::Style::Italic
-                        } else {
-                            font::Style::Normal
-                        },
-                        ..Font::default()
-                    })
-                } else {
-                    span
-                };
-
-                let span =
-                    span.color_maybe(link.then(|| theme.palette().primary));
-
-                spans.push(span);
-            }
-
-            None
-        }
-        pulldown_cmark::Event::Code(code) => {
-            spans.push(span(code.into_string()).font(Font::MONOSPACE));
-            None
-        }
-        pulldown_cmark::Event::SoftBreak => {
-            spans.push(span(" "));
-            None
-        }
-        pulldown_cmark::Event::HardBreak => {
-            spans.push(span("\n"));
-            None
-        }
-        _ => None,
-    })
 }

--- a/examples/markdown/src/main.rs
+++ b/examples/markdown/src/main.rs
@@ -1,0 +1,172 @@
+use iced::font;
+use iced::padding;
+use iced::widget::{
+    self, column, container, rich_text, row, span, text_editor,
+};
+use iced::{Element, Fill, Font, Task, Theme};
+
+pub fn main() -> iced::Result {
+    iced::application("Markdown - Iced", Markdown::update, Markdown::view)
+        .theme(Markdown::theme)
+        .run_with(Markdown::new)
+}
+
+struct Markdown {
+    content: text_editor::Content,
+}
+
+#[derive(Debug, Clone)]
+enum Message {
+    Edit(text_editor::Action),
+}
+
+impl Markdown {
+    fn new() -> (Self, Task<Message>) {
+        (
+            Self {
+                content: text_editor::Content::with_text(
+                    "# Markdown Editor\nType your Markdown here...",
+                ),
+            },
+            widget::focus_next(),
+        )
+    }
+    fn update(&mut self, message: Message) {
+        match message {
+            Message::Edit(action) => {
+                self.content.perform(action);
+            }
+        }
+    }
+
+    fn view(&self) -> Element<Message> {
+        let editor = text_editor(&self.content)
+            .on_action(Message::Edit)
+            .height(Fill)
+            .padding(10)
+            .font(Font::MONOSPACE);
+
+        let preview = {
+            let markdown = self.content.text();
+            let parser = pulldown_cmark::Parser::new(&markdown);
+
+            let mut strong = false;
+            let mut emphasis = false;
+            let mut heading = None;
+            let mut spans = Vec::new();
+
+            let items = parser.filter_map(|event| match event {
+                pulldown_cmark::Event::Start(tag) => match tag {
+                    pulldown_cmark::Tag::Strong => {
+                        strong = true;
+                        None
+                    }
+                    pulldown_cmark::Tag::Emphasis => {
+                        emphasis = true;
+                        None
+                    }
+                    pulldown_cmark::Tag::Heading { level, .. } => {
+                        heading = Some(level);
+                        None
+                    }
+                    _ => None,
+                },
+                pulldown_cmark::Event::End(tag) => match tag {
+                    pulldown_cmark::TagEnd::Emphasis => {
+                        emphasis = false;
+                        None
+                    }
+                    pulldown_cmark::TagEnd::Strong => {
+                        strong = false;
+                        None
+                    }
+                    pulldown_cmark::TagEnd::Heading(_) => {
+                        heading = None;
+                        Some(
+                            container(rich_text(spans.drain(..)))
+                                .padding(padding::bottom(5))
+                                .into(),
+                        )
+                    }
+                    pulldown_cmark::TagEnd::Paragraph => Some(
+                        container(rich_text(spans.drain(..)))
+                            .padding(padding::bottom(15))
+                            .into(),
+                    ),
+                    pulldown_cmark::TagEnd::CodeBlock => Some(
+                        container(
+                            container(
+                                rich_text(spans.drain(..))
+                                    .font(Font::MONOSPACE),
+                            )
+                            .width(Fill)
+                            .padding(10)
+                            .style(container::rounded_box),
+                        )
+                        .padding(padding::bottom(15))
+                        .into(),
+                    ),
+                    _ => None,
+                },
+                pulldown_cmark::Event::Text(text) => {
+                    let span = span(text.into_string());
+
+                    let span = match heading {
+                        None => span,
+                        Some(heading) => span.size(match heading {
+                            pulldown_cmark::HeadingLevel::H1 => 32,
+                            pulldown_cmark::HeadingLevel::H2 => 28,
+                            pulldown_cmark::HeadingLevel::H3 => 24,
+                            pulldown_cmark::HeadingLevel::H4 => 20,
+                            pulldown_cmark::HeadingLevel::H5 => 16,
+                            pulldown_cmark::HeadingLevel::H6 => 16,
+                        }),
+                    };
+
+                    let span = if strong || emphasis {
+                        span.font(Font {
+                            weight: if strong {
+                                font::Weight::Bold
+                            } else {
+                                font::Weight::Normal
+                            },
+                            style: if emphasis {
+                                font::Style::Italic
+                            } else {
+                                font::Style::Normal
+                            },
+                            ..Font::default()
+                        })
+                    } else {
+                        span
+                    };
+
+                    spans.push(span);
+
+                    None
+                }
+                pulldown_cmark::Event::Code(code) => {
+                    spans.push(span(code.into_string()).font(Font::MONOSPACE));
+                    None
+                }
+                pulldown_cmark::Event::SoftBreak => {
+                    spans.push(span(" "));
+                    None
+                }
+                pulldown_cmark::Event::HardBreak => {
+                    spans.push(span("\n"));
+                    None
+                }
+                _ => None,
+            });
+
+            column(items).width(Fill)
+        };
+
+        row![editor, preview].spacing(10).padding(10).into()
+    }
+
+    fn theme(&self) -> Theme {
+        Theme::TokyoNight
+    }
+}

--- a/examples/markdown/src/main.rs
+++ b/examples/markdown/src/main.rs
@@ -60,13 +60,10 @@ impl Markdown {
 
         let preview = markdown(&self.items);
 
-        row![
-            editor,
-            scrollable(preview).spacing(10).width(Fill).height(Fill)
-        ]
-        .spacing(10)
-        .padding(10)
-        .into()
+        row![editor, scrollable(preview).spacing(10).height(Fill)]
+            .spacing(10)
+            .padding(10)
+            .into()
     }
 
     fn theme(&self) -> Theme {

--- a/examples/markdown/src/main.rs
+++ b/examples/markdown/src/main.rs
@@ -1,7 +1,6 @@
-use iced::font;
-use iced::padding;
 use iced::widget::{
-    self, column, container, rich_text, row, span, text_editor,
+    self, column, container, rich_text, row, scrollable, span, text,
+    text_editor,
 };
 use iced::{Element, Fill, Font, Task, Theme};
 
@@ -13,6 +12,8 @@ pub fn main() -> iced::Result {
 
 struct Markdown {
     content: text_editor::Content,
+    items: Vec<Item>,
+    theme: Theme,
 }
 
 #[derive(Debug, Clone)]
@@ -22,11 +23,15 @@ enum Message {
 
 impl Markdown {
     fn new() -> (Self, Task<Message>) {
+        const INITIAL_CONTENT: &str = include_str!("../overview.md");
+
+        let theme = Theme::TokyoNight;
+
         (
             Self {
-                content: text_editor::Content::with_text(
-                    "# Markdown Editor\nType your Markdown here...",
-                ),
+                content: text_editor::Content::with_text(INITIAL_CONTENT),
+                items: parse(INITIAL_CONTENT, &theme).collect(),
+                theme,
             },
             widget::focus_next(),
         )
@@ -34,7 +39,14 @@ impl Markdown {
     fn update(&mut self, message: Message) {
         match message {
             Message::Edit(action) => {
+                let is_edit = action.is_edit();
+
                 self.content.perform(action);
+
+                if is_edit {
+                    self.items =
+                        parse(&self.content.text(), &self.theme).collect();
+                }
             }
         }
     }
@@ -46,127 +58,225 @@ impl Markdown {
             .padding(10)
             .font(Font::MONOSPACE);
 
-        let preview = {
-            let markdown = self.content.text();
-            let parser = pulldown_cmark::Parser::new(&markdown);
+        let preview = markdown(&self.items);
 
-            let mut strong = false;
-            let mut emphasis = false;
-            let mut heading = None;
-            let mut spans = Vec::new();
-
-            let items = parser.filter_map(|event| match event {
-                pulldown_cmark::Event::Start(tag) => match tag {
-                    pulldown_cmark::Tag::Strong => {
-                        strong = true;
-                        None
-                    }
-                    pulldown_cmark::Tag::Emphasis => {
-                        emphasis = true;
-                        None
-                    }
-                    pulldown_cmark::Tag::Heading { level, .. } => {
-                        heading = Some(level);
-                        None
-                    }
-                    _ => None,
-                },
-                pulldown_cmark::Event::End(tag) => match tag {
-                    pulldown_cmark::TagEnd::Emphasis => {
-                        emphasis = false;
-                        None
-                    }
-                    pulldown_cmark::TagEnd::Strong => {
-                        strong = false;
-                        None
-                    }
-                    pulldown_cmark::TagEnd::Heading(_) => {
-                        heading = None;
-                        Some(
-                            container(rich_text(spans.drain(..)))
-                                .padding(padding::bottom(5))
-                                .into(),
-                        )
-                    }
-                    pulldown_cmark::TagEnd::Paragraph => Some(
-                        container(rich_text(spans.drain(..)))
-                            .padding(padding::bottom(15))
-                            .into(),
-                    ),
-                    pulldown_cmark::TagEnd::CodeBlock => Some(
-                        container(
-                            container(
-                                rich_text(spans.drain(..))
-                                    .font(Font::MONOSPACE),
-                            )
-                            .width(Fill)
-                            .padding(10)
-                            .style(container::rounded_box),
-                        )
-                        .padding(padding::bottom(15))
-                        .into(),
-                    ),
-                    _ => None,
-                },
-                pulldown_cmark::Event::Text(text) => {
-                    let span = span(text.into_string());
-
-                    let span = match heading {
-                        None => span,
-                        Some(heading) => span.size(match heading {
-                            pulldown_cmark::HeadingLevel::H1 => 32,
-                            pulldown_cmark::HeadingLevel::H2 => 28,
-                            pulldown_cmark::HeadingLevel::H3 => 24,
-                            pulldown_cmark::HeadingLevel::H4 => 20,
-                            pulldown_cmark::HeadingLevel::H5 => 16,
-                            pulldown_cmark::HeadingLevel::H6 => 16,
-                        }),
-                    };
-
-                    let span = if strong || emphasis {
-                        span.font(Font {
-                            weight: if strong {
-                                font::Weight::Bold
-                            } else {
-                                font::Weight::Normal
-                            },
-                            style: if emphasis {
-                                font::Style::Italic
-                            } else {
-                                font::Style::Normal
-                            },
-                            ..Font::default()
-                        })
-                    } else {
-                        span
-                    };
-
-                    spans.push(span);
-
-                    None
-                }
-                pulldown_cmark::Event::Code(code) => {
-                    spans.push(span(code.into_string()).font(Font::MONOSPACE));
-                    None
-                }
-                pulldown_cmark::Event::SoftBreak => {
-                    spans.push(span(" "));
-                    None
-                }
-                pulldown_cmark::Event::HardBreak => {
-                    spans.push(span("\n"));
-                    None
-                }
-                _ => None,
-            });
-
-            column(items).width(Fill)
-        };
-
-        row![editor, preview].spacing(10).padding(10).into()
+        row![
+            editor,
+            scrollable(preview).spacing(10).width(Fill).height(Fill)
+        ]
+        .spacing(10)
+        .padding(10)
+        .into()
     }
 
     fn theme(&self) -> Theme {
         Theme::TokyoNight
     }
+}
+
+fn markdown<'a>(
+    items: impl IntoIterator<Item = &'a Item>,
+) -> Element<'a, Message> {
+    use iced::padding;
+
+    let blocks = items.into_iter().enumerate().map(|(i, item)| match item {
+        Item::Heading(heading) => container(rich_text(heading))
+            .padding(padding::top(if i > 0 { 8 } else { 0 }))
+            .into(),
+        Item::Paragraph(paragraph) => rich_text(paragraph).into(),
+        Item::List { start: None, items } => column(
+            items
+                .iter()
+                .map(|item| row!["•", rich_text(item)].spacing(10).into()),
+        )
+        .spacing(10)
+        .into(),
+        Item::List {
+            start: Some(start),
+            items,
+        } => column(items.iter().enumerate().map(|(i, item)| {
+            row![text!("{}.", i as u64 + *start), rich_text(item)]
+                .spacing(10)
+                .into()
+        }))
+        .spacing(10)
+        .into(),
+        Item::CodeBlock(code) => {
+            container(rich_text(code).font(Font::MONOSPACE).size(12))
+                .width(Fill)
+                .padding(10)
+                .style(container::rounded_box)
+                .into()
+        }
+    });
+
+    column(blocks).width(Fill).spacing(16).into()
+}
+
+#[derive(Debug, Clone)]
+enum Item {
+    Heading(Vec<text::Span<'static>>),
+    Paragraph(Vec<text::Span<'static>>),
+    CodeBlock(Vec<text::Span<'static>>),
+    List {
+        start: Option<u64>,
+        items: Vec<Vec<text::Span<'static>>>,
+    },
+}
+
+fn parse<'a>(
+    markdown: &'a str,
+    theme: &'a Theme,
+) -> impl Iterator<Item = Item> + 'a {
+    use iced::font;
+    use iced::highlighter::{self, Highlighter};
+    use text::Highlighter as _;
+
+    let mut spans = Vec::new();
+    let mut heading = None;
+    let mut strong = false;
+    let mut emphasis = false;
+    let mut link = false;
+    let mut list = Vec::new();
+    let mut list_start = None;
+    let mut highlighter = None;
+
+    let parser = pulldown_cmark::Parser::new(markdown);
+
+    // We want to keep the `spans` capacity
+    #[allow(clippy::drain_collect)]
+    parser.filter_map(move |event| match event {
+        pulldown_cmark::Event::Start(tag) => match tag {
+            pulldown_cmark::Tag::Heading { level, .. } => {
+                heading = Some(level);
+                None
+            }
+            pulldown_cmark::Tag::Strong => {
+                strong = true;
+                None
+            }
+            pulldown_cmark::Tag::Emphasis => {
+                emphasis = true;
+                None
+            }
+            pulldown_cmark::Tag::Link { .. } => {
+                link = true;
+                None
+            }
+            pulldown_cmark::Tag::List(first_item) => {
+                list_start = first_item;
+                None
+            }
+            pulldown_cmark::Tag::CodeBlock(
+                pulldown_cmark::CodeBlockKind::Fenced(language),
+            ) => {
+                highlighter = Some(Highlighter::new(&highlighter::Settings {
+                    theme: highlighter::Theme::Base16Ocean,
+                    token: language.to_string(),
+                }));
+
+                None
+            }
+            _ => None,
+        },
+        pulldown_cmark::Event::End(tag) => match tag {
+            pulldown_cmark::TagEnd::Heading(_) => {
+                heading = None;
+                Some(Item::Heading(spans.drain(..).collect()))
+            }
+            pulldown_cmark::TagEnd::Emphasis => {
+                emphasis = false;
+                None
+            }
+            pulldown_cmark::TagEnd::Strong => {
+                strong = false;
+                None
+            }
+            pulldown_cmark::TagEnd::Link => {
+                link = false;
+                None
+            }
+            pulldown_cmark::TagEnd::Paragraph => {
+                Some(Item::Paragraph(spans.drain(..).collect()))
+            }
+            pulldown_cmark::TagEnd::List(_) => Some(Item::List {
+                start: list_start,
+                items: list.drain(..).collect(),
+            }),
+            pulldown_cmark::TagEnd::Item => {
+                list.push(spans.drain(..).collect());
+                None
+            }
+            pulldown_cmark::TagEnd::CodeBlock => {
+                highlighter = None;
+                Some(Item::CodeBlock(spans.drain(..).collect()))
+            }
+            _ => None,
+        },
+        pulldown_cmark::Event::Text(text) => {
+            if let Some(highlighter) = &mut highlighter {
+                for (range, highlight) in
+                    highlighter.highlight_line(text.as_ref())
+                {
+                    let span = span(text[range].to_owned())
+                        .color_maybe(highlight.color())
+                        .font_maybe(highlight.font());
+
+                    spans.push(span);
+                }
+            } else {
+                let span = span(text.into_string());
+
+                let span = match heading {
+                    None => span,
+                    Some(heading) => span.size(match heading {
+                        pulldown_cmark::HeadingLevel::H1 => 32,
+                        pulldown_cmark::HeadingLevel::H2 => 28,
+                        pulldown_cmark::HeadingLevel::H3 => 24,
+                        pulldown_cmark::HeadingLevel::H4 => 20,
+                        pulldown_cmark::HeadingLevel::H5 => 16,
+                        pulldown_cmark::HeadingLevel::H6 => 16,
+                    }),
+                };
+
+                let span = if strong || emphasis {
+                    span.font(Font {
+                        weight: if strong {
+                            font::Weight::Bold
+                        } else {
+                            font::Weight::Normal
+                        },
+                        style: if emphasis {
+                            font::Style::Italic
+                        } else {
+                            font::Style::Normal
+                        },
+                        ..Font::default()
+                    })
+                } else {
+                    span
+                };
+
+                let span =
+                    span.color_maybe(link.then(|| theme.palette().primary));
+
+                spans.push(span);
+            }
+
+            None
+        }
+        pulldown_cmark::Event::Code(code) => {
+            spans.push(span(code.into_string()).font(Font::MONOSPACE));
+            None
+        }
+        pulldown_cmark::Event::SoftBreak => {
+            spans.push(span(" "));
+            None
+        }
+        pulldown_cmark::Event::HardBreak => {
+            spans.push(span("\n"));
+            None
+        }
+        _ => None,
+    })
 }

--- a/examples/markdown/src/main.rs
+++ b/examples/markdown/src/main.rs
@@ -68,6 +68,6 @@ impl Markdown {
     }
 
     fn theme(&self) -> Theme {
-        Theme::TokyoNight
+        self.theme.clone()
     }
 }

--- a/graphics/src/text.rs
+++ b/graphics/src/text.rs
@@ -232,13 +232,14 @@ impl PartialEq for Raw {
 
 /// Measures the dimensions of the given [`cosmic_text::Buffer`].
 pub fn measure(buffer: &cosmic_text::Buffer) -> Size {
-    let (width, total_lines) = buffer
-        .layout_runs()
-        .fold((0.0, 0usize), |(width, total_lines), run| {
-            (run.line_w.max(width), total_lines + 1)
-        });
+    let (width, height) =
+        buffer
+            .layout_runs()
+            .fold((0.0, 0.0), |(width, height), run| {
+                (run.line_w.max(width), height + run.line_height)
+            });
 
-    Size::new(width, total_lines as f32 * buffer.metrics().line_height)
+    Size::new(width, height)
 }
 
 /// Returns the attributes of the given [`Font`].

--- a/widget/Cargo.toml
+++ b/widget/Cargo.toml
@@ -22,8 +22,10 @@ lazy = ["ouroboros"]
 image = ["iced_renderer/image"]
 svg = ["iced_renderer/svg"]
 canvas = ["iced_renderer/geometry"]
-qr_code = ["canvas", "qrcode"]
+qr_code = ["canvas", "dep:qrcode"]
 wgpu = ["iced_renderer/wgpu"]
+markdown = ["dep:pulldown-cmark"]
+highlighter = ["dep:iced_highlighter"]
 advanced = []
 
 [dependencies]
@@ -41,3 +43,9 @@ ouroboros.optional = true
 
 qrcode.workspace = true
 qrcode.optional = true
+
+pulldown-cmark.workspace = true
+pulldown-cmark.optional = true
+
+iced_highlighter.workspace = true
+iced_highlighter.optional = true

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -7,7 +7,6 @@ use crate::core;
 use crate::core::widget::operation;
 use crate::core::{Element, Length, Pixels, Widget};
 use crate::keyed;
-use crate::markdown::{self};
 use crate::overlay;
 use crate::pick_list::{self, PickList};
 use crate::progress_bar::{self, ProgressBar};
@@ -705,7 +704,7 @@ pub fn span<'a, Font>(
 
 #[cfg(feature = "markdown")]
 #[doc(inline)]
-pub use markdown::view as markdown;
+pub use crate::markdown::view as markdown;
 
 /// Creates a new [`Checkbox`].
 ///

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -7,6 +7,7 @@ use crate::core;
 use crate::core::widget::operation;
 use crate::core::{Element, Length, Pixels, Widget};
 use crate::keyed;
+use crate::markdown::{self};
 use crate::overlay;
 use crate::pick_list::{self, PickList};
 use crate::progress_bar::{self, ProgressBar};
@@ -701,6 +702,10 @@ pub fn span<'a, Font>(
 ) -> text::Span<'a, Font> {
     text::Span::new(text)
 }
+
+#[cfg(feature = "markdown")]
+#[doc(inline)]
+pub use markdown::view as markdown;
 
 /// Creates a new [`Checkbox`].
 ///

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -112,6 +112,19 @@ macro_rules! text {
     };
 }
 
+/// Creates some [`Rich`] text with the given spans.
+///
+/// [`Rich`]: text::Rich
+#[macro_export]
+macro_rules! rich_text {
+    () => (
+        $crate::Column::new()
+    );
+    ($($x:expr),+ $(,)?) => (
+        $crate::text::Rich::with_spans([$($crate::text::Span::from($x)),+])
+    );
+}
+
 /// Creates a new [`Container`] with the provided content.
 ///
 /// [`Container`]: crate::Container
@@ -646,8 +659,6 @@ where
 }
 
 /// Creates a new [`Text`] widget with the provided content.
-///
-/// [`Text`]: core::widget::Text
 pub fn text<'a, Theme, Renderer>(
     text: impl text::IntoFragment<'a>,
 ) -> Text<'a, Theme, Renderer>
@@ -659,8 +670,6 @@ where
 }
 
 /// Creates a new [`Text`] widget that displays the provided value.
-///
-/// [`Text`]: core::widget::Text
 pub fn value<'a, Theme, Renderer>(
     value: impl ToString,
 ) -> Text<'a, Theme, Renderer>
@@ -669,6 +678,28 @@ where
     Renderer: core::text::Renderer,
 {
     Text::new(value.to_string())
+}
+
+/// Creates a new [`Rich`] text widget with the provided spans.
+///
+/// [`Rich`]: text::Rich
+pub fn rich_text<'a, Theme, Renderer>(
+    spans: impl IntoIterator<Item = text::Span<'a, Renderer::Font>>,
+) -> text::Rich<'a, Theme, Renderer>
+where
+    Theme: text::Catalog + 'a,
+    Renderer: core::text::Renderer,
+{
+    text::Rich::with_spans(spans)
+}
+
+/// Creates a new [`Span`] of text with the provided content.
+///
+/// [`Span`]: text::Span
+pub fn span<'a, Font>(
+    text: impl text::IntoFragment<'a>,
+) -> text::Span<'a, Font> {
+    text::Span::new(text)
 }
 
 /// Creates a new [`Checkbox`].

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -24,7 +24,7 @@ use crate::tooltip::{self, Tooltip};
 use crate::vertical_slider::{self, VerticalSlider};
 use crate::{Column, MouseArea, Row, Space, Stack, Themer};
 
-use std::borrow::Borrow;
+use std::borrow::{Borrow, Cow};
 use std::ops::RangeInclusive;
 
 /// Creates a [`Column`] with the given children.
@@ -684,7 +684,7 @@ where
 ///
 /// [`Rich`]: text::Rich
 pub fn rich_text<'a, Theme, Renderer>(
-    spans: impl IntoIterator<Item = text::Span<'a, Renderer::Font>>,
+    spans: impl Into<Cow<'a, [text::Span<'a, Renderer::Font>]>>,
 ) -> text::Rich<'a, Theme, Renderer>
 where
     Theme: text::Catalog + 'a,

--- a/widget/src/lib.rs
+++ b/widget/src/lib.rs
@@ -130,5 +130,8 @@ pub mod qr_code;
 #[doc(no_inline)]
 pub use qr_code::QRCode;
 
+#[cfg(feature = "markdown")]
+pub mod markdown;
+
 pub use crate::core::theme::{self, Theme};
 pub use renderer::Renderer;

--- a/widget/src/markdown.rs
+++ b/widget/src/markdown.rs
@@ -1,0 +1,246 @@
+//! Parse and display Markdown.
+//!
+//! You can enable the `highlighter` feature for syntax highligting
+//! in code blocks.
+//!
+//! Only the variants of [`Item`] are currently supported.
+use crate::core::font::{self, Font};
+use crate::core::padding;
+use crate::core::theme::{self, Theme};
+use crate::core::{self, Element, Length};
+use crate::{column, container, rich_text, row, span, text};
+
+/// A Markdown item.
+#[derive(Debug, Clone)]
+pub enum Item {
+    /// A heading.
+    Heading(Vec<text::Span<'static>>),
+    /// A paragraph.
+    Paragraph(Vec<text::Span<'static>>),
+    /// A code block.
+    ///
+    /// You can enable the `highlighter` feature for syntax highligting.
+    CodeBlock(Vec<text::Span<'static>>),
+    /// A list.
+    List {
+        /// The first number of the list, if it is ordered.
+        start: Option<u64>,
+        /// The items of the list.
+        items: Vec<Vec<text::Span<'static>>>,
+    },
+}
+
+/// Parse the given Markdown content.
+pub fn parse(
+    markdown: &str,
+    palette: theme::Palette,
+) -> impl Iterator<Item = Item> + '_ {
+    let mut spans = Vec::new();
+    let mut heading = None;
+    let mut strong = false;
+    let mut emphasis = false;
+    let mut link = false;
+    let mut list = Vec::new();
+    let mut list_start = None;
+
+    #[cfg(feature = "highlighter")]
+    let mut highlighter = None;
+
+    let parser = pulldown_cmark::Parser::new(markdown);
+
+    // We want to keep the `spans` capacity
+    #[allow(clippy::drain_collect)]
+    parser.filter_map(move |event| match event {
+        pulldown_cmark::Event::Start(tag) => match tag {
+            pulldown_cmark::Tag::Heading { level, .. } => {
+                heading = Some(level);
+                None
+            }
+            pulldown_cmark::Tag::Strong => {
+                strong = true;
+                None
+            }
+            pulldown_cmark::Tag::Emphasis => {
+                emphasis = true;
+                None
+            }
+            pulldown_cmark::Tag::Link { .. } => {
+                link = true;
+                None
+            }
+            pulldown_cmark::Tag::List(first_item) => {
+                list_start = first_item;
+                None
+            }
+            pulldown_cmark::Tag::CodeBlock(
+                pulldown_cmark::CodeBlockKind::Fenced(_language),
+            ) => {
+                #[cfg(feature = "highlighter")]
+                {
+                    use iced_highlighter::{self, Highlighter};
+                    use text::Highlighter as _;
+
+                    highlighter =
+                        Some(Highlighter::new(&iced_highlighter::Settings {
+                            theme: iced_highlighter::Theme::Base16Ocean,
+                            token: _language.to_string(),
+                        }));
+                }
+
+                None
+            }
+            _ => None,
+        },
+        pulldown_cmark::Event::End(tag) => match tag {
+            pulldown_cmark::TagEnd::Heading(_) => {
+                heading = None;
+                Some(Item::Heading(spans.drain(..).collect()))
+            }
+            pulldown_cmark::TagEnd::Emphasis => {
+                emphasis = false;
+                None
+            }
+            pulldown_cmark::TagEnd::Strong => {
+                strong = false;
+                None
+            }
+            pulldown_cmark::TagEnd::Link => {
+                link = false;
+                None
+            }
+            pulldown_cmark::TagEnd::Paragraph => {
+                Some(Item::Paragraph(spans.drain(..).collect()))
+            }
+            pulldown_cmark::TagEnd::List(_) => Some(Item::List {
+                start: list_start,
+                items: list.drain(..).collect(),
+            }),
+            pulldown_cmark::TagEnd::Item => {
+                list.push(spans.drain(..).collect());
+                None
+            }
+            pulldown_cmark::TagEnd::CodeBlock => {
+                #[cfg(feature = "highlighter")]
+                {
+                    highlighter = None;
+                }
+
+                Some(Item::CodeBlock(spans.drain(..).collect()))
+            }
+            _ => None,
+        },
+        pulldown_cmark::Event::Text(text) => {
+            #[cfg(feature = "highlighter")]
+            if let Some(highlighter) = &mut highlighter {
+                use text::Highlighter as _;
+
+                for (range, highlight) in
+                    highlighter.highlight_line(text.as_ref())
+                {
+                    let span = span(text[range].to_owned())
+                        .color_maybe(highlight.color())
+                        .font_maybe(highlight.font());
+
+                    spans.push(span);
+                }
+
+                return None;
+            }
+
+            let span = span(text.into_string());
+
+            let span = match heading {
+                None => span,
+                Some(heading) => span.size(match heading {
+                    pulldown_cmark::HeadingLevel::H1 => 32,
+                    pulldown_cmark::HeadingLevel::H2 => 28,
+                    pulldown_cmark::HeadingLevel::H3 => 24,
+                    pulldown_cmark::HeadingLevel::H4 => 20,
+                    pulldown_cmark::HeadingLevel::H5 => 16,
+                    pulldown_cmark::HeadingLevel::H6 => 16,
+                }),
+            };
+
+            let span = if strong || emphasis {
+                span.font(Font {
+                    weight: if strong {
+                        font::Weight::Bold
+                    } else {
+                        font::Weight::Normal
+                    },
+                    style: if emphasis {
+                        font::Style::Italic
+                    } else {
+                        font::Style::Normal
+                    },
+                    ..Font::default()
+                })
+            } else {
+                span
+            };
+
+            let span = span.color_maybe(link.then_some(palette.primary));
+
+            spans.push(span);
+
+            None
+        }
+        pulldown_cmark::Event::Code(code) => {
+            spans.push(span(code.into_string()).font(Font::MONOSPACE));
+            None
+        }
+        pulldown_cmark::Event::SoftBreak => {
+            spans.push(span(" "));
+            None
+        }
+        pulldown_cmark::Event::HardBreak => {
+            spans.push(span("\n"));
+            None
+        }
+        _ => None,
+    })
+}
+
+/// Display a bunch of Markdown items.
+///
+/// You can obtain the items with [`parse`].
+pub fn view<'a, Message, Renderer>(
+    items: impl IntoIterator<Item = &'a Item>,
+) -> Element<'a, Message, Theme, Renderer>
+where
+    Message: 'a,
+    Renderer: core::text::Renderer<Font = Font> + 'a,
+{
+    let blocks = items.into_iter().enumerate().map(|(i, item)| match item {
+        Item::Heading(heading) => container(rich_text(heading))
+            .padding(padding::top(if i > 0 { 8 } else { 0 }))
+            .into(),
+        Item::Paragraph(paragraph) => rich_text(paragraph).into(),
+        Item::List { start: None, items } => column(
+            items
+                .iter()
+                .map(|item| row!["•", rich_text(item)].spacing(10).into()),
+        )
+        .spacing(10)
+        .into(),
+        Item::List {
+            start: Some(start),
+            items,
+        } => column(items.iter().enumerate().map(|(i, item)| {
+            row![text!("{}.", i as u64 + *start), rich_text(item)]
+                .spacing(10)
+                .into()
+        }))
+        .spacing(10)
+        .into(),
+        Item::CodeBlock(code) => {
+            container(rich_text(code).font(Font::MONOSPACE).size(12))
+                .width(Length::Fill)
+                .padding(10)
+                .style(container::rounded_box)
+                .into()
+        }
+    });
+
+    Element::new(column(blocks).width(Length::Fill).spacing(16))
+}

--- a/widget/src/pick_list.rs
+++ b/widget/src/pick_list.rs
@@ -6,7 +6,8 @@ use crate::core::layout;
 use crate::core::mouse;
 use crate::core::overlay;
 use crate::core::renderer;
-use crate::core::text::{self, Paragraph as _, Text};
+use crate::core::text::paragraph;
+use crate::core::text::{self, Text};
 use crate::core::touch;
 use crate::core::widget::tree::{self, Tree};
 use crate::core::{
@@ -622,8 +623,8 @@ struct State<P: text::Paragraph> {
     keyboard_modifiers: keyboard::Modifiers,
     is_open: bool,
     hovered_option: Option<usize>,
-    options: Vec<P>,
-    placeholder: P,
+    options: Vec<paragraph::Plain<P>>,
+    placeholder: paragraph::Plain<P>,
 }
 
 impl<P: text::Paragraph> State<P> {
@@ -635,7 +636,7 @@ impl<P: text::Paragraph> State<P> {
             is_open: bool::default(),
             hovered_option: Option::default(),
             options: Vec::new(),
-            placeholder: P::default(),
+            placeholder: paragraph::Plain::default(),
         }
     }
 }

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -62,18 +62,26 @@ where
         .validate()
     }
 
-    fn validate(self) -> Self {
+    fn validate(mut self) -> Self {
+        let size_hint = self.content.as_widget().size_hint();
+
         debug_assert!(
-            self.direction.vertical().is_none()
-                || !self.content.as_widget().size_hint().height.is_fill(),
+            self.direction.vertical().is_none() || !size_hint.height.is_fill(),
             "scrollable content must not fill its vertical scrolling axis"
         );
 
         debug_assert!(
-            self.direction.horizontal().is_none()
-                || !self.content.as_widget().size_hint().width.is_fill(),
+            self.direction.horizontal().is_none() || !size_hint.width.is_fill(),
             "scrollable content must not fill its horizontal scrolling axis"
         );
+
+        if self.direction.horizontal().is_none() {
+            self.width = self.width.enclose(size_hint.width);
+        }
+
+        if self.direction.vertical().is_none() {
+            self.height = self.height.enclose(size_hint.height);
+        }
 
         self
     }

--- a/widget/src/text.rs
+++ b/widget/src/text.rs
@@ -1,5 +1,9 @@
 //! Draw and interact with text.
+mod rich;
+
+pub use crate::core::text::{Fragment, IntoFragment, Span};
 pub use crate::core::widget::text::*;
+pub use rich::Rich;
 
 /// A paragraph.
 pub type Text<'a, Theme = crate::Theme, Renderer = crate::Renderer> =

--- a/widget/src/text.rs
+++ b/widget/src/text.rs
@@ -1,7 +1,7 @@
 //! Draw and interact with text.
 mod rich;
 
-pub use crate::core::text::{Fragment, IntoFragment, Span};
+pub use crate::core::text::{Fragment, Highlighter, IntoFragment, Span};
 pub use crate::core::widget::text::*;
 pub use rich::Rich;
 

--- a/widget/src/text/rich.rs
+++ b/widget/src/text/rich.rs
@@ -1,0 +1,317 @@
+use crate::core::alignment;
+use crate::core::layout::{self, Layout};
+use crate::core::mouse;
+use crate::core::renderer;
+use crate::core::text::{Paragraph, Span};
+use crate::core::widget::text::{
+    self, Catalog, LineHeight, Shaping, Style, StyleFn,
+};
+use crate::core::widget::tree::{self, Tree};
+use crate::core::{
+    self, Color, Element, Length, Pixels, Rectangle, Size, Widget,
+};
+
+/// A bunch of [`Rich`] text.
+#[derive(Debug)]
+pub struct Rich<'a, Theme = crate::Theme, Renderer = crate::Renderer>
+where
+    Theme: Catalog,
+    Renderer: core::text::Renderer,
+{
+    spans: Vec<Span<'a, Renderer::Font>>,
+    size: Option<Pixels>,
+    line_height: LineHeight,
+    width: Length,
+    height: Length,
+    font: Option<Renderer::Font>,
+    align_x: alignment::Horizontal,
+    align_y: alignment::Vertical,
+    class: Theme::Class<'a>,
+}
+
+impl<'a, Theme, Renderer> Rich<'a, Theme, Renderer>
+where
+    Theme: Catalog,
+    Renderer: core::text::Renderer,
+{
+    /// Creates a new empty [`Rich`] text.
+    pub fn new() -> Self {
+        Self {
+            spans: Vec::new(),
+            size: None,
+            line_height: LineHeight::default(),
+            width: Length::Shrink,
+            height: Length::Shrink,
+            font: None,
+            align_x: alignment::Horizontal::Left,
+            align_y: alignment::Vertical::Top,
+            class: Theme::default(),
+        }
+    }
+
+    /// Creates a new [`Rich`] text with the given text spans.
+    pub fn with_spans(
+        spans: impl IntoIterator<Item = Span<'a, Renderer::Font>>,
+    ) -> Self {
+        Self {
+            spans: spans.into_iter().collect(),
+            ..Self::new()
+        }
+    }
+
+    /// Sets the default size of the [`Rich`] text.
+    pub fn size(mut self, size: impl Into<Pixels>) -> Self {
+        self.size = Some(size.into());
+        self
+    }
+
+    /// Sets the defualt [`LineHeight`] of the [`Rich`] text.
+    pub fn line_height(mut self, line_height: impl Into<LineHeight>) -> Self {
+        self.line_height = line_height.into();
+        self
+    }
+
+    /// Sets the default font of the [`Rich`] text.
+    pub fn font(mut self, font: impl Into<Renderer::Font>) -> Self {
+        self.font = Some(font.into());
+        self
+    }
+
+    /// Sets the width of the [`Rich`] text boundaries.
+    pub fn width(mut self, width: impl Into<Length>) -> Self {
+        self.width = width.into();
+        self
+    }
+
+    /// Sets the height of the [`Rich`] text boundaries.
+    pub fn height(mut self, height: impl Into<Length>) -> Self {
+        self.height = height.into();
+        self
+    }
+
+    /// Centers the [`Rich`] text, both horizontally and vertically.
+    pub fn center(self) -> Self {
+        self.align_x(alignment::Horizontal::Center)
+            .align_y(alignment::Vertical::Center)
+    }
+
+    /// Sets the [`alignment::Horizontal`] of the [`Rich`] text.
+    pub fn align_x(
+        mut self,
+        alignment: impl Into<alignment::Horizontal>,
+    ) -> Self {
+        self.align_x = alignment.into();
+        self
+    }
+
+    /// Sets the [`alignment::Vertical`] of the [`Rich`] text.
+    pub fn align_y(
+        mut self,
+        alignment: impl Into<alignment::Vertical>,
+    ) -> Self {
+        self.align_y = alignment.into();
+        self
+    }
+
+    /// Sets the default style of the [`Rich`] text.
+    #[must_use]
+    pub fn style(mut self, style: impl Fn(&Theme) -> Style + 'a) -> Self
+    where
+        Theme::Class<'a>: From<StyleFn<'a, Theme>>,
+    {
+        self.class = (Box::new(style) as StyleFn<'a, Theme>).into();
+        self
+    }
+
+    /// Sets the default [`Color`] of the [`Rich`] text.
+    pub fn color(self, color: impl Into<Color>) -> Self
+    where
+        Theme::Class<'a>: From<StyleFn<'a, Theme>>,
+    {
+        self.color_maybe(Some(color))
+    }
+
+    /// Sets the default [`Color`] of the [`Rich`] text, if `Some`.
+    pub fn color_maybe(self, color: Option<impl Into<Color>>) -> Self
+    where
+        Theme::Class<'a>: From<StyleFn<'a, Theme>>,
+    {
+        let color = color.map(Into::into);
+
+        self.style(move |_theme| Style { color })
+    }
+
+    /// Sets the default style class of the [`Rich`] text.
+    #[cfg(feature = "advanced")]
+    #[must_use]
+    pub fn class(mut self, class: impl Into<Theme::Class<'a>>) -> Self {
+        self.class = class.into();
+        self
+    }
+
+    /// Adds a new text [`Span`] to the [`Rich`] text.
+    pub fn push(mut self, span: impl Into<Span<'a, Renderer::Font>>) -> Self {
+        self.spans.push(span.into());
+        self
+    }
+}
+
+impl<'a, Theme, Renderer> Default for Rich<'a, Theme, Renderer>
+where
+    Theme: Catalog,
+    Renderer: core::text::Renderer,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+struct State<P: Paragraph> {
+    spans: Vec<Span<'static, P::Font>>,
+    paragraph: P,
+}
+
+impl<'a, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
+    for Rich<'a, Theme, Renderer>
+where
+    Theme: Catalog,
+    Renderer: core::text::Renderer,
+{
+    fn tag(&self) -> tree::Tag {
+        tree::Tag::of::<State<Renderer::Paragraph>>()
+    }
+
+    fn state(&self) -> tree::State {
+        tree::State::new(State {
+            spans: Vec::new(),
+            paragraph: Renderer::Paragraph::default(),
+        })
+    }
+
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: self.width,
+            height: self.height,
+        }
+    }
+
+    fn layout(
+        &self,
+        tree: &mut Tree,
+        renderer: &Renderer,
+        limits: &layout::Limits,
+    ) -> layout::Node {
+        layout(
+            tree.state.downcast_mut::<State<Renderer::Paragraph>>(),
+            renderer,
+            limits,
+            self.width,
+            self.height,
+            self.spans.as_slice(),
+            self.line_height,
+            self.size,
+            self.font,
+            self.align_x,
+            self.align_y,
+        )
+    }
+
+    fn draw(
+        &self,
+        tree: &Tree,
+        renderer: &mut Renderer,
+        theme: &Theme,
+        defaults: &renderer::Style,
+        layout: Layout<'_>,
+        _cursor_position: mouse::Cursor,
+        viewport: &Rectangle,
+    ) {
+        let state = tree.state.downcast_ref::<State<Renderer::Paragraph>>();
+        let style = theme.style(&self.class);
+
+        text::draw(
+            renderer,
+            defaults,
+            layout,
+            &state.paragraph,
+            style,
+            viewport,
+        );
+    }
+}
+
+fn layout<Renderer>(
+    state: &mut State<Renderer::Paragraph>,
+    renderer: &Renderer,
+    limits: &layout::Limits,
+    width: Length,
+    height: Length,
+    spans: &[Span<'_, Renderer::Font>],
+    line_height: LineHeight,
+    size: Option<Pixels>,
+    font: Option<Renderer::Font>,
+    horizontal_alignment: alignment::Horizontal,
+    vertical_alignment: alignment::Vertical,
+) -> layout::Node
+where
+    Renderer: core::text::Renderer,
+{
+    layout::sized(limits, width, height, |limits| {
+        let bounds = limits.max();
+
+        let size = size.unwrap_or_else(|| renderer.default_size());
+        let font = font.unwrap_or_else(|| renderer.default_font());
+
+        let text_with_spans = || core::Text {
+            content: spans,
+            bounds,
+            size,
+            line_height,
+            font,
+            horizontal_alignment,
+            vertical_alignment,
+            shaping: Shaping::Advanced,
+        };
+
+        if state.spans != spans {
+            state.paragraph =
+                Renderer::Paragraph::with_spans(text_with_spans());
+            state.spans = spans.iter().cloned().map(Span::to_static).collect();
+        } else {
+            match state.paragraph.compare(core::Text {
+                content: (),
+                bounds,
+                size,
+                line_height,
+                font,
+                horizontal_alignment,
+                vertical_alignment,
+                shaping: Shaping::Advanced,
+            }) {
+                core::text::Difference::None => {}
+                core::text::Difference::Bounds => {
+                    state.paragraph.resize(bounds);
+                }
+                core::text::Difference::Shape => {
+                    state.paragraph =
+                        Renderer::Paragraph::with_spans(text_with_spans());
+                }
+            }
+        }
+
+        state.paragraph.min_bounds()
+    })
+}
+
+impl<'a, Message, Theme, Renderer> From<Rich<'a, Theme, Renderer>>
+    for Element<'a, Message, Theme, Renderer>
+where
+    Theme: Catalog + 'a,
+    Renderer: core::text::Renderer + 'a,
+{
+    fn from(
+        text: Rich<'a, Theme, Renderer>,
+    ) -> Element<'a, Message, Theme, Renderer> {
+        Element::new(text)
+    }
+}

--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -9,6 +9,7 @@ use crate::core::renderer;
 use crate::core::text::editor::{Cursor, Editor as _};
 use crate::core::text::highlighter::{self, Highlighter};
 use crate::core::text::{self, LineHeight};
+use crate::core::widget::operation;
 use crate::core::widget::{self, Widget};
 use crate::core::{
     Background, Border, Color, Element, Length, Padding, Pixels, Rectangle,
@@ -338,6 +339,22 @@ impl<Highlighter: text::Highlighter> State<Highlighter> {
     }
 }
 
+impl<Highlighter: text::Highlighter> operation::Focusable
+    for State<Highlighter>
+{
+    fn is_focused(&self) -> bool {
+        self.is_focused
+    }
+
+    fn focus(&mut self) {
+        self.is_focused = true;
+    }
+
+    fn unfocus(&mut self) {
+        self.is_focused = false;
+    }
+}
+
 impl<'a, Highlighter, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
     for TextEditor<'a, Highlighter, Message, Theme, Renderer>
 where
@@ -639,6 +656,18 @@ where
         } else {
             mouse::Interaction::default()
         }
+    }
+
+    fn operate(
+        &self,
+        tree: &mut widget::Tree,
+        _layout: Layout<'_>,
+        _renderer: &Renderer,
+        operation: &mut dyn widget::Operation<()>,
+    ) {
+        let state = tree.state.downcast_mut::<State<Highlighter>>();
+
+        operation.focusable(state, None);
     }
 }
 


### PR DESCRIPTION
This PR implements support for __*rich* text__ on top of `cosmic-text` and also introduces `markdown` helpers in the `widget` module.

# Rich Text
Rich text can be created on-the-fly with the `span` helper and the `rich_text!` macro (analogous to `column!` and `row!`):

```rust
use iced::widget::{rich_text, span};
use iced::Font;

rich_text!["Hello ", span("iced").font(Font::MONOSPACE).size(20)]
```

Or you can store the spans in your application state and borrow them directly with the `rich_text` function:

```rust
rich_text(&self.my_cached_spans)
```

This can be useful if you are generating rich text as a result of some expensive operation, like parsing.

# Markdown
Markdown support can be enabled with the new `markdown` feature.

Then, you can parse markdown with the `parse` function:

```rust
use iced::widget::markdown;

self.items = markdown::parse("# Some markdown!", Theme::TokyoNight.palette()).collect();
```

For now, colors need to be attached to spans during construction; therefore, a `theme::Palette` is needed.

Once parsed, you can render it:

```rust
use iced::widget::markdown;

markdown(&self.items)
```

Further configuration options will be added eventually.

-------------

To showcase all of this, I have created a simple Markdown editor example:

![image](https://github.com/user-attachments/assets/73011884-d2e5-4510-a9ac-6cf1e062f28f)

Code blocks will be automatically highlighted if the `highlighter` feature is enabled.