### PR TITLE
Expose `Clipboard` to `canvas::Program`

### DIFF
--- a/examples/bezier_tool/src/main.rs
+++ b/examples/bezier_tool/src/main.rs
@@ -96,6 +96,7 @@ mod bezier {
             event: Event,
             bounds: Rectangle,
             cursor: mouse::Cursor,
+            _clipboard: &mut dyn iced::advanced::Clipboard,
         ) -> (event::Status, Option<Curve>) {
             let Some(cursor_position) = cursor.position_in(bounds) else {
                 return (event::Status::Ignored, None);

--- a/examples/game_of_life/src/main.rs
+++ b/examples/game_of_life/src/main.rs
@@ -383,6 +383,7 @@ mod grid {
             event: Event,
             bounds: Rectangle,
             cursor: mouse::Cursor,
+            _clipboard: &mut dyn iced::advanced::Clipboard,
         ) -> (event::Status, Option<Message>) {
             if let Event::Mouse(mouse::Event::ButtonReleased(_)) = event {
                 *interaction = Interaction::None;

--- a/examples/multitouch/src/main.rs
+++ b/examples/multitouch/src/main.rs
@@ -59,6 +59,7 @@ impl canvas::Program<Message> for Multitouch {
         event: event::Event,
         _bounds: Rectangle,
         _cursor: mouse::Cursor,
+        _clipboard: &mut dyn iced::advanced::Clipboard,
     ) -> (event::Status, Option<Message>) {
         match event {
             event::Event::Touch(touch_event) => match touch_event {

--- a/examples/sierpinski_triangle/src/main.rs
+++ b/examples/sierpinski_triangle/src/main.rs
@@ -80,6 +80,7 @@ impl canvas::Program<Message> for SierpinskiGraph {
         event: Event,
         bounds: Rectangle,
         cursor: mouse::Cursor,
+        _clipboard: &mut dyn iced::advanced::Clipboard,
     ) -> (event::Status, Option<Message>) {
         let Some(cursor_position) = cursor.position_in(bounds) else {
             return (event::Status::Ignored, None);

--- a/widget/src/canvas.rs
+++ b/widget/src/canvas.rs
@@ -160,7 +160,7 @@ where
         layout: Layout<'_>,
         cursor: mouse::Cursor,
         _renderer: &Renderer,
-        _clipboard: &mut dyn Clipboard,
+        clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, Message>,
         _viewport: &Rectangle,
     ) -> event::Status {
@@ -178,8 +178,13 @@ where
         if let Some(canvas_event) = canvas_event {
             let state = tree.state.downcast_mut::<P::State>();
 
-            let (event_status, message) =
-                self.program.update(state, canvas_event, bounds, cursor);
+            let (event_status, message) = self.program.update(
+                state,
+                canvas_event,
+                bounds,
+                cursor,
+                clipboard,
+            );
 
             if let Some(message) = message {
                 shell.publish(message);

--- a/widget/src/canvas/program.rs
+++ b/widget/src/canvas/program.rs
@@ -1,7 +1,7 @@
 use crate::canvas::event::{self, Event};
 use crate::canvas::mouse;
 use crate::canvas::Geometry;
-use crate::core::Rectangle;
+use crate::core::{Clipboard, Rectangle};
 use crate::graphics::geometry;
 
 /// The state and logic of a [`Canvas`].
@@ -34,6 +34,7 @@ where
         _event: Event,
         _bounds: Rectangle,
         _cursor: mouse::Cursor,
+        _clipboard: &mut dyn Clipboard,
     ) -> (event::Status, Option<Message>) {
         (event::Status::Ignored, None)
     }
@@ -84,8 +85,9 @@ where
         event: Event,
         bounds: Rectangle,
         cursor: mouse::Cursor,
+        clipboard: &mut dyn Clipboard,
     ) -> (event::Status, Option<Message>) {
-        T::update(self, state, event, bounds, cursor)
+        T::update(self, state, event, bounds, cursor, clipboard)
     }
 
     fn draw(


### PR DESCRIPTION
This PR lets `canvas::Program` access the `Clipboard`.

My specific use case is an interactive canvas board with shapes where I can cut, copy and paste shapes around.