### PR TITLE
Expose physical keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ pkg/
 Cargo.lock
 dist/
 traces/
+
+.idea/

--- a/core/src/keyboard.rs
+++ b/core/src/keyboard.rs
@@ -4,8 +4,10 @@ pub mod key;
 mod event;
 mod location;
 mod modifiers;
+mod physical_key;
 
 pub use event::Event;
 pub use key::Key;
 pub use location::Location;
 pub use modifiers::Modifiers;
+pub use physical_key::{KeyCode, NativeKey, NativeKeyCode, PhysicalKey};

--- a/core/src/keyboard/event.rs
+++ b/core/src/keyboard/event.rs
@@ -1,3 +1,4 @@
+use crate::keyboard::physical_key::PhysicalKey;
 use crate::keyboard::{Key, Location, Modifiers};
 use crate::SmolStr;
 
@@ -14,6 +15,9 @@ pub enum Event {
         /// The key pressed.
         key: Key,
 
+        /// The physical key pressed.
+        physical_key: PhysicalKey,
+
         /// The location of the key.
         location: Location,
 
@@ -28,6 +32,9 @@ pub enum Event {
     KeyReleased {
         /// The key released.
         key: Key,
+
+        /// The physical key released.
+        physical_key: PhysicalKey,
 
         /// The location of the key.
         location: Location,

--- a/core/src/keyboard/physical_key.rs
+++ b/core/src/keyboard/physical_key.rs
@@ -1,0 +1,667 @@
+#![allow(missing_docs)]
+//! Types related to the keyboard.
+
+pub use crate::SmolStr;
+
+/// Contains the platform-native physical key identifier
+///
+/// The exact values vary from platform to platform (which is part of why this is a per-platform
+/// enum), but the values are primarily tied to the key's physical location on the keyboard.
+///
+/// This enum is primarily used to store raw keycodes when Winit doesn't map a given native
+/// physical key identifier to a meaningful [`KeyCode`] variant. In the presence of identifiers we
+/// haven't mapped for you yet, this lets you use use [`KeyCode`] to:
+///
+/// - Correctly match key press and release events.
+/// - On non-web platforms, support assigning keybinds to virtually any key through a UI.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum NativeKeyCode {
+    Unidentified,
+    /// An Android "scancode".
+    Android(u32),
+    /// A macOS "scancode".
+    MacOS(u16),
+    /// A Windows "scancode".
+    Windows(u16),
+    /// An XKB "keycode".
+    Xkb(u32),
+}
+
+impl std::fmt::Debug for NativeKeyCode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use NativeKeyCode::{Android, MacOS, Unidentified, Windows, Xkb};
+        let mut debug_tuple;
+        match self {
+            Unidentified => {
+                debug_tuple = f.debug_tuple("Unidentified");
+            }
+            Android(code) => {
+                debug_tuple = f.debug_tuple("Android");
+                let _ = debug_tuple.field(&format_args!("0x{code:04X}"));
+            }
+            MacOS(code) => {
+                debug_tuple = f.debug_tuple("MacOS");
+                let _ = debug_tuple.field(&format_args!("0x{code:04X}"));
+            }
+            Windows(code) => {
+                debug_tuple = f.debug_tuple("Windows");
+                let _ = debug_tuple.field(&format_args!("0x{code:04X}"));
+            }
+            Xkb(code) => {
+                debug_tuple = f.debug_tuple("Xkb");
+                let _ = debug_tuple.field(&format_args!("0x{code:04X}"));
+            }
+        }
+        debug_tuple.finish()
+    }
+}
+
+/// Contains the platform-native logical key identifier
+///
+/// Exactly what that means differs from platform to platform, but the values are to some degree
+/// tied to the currently active keyboard layout. The same key on the same keyboard may also report
+/// different values on different platforms, which is one of the reasons this is a per-platform
+/// enum.
+///
+/// This enum is primarily used to store raw keysym when Winit doesn't map a given native logical
+/// key identifier to a meaningful [`Key`] variant. This lets you use [`Key`], and let the user
+/// define keybinds which work in the presence of identifiers we haven't mapped for you yet.
+///
+/// [`Key`]: crate::keyboard::key::Key
+#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum NativeKey {
+    Unidentified,
+    /// An Android "keycode", which is similar to a "virtual-key code" on Windows.
+    Android(u32),
+    /// A macOS "scancode". There does not appear to be any direct analogue to either keysyms or
+    /// "virtual-key" codes in macOS, so we report the scancode instead.
+    MacOS(u16),
+    /// A Windows "virtual-key code".
+    Windows(u16),
+    /// An XKB "keysym".
+    Xkb(u32),
+    /// A "key value string".
+    Web(SmolStr),
+}
+
+impl std::fmt::Debug for NativeKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use NativeKey::{Android, MacOS, Unidentified, Web, Windows, Xkb};
+        let mut debug_tuple;
+        match self {
+            Unidentified => {
+                debug_tuple = f.debug_tuple("Unidentified");
+            }
+            Android(code) => {
+                debug_tuple = f.debug_tuple("Android");
+                let _ = debug_tuple.field(&format_args!("0x{code:04X}"));
+            }
+            MacOS(code) => {
+                debug_tuple = f.debug_tuple("MacOS");
+                let _ = debug_tuple.field(&format_args!("0x{code:04X}"));
+            }
+            Windows(code) => {
+                debug_tuple = f.debug_tuple("Windows");
+                let _ = debug_tuple.field(&format_args!("0x{code:04X}"));
+            }
+            Xkb(code) => {
+                debug_tuple = f.debug_tuple("Xkb");
+                let _ = debug_tuple.field(&format_args!("0x{code:04X}"));
+            }
+            Web(code) => {
+                debug_tuple = f.debug_tuple("Web");
+                let _ = debug_tuple.field(code);
+            }
+        }
+        debug_tuple.finish()
+    }
+}
+
+impl From<NativeKeyCode> for NativeKey {
+    #[inline]
+    fn from(code: NativeKeyCode) -> Self {
+        match code {
+            NativeKeyCode::Unidentified => NativeKey::Unidentified,
+            NativeKeyCode::Android(x) => NativeKey::Android(x),
+            NativeKeyCode::MacOS(x) => NativeKey::MacOS(x),
+            NativeKeyCode::Windows(x) => NativeKey::Windows(x),
+            NativeKeyCode::Xkb(x) => NativeKey::Xkb(x),
+        }
+    }
+}
+
+impl PartialEq<NativeKey> for NativeKeyCode {
+    #[allow(clippy::cmp_owned)] // uses less code than direct match; target is stack allocated
+    #[inline]
+    fn eq(&self, rhs: &NativeKey) -> bool {
+        NativeKey::from(*self) == *rhs
+    }
+}
+
+impl PartialEq<NativeKeyCode> for NativeKey {
+    #[inline]
+    fn eq(&self, rhs: &NativeKeyCode) -> bool {
+        rhs == self
+    }
+}
+
+/// Represents the location of a physical key.
+///
+/// This type is a superset of [`KeyCode`], including an [`Unidentified`][Self::Unidentified]
+/// variant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum PhysicalKey {
+    /// A known key code
+    Code(KeyCode),
+    /// This variant is used when the key cannot be translated to a [`KeyCode`]
+    ///
+    /// The native keycode is provided (if available) so you're able to more reliably match
+    /// key-press and key-release events by hashing the [`PhysicalKey`]. It is also possible to use
+    /// this for keybinds for non-standard keys, but such keybinds are tied to a given platform.
+    Unidentified(NativeKeyCode),
+}
+
+impl From<KeyCode> for PhysicalKey {
+    #[inline]
+    fn from(code: KeyCode) -> Self {
+        PhysicalKey::Code(code)
+    }
+}
+
+impl From<NativeKeyCode> for PhysicalKey {
+    #[inline]
+    fn from(code: NativeKeyCode) -> Self {
+        PhysicalKey::Unidentified(code)
+    }
+}
+
+impl PartialEq<KeyCode> for PhysicalKey {
+    #[inline]
+    fn eq(&self, rhs: &KeyCode) -> bool {
+        match self {
+            PhysicalKey::Code(ref code) => code == rhs,
+            PhysicalKey::Unidentified(_) => false,
+        }
+    }
+}
+
+impl PartialEq<PhysicalKey> for KeyCode {
+    #[inline]
+    fn eq(&self, rhs: &PhysicalKey) -> bool {
+        rhs == self
+    }
+}
+
+impl PartialEq<NativeKeyCode> for PhysicalKey {
+    #[inline]
+    fn eq(&self, rhs: &NativeKeyCode) -> bool {
+        match self {
+            PhysicalKey::Unidentified(ref code) => code == rhs,
+            PhysicalKey::Code(_) => false,
+        }
+    }
+}
+
+impl PartialEq<PhysicalKey> for NativeKeyCode {
+    #[inline]
+    fn eq(&self, rhs: &PhysicalKey) -> bool {
+        rhs == self
+    }
+}
+
+/// Code representing the location of a physical key
+///
+/// This mostly conforms to the UI Events Specification's [`KeyboardEvent.code`] with a few
+/// exceptions:
+/// - The keys that the specification calls "MetaLeft" and "MetaRight" are named "SuperLeft" and
+///   "SuperRight" here.
+/// - The key that the specification calls "Super" is reported as `Unidentified` here.
+///
+/// [`KeyboardEvent.code`]: https://w3c.github.io/uievents-code/#code-value-tables
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum KeyCode {
+    /// <kbd>`</kbd> on a US keyboard. This is also called a backtick or grave.
+    /// This is the <kbd>半角</kbd>/<kbd>全角</kbd>/<kbd>漢字</kbd>
+    /// (hankaku/zenkaku/kanji) key on Japanese keyboards
+    Backquote,
+    /// Used for both the US <kbd>\\</kbd> (on the 101-key layout) and also for the key
+    /// located between the <kbd>"</kbd> and <kbd>Enter</kbd> keys on row C of the 102-,
+    /// 104- and 106-key layouts.
+    /// Labeled <kbd>#</kbd> on a UK (102) keyboard.
+    Backslash,
+    /// <kbd>[</kbd> on a US keyboard.
+    BracketLeft,
+    /// <kbd>]</kbd> on a US keyboard.
+    BracketRight,
+    /// <kbd>,</kbd> on a US keyboard.
+    Comma,
+    /// <kbd>0</kbd> on a US keyboard.
+    Digit0,
+    /// <kbd>1</kbd> on a US keyboard.
+    Digit1,
+    /// <kbd>2</kbd> on a US keyboard.
+    Digit2,
+    /// <kbd>3</kbd> on a US keyboard.
+    Digit3,
+    /// <kbd>4</kbd> on a US keyboard.
+    Digit4,
+    /// <kbd>5</kbd> on a US keyboard.
+    Digit5,
+    /// <kbd>6</kbd> on a US keyboard.
+    Digit6,
+    /// <kbd>7</kbd> on a US keyboard.
+    Digit7,
+    /// <kbd>8</kbd> on a US keyboard.
+    Digit8,
+    /// <kbd>9</kbd> on a US keyboard.
+    Digit9,
+    /// <kbd>=</kbd> on a US keyboard.
+    Equal,
+    /// Located between the left <kbd>Shift</kbd> and <kbd>Z</kbd> keys.
+    /// Labeled <kbd>\\</kbd> on a UK keyboard.
+    IntlBackslash,
+    /// Located between the <kbd>/</kbd> and right <kbd>Shift</kbd> keys.
+    /// Labeled <kbd>\\</kbd> (ro) on a Japanese keyboard.
+    IntlRo,
+    /// Located between the <kbd>=</kbd> and <kbd>Backspace</kbd> keys.
+    /// Labeled <kbd>¥</kbd> (yen) on a Japanese keyboard. <kbd>\\</kbd> on a
+    /// Russian keyboard.
+    IntlYen,
+    /// <kbd>a</kbd> on a US keyboard.
+    /// Labeled <kbd>q</kbd> on an AZERTY (e.g., French) keyboard.
+    KeyA,
+    /// <kbd>b</kbd> on a US keyboard.
+    KeyB,
+    /// <kbd>c</kbd> on a US keyboard.
+    KeyC,
+    /// <kbd>d</kbd> on a US keyboard.
+    KeyD,
+    /// <kbd>e</kbd> on a US keyboard.
+    KeyE,
+    /// <kbd>f</kbd> on a US keyboard.
+    KeyF,
+    /// <kbd>g</kbd> on a US keyboard.
+    KeyG,
+    /// <kbd>h</kbd> on a US keyboard.
+    KeyH,
+    /// <kbd>i</kbd> on a US keyboard.
+    KeyI,
+    /// <kbd>j</kbd> on a US keyboard.
+    KeyJ,
+    /// <kbd>k</kbd> on a US keyboard.
+    KeyK,
+    /// <kbd>l</kbd> on a US keyboard.
+    KeyL,
+    /// <kbd>m</kbd> on a US keyboard.
+    KeyM,
+    /// <kbd>n</kbd> on a US keyboard.
+    KeyN,
+    /// <kbd>o</kbd> on a US keyboard.
+    KeyO,
+    /// <kbd>p</kbd> on a US keyboard.
+    KeyP,
+    /// <kbd>q</kbd> on a US keyboard.
+    /// Labeled <kbd>a</kbd> on an AZERTY (e.g., French) keyboard.
+    KeyQ,
+    /// <kbd>r</kbd> on a US keyboard.
+    KeyR,
+    /// <kbd>s</kbd> on a US keyboard.
+    KeyS,
+    /// <kbd>t</kbd> on a US keyboard.
+    KeyT,
+    /// <kbd>u</kbd> on a US keyboard.
+    KeyU,
+    /// <kbd>v</kbd> on a US keyboard.
+    KeyV,
+    /// <kbd>w</kbd> on a US keyboard.
+    /// Labeled <kbd>z</kbd> on an AZERTY (e.g., French) keyboard.
+    KeyW,
+    /// <kbd>x</kbd> on a US keyboard.
+    KeyX,
+    /// <kbd>y</kbd> on a US keyboard.
+    /// Labeled <kbd>z</kbd> on a QWERTZ (e.g., German) keyboard.
+    KeyY,
+    /// <kbd>z</kbd> on a US keyboard.
+    /// Labeled <kbd>w</kbd> on an AZERTY (e.g., French) keyboard, and <kbd>y</kbd> on a
+    /// QWERTZ (e.g., German) keyboard.
+    KeyZ,
+    /// <kbd>-</kbd> on a US keyboard.
+    Minus,
+    /// <kbd>.</kbd> on a US keyboard.
+    Period,
+    /// <kbd>'</kbd> on a US keyboard.
+    Quote,
+    /// <kbd>;</kbd> on a US keyboard.
+    Semicolon,
+    /// <kbd>/</kbd> on a US keyboard.
+    Slash,
+    /// <kbd>Alt</kbd>, <kbd>Option</kbd>, or <kbd>⌥</kbd>.
+    AltLeft,
+    /// <kbd>Alt</kbd>, <kbd>Option</kbd>, or <kbd>⌥</kbd>.
+    /// This is labeled <kbd>AltGr</kbd> on many keyboard layouts.
+    AltRight,
+    /// <kbd>Backspace</kbd> or <kbd>⌫</kbd>.
+    /// Labeled <kbd>Delete</kbd> on Apple keyboards.
+    Backspace,
+    /// <kbd>CapsLock</kbd> or <kbd>⇪</kbd>
+    CapsLock,
+    /// The application context menu key, which is typically found between the right
+    /// <kbd>Super</kbd> key and the right <kbd>Control</kbd> key.
+    ContextMenu,
+    /// <kbd>Control</kbd> or <kbd>⌃</kbd>
+    ControlLeft,
+    /// <kbd>Control</kbd> or <kbd>⌃</kbd>
+    ControlRight,
+    /// <kbd>Enter</kbd> or <kbd>↵</kbd>. Labeled <kbd>Return</kbd> on Apple keyboards.
+    Enter,
+    /// The Windows, <kbd>⌘</kbd>, <kbd>Command</kbd>, or other OS symbol key.
+    SuperLeft,
+    /// The Windows, <kbd>⌘</kbd>, <kbd>Command</kbd>, or other OS symbol key.
+    SuperRight,
+    /// <kbd>Shift</kbd> or <kbd>⇧</kbd>
+    ShiftLeft,
+    /// <kbd>Shift</kbd> or <kbd>⇧</kbd>
+    ShiftRight,
+    /// <kbd> </kbd> (space)
+    Space,
+    /// <kbd>Tab</kbd> or <kbd>⇥</kbd>
+    Tab,
+    /// Japanese: <kbd>変</kbd> (henkan)
+    Convert,
+    /// Japanese: <kbd>カタカナ</kbd>/<kbd>ひらがな</kbd>/<kbd>ローマ字</kbd>
+    /// (katakana/hiragana/romaji)
+    KanaMode,
+    /// Korean: HangulMode <kbd>한/영</kbd> (han/yeong)
+    ///
+    /// Japanese (Mac keyboard): <kbd>か</kbd> (kana)
+    Lang1,
+    /// Korean: Hanja <kbd>한</kbd> (hanja)
+    ///
+    /// Japanese (Mac keyboard): <kbd>英</kbd> (eisu)
+    Lang2,
+    /// Japanese (word-processing keyboard): Katakana
+    Lang3,
+    /// Japanese (word-processing keyboard): Hiragana
+    Lang4,
+    /// Japanese (word-processing keyboard): Zenkaku/Hankaku
+    Lang5,
+    /// Japanese: <kbd>無変換</kbd> (muhenkan)
+    NonConvert,
+    /// <kbd>⌦</kbd>. The forward delete key.
+    /// Note that on Apple keyboards, the key labelled <kbd>Delete</kbd> on the main part of
+    /// the keyboard is encoded as [`Backspace`].
+    ///
+    /// [`Backspace`]: Self::Backspace
+    Delete,
+    /// <kbd>Page Down</kbd>, <kbd>End</kbd>, or <kbd>↘</kbd>
+    End,
+    /// <kbd>Help</kbd>. Not present on standard PC keyboards.
+    Help,
+    /// <kbd>Home</kbd> or <kbd>↖</kbd>
+    Home,
+    /// <kbd>Insert</kbd> or <kbd>Ins</kbd>. Not present on Apple keyboards.
+    Insert,
+    /// <kbd>Page Down</kbd>, <kbd>PgDn</kbd>, or <kbd>⇟</kbd>
+    PageDown,
+    /// <kbd>Page Up</kbd>, <kbd>PgUp</kbd>, or <kbd>⇞</kbd>
+    PageUp,
+    /// <kbd>↓</kbd>
+    ArrowDown,
+    /// <kbd>←</kbd>
+    ArrowLeft,
+    /// <kbd>→</kbd>
+    ArrowRight,
+    /// <kbd>↑</kbd>
+    ArrowUp,
+    /// On the Mac, this is used for the numpad <kbd>Clear</kbd> key.
+    NumLock,
+    /// <kbd>0 Ins</kbd> on a keyboard. <kbd>0</kbd> on a phone or remote control
+    Numpad0,
+    /// <kbd>1 End</kbd> on a keyboard. <kbd>1</kbd> or <kbd>1 QZ</kbd> on a phone or remote
+    /// control
+    Numpad1,
+    /// <kbd>2 ↓</kbd> on a keyboard. <kbd>2 ABC</kbd> on a phone or remote control
+    Numpad2,
+    /// <kbd>3 PgDn</kbd> on a keyboard. <kbd>3 DEF</kbd> on a phone or remote control
+    Numpad3,
+    /// <kbd>4 ←</kbd> on a keyboard. <kbd>4 GHI</kbd> on a phone or remote control
+    Numpad4,
+    /// <kbd>5</kbd> on a keyboard. <kbd>5 JKL</kbd> on a phone or remote control
+    Numpad5,
+    /// <kbd>6 →</kbd> on a keyboard. <kbd>6 MNO</kbd> on a phone or remote control
+    Numpad6,
+    /// <kbd>7 Home</kbd> on a keyboard. <kbd>7 PQRS</kbd> or <kbd>7 PRS</kbd> on a phone
+    /// or remote control
+    Numpad7,
+    /// <kbd>8 ↑</kbd> on a keyboard. <kbd>8 TUV</kbd> on a phone or remote control
+    Numpad8,
+    /// <kbd>9 PgUp</kbd> on a keyboard. <kbd>9 WXYZ</kbd> or <kbd>9 WXY</kbd> on a phone
+    /// or remote control
+    Numpad9,
+    /// <kbd>+</kbd>
+    NumpadAdd,
+    /// Found on the Microsoft Natural Keyboard.
+    NumpadBackspace,
+    /// <kbd>C</kbd> or <kbd>A</kbd> (All Clear). Also for use with numpads that have a
+    /// <kbd>Clear</kbd> key that is separate from the <kbd>NumLock</kbd> key. On the Mac, the
+    /// numpad <kbd>Clear</kbd> key is encoded as [`NumLock`].
+    ///
+    /// [`NumLock`]: Self::NumLock
+    NumpadClear,
+    /// <kbd>C</kbd> (Clear Entry)
+    NumpadClearEntry,
+    /// <kbd>,</kbd> (thousands separator). For locales where the thousands separator
+    /// is a "." (e.g., Brazil), this key may generate a <kbd>.</kbd>.
+    NumpadComma,
+    /// <kbd>. Del</kbd>. For locales where the decimal separator is "," (e.g.,
+    /// Brazil), this key may generate a <kbd>,</kbd>.
+    NumpadDecimal,
+    /// <kbd>/</kbd>
+    NumpadDivide,
+    NumpadEnter,
+    /// <kbd>=</kbd>
+    NumpadEqual,
+    /// <kbd>#</kbd> on a phone or remote control device. This key is typically found
+    /// below the <kbd>9</kbd> key and to the right of the <kbd>0</kbd> key.
+    NumpadHash,
+    /// <kbd>M</kbd> Add current entry to the value stored in memory.
+    NumpadMemoryAdd,
+    /// <kbd>M</kbd> Clear the value stored in memory.
+    NumpadMemoryClear,
+    /// <kbd>M</kbd> Replace the current entry with the value stored in memory.
+    NumpadMemoryRecall,
+    /// <kbd>M</kbd> Replace the value stored in memory with the current entry.
+    NumpadMemoryStore,
+    /// <kbd>M</kbd> Subtract current entry from the value stored in memory.
+    NumpadMemorySubtract,
+    /// <kbd>*</kbd> on a keyboard. For use with numpads that provide mathematical
+    /// operations (<kbd>+</kbd>, <kbd>-</kbd> <kbd>*</kbd> and <kbd>/</kbd>).
+    ///
+    /// Use `NumpadStar` for the <kbd>*</kbd> key on phones and remote controls.
+    NumpadMultiply,
+    /// <kbd>(</kbd> Found on the Microsoft Natural Keyboard.
+    NumpadParenLeft,
+    /// <kbd>)</kbd> Found on the Microsoft Natural Keyboard.
+    NumpadParenRight,
+    /// <kbd>*</kbd> on a phone or remote control device.
+    ///
+    /// This key is typically found below the <kbd>7</kbd> key and to the left of
+    /// the <kbd>0</kbd> key.
+    ///
+    /// Use <kbd>"NumpadMultiply"</kbd> for the <kbd>*</kbd> key on
+    /// numeric keypads.
+    NumpadStar,
+    /// <kbd>-</kbd>
+    NumpadSubtract,
+    /// <kbd>Esc</kbd> or <kbd>⎋</kbd>
+    Escape,
+    /// <kbd>Fn</kbd> This is typically a hardware key that does not generate a separate code.
+    Fn,
+    /// <kbd>FLock</kbd> or <kbd>FnLock</kbd>. Function Lock key. Found on the Microsoft
+    /// Natural Keyboard.
+    FnLock,
+    /// <kbd>PrtScr SysRq</kbd> or <kbd>Print Screen</kbd>
+    PrintScreen,
+    /// <kbd>Scroll Lock</kbd>
+    ScrollLock,
+    /// <kbd>Pause Break</kbd>
+    Pause,
+    /// Some laptops place this key to the left of the <kbd>↑</kbd> key.
+    ///
+    /// This also the "back" button (triangle) on Android.
+    BrowserBack,
+    BrowserFavorites,
+    /// Some laptops place this key to the right of the <kbd>↑</kbd> key.
+    BrowserForward,
+    /// The "home" button on Android.
+    BrowserHome,
+    BrowserRefresh,
+    BrowserSearch,
+    BrowserStop,
+    /// <kbd>Eject</kbd> or <kbd>⏏</kbd>. This key is placed in the function section on some Apple
+    /// keyboards.
+    Eject,
+    /// Sometimes labelled <kbd>My Computer</kbd> on the keyboard
+    LaunchApp1,
+    /// Sometimes labelled <kbd>Calculator</kbd> on the keyboard
+    LaunchApp2,
+    LaunchMail,
+    MediaPlayPause,
+    MediaSelect,
+    MediaStop,
+    MediaTrackNext,
+    MediaTrackPrevious,
+    /// This key is placed in the function section on some Apple keyboards, replacing the
+    /// <kbd>Eject</kbd> key.
+    Power,
+    Sleep,
+    AudioVolumeDown,
+    AudioVolumeMute,
+    AudioVolumeUp,
+    WakeUp,
+    // Legacy modifier key. Also called "Super" in certain places.
+    Meta,
+    // Legacy modifier key.
+    Hyper,
+    Turbo,
+    Abort,
+    Resume,
+    Suspend,
+    /// Found on Sun’s USB keyboard.
+    Again,
+    /// Found on Sun’s USB keyboard.
+    Copy,
+    /// Found on Sun’s USB keyboard.
+    Cut,
+    /// Found on Sun’s USB keyboard.
+    Find,
+    /// Found on Sun’s USB keyboard.
+    Open,
+    /// Found on Sun’s USB keyboard.
+    Paste,
+    /// Found on Sun’s USB keyboard.
+    Props,
+    /// Found on Sun’s USB keyboard.
+    Select,
+    /// Found on Sun’s USB keyboard.
+    Undo,
+    /// Use for dedicated <kbd>ひらがな</kbd> key found on some Japanese word processing keyboards.
+    Hiragana,
+    /// Use for dedicated <kbd>カタカナ</kbd> key found on some Japanese word processing keyboards.
+    Katakana,
+    /// General-purpose function key.
+    /// Usually found at the top of the keyboard.
+    F1,
+    /// General-purpose function key.
+    /// Usually found at the top of the keyboard.
+    F2,
+    /// General-purpose function key.
+    /// Usually found at the top of the keyboard.
+    F3,
+    /// General-purpose function key.
+    /// Usually found at the top of the keyboard.
+    F4,
+    /// General-purpose function key.
+    /// Usually found at the top of the keyboard.
+    F5,
+    /// General-purpose function key.
+    /// Usually found at the top of the keyboard.
+    F6,
+    /// General-purpose function key.
+    /// Usually found at the top of the keyboard.
+    F7,
+    /// General-purpose function key.
+    /// Usually found at the top of the keyboard.
+    F8,
+    /// General-purpose function key.
+    /// Usually found at the top of the keyboard.
+    F9,
+    /// General-purpose function key.
+    /// Usually found at the top of the keyboard.
+    F10,
+    /// General-purpose function key.
+    /// Usually found at the top of the keyboard.
+    F11,
+    /// General-purpose function key.
+    /// Usually found at the top of the keyboard.
+    F12,
+    /// General-purpose function key.
+    /// Usually found at the top of the keyboard.
+    F13,
+    /// General-purpose function key.
+    /// Usually found at the top of the keyboard.
+    F14,
+    /// General-purpose function key.
+    /// Usually found at the top of the keyboard.
+    F15,
+    /// General-purpose function key.
+    /// Usually found at the top of the keyboard.
+    F16,
+    /// General-purpose function key.
+    /// Usually found at the top of the keyboard.
+    F17,
+    /// General-purpose function key.
+    /// Usually found at the top of the keyboard.
+    F18,
+    /// General-purpose function key.
+    /// Usually found at the top of the keyboard.
+    F19,
+    /// General-purpose function key.
+    /// Usually found at the top of the keyboard.
+    F20,
+    /// General-purpose function key.
+    /// Usually found at the top of the keyboard.
+    F21,
+    /// General-purpose function key.
+    /// Usually found at the top of the keyboard.
+    F22,
+    /// General-purpose function key.
+    /// Usually found at the top of the keyboard.
+    F23,
+    /// General-purpose function key.
+    /// Usually found at the top of the keyboard.
+    F24,
+    /// General-purpose function key.
+    F25,
+    /// General-purpose function key.
+    F26,
+    /// General-purpose function key.
+    F27,
+    /// General-purpose function key.
+    F28,
+    /// General-purpose function key.
+    F29,
+    /// General-purpose function key.
+    F30,
+    /// General-purpose function key.
+    F31,
+    /// General-purpose function key.
+    F32,
+    /// General-purpose function key.
+    F33,
+    /// General-purpose function key.
+    F34,
+    /// General-purpose function key.
+    F35,
+}

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -7,6 +7,7 @@ use crate::core::mouse;
 use crate::core::touch;
 use crate::core::window;
 use crate::core::{Event, Point, Size};
