### PR TITLE
Add `Link` support to `rich_text` widget

### DIFF
--- a/core/src/renderer/null.rs
+++ b/core/src/renderer/null.rs
@@ -77,8 +77,8 @@ impl text::Paragraph for () {
 
     fn with_text(_text: Text<&str>) -> Self {}
 
-    fn with_spans(
-        _text: Text<&[text::Span<'_, Self::Font>], Self::Font>,
+    fn with_spans<Link>(
+        _text: Text<&[text::Span<'_, Link, Self::Font>], Self::Font>,
     ) -> Self {
     }
 
@@ -105,6 +105,10 @@ impl text::Paragraph for () {
     }
 
     fn hit_test(&self, _point: Point) -> Option<text::Hit> {
+        None
+    }
+
+    fn hit_span(&self, _point: Point) -> Option<usize> {
         None
     }
 }

--- a/core/src/text.rs
+++ b/core/src/text.rs
@@ -223,8 +223,8 @@ pub trait Renderer: crate::Renderer {
 }
 
 /// A span of text.
-#[derive(Debug, Clone, PartialEq)]
-pub struct Span<'a, Font = crate::Font> {
+#[derive(Debug, Clone)]
+pub struct Span<'a, Link = (), Font = crate::Font> {
     /// The [`Fragment`] of text.
     pub text: Fragment<'a>,
     /// The size of the [`Span`] in [`Pixels`].
@@ -235,9 +235,11 @@ pub struct Span<'a, Font = crate::Font> {
     pub font: Option<Font>,
     /// The [`Color`] of the [`Span`].
     pub color: Option<Color>,
+    /// The link of the [`Span`].
+    pub link: Option<Link>,
 }
 
-impl<'a, Font> Span<'a, Font> {
+impl<'a, Link, Font> Span<'a, Link, Font> {
     /// Creates a new [`Span`] of text with the given text fragment.
     pub fn new(fragment: impl IntoFragment<'a>) -> Self {
         Self {
@@ -246,6 +248,7 @@ impl<'a, Font> Span<'a, Font> {
             line_height: None,
             font: None,
             color: None,
+            link: None,
         }
     }
 
@@ -285,14 +288,27 @@ impl<'a, Font> Span<'a, Font> {
         self
     }
 
+    /// Sets the link of the [`Span`].
+    pub fn link(mut self, link: impl Into<Link>) -> Self {
+        self.link = Some(link.into());
+        self
+    }
+
+    /// Sets the link of the [`Span`], if any.
+    pub fn link_maybe(mut self, link: Option<impl Into<Link>>) -> Self {
+        self.link = link.map(Into::into);
+        self
+    }
+
     /// Turns the [`Span`] into a static one.
-    pub fn to_static(self) -> Span<'static, Font> {
+    pub fn to_static(self) -> Span<'static, Link, Font> {
         Span {
             text: Cow::Owned(self.text.into_owned()),
             size: self.size,
             line_height: self.line_height,
             font: self.font,
             color: self.color,
+            link: self.link,
         }
     }
 }
@@ -300,6 +316,16 @@ impl<'a, Font> Span<'a, Font> {
 impl<'a, Font> From<&'a str> for Span<'a, Font> {
     fn from(value: &'a str) -> Self {
         Span::new(value)
+    }
+}
+
+impl<'a, Link, Font: PartialEq> PartialEq for Span<'a, Link, Font> {
+    fn eq(&self, other: &Self) -> bool {
+        self.text == other.text
+            && self.size == other.size
+            && self.line_height == other.line_height
+            && self.font == other.font
+            && self.color == other.color
     }
 }
 

--- a/core/src/text/paragraph.rs
+++ b/core/src/text/paragraph.rs
@@ -12,7 +12,9 @@ pub trait Paragraph: Sized + Default {
     fn with_text(text: Text<&str, Self::Font>) -> Self;
 
     /// Creates a new [`Paragraph`] laid out with the given [`Text`].
-    fn with_spans(text: Text<&[Span<'_, Self::Font>], Self::Font>) -> Self;
+    fn with_spans<Link>(
+        text: Text<&[Span<'_, Link, Self::Font>], Self::Font>,
+    ) -> Self;
 
     /// Lays out the [`Paragraph`] with some new boundaries.
     fn resize(&mut self, new_bounds: Size);
@@ -34,6 +36,11 @@ pub trait Paragraph: Sized + Default {
     /// Tests whether the provided point is within the boundaries of the
     /// [`Paragraph`], returning information about the nearest character.
     fn hit_test(&self, point: Point) -> Option<Hit>;
+
+    /// Tests whether the provided point is within the boundaries of a
+    /// [`Span`] in the [`Paragraph`], returning the index of the [`Span`]
+    /// that was hit.
+    fn hit_span(&self, point: Point) -> Option<usize>;
 
     /// Returns the distance to the given grapheme index in the [`Paragraph`].
     fn grapheme_position(&self, line: usize, index: usize) -> Option<Point>;

--- a/examples/markdown/Cargo.toml
+++ b/examples/markdown/Cargo.toml
@@ -8,3 +8,5 @@ publish = false
 [dependencies]
 iced.workspace = true
 iced.features = ["markdown", "highlighter", "debug"]
+
+open = "5.3"

--- a/examples/markdown/src/main.rs
+++ b/examples/markdown/src/main.rs
@@ -52,7 +52,7 @@ impl Markdown {
                 }
             }
             Message::LinkClicked(link) => {
-                let _ = open::that(link);
+                let _ = open::that_in_background(link);
             }
         }
     }

--- a/examples/markdown/src/main.rs
+++ b/examples/markdown/src/main.rs
@@ -16,6 +16,7 @@ struct Markdown {
 #[derive(Debug, Clone)]
 enum Message {
     Edit(text_editor::Action),
+    LinkClicked(String),
 }
 
 impl Markdown {
@@ -50,6 +51,9 @@ impl Markdown {
                     .collect();
                 }
             }
+            Message::LinkClicked(link) => {
+                let _ = open::that(link);
+            }
         }
     }
 
@@ -60,7 +64,7 @@ impl Markdown {
             .padding(10)
             .font(Font::MONOSPACE);
 
-        let preview = markdown(&self.items);
+        let preview = markdown(&self.items, Message::LinkClicked);
 
         row![editor, scrollable(preview).spacing(10).height(Fill)]
             .spacing(10)

--- a/graphics/src/text/paragraph.rs
+++ b/graphics/src/text/paragraph.rs
@@ -123,15 +123,7 @@ impl core::text::Paragraph for Paragraph {
         buffer.set_rich_text(
             font_system.raw(),
             text.content.iter().enumerate().map(|(i, span)| {
-                let attrs = if let Some(font) = span.font {
-                    cosmic_text::Attrs::new()
-                        .family(text::to_family(font.family))
-                        .weight(text::to_weight(font.weight))
-                        .stretch(text::to_stretch(font.stretch))
-                        .style(text::to_style(font.style))
-                } else {
-                    text::to_attributes(text.font)
-                };
+                let attrs = text::to_attributes(span.font.unwrap_or(text.font));
 
                 let attrs = match (span.size, span.line_height) {
                     (None, None) => attrs,

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -683,10 +683,11 @@ where
 /// Creates a new [`Rich`] text widget with the provided spans.
 ///
 /// [`Rich`]: text::Rich
-pub fn rich_text<'a, Theme, Renderer>(
-    spans: impl Into<Cow<'a, [text::Span<'a, Renderer::Font>]>>,
-) -> text::Rich<'a, Theme, Renderer>
+pub fn rich_text<'a, Message, Link, Theme, Renderer>(
+    spans: impl Into<Cow<'a, [text::Span<'a, Link, Renderer::Font>]>>,
+) -> text::Rich<'a, Message, Link, Theme, Renderer>
 where
+    Link: Clone,
     Theme: text::Catalog + 'a,
     Renderer: core::text::Renderer,
 {

--- a/widget/src/markdown.rs
+++ b/widget/src/markdown.rs
@@ -278,7 +278,7 @@ pub fn parse(
 /// You can obtain the items with [`parse`].
 pub fn view<'a, Message, Renderer>(
     items: impl IntoIterator<Item = &'a Item>,
-    on_link_click: impl Fn(String) -> Message + Copy + 'a,
+    on_link: impl Fn(String) -> Message + Copy + 'a,
 ) -> Element<'a, Message, Theme, Renderer>
 where
     Message: 'a,
@@ -286,16 +286,16 @@ where
 {
     let blocks = items.into_iter().enumerate().map(|(i, item)| match item {
         Item::Heading(heading) => {
-            container(rich_text(heading).on_link_click(on_link_click))
+            container(rich_text(heading).on_link(on_link))
                 .padding(padding::top(if i > 0 { 8 } else { 0 }))
                 .into()
         }
         Item::Paragraph(paragraph) => {
-            rich_text(paragraph).on_link_click(on_link_click).into()
+            rich_text(paragraph).on_link(on_link).into()
         }
         Item::List { start: None, items } => {
             column(items.iter().map(|items| {
-                row!["•", view(items, on_link_click)].spacing(10).into()
+                row!["•", view(items, on_link)].spacing(10).into()
             }))
             .spacing(10)
             .into()
@@ -304,7 +304,7 @@ where
             start: Some(start),
             items,
         } => column(items.iter().enumerate().map(|(i, items)| {
-            row![text!("{}.", i as u64 + *start), view(items, on_link_click)]
+            row![text!("{}.", i as u64 + *start), view(items, on_link)]
                 .spacing(10)
                 .into()
         }))
@@ -314,7 +314,7 @@ where
             rich_text(code)
                 .font(Font::MONOSPACE)
                 .size(12)
-                .on_link_click(on_link_click),
+                .on_link(on_link),
         )
         .width(Length::Fill)
         .padding(10)

--- a/widget/src/text/rich.rs
+++ b/widget/src/text/rich.rs
@@ -312,7 +312,7 @@ where
                     {
                         match state.paragraph.hit_span(position) {
                             Some(span) if span == span_pressed => {
-                                if let Some(link) = state
+                                if let Some(link) = self
                                     .spans
                                     .get(span)
                                     .and_then(|span| span.link.clone())
@@ -351,7 +351,7 @@ where
             if let Some(span) = state
                 .paragraph
                 .hit_span(position)
-                .and_then(|span| state.spans.get(span))
+                .and_then(|span| self.spans.get(span))
             {
                 if span.link.is_some() {
                     return mouse::Interaction::Pointer;

--- a/widget/src/text/rich.rs
+++ b/widget/src/text/rich.rs
@@ -37,7 +37,7 @@ pub struct Rich<
     align_x: alignment::Horizontal,
     align_y: alignment::Vertical,
     class: Theme::Class<'a>,
-    on_link_click: Option<Box<dyn Fn(Link) -> Message + 'a>>,
+    on_link: Option<Box<dyn Fn(Link) -> Message + 'a>>,
 }
 
 impl<'a, Message, Link, Theme, Renderer>
@@ -59,7 +59,7 @@ where
             align_x: alignment::Horizontal::Left,
             align_y: alignment::Vertical::Top,
             class: Theme::default(),
-            on_link_click: None,
+            on_link: None,
         }
     }
 
@@ -156,11 +156,8 @@ where
     }
 
     /// Sets the message handler for link clicks on the [`Rich`] text.
-    pub fn on_link_click(
-        mut self,
-        on_link_click: impl Fn(Link) -> Message + 'a,
-    ) -> Self {
-        self.on_link_click = Some(Box::new(on_link_click));
+    pub fn on_link(mut self, on_link: impl Fn(Link) -> Message + 'a) -> Self {
+        self.on_link = Some(Box::new(on_link));
         self
     }
 
@@ -285,7 +282,7 @@ where
         shell: &mut Shell<'_, Message>,
         _viewport: &Rectangle,
     ) -> event::Status {
-        let Some(on_link_click) = self.on_link_click.as_ref() else {
+        let Some(on_link_click) = self.on_link.as_ref() else {
             return event::Status::Ignored;
         };
 
@@ -342,7 +339,7 @@ where
         _viewport: &Rectangle,
         _renderer: &Renderer,
     ) -> mouse::Interaction {
-        if self.on_link_click.is_none() {
+        if self.on_link.is_none() {
             return mouse::Interaction::None;
         }
 


### PR DESCRIPTION
This PR introduces hyperlink support to the `rich_text` and `span` widgets.

The link type is generic; so you do not necessarily need to rely on strings for your links:

```rust
enum Message {
    LinkClicked(Link)
}

enum Link {
    Rust,
    Iced,
}

rich_text![
    "Here are 2 links: ",
    span("Rust").link(Link::Rust),
    " and ",
    span("Iced").link(Link::Iced)
]
.on_link(Message::LinkClicked)
```

The `markdown` widget does use strings as links, for obvious reasons.