### PR TITLE
Add background styling to span / rich text

### DIFF
--- a/core/src/renderer/null.rs
+++ b/core/src/renderer/null.rs
@@ -111,6 +111,10 @@ impl text::Paragraph for () {
     fn hit_span(&self, _point: Point) -> Option<usize> {
         None
     }
+
+    fn span_bounds(&self, _index: usize) -> Vec<Rectangle> {
+        vec![]
+    }
 }
 
 impl text::Editor for () {

--- a/core/src/size.rs
+++ b/core/src/size.rs
@@ -99,6 +99,20 @@ impl<T> From<Size<T>> for Vector<T> {
     }
 }
 
+impl<T> std::ops::Add for Size<T>
+where
+    T: std::ops::Add<Output = T>,
+{
+    type Output = Size<T>;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Size {
+            width: self.width + rhs.width,
+            height: self.height + rhs.height,
+        }
+    }
+}
+
 impl<T> std::ops::Sub for Size<T>
 where
     T: std::ops::Sub<Output = T>,

--- a/core/src/text.rs
+++ b/core/src/text.rs
@@ -8,7 +8,9 @@ pub use highlighter::Highlighter;
 pub use paragraph::Paragraph;
 
 use crate::alignment;
-use crate::{Background, Border, Color, Pixels, Point, Rectangle, Size};
+use crate::{
+    Background, Border, Color, Padding, Pixels, Point, Rectangle, Size,
+};
 
 use std::borrow::Cow;
 use std::hash::{Hash, Hasher};
@@ -239,6 +241,10 @@ pub struct Span<'a, Link = (), Font = crate::Font> {
     pub link: Option<Link>,
     /// The [`Highlight`] of the [`Span`].
     pub highlight: Option<Highlight>,
+    /// The [`Padding`] of the [`Span`].
+    ///
+    /// Currently, it only affects the bounds of the [`Highlight`].
+    pub padding: Padding,
 }
 
 /// A text highlight.
@@ -261,6 +267,7 @@ impl<'a, Link, Font> Span<'a, Link, Font> {
             color: None,
             highlight: None,
             link: None,
+            padding: Padding::ZERO,
         }
     }
 
@@ -297,6 +304,18 @@ impl<'a, Link, Font> Span<'a, Link, Font> {
     /// Sets the [`Color`] of the [`Span`], if any.
     pub fn color_maybe(mut self, color: Option<impl Into<Color>>) -> Self {
         self.color = color.map(Into::into);
+        self
+    }
+
+    /// Sets the link of the [`Span`].
+    pub fn link(mut self, link: impl Into<Link>) -> Self {
+        self.link = Some(link.into());
+        self
+    }
+
+    /// Sets the link of the [`Span`], if any.
+    pub fn link_maybe(mut self, link: Option<impl Into<Link>>) -> Self {
+        self.link = link.map(Into::into);
         self
     }
 
@@ -355,15 +374,15 @@ impl<'a, Link, Font> Span<'a, Link, Font> {
         self
     }
 
-    /// Sets the link of the [`Span`].
-    pub fn link(mut self, link: impl Into<Link>) -> Self {
-        self.link = Some(link.into());
-        self
-    }
-
-    /// Sets the link of the [`Span`], if any.
-    pub fn link_maybe(mut self, link: Option<impl Into<Link>>) -> Self {
-        self.link = link.map(Into::into);
+    /// Sets the [`Padding`] of the [`Span`].
+    ///
+    /// It only affects the [`background`] and [`border`] of the
+    /// [`Span`], currently.
+    ///
+    /// [`background`]: Self::background
+    /// [`border`]: Self::border
+    pub fn padding(mut self, padding: impl Into<Padding>) -> Self {
+        self.padding = padding.into();
         self
     }
 
@@ -377,6 +396,7 @@ impl<'a, Link, Font> Span<'a, Link, Font> {
             color: self.color,
             link: self.link,
             highlight: self.highlight,
+            padding: self.padding,
         }
     }
 }

