### PR TITLE
Display top contents in `hover` widget when focused

### DIFF
--- a/core/src/element.rs
+++ b/core/src/element.rs
@@ -304,7 +304,7 @@ where
         tree: &mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
-        operation: &mut dyn widget::Operation<()>,
+        operation: &mut dyn widget::Operation,
     ) {
         self.widget.operate(tree, layout, renderer, operation);
     }
@@ -440,7 +440,7 @@ where
         state: &mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
-        operation: &mut dyn widget::Operation<()>,
+        operation: &mut dyn widget::Operation,
     ) {
         self.element
             .widget

--- a/core/src/overlay.rs
+++ b/core/src/overlay.rs
@@ -41,7 +41,7 @@ where
         &mut self,
         _layout: Layout<'_>,
         _renderer: &Renderer,
-        _operation: &mut dyn widget::Operation<()>,
+        _operation: &mut dyn widget::Operation,
     ) {
     }
 

--- a/core/src/overlay/element.rs
+++ b/core/src/overlay/element.rs
@@ -92,7 +92,7 @@ where
         &mut self,
         layout: Layout<'_>,
         renderer: &Renderer,
-        operation: &mut dyn widget::Operation<()>,
+        operation: &mut dyn widget::Operation,
     ) {
         self.overlay.operate(layout, renderer, operation);
     }
@@ -144,7 +144,7 @@ where
         &mut self,
         layout: Layout<'_>,
         renderer: &Renderer,
-        operation: &mut dyn widget::Operation<()>,
+        operation: &mut dyn widget::Operation,
     ) {
         self.content.operate(layout, renderer, operation);
     }

--- a/core/src/overlay/group.rs
+++ b/core/src/overlay/group.rs
@@ -132,7 +132,7 @@ where
         &mut self,
         layout: Layout<'_>,
         renderer: &Renderer,
