### PR TITLE
Clarify the feature required to use `Component`

### DIFF
--- a/widget/src/lazy/component.rs
+++ b/widget/src/lazy/component.rs
@@ -30,6 +30,10 @@ use std::rc::Rc;
 ///
 /// Additionally, a [`Component`] is capable of producing a `Message` to notify
 /// the parent application of any relevant interactions.
+///
+/// This trait is available when the `lazy` feature of this crate is enabled.
+/// This feature is *not* enabled by default, so you must enable it before using
+/// `Component`.
 pub trait Component<Message, Theme = crate::Theme, Renderer = crate::Renderer> {
     /// The internal state of this [`Component`].
     type State: Default;


### PR DESCRIPTION
As in #2515, it seems that it's a little confusing how to use `Component` at first glance. This PR aims to clarify that by adding a small note in `Component`'s doc comment explaining that the `lazy` feature must be enabled for the trait to be used.

This is my first PR here, so apologies if it's done the wrong way or is too small. I'm just hoping to ease other new `iced` users' understanding of the library in a small way. Thank you for your time! Iced is a very well-designed library and I'm happy to be able to use it for my Rust hobby projects that require a GUI.

Closes #2515.