--- a/core/src/text.rs
+++ b/core/src/text.rs
@@ -8,7 +8,7 @@ pub use highlighter::Highlighter;
 pub use paragraph::Paragraph;
 
 use crate::alignment;
-use crate::{Color, Pixels, Point, Rectangle, Size};
+use crate::{Border, Color, Pixels, Point, Rectangle, Size};
 
 use std::borrow::Cow;
 use std::hash::{Hash, Hasher};
@@ -235,6 +235,8 @@ pub struct Span<'a, Link = (), Font = crate::Font> {
     pub font: Option<Font>,
     /// The [`Color`] of the [`Span`].
     pub color: Option<Color>,
+    /// The [`Background`] of the [`Span`].
+    pub background: Option<Background>,
     /// The link of the [`Span`].
     pub link: Option<Link>,
 }
@@ -248,6 +250,7 @@ impl<'a, Link, Font> Span<'a, Link, Font> {
             line_height: None,
             font: None,
             color: None,
+            background: None,
             link: None,
         }
     }
@@ -288,6 +291,21 @@ impl<'a, Link, Font> Span<'a, Link, Font> {
         self
     }
 
+    /// Sets the [`Background`] of the [`Span`].
+    pub fn background(mut self, background: impl Into<Background>) -> Self {
+        self.background = Some(background.into());
+        self
+    }
+
+    /// Sets the [`Background`] of the [`Span`], if any.
+    pub fn background_maybe(
+        mut self,
+        background: Option<impl Into<Background>>,
+    ) -> Self {
+        self.background = background.map(Into::into);
+        self
+    }
+
     /// Sets the link of the [`Span`].
     pub fn link(mut self, link: impl Into<Link>) -> Self {
         self.link = Some(link.into());
@@ -308,6 +326,7 @@ impl<'a, Link, Font> Span<'a, Link, Font> {
             line_height: self.line_height,
             font: self.font,
             color: self.color,
+            background: self.background,
             link: self.link,
         }
     }
@@ -406,3 +425,21 @@ into_fragment!(isize);
 
 into_fragment!(f32);
 into_fragment!(f64);
+
+/// The background style of text
+#[derive(Debug, Clone, Copy)]
+pub struct Background {
+    /// The background [`Color`]
+    pub color: Color,
+    /// The background [`Border`]
+    pub border: Border,
+}
+
+impl From<Color> for Background {
+    fn from(color: Color) -> Self {
+        Background {
+            color,
+            border: Border::default(),
+        }
+    }
+}

--- a/core/src/text/paragraph.rs
+++ b/core/src/text/paragraph.rs
@@ -1,7 +1,7 @@
 //! Draw paragraphs.
 use crate::alignment;
 use crate::text::{Difference, Hit, Span, Text};