+use winit::keyboard::{KeyCode, NativeKeyCode, PhysicalKey};
 
 /// Converts some [`window::Settings`] into some `WindowAttributes` from `winit`.
 pub fn window_attributes(
@@ -215,9 +216,13 @@ pub fn window_event(
             }.filter(|text| !text.as_str().chars().any(is_private_use));
 
             let winit::event::KeyEvent {
-                state, location, ..
+                state,
+                location,
+                physical_key,
+                ..
             } = event;
             let key = key(logical_key);
+            let physical_key = self::physical_key(physical_key);
             let modifiers = self::modifiers(modifiers);
 
             let location = match location {
@@ -237,6 +242,7 @@ pub fn window_event(
                 winit::event::ElementState::Pressed => {
                     keyboard::Event::KeyPressed {
                         key,
+                        physical_key,
                         modifiers,
                         location,
                         text,
@@ -245,6 +251,7 @@ pub fn window_event(
                 winit::event::ElementState::Released => {
                     keyboard::Event::KeyReleased {
                         key,
+                        physical_key,
                         modifiers,
                         location,
                     }
@@ -828,6 +835,616 @@ pub fn key(key: winit::keyboard::Key) -> keyboard::Key {
             })
         }
         _ => keyboard::Key::Unidentified,
+    }
+}
+
+/// Converts physical key code from winit to an iced key code.
+pub fn physical_key(key: PhysicalKey) -> keyboard::PhysicalKey {
+    match key {
+        PhysicalKey::Code(KeyCode::Backquote) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Backquote)
+        }
+        PhysicalKey::Code(KeyCode::Backslash) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Backslash)
+        }
+        PhysicalKey::Code(KeyCode::BracketLeft) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::BracketLeft)
+        }
+        PhysicalKey::Code(KeyCode::BracketRight) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::BracketRight)
+        }
+        PhysicalKey::Code(KeyCode::Comma) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Comma)
+        }
+        PhysicalKey::Code(KeyCode::Digit0) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Digit0)
+        }
+        PhysicalKey::Code(KeyCode::Digit1) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Digit1)
+        }
+        PhysicalKey::Code(KeyCode::Digit2) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Digit2)
+        }
+        PhysicalKey::Code(KeyCode::Digit3) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Digit3)
+        }
+        PhysicalKey::Code(KeyCode::Digit4) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Digit4)
+        }
+        PhysicalKey::Code(KeyCode::Digit5) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Digit5)
+        }
+        PhysicalKey::Code(KeyCode::Digit6) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Digit6)
+        }
+        PhysicalKey::Code(KeyCode::Digit7) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Digit7)
+        }
+        PhysicalKey::Code(KeyCode::Digit8) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Digit8)
+        }
+        PhysicalKey::Code(KeyCode::Digit9) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Digit9)
+        }
+        PhysicalKey::Code(KeyCode::Equal) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Equal)
+        }
+        PhysicalKey::Code(KeyCode::IntlBackslash) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::IntlBackslash)
+        }
+        PhysicalKey::Code(KeyCode::IntlRo) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::IntlRo)
+        }
+        PhysicalKey::Code(KeyCode::IntlYen) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::IntlYen)
+        }
+        PhysicalKey::Code(KeyCode::KeyA) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::KeyA)
+        }
+        PhysicalKey::Code(KeyCode::KeyB) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::KeyB)
+        }
+        PhysicalKey::Code(KeyCode::KeyC) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::KeyC)
+        }
+        PhysicalKey::Code(KeyCode::KeyD) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::KeyD)
+        }
+        PhysicalKey::Code(KeyCode::KeyE) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::KeyE)
+        }
+        PhysicalKey::Code(KeyCode::KeyF) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::KeyF)
+        }
+        PhysicalKey::Code(KeyCode::KeyG) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::KeyG)
+        }
+        PhysicalKey::Code(KeyCode::KeyH) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::KeyH)
+        }
+        PhysicalKey::Code(KeyCode::KeyI) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::KeyI)
+        }
+        PhysicalKey::Code(KeyCode::KeyJ) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::KeyJ)
+        }
+        PhysicalKey::Code(KeyCode::KeyK) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::KeyK)
+        }
+        PhysicalKey::Code(KeyCode::KeyL) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::KeyL)
+        }
+        PhysicalKey::Code(KeyCode::KeyM) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::KeyM)
+        }
+        PhysicalKey::Code(KeyCode::KeyN) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::KeyN)
+        }
+        PhysicalKey::Code(KeyCode::KeyO) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::KeyO)
+        }
+        PhysicalKey::Code(KeyCode::KeyP) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::KeyP)
+        }
+        PhysicalKey::Code(KeyCode::KeyQ) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::KeyQ)
+        }
+        PhysicalKey::Code(KeyCode::KeyR) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::KeyR)
+        }
+        PhysicalKey::Code(KeyCode::KeyS) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::KeyS)
+        }
+        PhysicalKey::Code(KeyCode::KeyT) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::KeyT)
+        }
+        PhysicalKey::Code(KeyCode::KeyU) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::KeyU)
+        }
+        PhysicalKey::Code(KeyCode::KeyV) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::KeyV)
+        }
+        PhysicalKey::Code(KeyCode::KeyW) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::KeyW)
+        }
+        PhysicalKey::Code(KeyCode::KeyX) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::KeyX)
+        }
+        PhysicalKey::Code(KeyCode::KeyY) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::KeyY)
+        }
+        PhysicalKey::Code(KeyCode::KeyZ) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::KeyZ)
+        }
+        PhysicalKey::Code(KeyCode::Minus) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Minus)
+        }
+        PhysicalKey::Code(KeyCode::Period) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Period)
+        }
+        PhysicalKey::Code(KeyCode::Quote) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Quote)
+        }
+        PhysicalKey::Code(KeyCode::Semicolon) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Semicolon)
+        }
+        PhysicalKey::Code(KeyCode::Slash) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Slash)
+        }
+        PhysicalKey::Code(KeyCode::AltLeft) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::AltLeft)
+        }
+        PhysicalKey::Code(KeyCode::AltRight) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::AltRight)
+        }
+        PhysicalKey::Code(KeyCode::Backspace) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Backspace)
+        }
+        PhysicalKey::Code(KeyCode::CapsLock) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::CapsLock)
+        }
+        PhysicalKey::Code(KeyCode::ContextMenu) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::ContextMenu)
+        }
+        PhysicalKey::Code(KeyCode::ControlLeft) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::ControlLeft)
+        }
+        PhysicalKey::Code(KeyCode::ControlRight) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::ControlRight)
+        }
+        PhysicalKey::Code(KeyCode::Enter) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Enter)
+        }
+        PhysicalKey::Code(KeyCode::SuperLeft) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::SuperLeft)
+        }
+        PhysicalKey::Code(KeyCode::SuperRight) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::SuperRight)
+        }
+        PhysicalKey::Code(KeyCode::ShiftLeft) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::ShiftLeft)
+        }
+        PhysicalKey::Code(KeyCode::ShiftRight) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::ShiftRight)
+        }
+        PhysicalKey::Code(KeyCode::Space) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Space)
+        }
+        PhysicalKey::Code(KeyCode::Tab) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Tab)
+        }
+        PhysicalKey::Code(KeyCode::Convert) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Convert)
+        }
+        PhysicalKey::Code(KeyCode::KanaMode) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::KanaMode)
+        }
+        PhysicalKey::Code(KeyCode::Lang1) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Lang1)
+        }
+        PhysicalKey::Code(KeyCode::Lang2) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Lang2)
+        }
+        PhysicalKey::Code(KeyCode::Lang3) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Lang3)
+        }
+        PhysicalKey::Code(KeyCode::Lang4) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Lang4)
+        }
+        PhysicalKey::Code(KeyCode::Lang5) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Lang5)
+        }
+        PhysicalKey::Code(KeyCode::NonConvert) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::NonConvert)
+        }
+        PhysicalKey::Code(KeyCode::Delete) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Delete)
+        }
+        PhysicalKey::Code(KeyCode::End) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::End)
+        }
+        PhysicalKey::Code(KeyCode::Help) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Help)
+        }
+        PhysicalKey::Code(KeyCode::Home) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Home)
+        }
+        PhysicalKey::Code(KeyCode::Insert) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Insert)
+        }
+        PhysicalKey::Code(KeyCode::PageDown) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::PageDown)
+        }
+        PhysicalKey::Code(KeyCode::PageUp) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::PageUp)
+        }
+        PhysicalKey::Code(KeyCode::ArrowDown) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::ArrowDown)
+        }
+        PhysicalKey::Code(KeyCode::ArrowLeft) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::ArrowLeft)
+        }
+        PhysicalKey::Code(KeyCode::ArrowRight) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::ArrowRight)
+        }
+        PhysicalKey::Code(KeyCode::ArrowUp) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::ArrowUp)
+        }
+        PhysicalKey::Code(KeyCode::NumLock) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::NumLock)
+        }
+        PhysicalKey::Code(KeyCode::Numpad0) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Numpad0)
+        }
+        PhysicalKey::Code(KeyCode::Numpad1) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Numpad1)
+        }
+        PhysicalKey::Code(KeyCode::Numpad2) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Numpad2)
+        }
+        PhysicalKey::Code(KeyCode::Numpad3) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Numpad3)
+        }
+        PhysicalKey::Code(KeyCode::Numpad4) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Numpad4)
+        }
+        PhysicalKey::Code(KeyCode::Numpad5) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Numpad5)
+        }
+        PhysicalKey::Code(KeyCode::Numpad6) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Numpad6)
+        }
+        PhysicalKey::Code(KeyCode::Numpad7) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Numpad7)
+        }
+        PhysicalKey::Code(KeyCode::Numpad8) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Numpad8)
+        }
+        PhysicalKey::Code(KeyCode::Numpad9) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Numpad9)
+        }
+        PhysicalKey::Code(KeyCode::NumpadAdd) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::NumpadAdd)
+        }
+        PhysicalKey::Code(KeyCode::NumpadBackspace) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::NumpadBackspace)
+        }
+        PhysicalKey::Code(KeyCode::NumpadClear) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::NumpadClear)
+        }
+        PhysicalKey::Code(KeyCode::NumpadClearEntry) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::NumpadClearEntry)
+        }
+        PhysicalKey::Code(KeyCode::NumpadComma) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::NumpadComma)
+        }
+        PhysicalKey::Code(KeyCode::NumpadDecimal) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::NumpadDecimal)
+        }
+        PhysicalKey::Code(KeyCode::NumpadDivide) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::NumpadDivide)
+        }
+        PhysicalKey::Code(KeyCode::NumpadEnter) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::NumpadEnter)
+        }
+        PhysicalKey::Code(KeyCode::NumpadEqual) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::NumpadEqual)
+        }
+        PhysicalKey::Code(KeyCode::NumpadHash) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::NumpadHash)
+        }
+        PhysicalKey::Code(KeyCode::NumpadMemoryAdd) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::NumpadMemoryAdd)
+        }
+        PhysicalKey::Code(KeyCode::NumpadMemoryClear) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::NumpadMemoryClear)
+        }
+        PhysicalKey::Code(KeyCode::NumpadMemoryRecall) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::NumpadMemoryRecall)
+        }
+        PhysicalKey::Code(KeyCode::NumpadMemoryStore) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::NumpadMemoryStore)
+        }
+        PhysicalKey::Code(KeyCode::NumpadMemorySubtract) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::NumpadMemorySubtract)
+        }
+        PhysicalKey::Code(KeyCode::NumpadMultiply) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::NumpadMultiply)
+        }
+        PhysicalKey::Code(KeyCode::NumpadParenLeft) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::NumpadParenLeft)
+        }
+        PhysicalKey::Code(KeyCode::NumpadParenRight) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::NumpadParenRight)
+        }
+        PhysicalKey::Code(KeyCode::NumpadStar) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::NumpadStar)
+        }
+        PhysicalKey::Code(KeyCode::NumpadSubtract) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::NumpadSubtract)
+        }
+        PhysicalKey::Code(KeyCode::Escape) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Escape)
+        }
+        PhysicalKey::Code(KeyCode::Fn) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Fn)
+        }
+        PhysicalKey::Code(KeyCode::FnLock) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::FnLock)
+        }
+        PhysicalKey::Code(KeyCode::PrintScreen) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::PrintScreen)
+        }
+        PhysicalKey::Code(KeyCode::ScrollLock) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::ScrollLock)
+        }
+        PhysicalKey::Code(KeyCode::Pause) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Pause)
+        }
+        PhysicalKey::Code(KeyCode::BrowserBack) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::BrowserBack)
+        }
+        PhysicalKey::Code(KeyCode::BrowserFavorites) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::BrowserFavorites)
+        }
+        PhysicalKey::Code(KeyCode::BrowserForward) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::BrowserForward)
+        }
+        PhysicalKey::Code(KeyCode::BrowserHome) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::BrowserHome)
+        }
+        PhysicalKey::Code(KeyCode::BrowserRefresh) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::BrowserRefresh)
+        }
+        PhysicalKey::Code(KeyCode::BrowserSearch) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::BrowserSearch)
+        }
+        PhysicalKey::Code(KeyCode::BrowserStop) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::BrowserStop)
+        }
+        PhysicalKey::Code(KeyCode::Eject) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Eject)
+        }
+        PhysicalKey::Code(KeyCode::LaunchApp1) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::LaunchApp1)
+        }
+        PhysicalKey::Code(KeyCode::LaunchApp2) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::LaunchApp2)
+        }
+        PhysicalKey::Code(KeyCode::LaunchMail) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::LaunchMail)
+        }
+        PhysicalKey::Code(KeyCode::MediaPlayPause) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::MediaPlayPause)
+        }
+        PhysicalKey::Code(KeyCode::MediaSelect) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::MediaSelect)
+        }
+        PhysicalKey::Code(KeyCode::MediaStop) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::MediaStop)
+        }
+        PhysicalKey::Code(KeyCode::MediaTrackNext) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::MediaTrackNext)
+        }
+        PhysicalKey::Code(KeyCode::MediaTrackPrevious) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::MediaTrackPrevious)
+        }
+        PhysicalKey::Code(KeyCode::Power) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Power)
+        }
+        PhysicalKey::Code(KeyCode::Sleep) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Sleep)
+        }
+        PhysicalKey::Code(KeyCode::AudioVolumeDown) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::AudioVolumeDown)
+        }
+        PhysicalKey::Code(KeyCode::AudioVolumeMute) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::AudioVolumeMute)
+        }
+        PhysicalKey::Code(KeyCode::AudioVolumeUp) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::AudioVolumeUp)
+        }
+        PhysicalKey::Code(KeyCode::WakeUp) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::WakeUp)
+        }
+        PhysicalKey::Code(KeyCode::Meta) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Meta)
+        }
+        PhysicalKey::Code(KeyCode::Hyper) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Hyper)
+        }
+        PhysicalKey::Code(KeyCode::Turbo) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Turbo)
+        }
+        PhysicalKey::Code(KeyCode::Abort) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Abort)
+        }
+        PhysicalKey::Code(KeyCode::Resume) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Resume)
+        }
+        PhysicalKey::Code(KeyCode::Suspend) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Suspend)
+        }
+        PhysicalKey::Code(KeyCode::Again) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Again)
+        }
+        PhysicalKey::Code(KeyCode::Copy) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Copy)
+        }
+        PhysicalKey::Code(KeyCode::Cut) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Cut)
+        }
+        PhysicalKey::Code(KeyCode::Find) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Find)
+        }
+        PhysicalKey::Code(KeyCode::Open) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Open)
+        }
+        PhysicalKey::Code(KeyCode::Paste) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Paste)
+        }
+        PhysicalKey::Code(KeyCode::Props) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Props)
+        }
+        PhysicalKey::Code(KeyCode::Select) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Select)
+        }
+        PhysicalKey::Code(KeyCode::Undo) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Undo)
+        }
+        PhysicalKey::Code(KeyCode::Hiragana) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Hiragana)
+        }
+        PhysicalKey::Code(KeyCode::Katakana) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::Katakana)
+        }
+        PhysicalKey::Code(KeyCode::F1) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::F1)
+        }
+        PhysicalKey::Code(KeyCode::F2) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::F2)
+        }
+        PhysicalKey::Code(KeyCode::F3) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::F3)
+        }
+        PhysicalKey::Code(KeyCode::F4) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::F4)
+        }
+        PhysicalKey::Code(KeyCode::F5) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::F5)
+        }
+        PhysicalKey::Code(KeyCode::F6) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::F6)
+        }
+        PhysicalKey::Code(KeyCode::F7) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::F7)
+        }
+        PhysicalKey::Code(KeyCode::F8) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::F8)
+        }
+        PhysicalKey::Code(KeyCode::F9) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::F9)
+        }
+        PhysicalKey::Code(KeyCode::F10) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::F10)
+        }
+        PhysicalKey::Code(KeyCode::F11) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::F11)
+        }
+        PhysicalKey::Code(KeyCode::F12) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::F12)
+        }
+        PhysicalKey::Code(KeyCode::F13) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::F13)
+        }
+        PhysicalKey::Code(KeyCode::F14) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::F14)
+        }
+        PhysicalKey::Code(KeyCode::F15) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::F15)
+        }
+        PhysicalKey::Code(KeyCode::F16) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::F16)
+        }
+        PhysicalKey::Code(KeyCode::F17) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::F17)
+        }
+        PhysicalKey::Code(KeyCode::F18) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::F18)
+        }
+        PhysicalKey::Code(KeyCode::F19) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::F19)
+        }
+        PhysicalKey::Code(KeyCode::F20) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::F20)
+        }
+        PhysicalKey::Code(KeyCode::F21) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::F21)
+        }
+        PhysicalKey::Code(KeyCode::F22) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::F22)
+        }
+        PhysicalKey::Code(KeyCode::F23) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::F23)
+        }
+        PhysicalKey::Code(KeyCode::F24) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::F24)
+        }
+        PhysicalKey::Code(KeyCode::F25) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::F25)
+        }
+        PhysicalKey::Code(KeyCode::F26) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::F26)
+        }
+        PhysicalKey::Code(KeyCode::F27) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::F27)
+        }
+        PhysicalKey::Code(KeyCode::F28) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::F28)
+        }
+        PhysicalKey::Code(KeyCode::F29) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::F29)
+        }
+        PhysicalKey::Code(KeyCode::F30) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::F30)
+        }
+        PhysicalKey::Code(KeyCode::F31) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::F31)
+        }
+        PhysicalKey::Code(KeyCode::F32) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::F32)
+        }
+        PhysicalKey::Code(KeyCode::F33) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::F33)
+        }
+        PhysicalKey::Code(KeyCode::F34) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::F34)
+        }
+        PhysicalKey::Code(KeyCode::F35) => {
+            keyboard::PhysicalKey::Code(keyboard::KeyCode::F35)
+        }
+        PhysicalKey::Code(_) => unreachable!(), // needed because of #[non_exhaustive] in winit
+        PhysicalKey::Unidentified(native_key_code) => {
+            let native_key_code = match native_key_code {
+                NativeKeyCode::Unidentified => {
+                    keyboard::NativeKeyCode::Unidentified
+                }
+                NativeKeyCode::Android(scancode) => {
+                    keyboard::NativeKeyCode::Android(scancode)
+                }
+                NativeKeyCode::MacOS(scancode) => {
+                    keyboard::NativeKeyCode::MacOS(scancode)
+                }
+                NativeKeyCode::Windows(scancode) => {
+                    keyboard::NativeKeyCode::Windows(scancode)
+                }
+                NativeKeyCode::Xkb(keycode) => {
+                    keyboard::NativeKeyCode::Xkb(keycode)
+                }
+            };
+
+            keyboard::PhysicalKey::Unidentified(native_key_code)
+        }
     }
 }
 


### PR DESCRIPTION
Expose winit physical keys, aka native key codes. Useful for shortcuts that a based on actual position of keys. 

The data model basically just a copy from winit with some changes:
- `unreachable!()` in conversion function because of non_exhaustive, there is non_exhaustive_omitted_patterns lint which could help, but it is nightly-only
- removed serde feature
- added `#![allow(missing_docs)]` on top of file
- run cargo fmt with several small styling changes to make ci/cd happy 

~~Alternative would be to re-export types from winit. Let me know which one do you prefer.~~ winit is abstracted away 