-        operation: &mut dyn widget::Operation<()>,
+        operation: &mut dyn widget::Operation,
     ) {
         operation.container(None, layout.bounds(), &mut |operation| {
             self.children.iter_mut().zip(layout.children()).for_each(

--- a/core/src/widget.rs
+++ b/core/src/widget.rs
@@ -105,7 +105,7 @@ where
         _state: &mut Tree,
         _layout: Layout<'_>,
         _renderer: &Renderer,
-        _operation: &mut dyn Operation<()>,
+        _operation: &mut dyn Operation,
     ) {
     }
 

--- a/examples/toast/src/main.rs
+++ b/examples/toast/src/main.rs
@@ -347,7 +347,7 @@ mod toast {
             state: &mut Tree,
             layout: Layout<'_>,
             renderer: &Renderer,
-            operation: &mut dyn Operation<()>,
+            operation: &mut dyn Operation,
         ) {
             operation.container(None, layout.bounds(), &mut |operation| {
                 self.content.as_widget().operate(
@@ -589,7 +589,7 @@ mod toast {
             &mut self,
             layout: Layout<'_>,
             renderer: &Renderer,
-            operation: &mut dyn widget::Operation<()>,
+            operation: &mut dyn widget::Operation,
         ) {
             operation.container(None, layout.bounds(), &mut |operation| {
                 self.toasts

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -59,7 +59,7 @@ pub enum Action<T> {
     },
 
     /// Run a widget operation.
-    Widget(Box<dyn widget::Operation<()>>),
+    Widget(Box<dyn widget::Operation>),
 
     /// Run a clipboard action.
     Clipboard(clipboard::Action),
@@ -79,7 +79,7 @@ pub enum Action<T> {
 
 impl<T> Action<T> {
     /// Creates a new [`Action::Widget`] with the given [`widget::Operation`].
-    pub fn widget(operation: impl widget::Operation<()> + 'static) -> Self {
+    pub fn widget(operation: impl widget::Operation + 'static) -> Self {
         Self::Widget(Box::new(operation))
     }
 

--- a/runtime/src/multi_window/state.rs
+++ b/runtime/src/multi_window/state.rs
@@ -205,7 +205,7 @@ where
     pub fn operate(
         &mut self,
         renderer: &mut P::Renderer,
-        operations: impl Iterator<Item = Box<dyn Operation<()>>>,
+        operations: impl Iterator<Item = Box<dyn Operation>>,
         bounds: Size,
         debug: &mut Debug,
     ) {

--- a/runtime/src/overlay/nested.rs
+++ b/runtime/src/overlay/nested.rs
@@ -131,13 +131,13 @@ where
         &mut self,
         layout: Layout<'_>,
         renderer: &Renderer,
-        operation: &mut dyn widget::Operation<()>,
+        operation: &mut dyn widget::Operation,
     ) {
         fn recurse<Message, Theme, Renderer>(
             element: &mut overlay::Element<'_, Message, Theme, Renderer>,
             layout: Layout<'_>,
             renderer: &Renderer,
-            operation: &mut dyn widget::Operation<()>,
+            operation: &mut dyn widget::Operation,
         ) where
             Renderer: renderer::Renderer,
         {

--- a/runtime/src/program/state.rs
+++ b/runtime/src/program/state.rs
@@ -178,7 +178,7 @@ where
     pub fn operate(
         &mut self,
         renderer: &mut P::Renderer,
-        operations: impl Iterator<Item = Box<dyn Operation<()>>>,
+        operations: impl Iterator<Item = Box<dyn Operation>>,
         bounds: Size,
         debug: &mut Debug,
     ) {

--- a/runtime/src/user_interface.rs
+++ b/runtime/src/user_interface.rs
@@ -566,7 +566,7 @@ where
     pub fn operate(
         &mut self,
         renderer: &Renderer,
-        operation: &mut dyn widget::Operation<()>,
+        operation: &mut dyn widget::Operation,
     ) {
         self.root.as_widget().operate(
             &mut self.state,

--- a/widget/src/button.rs
+++ b/widget/src/button.rs
@@ -236,7 +236,7 @@ where
         tree: &mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
-        operation: &mut dyn Operation<()>,
+        operation: &mut dyn Operation,
     ) {
         operation.container(None, layout.bounds(), &mut |operation| {
             self.content.as_widget().operate(

--- a/widget/src/column.rs
+++ b/widget/src/column.rs
@@ -222,7 +222,7 @@ where
         tree: &mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
-        operation: &mut dyn Operation<()>,
+        operation: &mut dyn Operation,
     ) {
         operation.container(None, layout.bounds(), &mut |operation| {
             self.children

--- a/widget/src/container.rs
+++ b/widget/src/container.rs
@@ -245,7 +245,7 @@ where
         tree: &mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
-        operation: &mut dyn Operation<()>,
+        operation: &mut dyn Operation,
     ) {
         operation.container(
             self.id.as_ref().map(|id| &id.0),

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -289,7 +289,7 @@ where
             state: &mut Tree,
             layout: Layout<'_>,
             renderer: &Renderer,
-            operation: &mut dyn operation::Operation<()>,
+            operation: &mut dyn operation::Operation,
         ) {
             self.content
                 .as_widget()
@@ -491,7 +491,7 @@ where
             tree: &mut Tree,
             layout: Layout<'_>,
             renderer: &Renderer,
-            operation: &mut dyn operation::Operation<()>,
+            operation: &mut dyn operation::Operation,
         ) {
             let children = [&self.base, &self.top]
                 .into_iter()

--- a/widget/src/keyed/column.rs
+++ b/widget/src/keyed/column.rs
@@ -265,7 +265,7 @@ where
         tree: &mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
-        operation: &mut dyn Operation<()>,
+        operation: &mut dyn Operation,
     ) {
         operation.container(None, layout.bounds(), &mut |operation| {
             self.children

--- a/widget/src/lazy.rs
+++ b/widget/src/lazy.rs
@@ -182,7 +182,7 @@ where
         tree: &mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
-        operation: &mut dyn widget::Operation<()>,
+        operation: &mut dyn widget::Operation,
     ) {
         self.with_element(|element| {
             element.as_widget().operate(

--- a/widget/src/lazy/component.rs
+++ b/widget/src/lazy/component.rs
@@ -59,7 +59,7 @@ pub trait Component<Message, Theme = crate::Theme, Renderer = crate::Renderer> {
     fn operate(
         &self,
         _state: &mut Self::State,
-        _operation: &mut dyn widget::Operation<()>,
+        _operation: &mut dyn widget::Operation,
     ) {
     }
 
@@ -172,7 +172,7 @@ where
 
     fn rebuild_element_with_operation(
         &self,
-        operation: &mut dyn widget::Operation<()>,
+        operation: &mut dyn widget::Operation,
     ) {
         let heads = self.state.borrow_mut().take().unwrap().into_heads();
 
@@ -358,7 +358,7 @@ where
         tree: &mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
-        operation: &mut dyn widget::Operation<()>,
+        operation: &mut dyn widget::Operation,
     ) {
         self.rebuild_element_with_operation(operation);
 

--- a/widget/src/lazy/responsive.rs
+++ b/widget/src/lazy/responsive.rs
@@ -161,7 +161,7 @@ where
         tree: &mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
-        operation: &mut dyn widget::Operation<()>,
+        operation: &mut dyn widget::Operation,
     ) {
         let state = tree.state.downcast_mut::<State>();
         let mut content = self.content.borrow_mut();

--- a/widget/src/mouse_area.rs
+++ b/widget/src/mouse_area.rs
@@ -178,7 +178,7 @@ where
         tree: &mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
-        operation: &mut dyn Operation<()>,
+        operation: &mut dyn Operation,
     ) {
         self.content.as_widget().operate(
             &mut tree.children[0],

--- a/widget/src/pane_grid.rs
+++ b/widget/src/pane_grid.rs
@@ -324,7 +324,7 @@ where
         tree: &mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
-        operation: &mut dyn widget::Operation<()>,
+        operation: &mut dyn widget::Operation,
     ) {
         operation.container(None, layout.bounds(), &mut |operation| {
             self.contents

--- a/widget/src/pane_grid/content.rs
+++ b/widget/src/pane_grid/content.rs
@@ -214,7 +214,7 @@ where
         tree: &mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
-        operation: &mut dyn widget::Operation<()>,
+        operation: &mut dyn widget::Operation,
     ) {
         let body_layout = if let Some(title_bar) = &self.title_bar {
             let mut children = layout.children();

--- a/widget/src/pane_grid/title_bar.rs
+++ b/widget/src/pane_grid/title_bar.rs
@@ -278,7 +278,7 @@ where
         tree: &mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
-        operation: &mut dyn widget::Operation<()>,
+        operation: &mut dyn widget::Operation,
     ) {
         let mut children = layout.children();
         let padded = children.next().unwrap();

--- a/widget/src/row.rs
+++ b/widget/src/row.rs
@@ -218,7 +218,7 @@ where
         tree: &mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
-        operation: &mut dyn Operation<()>,
+        operation: &mut dyn Operation,
     ) {
         operation.container(None, layout.bounds(), &mut |operation| {
             self.children
@@ -470,7 +470,7 @@ where
         tree: &mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
-        operation: &mut dyn Operation<()>,
+        operation: &mut dyn Operation,
     ) {
         self.row.operate(tree, layout, renderer, operation);
     }

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -415,7 +415,7 @@ where
         tree: &mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
-        operation: &mut dyn Operation<()>,
+        operation: &mut dyn Operation,
     ) {
         let state = tree.state.downcast_mut::<State>();
 

--- a/widget/src/stack.rs
+++ b/widget/src/stack.rs
@@ -189,7 +189,7 @@ where
         tree: &mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
-        operation: &mut dyn Operation<()>,
+        operation: &mut dyn Operation,
     ) {
         operation.container(None, layout.bounds(), &mut |operation| {
             self.children

--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -885,7 +885,7 @@ where
         tree: &mut widget::Tree,
         _layout: Layout<'_>,
         _renderer: &Renderer,
-        operation: &mut dyn widget::Operation<()>,
+        operation: &mut dyn widget::Operation,
     ) {
         let state = tree.state.downcast_mut::<State<Highlighter>>();
 

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -542,7 +542,7 @@ where
         tree: &mut Tree,
         _layout: Layout<'_>,
         _renderer: &Renderer,
-        operation: &mut dyn Operation<()>,
+        operation: &mut dyn Operation,
     ) {
         let state = tree.state.downcast_mut::<State<Renderer::Paragraph>>();
 

--- a/widget/src/themer.rs
+++ b/widget/src/themer.rs
@@ -104,7 +104,7 @@ where
         tree: &mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
-        operation: &mut dyn Operation<()>,
+        operation: &mut dyn Operation,
     ) {
         self.content
             .as_widget()
@@ -236,7 +236,7 @@ where
                 &mut self,
                 layout: Layout<'_>,
                 renderer: &Renderer,
-                operation: &mut dyn Operation<()>,
+                operation: &mut dyn Operation,
             ) {
                 self.content.operate(layout, renderer, operation);
             }


### PR DESCRIPTION
This PR introduces a couple of useful helpers for dealing with widget operations:

- `black_box` erases the returning type of an `Operation`; so it can be fed to `Widget::operate`.
- `chain` creates a sequence of operations; feeding the output of the first one to a function that creates a second one.

These changes allow us to easily keep track of the focused state inside parts of the widget tree. For instance, the `hover` widget now keeps displaying the widgets on top if any of them are focused.
