### PR TITLE
Scrollbar disabled style status to allow custom styles for always visible, but not overflowing scrollbars.

### DIFF
--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -906,14 +906,21 @@ where
                 is_vertical_scrollbar_dragged: state
                     .y_scroller_grabbed_at
                     .is_some(),
+                is_horizontal_scrollbar_disabled: scrollbars.x_disabled(),
+                is_vertical_scrollbar_disabled: scrollbars.y_disabled(),
             }
         } else if cursor_over_scrollable.is_some() {
             Status::Hovered {
                 is_horizontal_scrollbar_hovered: mouse_over_x_scrollbar,
                 is_vertical_scrollbar_hovered: mouse_over_y_scrollbar,
+                is_horizontal_scrollbar_disabled: scrollbars.x_disabled(),
+                is_vertical_scrollbar_disabled: scrollbars.y_disabled(),
             }
         } else {
-            Status::Active
+            Status::Active {
+                is_horizontal_scrollbar_disabled: scrollbars.x_disabled(),
+                is_vertical_scrollbar_disabled: scrollbars.y_disabled(),
+            }
         };
 
         if let Event::Window(window::Event::RedrawRequested(_now)) = event {
@@ -968,8 +975,13 @@ where
             _ => mouse::Cursor::Unavailable,
         };
 
-        let style = theme
-            .style(&self.class, self.last_status.unwrap_or(Status::Active));
+        let style = theme.style(
+            &self.class,
+            self.last_status.unwrap_or(Status::Active {
+                is_horizontal_scrollbar_disabled: false,
+                is_vertical_scrollbar_disabled: false,
+            }),
+        );
 
         container::draw_background(renderer, &style.container, layout.bounds());
 
