### PR TITLE
Underline support for `rich_text`

### DIFF
--- a/core/src/text.rs
+++ b/core/src/text.rs
@@ -245,6 +245,8 @@ pub struct Span<'a, Link = (), Font = crate::Font> {
     ///
     /// Currently, it only affects the bounds of the [`Highlight`].
     pub padding: Padding,
+    /// Whether the [`Span`] should be underlined or not.
+    pub underline: bool,
 }
 
 /// A text highlight.
@@ -268,6 +270,7 @@ impl<'a, Link, Font> Span<'a, Link, Font> {
             highlight: None,
             link: None,
             padding: Padding::ZERO,
+            underline: false,
         }
     }
 
@@ -386,6 +389,12 @@ impl<'a, Link, Font> Span<'a, Link, Font> {
         self
     }
 
+    /// Sets whether the [`Span`] shoud be underlined or not.
+    pub fn underline(mut self, underline: bool) -> Self {
+        self.underline = underline;
+        self
+    }
+
     /// Turns the [`Span`] into a static one.
     pub fn to_static(self) -> Span<'static, Link, Font> {
         Span {
@@ -397,6 +406,7 @@ impl<'a, Link, Font> Span<'a, Link, Font> {
             link: self.link,
             highlight: self.highlight,
             padding: self.padding,
+            underline: self.underline,
         }
     }
 }

--- a/widget/src/markdown.rs
+++ b/widget/src/markdown.rs
@@ -248,9 +248,7 @@ pub fn parse(
             };
 
             let span = if let Some(link) = link.as_ref() {
-                span.color(palette.primary)
-                    .link(link.clone())
-                    .underline(true)
+                span.color(palette.primary).link(link.clone())
             } else {
                 span
             };

--- a/widget/src/markdown.rs
+++ b/widget/src/markdown.rs
@@ -248,7 +248,9 @@ pub fn parse(
             };
 
             let span = if let Some(link) = link.as_ref() {
-                span.color(palette.primary).link(link.clone())
+                span.color(palette.primary)
+                    .link(link.clone())
+                    .underline(true)
             } else {
                 span
             };

--- a/widget/src/text/rich.rs
+++ b/widget/src/text/rich.rs
@@ -285,14 +285,15 @@ where
                 }
 
                 if span.underline || is_hovered_link {
+                    let size = span
+                        .size
+                        .or(self.size)
+                        .unwrap_or(renderer.default_size());
+
                     let line_height = span
                         .line_height
                         .unwrap_or(self.line_height)
-                        .to_absolute(
-                            span.size
-                                .or(self.size)
-                                .unwrap_or(renderer.default_size()),
-                        );
+                        .to_absolute(size);
 
                     for bounds in regions {
                         renderer.fill_quad(
@@ -302,7 +303,10 @@ where
                                         + translation
                                         + Vector::new(
                                             0.0,
-                                            line_height.0 * 0.8 + 1.0,
+                                            size.0
+                                                + (line_height.0 - size.0)
+                                                    / 2.0
+                                                - size.0 * 0.08,
                                         ),
                                     Size::new(bounds.width, 1.0),
                                 ),

--- a/widget/src/text/rich.rs
+++ b/widget/src/text/rich.rs
@@ -237,7 +237,7 @@ where
         theme: &Theme,
         defaults: &renderer::Style,
         layout: Layout<'_>,
-        _cursor: mouse::Cursor,
+        cursor: mouse::Cursor,
         viewport: &Rectangle,
     ) {
         let state = tree
@@ -246,8 +246,15 @@ where
 
         let style = theme.style(&self.class);
 
+        let hovered_span = cursor
+            .position_in(layout.bounds())
+            .and_then(|position| state.paragraph.hit_span(position));
+
         for (index, span) in self.spans.iter().enumerate() {
-            if span.highlight.is_some() || span.underline {
+            let is_hovered_link =
+                span.link.is_some() && Some(index) == hovered_span;
+
+            if span.highlight.is_some() || span.underline || is_hovered_link {
                 let translation = layout.position() - Point::ORIGIN;
                 let regions = state.paragraph.span_bounds(index);
 
@@ -277,7 +284,7 @@ where
                     }
                 }
 
-                if span.underline {
+                if span.underline || is_hovered_link {
                     let line_height = span
                         .line_height
                         .unwrap_or(self.line_height)


### PR DESCRIPTION
This PR introduces a new `underline` method to `text::Span` that can be used to underline text:

![image](https://github.com/user-attachments/assets/2059c292-eb6e-4fa4-8ed2-9e5c16b3deed)

It is far from perfect, but it may be good enough in some circumstances!