-use crate::{Point, Size};
+use crate::{Point, Rectangle, Size};
 
 /// A text paragraph.
 pub trait Paragraph: Sized + Default {
@@ -41,6 +41,10 @@ pub trait Paragraph: Sized + Default {
     /// [`Span`] in the [`Paragraph`], returning the index of the [`Span`]
     /// that was hit.
     fn hit_span(&self, point: Point) -> Option<usize>;
+
+    /// Returns all bounds for the provided [`Span`] index of the [`Paragraph`].
+    /// A [`Span`] can have multiple bounds for each line it's on.
+    fn span_bounds(&self, index: usize) -> Vec<Rectangle>;
 
     /// Returns the distance to the given grapheme index in the [`Paragraph`].
     fn grapheme_position(&self, line: usize, index: usize) -> Option<Point>;

--- a/examples/markdown/src/main.rs
+++ b/examples/markdown/src/main.rs
@@ -28,7 +28,7 @@ impl Markdown {
         (
             Self {
                 content: text_editor::Content::with_text(INITIAL_CONTENT),
-                items: markdown::parse(INITIAL_CONTENT, &theme.palette())
+                items: markdown::parse(INITIAL_CONTENT, theme.palette())
                     .collect(),
                 theme,
             },
@@ -46,7 +46,7 @@ impl Markdown {
                 if is_edit {
                     self.items = markdown::parse(
                         &self.content.text(),
-                        &self.theme.palette(),
+                        self.theme.palette(),
                     )
                     .collect();
                 }

--- a/examples/markdown/src/main.rs
+++ b/examples/markdown/src/main.rs
@@ -28,11 +28,8 @@ impl Markdown {
         (
             Self {
                 content: text_editor::Content::with_text(INITIAL_CONTENT),
-                items: markdown::parse(
-                    INITIAL_CONTENT,
-                    theme.extended_palette(),
-                )
-                .collect(),
+                items: markdown::parse(INITIAL_CONTENT, &theme.palette())
+                    .collect(),
                 theme,
             },
             widget::focus_next(),
@@ -49,7 +46,7 @@ impl Markdown {
                 if is_edit {
                     self.items = markdown::parse(
                         &self.content.text(),
-                        self.theme.extended_palette(),
+                        &self.theme.palette(),
                     )
                     .collect();
                 }

--- a/examples/markdown/src/main.rs
+++ b/examples/markdown/src/main.rs
@@ -28,8 +28,11 @@ impl Markdown {
         (
             Self {
                 content: text_editor::Content::with_text(INITIAL_CONTENT),
-                items: markdown::parse(INITIAL_CONTENT, theme.palette())
-                    .collect(),
+                items: markdown::parse(
+                    INITIAL_CONTENT,
+                    theme.extended_palette(),
+                )
+                .collect(),
                 theme,
             },
             widget::focus_next(),
@@ -46,7 +49,7 @@ impl Markdown {
                 if is_edit {
                     self.items = markdown::parse(
                         &self.content.text(),
-                        self.theme.palette(),
+                        self.theme.extended_palette(),
                     )
                     .collect();
                 }

--- a/widget/src/markdown.rs
+++ b/widget/src/markdown.rs
@@ -8,9 +8,8 @@ use crate::core::border;
 use crate::core::font::{self, Font};
 use crate::core::padding;
 use crate::core::text::Background;
-use crate::core::theme::palette;
-use crate::core::theme::Theme;
-use crate::core::{self, Element, Length, Pixels};
+use crate::core::theme::{self, Theme};
+use crate::core::{self, color, Color, Element, Length, Pixels};
 use crate::{column, container, rich_text, row, scrollable, span, text};
 
 pub use pulldown_cmark::HeadingLevel;
@@ -39,7 +38,7 @@ pub enum Item {
 /// Parse the given Markdown content.
 pub fn parse<'a>(
     markdown: &'a str,
-    palette: &'a palette::Extended,
+    palette: &'a theme::Palette,
 ) -> impl Iterator<Item = Item> + 'a {
     struct List {
         start: Option<u64>,
@@ -250,7 +249,7 @@ pub fn parse<'a>(
             };
 
             let span = if let Some(link) = link.as_ref() {
-                span.color(palette.primary.base.color).link(link.clone())
+                span.color(palette.primary).link(link.clone())
             } else {
                 span
             };
@@ -262,13 +261,14 @@ pub fn parse<'a>(
         pulldown_cmark::Event::Code(code) if !metadata && !table => {
             let span = span(code.into_string())
                 .font(Font::MONOSPACE)
+                .color(Color::WHITE)
                 .background(Background {
-                    color: palette.background.weak.color,
+                    color: color!(0x111111),
                     border: border::rounded(2),
                 });
 
             let span = if let Some(link) = link.as_ref() {
-                span.color(palette.primary.base.color).link(link.clone())
+                span.color(palette.primary).link(link.clone())
             } else {
                 span
             };

--- a/widget/src/markdown.rs
+++ b/widget/src/markdown.rs
@@ -35,10 +35,10 @@ pub enum Item {
 }
 
 /// Parse the given Markdown content.
-pub fn parse<'a>(
-    markdown: &'a str,
-    palette: &'a theme::Palette,
-) -> impl Iterator<Item = Item> + 'a {
+pub fn parse(
+    markdown: &str,
+    palette: theme::Palette,
+) -> impl Iterator<Item = Item> + '_ {
     struct List {
         start: Option<u64>,
         items: Vec<Vec<Item>>,

--- a/widget/src/markdown.rs
+++ b/widget/src/markdown.rs
@@ -4,9 +4,12 @@
 //! in code blocks.
 //!
 //! Only the variants of [`Item`] are currently supported.
+use crate::core::border;
 use crate::core::font::{self, Font};
 use crate::core::padding;
-use crate::core::theme::{self, Theme};
+use crate::core::text::Background;
+use crate::core::theme::palette;
+use crate::core::theme::Theme;
 use crate::core::{self, Element, Length, Pixels};
 use crate::{column, container, rich_text, row, scrollable, span, text};
 
@@ -34,10 +37,10 @@ pub enum Item {
 }
 
 /// Parse the given Markdown content.
-pub fn parse(
-    markdown: &str,
-    palette: theme::Palette,
-) -> impl Iterator<Item = Item> + '_ {
+pub fn parse<'a>(
+    markdown: &'a str,
+    palette: &'a palette::Extended,
+) -> impl Iterator<Item = Item> + 'a {
     struct List {
         start: Option<u64>,
         items: Vec<Vec<Item>>,
@@ -247,7 +250,7 @@ pub fn parse(
             };
 
             let span = if let Some(link) = link.as_ref() {
-                span.color(palette.primary).link(link.clone())
+                span.color(palette.primary.base.color).link(link.clone())
             } else {
                 span
             };
@@ -257,10 +260,15 @@ pub fn parse(
             None
         }
         pulldown_cmark::Event::Code(code) if !metadata && !table => {
-            let span = span(code.into_string()).font(Font::MONOSPACE);
+            let span = span(code.into_string())
+                .font(Font::MONOSPACE)
+                .background(Background {
+                    color: palette.background.weak.color,
+                    border: border::rounded(2),
+                });
 
             let span = if let Some(link) = link.as_ref() {
-                span.color(palette.primary).link(link.clone())
+                span.color(palette.primary.base.color).link(link.clone())
             } else {
                 span
             };

--- a/widget/src/markdown.rs
+++ b/widget/src/markdown.rs
@@ -262,7 +262,8 @@ pub fn parse<'a>(
                 .font(Font::MONOSPACE)
                 .color(Color::WHITE)
                 .background(color!(0x111111))
-                .border(border::rounded(2));
+                .border(border::rounded(2))
+                .padding(padding::left(2).right(2));
 
             let span = if let Some(link) = link.as_ref() {
                 span.color(palette.primary).link(link.clone())

--- a/widget/src/markdown.rs
+++ b/widget/src/markdown.rs
@@ -7,7 +7,6 @@
 use crate::core::border;
 use crate::core::font::{self, Font};
 use crate::core::padding;
-use crate::core::text::Background;
 use crate::core::theme::{self, Theme};
 use crate::core::{self, color, Color, Element, Length, Pixels};
 use crate::{column, container, rich_text, row, scrollable, span, text};
@@ -262,10 +261,8 @@ pub fn parse<'a>(
             let span = span(code.into_string())
                 .font(Font::MONOSPACE)
                 .color(Color::WHITE)
-                .background(Background {
-                    color: color!(0x111111),
-                    border: border::rounded(2),
-                });
+                .background(color!(0x111111))
+                .border(border::rounded(2));
 
             let span = if let Some(link) = link.as_ref() {
                 span.color(palette.primary).link(link.clone())

--- a/widget/src/text/rich.rs
+++ b/widget/src/text/rich.rs
@@ -9,8 +9,8 @@ use crate::core::widget::text::{
 };
 use crate::core::widget::tree::{self, Tree};
 use crate::core::{
-    self, Clipboard, Color, Element, Event, Layout, Length, Pixels, Rectangle,
-    Shell, Size, Widget,
+    self, Clipboard, Color, Element, Event, Layout, Length, Pixels, Point,
+    Rectangle, Shell, Size, Widget,
 };
 
 use std::borrow::Cow;
@@ -245,6 +245,24 @@ where
             .downcast_ref::<State<Link, Renderer::Paragraph>>();
 
         let style = theme.style(&self.class);
+
+        // Draw backgrounds
+        for (index, span) in self.spans.iter().enumerate() {
+            if let Some(background) = span.background {
+                let translation = layout.position() - Point::ORIGIN;
+
+                for bounds in state.paragraph.span_bounds(index) {
+                    renderer.fill_quad(
+                        renderer::Quad {
+                            bounds: bounds + translation,
+                            border: background.border,
+                            ..Default::default()
+                        },
+                        background.color,
+                    );
+                }
+            }
+        }
 
         text::draw(
             renderer,

--- a/widget/src/text/rich.rs
+++ b/widget/src/text/rich.rs
@@ -248,17 +248,17 @@ where
 
         // Draw backgrounds
         for (index, span) in self.spans.iter().enumerate() {
-            if let Some(background) = span.background {
+            if let Some(highlight) = span.highlight {
                 let translation = layout.position() - Point::ORIGIN;
 
                 for bounds in state.paragraph.span_bounds(index) {
                     renderer.fill_quad(
                         renderer::Quad {
                             bounds: bounds + translation,
-                            border: background.border,
+                            border: highlight.border,
                             ..Default::default()
                         },
-                        background.color,
+                        highlight.background,
                     );
                 }
             }

--- a/widget/src/text/rich.rs
+++ b/widget/src/text/rich.rs
@@ -246,7 +246,6 @@ where
 
         let style = theme.style(&self.class);
 
-        // Draw backgrounds
         for (index, span) in self.spans.iter().enumerate() {
             if let Some(highlight) = span.highlight {
                 let translation = layout.position() - Point::ORIGIN;

--- a/widget/src/text/rich.rs
+++ b/widget/src/text/rich.rs
@@ -10,7 +10,7 @@ use crate::core::widget::text::{
 use crate::core::widget::tree::{self, Tree};
 use crate::core::{
     self, Clipboard, Color, Element, Event, Layout, Length, Pixels, Point,
-    Rectangle, Shell, Size, Widget,
+    Rectangle, Shell, Size, Vector, Widget,
 };
 
 use std::borrow::Cow;
@@ -252,6 +252,16 @@ where
                 let translation = layout.position() - Point::ORIGIN;
 
                 for bounds in state.paragraph.span_bounds(index) {
+                    let bounds = Rectangle::new(
+                        bounds.position()
+                            - Vector::new(span.padding.left, span.padding.top),
+                        bounds.size()
+                            + Size::new(
+                                span.padding.horizontal(),
+                                span.padding.vertical(),
+                            ),
+                    );
+
                     renderer.fill_quad(
                         renderer::Quad {
                             bounds: bounds + translation,


### PR DESCRIPTION
Adds a new `text::Background` type which can be optionally specified on `Span`.

`rich_text` will use this to render background quads for spans where this is set.

A new `Paragraph::span_bounds` method is added to get the bounds of each span to enabled this.

https://github.com/user-attachments/assets/3d81d1bc-8d6d-4f66-8a4d-2440f5efa95a

I'm using this in Halloy:

![image](https://github.com/user-attachments/assets/65de9377-bf07-4918-8d05-1c198d48040f)
