### PR TITLE
Fix unnecessary COM initialization on Windows

### DIFF
--- a/winit/src/program.rs
+++ b/winit/src/program.rs
@@ -296,14 +296,22 @@ where
                 return;
             };
 
-            let window = match event_loop.create_window(
-                winit::window::WindowAttributes::default().with_visible(false),
-            ) {
-                Ok(window) => Arc::new(window),
-                Err(error) => {
-                    self.error = Some(Error::WindowCreationFailed(error));
-                    event_loop.exit();
-                    return;
+            let window = {
+                let attributes = winit::window::WindowAttributes::default();
+
+                #[cfg(target_os = "windows")]
+                let attributes = {
+                    use winit::platform::windows::WindowAttributesExtWindows;
+                    attributes.with_drag_and_drop(false)
+                };
+
+                match event_loop.create_window(attributes.with_visible(false)) {
+                    Ok(window) => Arc::new(window),
+                    Err(error) => {
+                        self.error = Some(Error::WindowCreationFailed(error));
+                        event_loop.exit();
+                        return;
+                    }
                 }
             };
 


### PR DESCRIPTION
I tracked the issue #2577  back to this [commit](https://github.com/iced-rs/iced/commit/341c9a3c12aa9d327ef1d8f168ea0adb9b5ad10b) and the file `winit/src/program.rs:L273`, where the window is first initialized with `default()` window options instead of the provided ones.

I am not going to lie, I don't know why we need to create a window with default attributes first and then initialize it again with proper attributes later, but if I change the first initialization to be without drag-and-drop support, then COM is initialized later only when it is really required.

I tested this change with `examples/events` and the reproduction code from the issue and everything works as I would expect it to on Windows.

Fixes #2577.
