### PR TITLE
Refactor Style methods

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.inlayHints.enabled": "offUnlessPressed"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "editor.inlayHints.enabled": "offUnlessPressed"
-}

--- a/widget/src/button.rs
+++ b/widget/src/button.rs
@@ -462,8 +462,8 @@ pub struct Style {
 }
 
 impl Style {
-    /// Updates the [`Style`] with the given [`Background`].
-    pub fn with_background(self, background: impl Into<Background>) -> Self {
+    /// Updates the [`Background`] of the [`Style`].
+    pub fn background(self, background: impl Into<Background>) -> Self {
         Self {
             background: Some(background.into()),
             ..self
@@ -501,7 +501,7 @@ impl Catalog for Theme {
     type Class<'a> = StyleFn<'a, Self>;
 
     fn default<'a>() -> Self::Class<'a> {
-        Box::new(primary)
+        Box::new(Style::standard)
     }
 
     fn style(&self, class: &Self::Class<'_>, status: Status) -> Style {
@@ -509,100 +509,113 @@ impl Catalog for Theme {
     }
 }
 
-/// A primary button; denoting a main action.
-pub fn primary(theme: &Theme, status: Status) -> Style {
-    let palette = theme.extended_palette();
-    let base = styled(palette.primary.strong);
-
-    match status {
-        Status::Active | Status::Pressed => base,
-        Status::Hovered => Style {
-            background: Some(Background::Color(palette.primary.base.color)),
-            ..base
-        },
-        Status::Disabled => disabled(base),
+impl Style {
+    /// A standard button
+    pub fn standard(theme: &Theme, status: Status) -> Self {
+        Self::primary(theme, status)
     }
-}
 
-/// A secondary button; denoting a complementary action.
-pub fn secondary(theme: &Theme, status: Status) -> Style {
-    let palette = theme.extended_palette();
-    let base = styled(palette.secondary.base);
+    /// A primary button; denoting a main action.
+    pub fn primary(theme: &Theme, status: Status) -> Self {
+        let palette = theme.extended_palette();
+        let base = Self::styled(palette.primary.strong);
 
-    match status {
-        Status::Active | Status::Pressed => base,
-        Status::Hovered => Style {
-            background: Some(Background::Color(palette.secondary.strong.color)),
-            ..base
-        },
-        Status::Disabled => disabled(base),
+        match status {
+            Status::Active | Status::Pressed => base,
+            Status::Hovered => Self {
+                background: Some(Background::Color(palette.primary.base.color)),
+                ..base
+            },
+            Status::Disabled => Self::disabled(base),
+        }
     }
-}
 
-/// A success button; denoting a good outcome.
-pub fn success(theme: &Theme, status: Status) -> Style {
-    let palette = theme.extended_palette();
-    let base = styled(palette.success.base);
+    /// A secondary button; denoting a complementary action.
+    pub fn secondary(theme: &Theme, status: Status) -> Self {
+        let palette = theme.extended_palette();
+        let base = Self::styled(palette.secondary.base);
 
-    match status {
-        Status::Active | Status::Pressed => base,
-        Status::Hovered => Style {
-            background: Some(Background::Color(palette.success.strong.color)),
-            ..base
-        },
-        Status::Disabled => disabled(base),
+        match status {
+            Status::Active | Status::Pressed => base,
+            Status::Hovered => Self {
+                background: Some(Background::Color(
+                    palette.secondary.strong.color,
+                )),
+                ..base
+            },
+            Status::Disabled => Self::disabled(base),
+        }
     }
-}
 
-/// A danger button; denoting a destructive action.
-pub fn danger(theme: &Theme, status: Status) -> Style {
-    let palette = theme.extended_palette();
-    let base = styled(palette.danger.base);
+    /// A success button; denoting a good outcome.
+    pub fn success(theme: &Theme, status: Status) -> Self {
+        let palette = theme.extended_palette();
+        let base = Self::styled(palette.success.base);
 
-    match status {
-        Status::Active | Status::Pressed => base,
-        Status::Hovered => Style {
-            background: Some(Background::Color(palette.danger.strong.color)),
-            ..base
-        },
-        Status::Disabled => disabled(base),
+        match status {
+            Status::Active | Status::Pressed => base,
+            Status::Hovered => Self {
+                background: Some(Background::Color(
+                    palette.success.strong.color,
+                )),
+                ..base
+            },
+            Status::Disabled => Self::disabled(base),
+        }
     }
-}
 
-/// A text button; useful for links.
-pub fn text(theme: &Theme, status: Status) -> Style {
-    let palette = theme.extended_palette();
+    /// A danger button; denoting a destructive action.
+    pub fn danger(theme: &Theme, status: Status) -> Self {
+        let palette = theme.extended_palette();
+        let base = Self::styled(palette.danger.base);
 
-    let base = Style {
-        text_color: palette.background.base.text,
-        ..Style::default()
-    };
-
-    match status {
-        Status::Active | Status::Pressed => base,
-        Status::Hovered => Style {
-            text_color: palette.background.base.text.scale_alpha(0.8),
-            ..base
-        },
-        Status::Disabled => disabled(base),
+        match status {
+            Status::Active | Status::Pressed => base,
+            Status::Hovered => Self {
+                background: Some(Background::Color(
+                    palette.danger.strong.color,
+                )),
+                ..base
+            },
+            Status::Disabled => Self::disabled(base),
+        }
     }
-}
 
-fn styled(pair: palette::Pair) -> Style {
-    Style {
-        background: Some(Background::Color(pair.color)),
-        text_color: pair.text,
-        border: border::rounded(2),
-        ..Style::default()
+    /// A text button; useful for links.
+    pub fn text(theme: &Theme, status: Status) -> Self {
+        let palette = theme.extended_palette();
+
+        let base = Self {
+            text_color: palette.background.base.text,
+            ..Self::default()
+        };
+
+        match status {
+            Status::Active | Status::Pressed => base,
+            Status::Hovered => Self {
+                text_color: palette.background.base.text.scale_alpha(0.8),
+                ..base
+            },
+            Status::Disabled => Self::disabled(base),
+        }
     }
-}
 
-fn disabled(style: Style) -> Style {
-    Style {
-        background: style
-            .background
-            .map(|background| background.scale_alpha(0.5)),
-        text_color: style.text_color.scale_alpha(0.5),
-        ..style
+    fn styled(pair: palette::Pair) -> Self {
+        Self {
+            background: Some(Background::Color(pair.color)),
+            text_color: pair.text,
+            border: border::rounded(2),
+            ..Self::default()
+        }
+    }
+
+    fn disabled(style: Self) -> Self {
+        Self {
+            background: style
+                .background
+                .map(|background| background.scale_alpha(0.5)),
+            text_color: style.text_color.scale_alpha(0.5),
+            ..style
+        }
     }
 }

--- a/widget/src/checkbox.rs
+++ b/widget/src/checkbox.rs
@@ -458,7 +458,7 @@ impl Catalog for Theme {
     type Class<'a> = StyleFn<'a, Self>;
 
     fn default<'a>() -> Self::Class<'a> {
-        Box::new(primary)
+        Box::new(Style::standard)
     }
 
     fn style(&self, class: &Self::Class<'_>, status: Status) -> Style {
@@ -466,128 +466,135 @@ impl Catalog for Theme {
     }
 }
 
-/// A primary checkbox; denoting a main toggle.
-pub fn primary(theme: &Theme, status: Status) -> Style {
-    let palette = theme.extended_palette();
-
-    match status {
-        Status::Active { is_checked } => styled(
-            palette.primary.strong.text,
-            palette.background.base,
-            palette.primary.strong,
-            is_checked,
-        ),
-        Status::Hovered { is_checked } => styled(
-            palette.primary.strong.text,
-            palette.background.weak,
-            palette.primary.base,
-            is_checked,
-        ),
-        Status::Disabled { is_checked } => styled(
-            palette.primary.strong.text,
-            palette.background.weak,
-            palette.background.strong,
-            is_checked,
-        ),
+impl Style {
+    /// A standard checkbox
+    pub fn standard(theme: &Theme, status: Status) -> Self {
+        Self::primary(theme, status)
     }
-}
 
-/// A secondary checkbox; denoting a complementary toggle.
-pub fn secondary(theme: &Theme, status: Status) -> Style {
-    let palette = theme.extended_palette();
+    /// A primary checkbox; denoting a main toggle.
+    pub fn primary(theme: &Theme, status: Status) -> Self {
+        let palette = theme.extended_palette();
 
-    match status {
-        Status::Active { is_checked } => styled(
-            palette.background.base.text,
-            palette.background.base,
-            palette.background.strong,
-            is_checked,
-        ),
-        Status::Hovered { is_checked } => styled(
-            palette.background.base.text,
-            palette.background.weak,
-            palette.background.strong,
-            is_checked,
-        ),
-        Status::Disabled { is_checked } => styled(
-            palette.background.strong.color,
-            palette.background.weak,
-            palette.background.weak,
-            is_checked,
-        ),
+        match status {
+            Status::Active { is_checked } => Self::styled(
+                palette.primary.strong.text,
+                palette.background.base,
+                palette.primary.strong,
+                is_checked,
+            ),
+            Status::Hovered { is_checked } => Self::styled(
+                palette.primary.strong.text,
+                palette.background.weak,
+                palette.primary.base,
+                is_checked,
+            ),
+            Status::Disabled { is_checked } => Self::styled(
+                palette.primary.strong.text,
+                palette.background.weak,
+                palette.background.strong,
+                is_checked,
+            ),
+        }
     }
-}
 
-/// A success checkbox; denoting a positive toggle.
-pub fn success(theme: &Theme, status: Status) -> Style {
-    let palette = theme.extended_palette();
+    /// A secondary checkbox; denoting a complementary toggle.
+    pub fn secondary(theme: &Theme, status: Status) -> Self {
+        let palette = theme.extended_palette();
 
-    match status {
-        Status::Active { is_checked } => styled(
-            palette.success.base.text,
-            palette.background.base,
-            palette.success.base,
-            is_checked,
-        ),
-        Status::Hovered { is_checked } => styled(
-            palette.success.base.text,
-            palette.background.weak,
-            palette.success.base,
-            is_checked,
-        ),
-        Status::Disabled { is_checked } => styled(
-            palette.success.base.text,
-            palette.background.weak,
-            palette.success.weak,
-            is_checked,
-        ),
+        match status {
+            Status::Active { is_checked } => Self::styled(
+                palette.background.base.text,
+                palette.background.base,
+                palette.background.strong,
+                is_checked,
+            ),
+            Status::Hovered { is_checked } => Self::styled(
+                palette.background.base.text,
+                palette.background.weak,
+                palette.background.strong,
+                is_checked,
+            ),
+            Status::Disabled { is_checked } => Self::styled(
+                palette.background.strong.color,
+                palette.background.weak,
+                palette.background.weak,
+                is_checked,
+            ),
+        }
     }
-}
 
-/// A danger checkbox; denoting a negaive toggle.
-pub fn danger(theme: &Theme, status: Status) -> Style {
-    let palette = theme.extended_palette();
+    /// A success checkbox; denoting a positive toggle.
+    pub fn success(theme: &Theme, status: Status) -> Self {
+        let palette = theme.extended_palette();
 
-    match status {
-        Status::Active { is_checked } => styled(
-            palette.danger.base.text,
-            palette.background.base,
-            palette.danger.base,
-            is_checked,
-        ),
-        Status::Hovered { is_checked } => styled(
-            palette.danger.base.text,
-            palette.background.weak,
-            palette.danger.base,
-            is_checked,
-        ),
-        Status::Disabled { is_checked } => styled(
-            palette.danger.base.text,
-            palette.background.weak,
-            palette.danger.weak,
-            is_checked,
-        ),
+        match status {
+            Status::Active { is_checked } => Self::styled(
+                palette.success.base.text,
+                palette.background.base,
+                palette.success.base,
+                is_checked,
+            ),
+            Status::Hovered { is_checked } => Self::styled(
+                palette.success.base.text,
+                palette.background.weak,
+                palette.success.base,
+                is_checked,
+            ),
+            Status::Disabled { is_checked } => Self::styled(
+                palette.success.base.text,
+                palette.background.weak,
+                palette.success.weak,
+                is_checked,
+            ),
+        }
     }
-}
 
-fn styled(
-    icon_color: Color,
-    base: palette::Pair,
-    accent: palette::Pair,
-    is_checked: bool,
-) -> Style {
-    Style {
-        background: Background::Color(if is_checked {
-            accent.color
-        } else {
-            base.color
-        }),
-        icon_color,
-        border: Border {
-            radius: 2.0.into(),
-            width: 1.0,
-            color: accent.color,
-        },
-        text_color: None,
+    /// A danger checkbox; denoting a negaive toggle.
+    pub fn danger(theme: &Theme, status: Status) -> Self {
+        let palette = theme.extended_palette();
+
+        match status {
+            Status::Active { is_checked } => Self::styled(
+                palette.danger.base.text,
+                palette.background.base,
+                palette.danger.base,
+                is_checked,
+            ),
+            Status::Hovered { is_checked } => Self::styled(
+                palette.danger.base.text,
+                palette.background.weak,
+                palette.danger.base,
+                is_checked,
+            ),
+            Status::Disabled { is_checked } => Self::styled(
+                palette.danger.base.text,
+                palette.background.weak,
+                palette.danger.weak,
+                is_checked,
+            ),
+        }
+    }
+
+    fn styled(
+        icon_color: Color,
+        base: palette::Pair,
+        accent: palette::Pair,
+        is_checked: bool,
+    ) -> Self {
+        Self {
+            background: Background::Color(if is_checked {
+                accent.color
+            } else {
+                base.color
+            }),
+            icon_color,
+            border: Border {
+                radius: 2.0.into(),
+                width: 1.0,
+                color: accent.color,
+            },
+            text_color: None,
+        }
     }
 }

--- a/widget/src/container.rs
+++ b/widget/src/container.rs
@@ -627,7 +627,12 @@ impl Catalog for Theme {
 
 impl Style {
     /// The standard [`Style`] of a [`Container`].
-    pub fn standard(_theme: &Theme) -> Self {
+    pub fn standard(theme: &Theme) -> Self {
+        Self::transparent(theme)
+    }
+
+    /// The transparent [`Style`] of a [`Container`].
+    pub fn transparent(_theme: &Theme) -> Self {
         Self::default()
     }
 

--- a/widget/src/container.rs
+++ b/widget/src/container.rs
@@ -547,7 +547,7 @@ pub struct Style {
 }
 
 impl Style {
-    /// Updates the text color of the [`Style`].
+    /// Updates the text [`Color`] of the [`Style`].
     pub fn color(self, color: impl Into<Color>) -> Self {
         Self {
             text_color: Some(color.into()),
@@ -555,7 +555,7 @@ impl Style {
         }
     }
 
-    /// Updates the border of the [`Style`].
+    /// Updates the [`Border`] of the [`Style`].
     pub fn border(self, border: impl Into<Border>) -> Self {
         Self {
             border: border.into(),
@@ -563,7 +563,7 @@ impl Style {
         }
     }
 
-    /// Updates the background of the [`Style`].
+    /// Updates the [`Background`] of the [`Style`].
     pub fn background(self, background: impl Into<Background>) -> Self {
         Self {
             background: Some(background.into()),
@@ -571,7 +571,7 @@ impl Style {
         }
     }
 
-    /// Updates the shadow of the [`Style`].
+    /// Updates the [`Shadow`] of the [`Style`].
     pub fn shadow(self, shadow: impl Into<Shadow>) -> Self {
         Self {
             shadow: shadow.into(),
@@ -617,7 +617,7 @@ impl Catalog for Theme {
     type Class<'a> = StyleFn<'a, Self>;
 
     fn default<'a>() -> Self::Class<'a> {
-        Box::new(transparent)
+        Box::new(Style::standard)
     }
 
     fn style(&self, class: &Self::Class<'_>) -> Style {
@@ -625,43 +625,45 @@ impl Catalog for Theme {
     }
 }
 
-/// A transparent [`Container`].
-pub fn transparent<Theme>(_theme: &Theme) -> Style {
-    Style::default()
-}
-
-/// A rounded [`Container`] with a background.
-pub fn rounded_box(theme: &Theme) -> Style {
-    let palette = theme.extended_palette();
-
-    Style {
-        background: Some(palette.background.weak.color.into()),
-        border: border::rounded(2),
-        ..Style::default()
+impl Style {
+    /// The standard [`Style`] of a [`Container`].
+    pub fn standard(_theme: &Theme) -> Self {
+        Self::default()
     }
-}
 
-/// A bordered [`Container`] with a background.
-pub fn bordered_box(theme: &Theme) -> Style {
-    let palette = theme.extended_palette();
+    /// A rounded [`Container`] with a background.
+    pub fn rounded_box(theme: &Theme) -> Self {
+        let palette = theme.extended_palette();
 
-    Style {
-        background: Some(palette.background.weak.color.into()),
-        border: Border {
-            width: 1.0,
-            radius: 0.0.into(),
-            color: palette.background.strong.color,
-        },
-        ..Style::default()
+        Self {
+            background: Some(palette.background.weak.color.into()),
+            border: border::rounded(2),
+            ..Self::default()
+        }
     }
-}
 
-/// A [`Container`] with a dark background and white text.
-pub fn dark(_theme: &Theme) -> Style {
-    Style {
-        background: Some(color!(0x111111).into()),
-        text_color: Some(Color::WHITE),
-        border: border::rounded(2),
-        ..Style::default()
+    /// A bordered [`Container`] with a background.
+    pub fn bordered_box(theme: &Theme) -> Self {
+        let palette = theme.extended_palette();
+
+        Self {
+            background: Some(palette.background.weak.color.into()),
+            border: Border {
+                width: 1.0,
+                radius: 0.0.into(),
+                color: palette.background.strong.color,
+            },
+            ..Self::default()
+        }
+    }
+
+    /// A [`Container`] with a dark background and white text.
+    pub fn dark(_theme: &Theme) -> Self {
+        Self {
+            background: Some(color!(0x111111).into()),
+            text_color: Some(Color::WHITE),
+            border: border::rounded(2),
+            ..Self::default()
+        }
     }
 }

--- a/widget/src/pane_grid.rs
+++ b/widget/src/pane_grid.rs
@@ -1182,7 +1182,7 @@ impl Catalog for Theme {
     type Class<'a> = StyleFn<'a, Self>;
 
     fn default<'a>() -> StyleFn<'a, Self> {
-        Box::new(default)
+        Box::new(Style::standard)
     }
 
     fn style(&self, class: &StyleFn<'_, Self>) -> Style {
@@ -1190,29 +1190,31 @@ impl Catalog for Theme {
     }
 }
 
-/// The default style of a [`PaneGrid`].
-pub fn default(theme: &Theme) -> Style {
-    let palette = theme.extended_palette();
+impl Style {
+    /// The standard style of a [`PaneGrid`].
+    pub fn standard(theme: &Theme) -> Self {
+        let palette = theme.extended_palette();
 
-    Style {
-        hovered_region: Highlight {
-            background: Background::Color(Color {
-                a: 0.5,
-                ..palette.primary.base.color
-            }),
-            border: Border {
-                width: 2.0,
-                color: palette.primary.strong.color,
-                radius: 0.0.into(),
+        Self {
+            hovered_region: Highlight {
+                background: Background::Color(Color {
+                    a: 0.5,
+                    ..palette.primary.base.color
+                }),
+                border: Border {
+                    width: 2.0,
+                    color: palette.primary.strong.color,
+                    radius: 0.0.into(),
+                },
             },
-        },
-        hovered_split: Line {
-            color: palette.primary.base.color,
-            width: 2.0,
-        },
-        picked_split: Line {
-            color: palette.primary.strong.color,
-            width: 2.0,
-        },
+            hovered_split: Line {
+                color: palette.primary.base.color,
+                width: 2.0,
+            },
+            picked_split: Line {
+                color: palette.primary.strong.color,
+                width: 2.0,
+            },
+        }
     }
 }

--- a/widget/src/pick_list.rs
+++ b/widget/src/pick_list.rs
@@ -747,7 +747,7 @@ impl Catalog for Theme {
     type Class<'a> = StyleFn<'a, Self>;
 
     fn default<'a>() -> StyleFn<'a, Self> {
-        Box::new(default)
+        Box::new(Style::standard)
     }
 
     fn style(&self, class: &StyleFn<'_, Self>, status: Status) -> Style {
@@ -755,30 +755,32 @@ impl Catalog for Theme {
     }
 }
 
-/// The default style of the field of a [`PickList`].
-pub fn default(theme: &Theme, status: Status) -> Style {
-    let palette = theme.extended_palette();
+impl Style {
+    /// The standard style of the field of a [`PickList`].
+    pub fn standard(theme: &Theme, status: Status) -> Self {
+        let palette = theme.extended_palette();
 
-    let active = Style {
-        text_color: palette.background.weak.text,
-        background: palette.background.weak.color.into(),
-        placeholder_color: palette.background.strong.color,
-        handle_color: palette.background.weak.text,
-        border: Border {
-            radius: 2.0.into(),
-            width: 1.0,
-            color: palette.background.strong.color,
-        },
-    };
-
-    match status {
-        Status::Active => active,
-        Status::Hovered | Status::Opened => Style {
+        let active = Self {
+            text_color: palette.background.weak.text,
+            background: palette.background.weak.color.into(),
+            placeholder_color: palette.background.strong.color,
+            handle_color: palette.background.weak.text,
             border: Border {
-                color: palette.primary.strong.color,
-                ..active.border
+                radius: 2.0.into(),
+                width: 1.0,
+                color: palette.background.strong.color,
             },
-            ..active
-        },
+        };
+
+        match status {
+            Status::Active => active,
+            Status::Hovered | Status::Opened => Style {
+                border: Border {
+                    color: palette.primary.strong.color,
+                    ..active.border
+                },
+                ..active
+            },
+        }
     }
 }

--- a/widget/src/progress_bar.rs
+++ b/widget/src/progress_bar.rs
@@ -206,7 +206,7 @@ impl Catalog for Theme {
     type Class<'a> = StyleFn<'a, Self>;
 
     fn default<'a>() -> Self::Class<'a> {
-        Box::new(primary)
+        Box::new(Style::standard)
     }
 
     fn style(&self, class: &Self::Class<'_>) -> Style {
@@ -214,47 +214,57 @@ impl Catalog for Theme {
     }
 }
 
-/// The primary style of a [`ProgressBar`].
-pub fn primary(theme: &Theme) -> Style {
-    let palette = theme.extended_palette();
+impl Style {
+    /// The standard style of a [`ProgressBar`].
+    pub fn standard(theme: &Theme) -> Self {
+        Self::primary(theme)
+    }
 
-    styled(
-        palette.background.strong.color,
-        palette.primary.strong.color,
-    )
-}
+    /// The primary style of a [`ProgressBar`].
+    pub fn primary(theme: &Theme) -> Self {
+        let palette = theme.extended_palette();
 
-/// The secondary style of a [`ProgressBar`].
-pub fn secondary(theme: &Theme) -> Style {
-    let palette = theme.extended_palette();
+        Self::styled(
+            palette.background.strong.color,
+            palette.primary.strong.color,
+        )
+    }
 
-    styled(
-        palette.background.strong.color,
-        palette.secondary.base.color,
-    )
-}
+    /// The secondary style of a [`ProgressBar`].
+    pub fn secondary(theme: &Theme) -> Self {
+        let palette = theme.extended_palette();
 
-/// The success style of a [`ProgressBar`].
-pub fn success(theme: &Theme) -> Style {
-    let palette = theme.extended_palette();
+        Self::styled(
+            palette.background.strong.color,
+            palette.secondary.base.color,
+        )
+    }
 
-    styled(palette.background.strong.color, palette.success.base.color)
-}
+    /// The success style of a [`ProgressBar`].
+    pub fn success(theme: &Theme) -> Self {
+        let palette = theme.extended_palette();
 
-/// The danger style of a [`ProgressBar`].
-pub fn danger(theme: &Theme) -> Style {
-    let palette = theme.extended_palette();
+        Self::styled(
+            palette.background.strong.color,
+            palette.success.base.color,
+        )
+    }
 
-    styled(palette.background.strong.color, palette.danger.base.color)
-}
+    /// The danger style of a [`ProgressBar`].
+    pub fn danger(theme: &Theme) -> Self {
+        let palette = theme.extended_palette();
 
-fn styled(
-    background: impl Into<Background>,
-    bar: impl Into<Background>,
-) -> Style {
-    Style {
-        background: background.into(),
-        bar: bar.into(),
-        border: border::rounded(2),
+        Self::styled(palette.background.strong.color, palette.danger.base.color)
+    }
+
+    fn styled(
+        background: impl Into<Background>,
+        bar: impl Into<Background>,
+    ) -> Self {
+        Self {
+            background: background.into(),
+            bar: bar.into(),
+            border: border::rounded(2),
+        }
     }
 }

--- a/widget/src/qr_code.rs
+++ b/widget/src/qr_code.rs
@@ -371,7 +371,7 @@ impl Catalog for Theme {
     type Class<'a> = StyleFn<'a, Self>;
 
     fn default<'a>() -> Self::Class<'a> {
-        Box::new(default)
+        Box::new(Style::standard)
     }
 
     fn style(&self, class: &Self::Class<'_>) -> Style {
@@ -379,12 +379,14 @@ impl Catalog for Theme {
     }
 }
 
-/// The default style of a [`QRCode`].
-pub fn default(theme: &Theme) -> Style {
-    let palette = theme.palette();
+impl Style {
+    /// The standard style of a [`QRCode`].
+    pub fn standard(theme: &Theme) -> Style {
+        let palette = theme.palette();
 
-    Style {
-        cell: palette.text,
-        background: palette.background,
+        Style {
+            cell: palette.text,
+            background: palette.background,
+        }
     }
 }

--- a/widget/src/radio.rs
+++ b/widget/src/radio.rs
@@ -433,7 +433,7 @@ impl Catalog for Theme {
     type Class<'a> = StyleFn<'a, Self>;
 
     fn default<'a>() -> Self::Class<'a> {
-        Box::new(default)
+        Box::new(Style::standard)
     }
 
     fn style(&self, class: &Self::Class<'_>, status: Status) -> Style {
@@ -441,24 +441,26 @@ impl Catalog for Theme {
     }
 }
 
-/// The default style of a [`Radio`] button.
-pub fn default(theme: &Theme, status: Status) -> Style {
-    let palette = theme.extended_palette();
+impl Style {
+    /// The standard style of a [`Radio`] button.
+    pub fn standard(theme: &Theme, status: Status) -> Style {
+        let palette = theme.extended_palette();
 
-    let active = Style {
-        background: Color::TRANSPARENT.into(),
-        dot_color: palette.primary.strong.color,
-        border_width: 1.0,
-        border_color: palette.primary.strong.color,
-        text_color: None,
-    };
-
-    match status {
-        Status::Active { .. } => active,
-        Status::Hovered { .. } => Style {
+        let active = Style {
+            background: Color::TRANSPARENT.into(),
             dot_color: palette.primary.strong.color,
-            background: palette.primary.weak.color.into(),
-            ..active
-        },
+            border_width: 1.0,
+            border_color: palette.primary.strong.color,
+            text_color: None,
+        };
+
+        match status {
+            Status::Active { .. } => active,
+            Status::Hovered { .. } => Style {
+                dot_color: palette.primary.strong.color,
+                background: palette.primary.weak.color.into(),
+                ..active
+            },
+        }
     }
 }

--- a/widget/src/rule.rs
+++ b/widget/src/rule.rs
@@ -250,7 +250,7 @@ impl Catalog for Theme {
     type Class<'a> = StyleFn<'a, Self>;
 
     fn default<'a>() -> Self::Class<'a> {
-        Box::new(default)
+        Box::new(Style::standard)
     }
 
     fn style(&self, class: &Self::Class<'_>) -> Style {
@@ -258,14 +258,16 @@ impl Catalog for Theme {
     }
 }
 
-/// The default styling of a [`Rule`].
-pub fn default(theme: &Theme) -> Style {
-    let palette = theme.extended_palette();
+impl Style {
+    /// The standard styling of a [`Rule`].
+    pub fn standard(theme: &Theme) -> Style {
+        let palette = theme.extended_palette();
 
-    Style {
-        color: palette.background.strong.color,
-        width: 1,
-        radius: 0.0.into(),
-        fill_mode: FillMode::Full,
+        Style {
+            color: palette.background.strong.color,
+            width: 1,
+            radius: 0.0.into(),
+            fill_mode: FillMode::Full,
+        }
     }
 }

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -1721,6 +1721,19 @@ pub struct Style {
     pub gap: Option<Background>,
 }
 
+impl Style {
+    /// Updates the [`Background`] of the [`Style`].
+    pub fn background(self, background: impl Into<Background>) -> Self {
+        Self {
+            container: container::Style {
+                background: Some(background.into()),
+                ..container::Style::default()
+            },
+            ..self
+        }
+    }
+}
+
 /// The appearance of the scrollbar of a scrollable.
 #[derive(Debug, Clone, Copy)]
 pub struct Rail {
@@ -1760,7 +1773,7 @@ impl Catalog for Theme {
     type Class<'a> = StyleFn<'a, Self>;
 
     fn default<'a>() -> Self::Class<'a> {
-        Box::new(default)
+        Box::new(Style::standard)
     }
 
     fn style(&self, class: &Self::Class<'_>, status: Status) -> Style {
@@ -1768,78 +1781,100 @@ impl Catalog for Theme {
     }
 }
 
-/// The default style of a [`Scrollable`].
-pub fn default(theme: &Theme, status: Status) -> Style {
-    let palette = theme.extended_palette();
+impl Default for Style {
+    fn default() -> Self {
+        let rail = Rail {
+            background: None,
+            border: Border::default(),
+            scroller: Scroller {
+                color: Color::BLACK,
+                border: border::rounded(2),
+            },
+        };
 
-    let scrollbar = Rail {
-        background: Some(palette.background.weak.color.into()),
-        border: border::rounded(2),
-        scroller: Scroller {
-            color: palette.background.strong.color,
-            border: border::rounded(2),
-        },
-    };
-
-    match status {
-        Status::Active => Style {
+        Self {
             container: container::Style::default(),
-            vertical_rail: scrollbar,
-            horizontal_rail: scrollbar,
+            horizontal_rail: rail,
+            vertical_rail: rail,
             gap: None,
-        },
-        Status::Hovered {
-            is_horizontal_scrollbar_hovered,
-            is_vertical_scrollbar_hovered,
-        } => {
-            let hovered_scrollbar = Rail {
-                scroller: Scroller {
-                    color: palette.primary.strong.color,
-                    ..scrollbar.scroller
-                },
-                ..scrollbar
-            };
-
-            Style {
-                container: container::Style::default(),
-                vertical_rail: if is_vertical_scrollbar_hovered {
-                    hovered_scrollbar
-                } else {
-                    scrollbar
-                },
-                horizontal_rail: if is_horizontal_scrollbar_hovered {
-                    hovered_scrollbar
-                } else {
-                    scrollbar
-                },
-                gap: None,
-            }
         }
-        Status::Dragged {
-            is_horizontal_scrollbar_dragged,
-            is_vertical_scrollbar_dragged,
-        } => {
-            let dragged_scrollbar = Rail {
-                scroller: Scroller {
-                    color: palette.primary.base.color,
-                    ..scrollbar.scroller
-                },
-                ..scrollbar
-            };
+    }
+}
 
-            Style {
+impl Style {
+    /// The standard [`Style`] of a [`Scrollable`].
+    pub fn standard(theme: &Theme, status: Status) -> Self {
+        let palette = theme.extended_palette();
+
+        let scrollbar = Rail {
+            background: Some(palette.background.weak.color.into()),
+            border: border::rounded(2),
+            scroller: Scroller {
+                color: palette.background.strong.color,
+                border: border::rounded(2),
+            },
+        };
+
+        match status {
+            Status::Active => Style {
                 container: container::Style::default(),
-                vertical_rail: if is_vertical_scrollbar_dragged {
-                    dragged_scrollbar
-                } else {
-                    scrollbar
-                },
-                horizontal_rail: if is_horizontal_scrollbar_dragged {
-                    dragged_scrollbar
-                } else {
-                    scrollbar
-                },
+                vertical_rail: scrollbar,
+                horizontal_rail: scrollbar,
                 gap: None,
+            },
+            Status::Hovered {
+                is_horizontal_scrollbar_hovered,
+                is_vertical_scrollbar_hovered,
+            } => {
+                let hovered_scrollbar = Rail {
+                    scroller: Scroller {
+                        color: palette.primary.strong.color,
+                        ..scrollbar.scroller
+                    },
+                    ..scrollbar
+                };
+
+                Self {
+                    container: container::Style::default(),
+                    vertical_rail: if is_vertical_scrollbar_hovered {
+                        hovered_scrollbar
+                    } else {
+                        scrollbar
+                    },
+                    horizontal_rail: if is_horizontal_scrollbar_hovered {
+                        hovered_scrollbar
+                    } else {
+                        scrollbar
+                    },
+                    gap: None,
+                }
+            }
+            Status::Dragged {
+                is_horizontal_scrollbar_dragged,
+                is_vertical_scrollbar_dragged,
+            } => {
+                let dragged_scrollbar = Rail {
+                    scroller: Scroller {
+                        color: palette.primary.base.color,
+                        ..scrollbar.scroller
+                    },
+                    ..scrollbar
+                };
+
+                Self {
+                    container: container::Style::default(),
+                    vertical_rail: if is_vertical_scrollbar_dragged {
+                        dragged_scrollbar
+                    } else {
+                        scrollbar
+                    },
+                    horizontal_rail: if is_horizontal_scrollbar_dragged {
+                        dragged_scrollbar
+                    } else {
+                        scrollbar
+                    },
+                    gap: None,
+                }
             }
         }
     }

--- a/widget/src/slider.rs
+++ b/widget/src/slider.rs
@@ -581,7 +581,7 @@ impl Catalog for Theme {
     type Class<'a> = StyleFn<'a, Self>;
 
     fn default<'a>() -> Self::Class<'a> {
-        Box::new(default)
+        Box::new(Style::standard)
     }
 
     fn style(&self, class: &Self::Class<'_>, status: Status) -> Style {
@@ -589,27 +589,29 @@ impl Catalog for Theme {
     }
 }
 
-/// The default style of a [`Slider`].
-pub fn default(theme: &Theme, status: Status) -> Style {
-    let palette = theme.extended_palette();
+impl Style {
+    /// The standard style of a [`Slider`].
+    pub fn standard(theme: &Theme, status: Status) -> Style {
+        let palette = theme.extended_palette();
 
-    let color = match status {
-        Status::Active => palette.primary.strong.color,
-        Status::Hovered => palette.primary.base.color,
-        Status::Dragged => palette.primary.strong.color,
-    };
+        let color = match status {
+            Status::Active => palette.primary.strong.color,
+            Status::Hovered => palette.primary.base.color,
+            Status::Dragged => palette.primary.strong.color,
+        };
 
-    Style {
-        rail: Rail {
-            colors: (color, palette.secondary.base.color),
-            width: 4.0,
-            border_radius: 2.0.into(),
-        },
-        handle: Handle {
-            shape: HandleShape::Circle { radius: 7.0 },
-            color,
-            border_color: Color::TRANSPARENT,
-            border_width: 0.0,
-        },
+        Style {
+            rail: Rail {
+                colors: (color, palette.secondary.base.color),
+                width: 4.0,
+                border_radius: 2.0.into(),
+            },
+            handle: Handle {
+                shape: HandleShape::Circle { radius: 7.0 },
+                color,
+                border_color: Color::TRANSPARENT,
+                border_width: 0.0,
+            },
+        }
     }
 }

--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -948,7 +948,7 @@ impl Catalog for Theme {
     type Class<'a> = StyleFn<'a, Self>;
 
     fn default<'a>() -> Self::Class<'a> {
-        Box::new(default)
+        Box::new(Style::standard)
     }
 
     fn style(&self, class: &Self::Class<'_>, status: Status) -> Style {
@@ -956,43 +956,45 @@ impl Catalog for Theme {
     }
 }
 
-/// The default style of a [`TextEditor`].
-pub fn default(theme: &Theme, status: Status) -> Style {
-    let palette = theme.extended_palette();
+impl Style {
+    /// The standard style of a [`TextEditor`].
+    pub fn standard(theme: &Theme, status: Status) -> Self {
+        let palette = theme.extended_palette();
 
-    let active = Style {
-        background: Background::Color(palette.background.base.color),
-        border: Border {
-            radius: 2.0.into(),
-            width: 1.0,
-            color: palette.background.strong.color,
-        },
-        icon: palette.background.weak.text,
-        placeholder: palette.background.strong.color,
-        value: palette.background.base.text,
-        selection: palette.primary.weak.color,
-    };
+        let active = Self {
+            background: Background::Color(palette.background.base.color),
+            border: Border {
+                radius: 2.0.into(),
+                width: 1.0,
+                color: palette.background.strong.color,
+            },
+            icon: palette.background.weak.text,
+            placeholder: palette.background.strong.color,
+            value: palette.background.base.text,
+            selection: palette.primary.weak.color,
+        };
 
-    match status {
-        Status::Active => active,
-        Status::Hovered => Style {
-            border: Border {
-                color: palette.background.base.text,
-                ..active.border
+        match status {
+            Status::Active => active,
+            Status::Hovered => Self {
+                border: Border {
+                    color: palette.background.base.text,
+                    ..active.border
+                },
+                ..active
             },
-            ..active
-        },
-        Status::Focused => Style {
-            border: Border {
-                color: palette.primary.strong.color,
-                ..active.border
+            Status::Focused => Self {
+                border: Border {
+                    color: palette.primary.strong.color,
+                    ..active.border
+                },
+                ..active
             },
-            ..active
-        },
-        Status::Disabled => Style {
-            background: Background::Color(palette.background.weak.color),
-            value: active.placeholder,
-            ..active
-        },
+            Status::Disabled => Self {
+                background: Background::Color(palette.background.weak.color),
+                value: active.placeholder,
+                ..active
+            },
+        }
     }
 }

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -1453,7 +1453,7 @@ impl Catalog for Theme {
     type Class<'a> = StyleFn<'a, Self>;
 
     fn default<'a>() -> Self::Class<'a> {
-        Box::new(default)
+        Box::new(Style::standard)
     }
 
     fn style(&self, class: &Self::Class<'_>, status: Status) -> Style {
@@ -1461,43 +1461,45 @@ impl Catalog for Theme {
     }
 }
 
-/// The default style of a [`TextInput`].
-pub fn default(theme: &Theme, status: Status) -> Style {
-    let palette = theme.extended_palette();
+impl Style {
+    /// The standard style of a [`TextInput`].
+    pub fn standard(theme: &Theme, status: Status) -> Self {
+        let palette = theme.extended_palette();
 
-    let active = Style {
-        background: Background::Color(palette.background.base.color),
-        border: Border {
-            radius: 2.0.into(),
-            width: 1.0,
-            color: palette.background.strong.color,
-        },
-        icon: palette.background.weak.text,
-        placeholder: palette.background.strong.color,
-        value: palette.background.base.text,
-        selection: palette.primary.weak.color,
-    };
+        let active = Self {
+            background: Background::Color(palette.background.base.color),
+            border: Border {
+                radius: 2.0.into(),
+                width: 1.0,
+                color: palette.background.strong.color,
+            },
+            icon: palette.background.weak.text,
+            placeholder: palette.background.strong.color,
+            value: palette.background.base.text,
+            selection: palette.primary.weak.color,
+        };
 
-    match status {
-        Status::Active => active,
-        Status::Hovered => Style {
-            border: Border {
-                color: palette.background.base.text,
-                ..active.border
+        match status {
+            Status::Active => active,
+            Status::Hovered => Self {
+                border: Border {
+                    color: palette.background.base.text,
+                    ..active.border
+                },
+                ..active
             },
-            ..active
-        },
-        Status::Focused => Style {
-            border: Border {
-                color: palette.primary.strong.color,
-                ..active.border
+            Status::Focused => Self {
+                border: Border {
+                    color: palette.primary.strong.color,
+                    ..active.border
+                },
+                ..active
             },
-            ..active
-        },
-        Status::Disabled => Style {
-            background: Background::Color(palette.background.weak.color),
-            value: active.placeholder,
-            ..active
-        },
+            Status::Disabled => Self {
+                background: Background::Color(palette.background.weak.color),
+                value: active.placeholder,
+                ..active
+            },
+        }
     }
 }

--- a/widget/src/toggler.rs
+++ b/widget/src/toggler.rs
@@ -434,7 +434,7 @@ impl Catalog for Theme {
     type Class<'a> = StyleFn<'a, Self>;
 
     fn default<'a>() -> Self::Class<'a> {
-        Box::new(default)
+        Box::new(Style::standard)
     }
 
     fn style(&self, class: &Self::Class<'_>, status: Status) -> Style {
@@ -442,46 +442,48 @@ impl Catalog for Theme {
     }
 }
 
-/// The default style of a [`Toggler`].
-pub fn default(theme: &Theme, status: Status) -> Style {
-    let palette = theme.extended_palette();
+impl Style {
+    /// The standard style of a [`Toggler`].
+    pub fn standard(theme: &Theme, status: Status) -> Self {
+        let palette = theme.extended_palette();
 
-    let background = match status {
-        Status::Active { is_toggled } | Status::Hovered { is_toggled } => {
-            if is_toggled {
-                palette.primary.strong.color
-            } else {
-                palette.background.strong.color
-            }
-        }
-    };
-
-    let foreground = match status {
-        Status::Active { is_toggled } => {
-            if is_toggled {
-                palette.primary.strong.text
-            } else {
-                palette.background.base.color
-            }
-        }
-        Status::Hovered { is_toggled } => {
-            if is_toggled {
-                Color {
-                    a: 0.5,
-                    ..palette.primary.strong.text
+        let background = match status {
+            Status::Active { is_toggled } | Status::Hovered { is_toggled } => {
+                if is_toggled {
+                    palette.primary.strong.color
+                } else {
+                    palette.background.strong.color
                 }
-            } else {
-                palette.background.weak.color
             }
-        }
-    };
+        };
 
-    Style {
-        background,
-        foreground,
-        foreground_border_width: 0.0,
-        foreground_border_color: Color::TRANSPARENT,
-        background_border_width: 0.0,
-        background_border_color: Color::TRANSPARENT,
+        let foreground = match status {
+            Status::Active { is_toggled } => {
+                if is_toggled {
+                    palette.primary.strong.text
+                } else {
+                    palette.background.base.color
+                }
+            }
+            Status::Hovered { is_toggled } => {
+                if is_toggled {
+                    Color {
+                        a: 0.5,
+                        ..palette.primary.strong.text
+                    }
+                } else {
+                    palette.background.weak.color
+                }
+            }
+        };
+
+        Self {
+            background,
+            foreground,
+            foreground_border_width: 0.0,
+            foreground_border_color: Color::TRANSPARENT,
+            background_border_width: 0.0,
+            background_border_color: Color::TRANSPARENT,
+        }
     }
 }

--- a/widget/src/vertical_slider.rs
+++ b/widget/src/vertical_slider.rs
@@ -1,9 +1,7 @@
 //! Display an interactive selector of a single value from a range of values.
 use std::ops::RangeInclusive;
 
-pub use crate::slider::{
-    default, Catalog, Handle, HandleShape, Status, Style, StyleFn,
-};
+pub use crate::slider::{Catalog, Handle, HandleShape, Status, Style, StyleFn};
 
 use crate::core::border::{self, Border};
 use crate::core::event::{self, Event};


### PR DESCRIPTION
### Pull Request: Refactor Styles and Introduce Standard Method

#### Changes:
1. **Bundled Style presets in `Style` Struct**:
   - All style presets are now organized within the `Style` struct.
2. **Introduced `standard` Method**:
   - Added the `standard` method to all styling presets for a consistent standard style.
   - The `default` style now serves as a blank, usable style.
3. **Added Background Helper for Scrollable**:
   - New helper added to simplify background styling for scrollable components.

#### Motivation:
- **Logical Organization**: Grouping styles in the `Style` struct centralizes and simplifies access.
- **Consistent Styling**: New users would expect `default` to match the standard styling (`primary`). The new standard method ensures that users have a clear and predictable way to access standard styling. This change ensures that when someone wants to change the background color of a standard button for example, they use standard `.style(|theme, status| button::Style::standard(theme, status).background(color!(255, 0, 0)))` and get the expected result.
- **Enhanced Readability**: The background helper for scrollable elements reduces repetitive code and improves code clarity.