### PR TITLE
Shortcut export for Length::Fixed

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -490,7 +490,7 @@ pub use iced_futures::Subscription;
 pub use alignment::Horizontal::{Left, Right};
 pub use alignment::Vertical::{Bottom, Top};
 pub use Alignment::Center;
-pub use Length::{Fill, FillPortion, Shrink};
+pub use Length::{Fill, FillPortion, Shrink, Fixed};
 
 pub mod task {
     //! Create runtime tasks.


### PR DESCRIPTION
This PR addresses a minor oversight by allowing `Length::Fixed` to be imported and used as `use iced::Fixed`, consistent with the other length variants.