@@ -1588,15 +1600,27 @@ impl Scrollbars {
     ) -> Self {
         let translation = state.translation(direction, bounds, content_bounds);
 
-        let show_scrollbar_x = direction.horizontal().filter(|scrollbar| {
-            scrollbar.spacing.is_some() || content_bounds.width > bounds.width
-        });
+        let show_scrollbar_x = direction
+            .horizontal()
+            .filter(|scrollbar| {
+                scrollbar.spacing.is_some()
+                    || content_bounds.width > bounds.width
+            })
+            .map(|properties| {
+                (properties, content_bounds.width <= bounds.width)
+            });
 
-        let show_scrollbar_y = direction.vertical().filter(|scrollbar| {
-            scrollbar.spacing.is_some() || content_bounds.height > bounds.height
-        });
+        let show_scrollbar_y = direction
+            .vertical()
+            .filter(|scrollbar| {
+                scrollbar.spacing.is_some()
+                    || content_bounds.height > bounds.height
+            })
+            .map(|properties| {
+                (properties, content_bounds.height <= bounds.height)
+            });
 
-        let y_scrollbar = if let Some(vertical) = show_scrollbar_y {
+        let y_scrollbar = if let Some((vertical, disabled)) = show_scrollbar_y {
             let Scrollbar {
                 width,
                 margin,
@@ -1607,7 +1631,7 @@ impl Scrollbars {
             // Adjust the height of the vertical scrollbar if the horizontal scrollbar
             // is present
             let x_scrollbar_height = show_scrollbar_x
-                .map_or(0.0, |h| h.width.max(h.scroller_width) + h.margin);
+                .map_or(0.0, |(h, _)| h.width.max(h.scroller_width) + h.margin);
 
             let total_scrollbar_width =
                 width.max(scroller_width) + 2.0 * margin;
@@ -1661,12 +1685,14 @@ impl Scrollbars {
                 bounds: scrollbar_bounds,
                 scroller,
                 alignment: vertical.alignment,
+                disabled,
             })
         } else {
             None
         };
 
-        let x_scrollbar = if let Some(horizontal) = show_scrollbar_x {
+        let x_scrollbar = if let Some((horizontal, disabled)) = show_scrollbar_x
+        {
             let Scrollbar {
                 width,
                 margin,
@@ -1730,6 +1756,7 @@ impl Scrollbars {
                 bounds: scrollbar_bounds,
                 scroller,
                 alignment: horizontal.alignment,
+                disabled,
             })
         } else {
             None
@@ -1756,6 +1783,14 @@ impl Scrollbars {
         } else {
             (false, false)
         }
+    }
+
+    fn y_disabled(&self) -> bool {
+        self.y.map(|y| y.disabled).unwrap_or(false)
+    }
+
+    fn x_disabled(&self) -> bool {
+        self.x.map(|x| x.disabled).unwrap_or(false)
     }
 
     fn grab_y_scroller(&self, cursor_position: Point) -> Option<f32> {
@@ -1804,6 +1839,7 @@ pub(super) mod internals {
         pub bounds: Rectangle,
         pub scroller: Option<Scroller>,
         pub alignment: Anchor,
+        pub disabled: bool,
     }
 
     impl Scrollbar {
@@ -1867,13 +1903,22 @@ pub(super) mod internals {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Status {
     /// The [`Scrollable`] can be interacted with.
-    Active,
+    Active {
+        /// Whether or not the horizontal scrollbar is disabled meaning the content isn't overflowing.
+        is_horizontal_scrollbar_disabled: bool,
+        /// Whether or not the vertical scrollbar is disabled meaning the content isn't overflowing.
+        is_vertical_scrollbar_disabled: bool,
+    },
     /// The [`Scrollable`] is being hovered.
     Hovered {
         /// Indicates if the horizontal scrollbar is being hovered.
         is_horizontal_scrollbar_hovered: bool,
         /// Indicates if the vertical scrollbar is being hovered.
         is_vertical_scrollbar_hovered: bool,
+        /// Whether or not the horizontal scrollbar is disabled meaning the content isn't overflowing.
+        is_horizontal_scrollbar_disabled: bool,
+        /// Whether or not the vertical scrollbar is disabled meaning the content isn't overflowing.
+        is_vertical_scrollbar_disabled: bool,
     },
     /// The [`Scrollable`] is being dragged.
     Dragged {
@@ -1881,6 +1926,10 @@ pub enum Status {
         is_horizontal_scrollbar_dragged: bool,
         /// Indicates if the vertical scrollbar is being dragged.
         is_vertical_scrollbar_dragged: bool,
+        /// Whether or not the horizontal scrollbar is disabled meaning the content isn't overflowing.
+        is_horizontal_scrollbar_disabled: bool,
+        /// Whether or not the vertical scrollbar is disabled meaning the content isn't overflowing.
+        is_vertical_scrollbar_disabled: bool,
     },
 }
 
@@ -1958,7 +2007,7 @@ pub fn default(theme: &Theme, status: Status) -> Style {
     };
 
     match status {
-        Status::Active => Style {
+        Status::Active { .. } => Style {
             container: container::Style::default(),
             vertical_rail: scrollbar,
             horizontal_rail: scrollbar,
@@ -1967,6 +2016,7 @@ pub fn default(theme: &Theme, status: Status) -> Style {
         Status::Hovered {
             is_horizontal_scrollbar_hovered,
             is_vertical_scrollbar_hovered,
+            ..
         } => {
             let hovered_scrollbar = Rail {
                 scroller: Scroller {
@@ -1994,6 +2044,7 @@ pub fn default(theme: &Theme, status: Status) -> Style {
         Status::Dragged {
             is_horizontal_scrollbar_dragged,
             is_vertical_scrollbar_dragged,
+            ..
         } => {
             let dragged_scrollbar = Rail {
                 scroller: Scroller {

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -1600,27 +1600,15 @@ impl Scrollbars {
     ) -> Self {
         let translation = state.translation(direction, bounds, content_bounds);
 
-        let show_scrollbar_x = direction
-            .horizontal()
-            .filter(|scrollbar| {
-                scrollbar.spacing.is_some()
-                    || content_bounds.width > bounds.width
-            })
-            .map(|properties| {
-                (properties, content_bounds.width <= bounds.width)
-            });
+        let show_scrollbar_x = direction.horizontal().filter(|scrollbar| {
+            scrollbar.spacing.is_some() || content_bounds.width > bounds.width
+        });
 
-        let show_scrollbar_y = direction
-            .vertical()
-            .filter(|scrollbar| {
-                scrollbar.spacing.is_some()
-                    || content_bounds.height > bounds.height
-            })
-            .map(|properties| {
-                (properties, content_bounds.height <= bounds.height)
-            });
+        let show_scrollbar_y = direction.vertical().filter(|scrollbar| {
+            scrollbar.spacing.is_some() || content_bounds.height > bounds.height
+        });
 
-        let y_scrollbar = if let Some((vertical, disabled)) = show_scrollbar_y {
+        let y_scrollbar = if let Some(vertical) = show_scrollbar_y {
             let Scrollbar {
                 width,
                 margin,
@@ -1631,7 +1619,7 @@ impl Scrollbars {
             // Adjust the height of the vertical scrollbar if the horizontal scrollbar
             // is present
             let x_scrollbar_height = show_scrollbar_x
-                .map_or(0.0, |(h, _)| h.width.max(h.scroller_width) + h.margin);
+                .map_or(0.0, |h| h.width.max(h.scroller_width) + h.margin);
 
             let total_scrollbar_width =
                 width.max(scroller_width) + 2.0 * margin;
@@ -1685,14 +1673,13 @@ impl Scrollbars {
                 bounds: scrollbar_bounds,
                 scroller,
                 alignment: vertical.alignment,
-                disabled,
+                disabled: content_bounds.height <= bounds.height,
             })
         } else {
             None
         };
 
-        let x_scrollbar = if let Some((horizontal, disabled)) = show_scrollbar_x
-        {
+        let x_scrollbar = if let Some(horizontal) = show_scrollbar_x {
             let Scrollbar {
                 width,
                 margin,
@@ -1756,7 +1743,7 @@ impl Scrollbars {
                 bounds: scrollbar_bounds,
                 scroller,
                 alignment: horizontal.alignment,
-                disabled,
+                disabled: content_bounds.width <= bounds.width,
             })
         } else {
             None

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -906,20 +906,20 @@ where
                 is_vertical_scrollbar_dragged: state
                     .y_scroller_grabbed_at
                     .is_some(),
-                is_horizontal_scrollbar_disabled: scrollbars.x_disabled(),
-                is_vertical_scrollbar_disabled: scrollbars.y_disabled(),
+                is_horizontal_scrollbar_disabled: scrollbars.is_x_disabled(),
+                is_vertical_scrollbar_disabled: scrollbars.is_y_disabled(),
             }
         } else if cursor_over_scrollable.is_some() {
             Status::Hovered {
                 is_horizontal_scrollbar_hovered: mouse_over_x_scrollbar,
                 is_vertical_scrollbar_hovered: mouse_over_y_scrollbar,
-                is_horizontal_scrollbar_disabled: scrollbars.x_disabled(),
-                is_vertical_scrollbar_disabled: scrollbars.y_disabled(),
+                is_horizontal_scrollbar_disabled: scrollbars.is_x_disabled(),
+                is_vertical_scrollbar_disabled: scrollbars.is_y_disabled(),
             }
         } else {
             Status::Active {
-                is_horizontal_scrollbar_disabled: scrollbars.x_disabled(),
-                is_vertical_scrollbar_disabled: scrollbars.y_disabled(),
+                is_horizontal_scrollbar_disabled: scrollbars.is_x_disabled(),
+                is_vertical_scrollbar_disabled: scrollbars.is_y_disabled(),
             }
         };
 
@@ -1772,11 +1772,11 @@ impl Scrollbars {
         }
     }
 
-    fn y_disabled(&self) -> bool {
+    fn is_y_disabled(&self) -> bool {
         self.y.map(|y| y.disabled).unwrap_or(false)
     }
 
-    fn x_disabled(&self) -> bool {
+    fn is_x_disabled(&self) -> bool {
         self.x.map(|x| x.disabled).unwrap_or(false)
     }
 


### PR DESCRIPTION
Feel free to change the 'name' of it. I originally used 'disabled' to signal that it's not usable, but still visible. 'Overflowing' may be a better term.