### PR TITLE
slider: handle mouse wheel events

### DIFF
--- a/widget/src/slider.rs
+++ b/widget/src/slider.rs
@@ -288,22 +288,6 @@ where
         };
 
         match event {
-            Event::Mouse(mouse::Event::WheelScrolled { delta }) => {
-                if let Some(_) = cursor.position_over(layout.bounds()) {
-                    let delta = match delta {
-                        mouse::ScrollDelta::Lines { x: _, y } => y,
-                        mouse::ScrollDelta::Pixels { x: _, y } => y,
-                    };
-
-                    if delta < 0.0 {
-                        let _ = decrement(current_value).map(change);
-                    } else {
-                        let _ = increment(current_value).map(change);
-                    }
-
-                    return event::Status::Captured;
-                }
-            }
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
             | Event::Touch(touch::Event::FingerPressed { .. }) => {
                 if let Some(cursor_position) =
@@ -336,6 +320,24 @@ where
             | Event::Touch(touch::Event::FingerMoved { .. }) => {
                 if is_dragging {
                     let _ = cursor.position().and_then(locate).map(change);
+
+                    return event::Status::Captured;
+                }
+            }
+            Event::Mouse(mouse::Event::WheelScrolled { delta })
+                if state.keyboard_modifiers.control() =>
+            {
+                if let Some(_) = cursor.position_over(layout.bounds()) {
+                    let delta = match delta {
+                        mouse::ScrollDelta::Lines { x: _, y } => y,
+                        mouse::ScrollDelta::Pixels { x: _, y } => y,
+                    };
+
+                    if delta < 0.0 {
+                        let _ = decrement(current_value).map(change);
+                    } else {
+                        let _ = increment(current_value).map(change);
+                    }
 
                     return event::Status::Captured;
                 }

--- a/widget/src/slider.rs
+++ b/widget/src/slider.rs
@@ -288,6 +288,22 @@ where
         };
 
         match event {
+            Event::Mouse(mouse::Event::WheelScrolled { delta }) => {
+                if let Some(_) = cursor.position_over(layout.bounds()) {
+                    let delta = match delta {
+                        mouse::ScrollDelta::Lines { x: _, y } => y,
+                        mouse::ScrollDelta::Pixels { x: _, y } => y,
+                    };
+
+                    if delta < 0.0 {
+                        let _ = decrement(current_value).map(change);
+                    } else {
+                        let _ = increment(current_value).map(change);
+                    }
+
+                    return event::Status::Captured;
+                }
+            }
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
             | Event::Touch(touch::Event::FingerPressed { .. }) => {
                 if let Some(cursor_position) =

--- a/widget/src/slider.rs
+++ b/widget/src/slider.rs
@@ -327,7 +327,7 @@ where
             Event::Mouse(mouse::Event::WheelScrolled { delta })
                 if state.keyboard_modifiers.control() =>
             {
-                if let Some(_) = cursor.position_over(layout.bounds()) {
+                if cursor.is_over(layout.bounds()) {
                     let delta = match delta {
                         mouse::ScrollDelta::Lines { x: _, y } => y,
                         mouse::ScrollDelta::Pixels { x: _, y } => y,
@@ -343,7 +343,7 @@ where
                 }
             }
             Event::Keyboard(keyboard::Event::KeyPressed { key, .. }) => {
-                if cursor.position_over(layout.bounds()).is_some() {
+                if cursor.is_over(layout.bounds()) {
                     match key {
                         Key::Named(key::Named::ArrowUp) => {
                             let _ = increment(current_value).map(change);

--- a/widget/src/vertical_slider.rs
+++ b/widget/src/vertical_slider.rs
@@ -291,6 +291,22 @@ where
         };
 
         match event {
+            Event::Mouse(mouse::Event::WheelScrolled { delta }) => {
+                if let Some(_) = cursor.position_over(layout.bounds()) {
+                    let delta = match delta {
+                        mouse::ScrollDelta::Lines { x: _, y } => y,
+                        mouse::ScrollDelta::Pixels { x: _, y } => y,
+                    };
+
+                    if delta < 0.0 {
+                        let _ = decrement(current_value).map(change);
+                    } else {
+                        let _ = increment(current_value).map(change);
+                    }
+
+                    return event::Status::Captured;
+                }
+            }
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
             | Event::Touch(touch::Event::FingerPressed { .. }) => {
                 if let Some(cursor_position) =

--- a/widget/src/vertical_slider.rs
+++ b/widget/src/vertical_slider.rs
@@ -291,22 +291,6 @@ where
         };
 
         match event {
-            Event::Mouse(mouse::Event::WheelScrolled { delta }) => {
-                if let Some(_) = cursor.position_over(layout.bounds()) {
-                    let delta = match delta {
-                        mouse::ScrollDelta::Lines { x: _, y } => y,
-                        mouse::ScrollDelta::Pixels { x: _, y } => y,
-                    };
-
-                    if delta < 0.0 {
-                        let _ = decrement(current_value).map(change);
-                    } else {
-                        let _ = increment(current_value).map(change);
-                    }
-
-                    return event::Status::Captured;
-                }
-            }
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
             | Event::Touch(touch::Event::FingerPressed { .. }) => {
                 if let Some(cursor_position) =
@@ -341,6 +325,24 @@ where
             | Event::Touch(touch::Event::FingerMoved { .. }) => {
                 if is_dragging {
                     let _ = cursor.position().and_then(locate).map(change);
+
+                    return event::Status::Captured;
+                }
+            }
+            Event::Mouse(mouse::Event::WheelScrolled { delta })
+                if state.keyboard_modifiers.control() =>
+            {
+                if let Some(_) = cursor.position_over(layout.bounds()) {
+                    let delta = match delta {
+                        mouse::ScrollDelta::Lines { x: _, y } => y,
+                        mouse::ScrollDelta::Pixels { x: _, y } => y,
+                    };
+
+                    if delta < 0.0 {
+                        let _ = decrement(current_value).map(change);
+                    } else {
+                        let _ = increment(current_value).map(change);
+                    }
 
                     return event::Status::Captured;
                 }

--- a/widget/src/vertical_slider.rs
+++ b/widget/src/vertical_slider.rs
@@ -332,7 +332,7 @@ where
             Event::Mouse(mouse::Event::WheelScrolled { delta })
                 if state.keyboard_modifiers.control() =>
             {
-                if let Some(_) = cursor.position_over(layout.bounds()) {
+                if cursor.is_over(layout.bounds()) {
                     let delta = match delta {
                         mouse::ScrollDelta::Lines { x: _, y } => y,
                         mouse::ScrollDelta::Pixels { x: _, y } => y,
@@ -348,7 +348,7 @@ where
                 }
             }
             Event::Keyboard(keyboard::Event::KeyPressed { key, .. }) => {
-                if cursor.position_over(layout.bounds()).is_some() {
+                if cursor.is_over(layout.bounds()) {
                     match key {
                         Key::Named(key::Named::ArrowUp) => {
                             let _ = increment(current_value).map(change);


### PR DESCRIPTION
Make `slider` + `vertical_slider` handle mouse wheel events -- i.e. when hovered, scrolling the mouse wheel will modify the slider.

---

Question: currently the slider is incr/decremented by `self.step` for both `ScrollDelta::Pixels` and `ScrollDelta::Lines`. This seems appropriate for `Lines`, but I'm not sure about `Pixels`. (It felt fine to me when testing, but I'm not sure what the "expected" behaviour is.)