### PR TITLE
Implement `Widget` for `()`

### DIFF
--- a/core/src/widget.rs
+++ b/core/src/widget.rs
@@ -4,6 +4,7 @@ pub mod text;
 pub mod tree;
 
 mod id;
+mod void;
 
 pub use id::Id;
 pub use operation::Operation;

--- a/core/src/widget/void.rs
+++ b/core/src/widget/void.rs
@@ -1,0 +1,48 @@
+use crate::layout;
+use crate::mouse;
+use crate::renderer;
+use crate::widget::{Widget, tree::Tree};
+use crate::{Element, Layout, Length, Rectangle, Size};
+
+impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer> for ()
+where
+    Renderer: renderer::Renderer,
+{
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: Length::Shrink,
+            height: Length::Shrink,
+        }
+    }
+
+    fn layout(
+        &self,
+        _tree: &mut Tree,
+        _renderer: &Renderer,
+        _limits: &layout::Limits,
+    ) -> layout::Node {
+        layout::Node::new(Size::ZERO)
+    }
+
+    fn draw(
+        &self,
+        _tree: &Tree,
+        _renderer: &mut Renderer,
+        _theme: &Theme,
+        _style: &renderer::Style,
+        _layout: Layout<'_>,
+        _cursor: mouse::Cursor,
+        _viewport: &Rectangle,
+    ) {
+    }
+}
+
+impl<'a, Message, Theme, Renderer> From<()>
+    for Element<'a, Message, Theme, Renderer>
+where
+    Renderer: renderer::Renderer,
+{
+    fn from(_: ()) -> Self {
+        Self::new(())
+    }
+}


### PR DESCRIPTION
Useful for creating composite widgets.

For example, I'm creating a grid of coloured buttons (like a colour palette in a paint program); creating a button looks like this:
```rust
/* snippet */
let button = button("")
    .style(move |_, status| button_color(current_color, status))
    .on_press(Event::Color(current_color))
    .width(cell_size)
    .height(cell_size);
```
Since "``""``" turns into a text widget, it seems a bit wasteful as it's just used to create lots of clicky things with with a background.

Implementing `Widget` for `()` can help in this case.