### PR TITLE
Update button Catalog and Style documentation

### DIFF
--- a/widget/src/button.rs
+++ b/widget/src/button.rs
@@ -471,6 +471,9 @@ pub enum Status {
 }
 
 /// The style of a button.
+/// 
+/// If not specified with [`Button::style`]
+/// the theme will provide the style.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Style {
     /// The [`Background`] of the button.
@@ -505,6 +508,47 @@ impl Default for Style {
 }
 
 /// The theme catalog of a [`Button`].
+/// 
+/// All themes that can be used with [`Button`]
+/// must implement this trait.
+/// 
+/// # Example
+/// ```no_run
+/// #[derive(Debug, Default)]
+/// pub enum ButtonStyles {
+///     #[default]
+///     Primary,
+///     Secondary,
+///     Danger
+/// }
+/// 
+/// impl Catalog for MyTheme {
+///     type Class<'a> = ButtonStyles;
+///     
+///     fn default<'a>() -> Self::Class<'a> {
+///         ButtonStyles::default()
+///     }
+///     
+/// 
+///     fn style(&self, class: &Self::Class<'_>, status: Status) -> Style {
+///         let mut style = Style::default();
+/// 
+///         match class {
+///             ButtonStyles::Primary => {
+///                 style.background = Some(Background::Color(Color::from_rgb(0.529, 0.808, 0.921)));
+///             },
+///             ButtonStyles::Secondary => {
+///                 style.background = Some(Background::Color(Color::WHITE));
+///             },
+///             ButtonStyles::Danger => {
+///                 style.background = Some(Background::Color(Color::from_rgb(0.941, 0.502, 0.502)));
+///             },
+///         }
+/// 
+///         style
+///     }
+/// }
+/// ```
 pub trait Catalog {
     /// The item class of the [`Catalog`].
     type Class<'a>;

--- a/widget/src/button.rs
+++ b/widget/src/button.rs
@@ -515,7 +515,7 @@ impl Default for Style {
 /// # Example
 /// ```no_run
 /// #[derive(Debug, Default)]
-/// pub enum ButtonStyles {
+/// pub enum ButtonClass {
 ///     #[default]
 ///     Primary,
 ///     Secondary,
@@ -523,10 +523,10 @@ impl Default for Style {
 /// }
 /// 
 /// impl Catalog for MyTheme {
-///     type Class<'a> = ButtonStyles;
+///     type Class<'a> = ButtonClass;
 ///     
 ///     fn default<'a>() -> Self::Class<'a> {
-///         ButtonStyles::default()
+///         ButtonClass::default()
 ///     }
 ///     
 /// 
@@ -534,13 +534,13 @@ impl Default for Style {
 ///         let mut style = Style::default();
 /// 
 ///         match class {
-///             ButtonStyles::Primary => {
+///             ButtonClass::Primary => {
 ///                 style.background = Some(Background::Color(Color::from_rgb(0.529, 0.808, 0.921)));
 ///             },
-///             ButtonStyles::Secondary => {
+///             ButtonClass::Secondary => {
 ///                 style.background = Some(Background::Color(Color::WHITE));
 ///             },
-///             ButtonStyles::Danger => {
+///             ButtonClass::Danger => {
 ///                 style.background = Some(Background::Color(Color::from_rgb(0.941, 0.502, 0.502)));
 ///             },
 ///         }
@@ -549,6 +549,10 @@ impl Default for Style {
 ///     }
 /// }
 /// ```
+/// 
+/// Although, in order to use [`Button::style`]
+/// with `MyTheme`, [`Catalog::Class`] must implement
+/// `From<StyleFn<'_, MyTheme>`.
 pub trait Catalog {
     /// The item class of the [`Catalog`].
     type Class<'a>;

--- a/widget/src/button.rs
+++ b/widget/src/button.rs
@@ -552,7 +552,7 @@ impl Default for Style {
 /// 
 /// Although, in order to use [`Button::style`]
 /// with `MyTheme`, [`Catalog::Class`] must implement
-/// `From<StyleFn<'_, MyTheme>`.
+/// `From<StyleFn<'_, MyTheme>>`.
 pub trait Catalog {
     /// The item class of the [`Catalog`].
     type Class<'a>;

--- a/widget/src/button.rs
+++ b/widget/src/button.rs
@@ -471,7 +471,7 @@ pub enum Status {
 }
 
 /// The style of a button.
-/// 
+///
 /// If not specified with [`Button::style`]
 /// the theme will provide the style.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -508,10 +508,10 @@ impl Default for Style {
 }
 
 /// The theme catalog of a [`Button`].
-/// 
+///
 /// All themes that can be used with [`Button`]
 /// must implement this trait.
-/// 
+///
 /// # Example
 /// ```no_run
 /// #[derive(Debug, Default)]
@@ -521,7 +521,7 @@ impl Default for Style {
 ///     Secondary,
 ///     Danger
 /// }
-/// 
+///
 /// impl Catalog for MyTheme {
 ///     type Class<'a> = ButtonClass;
 ///     
@@ -529,10 +529,10 @@ impl Default for Style {
 ///         ButtonClass::default()
 ///     }
 ///     
-/// 
+///
 ///     fn style(&self, class: &Self::Class<'_>, status: Status) -> Style {
 ///         let mut style = Style::default();
-/// 
+///
 ///         match class {
 ///             ButtonClass::Primary => {
 ///                 style.background = Some(Background::Color(Color::from_rgb(0.529, 0.808, 0.921)));
@@ -544,12 +544,12 @@ impl Default for Style {
 ///                 style.background = Some(Background::Color(Color::from_rgb(0.941, 0.502, 0.502)));
 ///             },
 ///         }
-/// 
+///
 ///         style
 ///     }
 /// }
 /// ```
-/// 
+///
 /// Although, in order to use [`Button::style`]
 /// with `MyTheme`, [`Catalog::Class`] must implement
 /// `From<StyleFn<'_, MyTheme>>`.

--- a/widget/src/button.rs
+++ b/widget/src/button.rs
@@ -514,6 +514,9 @@ impl Default for Style {
 ///
 /// # Example
 /// ```no_run
+/// # use iced_widget::core::{Color, Background};
+/// # use iced_widget::button::{Catalog, Status, Style};
+/// # struct MyTheme;
 /// #[derive(Debug, Default)]
 /// pub enum ButtonClass {
 ///     #[default]


### PR DESCRIPTION
Added a small explanation of where the button style comes from.
Added an example of implementing button catalog for a custom theme.

I ran the example to make sure it works on 0.13