### PR TITLE
Snap `Quad` lines to the pixel grid in `iced_wgpu`

### DIFF
--- a/wgpu/src/shader/quad/solid.wgsl
+++ b/wgpu/src/shader/quad/solid.wgsl
@@ -30,6 +30,15 @@ fn solid_vs_main(input: SolidVertexInput) -> SolidVertexOutput {
 
     var pos: vec2<f32> = (input.pos + min(input.shadow_offset, vec2<f32>(0.0, 0.0)) - input.shadow_blur_radius) * globals.scale;
     var scale: vec2<f32> = (input.scale + vec2<f32>(abs(input.shadow_offset.x), abs(input.shadow_offset.y)) + input.shadow_blur_radius * 2.0) * globals.scale;
+    var snap: vec2<f32> = vec2<f32>(0.0, 0.0);
+
+    if input.scale.x == 1.0 {
+        snap.x = round(pos.x) - pos.x;
+    }
+
+    if input.scale.y == 1.0 {
+        snap.y = round(pos.y) - pos.y;
+    }
 
     var min_border_radius = min(input.scale.x, input.scale.y) * 0.5;
     var border_radius: vec4<f32> = vec4<f32>(
@@ -43,13 +52,13 @@ fn solid_vs_main(input: SolidVertexInput) -> SolidVertexOutput {
         vec4<f32>(scale.x + 1.0, 0.0, 0.0, 0.0),
         vec4<f32>(0.0, scale.y + 1.0, 0.0, 0.0),
         vec4<f32>(0.0, 0.0, 1.0, 0.0),
-        vec4<f32>(pos - vec2<f32>(0.5, 0.5), 0.0, 1.0)
+        vec4<f32>(pos - vec2<f32>(0.5, 0.5) + snap, 0.0, 1.0)
     );
 
     out.position = globals.transform * transform * vec4<f32>(vertex_position(input.vertex_index), 0.0, 1.0);
     out.color = input.color;
     out.border_color = input.border_color;
-    out.pos = input.pos * globals.scale;
+    out.pos = input.pos * globals.scale + snap;
     out.scale = input.scale * globals.scale;
     out.border_radius = border_radius * globals.scale;
     out.border_width = input.border_width * globals.scale;


### PR DESCRIPTION
This should ensure the `Quad` primitives representing lines (1px thick) are always aligned to the pixel grid.

May introduce other artifacts, however.
