### PR TITLE
Fix `wasm32` deployments not displaying anything

### DIFF
--- a/winit/Cargo.toml
+++ b/winit/Cargo.toml
@@ -44,5 +44,5 @@ winapi.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys.workspace = true
-web-sys.features = ["Document", "Window"]
+web-sys.features = ["Document", "Window", "HtmlCanvasElement"]
 wasm-bindgen-futures.workspace = true

--- a/winit/src/program.rs
+++ b/winit/src/program.rs
@@ -251,8 +251,6 @@ where
         #[cfg(target_arch = "wasm32")]
         is_booted: std::rc::Rc<std::cell::RefCell<bool>>,
         #[cfg(target_arch = "wasm32")]
-        queued_events: Vec<Event<Action<Message>>>,
-        #[cfg(target_arch = "wasm32")]
         canvas: Option<web_sys::HtmlCanvasElement>,
     }
 
@@ -278,8 +276,6 @@ where
         #[cfg(target_arch = "wasm32")]
         is_booted: std::rc::Rc::new(std::cell::RefCell::new(false)),
         #[cfg(target_arch = "wasm32")]
-        queued_events: Vec::new(),
-        #[cfg(target_arch = "wasm32")]
         canvas: None,
     };
 
@@ -299,8 +295,6 @@ where
             else {
                 return;
             };
-
-            event_loop.set_control_flow(winit::event_loop::ControlFlow::Poll);
 
             let window = match event_loop.create_window(
                 winit::window::WindowAttributes::default().with_visible(false),
@@ -352,6 +346,9 @@ where
 
                     *is_booted.borrow_mut() = true;
                 });
+
+                event_loop
+                    .set_control_flow(winit::event_loop::ControlFlow::Poll);
             }
         }
 
@@ -361,6 +358,11 @@ where
             cause: winit::event::StartCause,
         ) {
             if self.boot.is_some() {
+                return;
+            }
+
+            #[cfg(target_arch = "wasm32")]
+            if !*self.is_booted.borrow() {
                 return;
             }
 
@@ -442,6 +444,11 @@ where
             &mut self,
             event_loop: &winit::event_loop::ActiveEventLoop,
         ) {
+            #[cfg(target_arch = "wasm32")]
+            if !*self.is_booted.borrow() {
+                return;
+            }
+
             self.process_event(
                 event_loop,
                 Event::EventLoopAwakened(winit::event::Event::AboutToWait),
@@ -459,19 +466,6 @@ where
             event_loop: &winit::event_loop::ActiveEventLoop,
             event: Event<Action<Message>>,
         ) {
-            #[cfg(target_arch = "wasm32")]
-            if !*self.is_booted.borrow() {
-                self.queued_events.push(event);
-                return;
-            } else if !self.queued_events.is_empty() {
-                let queued_events = std::mem::take(&mut self.queued_events);
-
-                // This won't infinitely recurse, since we `mem::take`
-                for event in queued_events {
-                    self.process_event(event_loop, event);
-                }
-            }
-
             if event_loop.exiting() {
                 return;
             }

--- a/winit/src/program.rs
+++ b/winit/src/program.rs
@@ -300,6 +300,8 @@ where
                 return;
             };
 
+            event_loop.set_control_flow(winit::event_loop::ControlFlow::Poll);
+
             let window = match event_loop.create_window(
                 winit::window::WindowAttributes::default().with_visible(false),
             ) {

--- a/winit/src/program.rs
+++ b/winit/src/program.rs
@@ -528,8 +528,8 @@ where
                                 #[cfg(target_arch = "wasm32")]
                                 let window_attributes = {
                                     use winit::platform::web::WindowAttributesExtWebSys;
-                                    log::info!("{:#?}", self.canvas);
-                                    window_attributes.with_canvas(self.canvas.take())
+                                    window_attributes
+                                        .with_canvas(self.canvas.take())
                                 };
 
                                 log::info!("Window attributes for id `{id:#?}`: {window_attributes:#?}");


### PR DESCRIPTION
This fixes a bug where `web` deployments of an `iced` application would silently fail, not displaying anything.

The problem can be tested by using `trunk serve` in any of the examples that support it.

It seems to have started after #2469, where changes were introduced to allow an application to be started without an window. Although an window is not necessarily shown at the start, it's still created silently, and this is necessary for the acquisition of the graphics device and it's initialization, after that the window is discarded and only created again when requested by the `runtime` (or quickly after that on "non-deamon" applications).

On the `wasm32` path of the code, the window contains the [`HTMLCanvasElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement), which in turn, has the [`getContext`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext) method and contains the [`WebGLRenderingContext`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext) which is necessary for properly displaying graphics on the `canvas`.
By discarding the window, we end up discarding the `HTMLCanvasElement` which is associated with the context and other graphics dependencies for proper rendering; creating a new window without using the correct associated `canvas` element which was used to initialize the context, then makes the `canvas` graphically display nothing.

There could multiple solutions to this, but the simplest seems to be to simply retain the `canvas` element, and re-use it to create the `window` through the [`with_canvas`](https://docs.rs/winit/latest/winit/platform/web/trait.WindowAttributesExtWebSys.html#tymethod.with_canvas) window attribute.

This PR changes the `wasm32` path to store the [`web_sys::HTMLCanvasElement`](https://docs.rs/web-sys/latest/web_sys/struct.HtmlCanvasElement.html) and use it on the `with_canvas` method when creating an window, I've also added logging for the window attributes to the relevant code, which could be helpful in future debugging of similar problems.

As for possible problems with this, the code doesn't make any guarantees for other windows, it'll certainly silently fail when asked to create new windows, since those are basically `canvas` elements on `wasm32` that are not properly created or maintained. Although I would add that this was already the case before the PR.

Closes #2480. 