### PR TITLE
Custom key binding support for `text_editor`

### DIFF
--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -1017,20 +1017,17 @@ impl<Message> Update<Message> {
                     Status::Active
                 };
 
+                let key_press = KeyPress {
+                    key,
+                    modifiers,
+                    text,
+                    status,
+                };
+
                 if let Some(key_binding) = key_binding {
-                    key_binding(KeyPress {
-                        key,
-                        modifiers,
-                        text,
-                        status,
-                    })
+                    key_binding(key_press)
                 } else {
-                    Binding::from_key_press(KeyPress {
-                        key,
-                        modifiers,
-                        text,
-                        status,
-                    })
+                    Binding::from_key_press(key_press)
                 }
                 .map(Self::Binding)
             }


### PR DESCRIPTION
This PR introduces custom key binding support for the `text_editor` widget.

You can use the new `key_binding` method, which accepts a closure that takes a `KeyPress` and optionally produces a `Binding`. You can obtain the default binding behavior with `Binding::from_key_press`.

For instance, let's say we want to produce a `Submit` message only when `Enter` is pressed without the `Shift` modifier:

```rust
text_editor(&self.content)
    .key_binding(|event| {
        let modifiers = event.modifiers;

        match text_editor::Binding::from_key_press(event) {
            Some(text_editor::Binding::Enter) if !modifiers.shift() => {
                Some(text_editor::Binding::Custom(Message::Submit))
            }
            binding => binding,
        }
    });
```

The `Binding` enum has a `Sequence(Vec<Binding>)` variant that can be used to produce combinations as well.

I believe these changes should allow users to implement custom key mappings in their editors, like Vim or Kakoune.