### PR TITLE
Drop short-hand notation support for `color!` macro

### DIFF
--- a/core/src/color.rs
+++ b/core/src/color.rs
@@ -229,13 +229,12 @@ impl From<[f32; 4]> for Color {
 /// assert_eq!(color!(0, 0, 0, 0.0), Color::TRANSPARENT);
 /// assert_eq!(color!(0xffffff), Color::from_rgb(1.0, 1.0, 1.0));
 /// assert_eq!(color!(0xffffff, 0.), Color::from_rgba(1.0, 1.0, 1.0, 0.0));
-/// assert_eq!(color!(0x123), Color::from_rgba8(0x11, 0x22, 0x33, 1.0));
-/// assert_eq!(color!(0x123), color!(0x112233));
+/// assert_eq!(color!(0x0000ff), Color::from_rgba(0.0, 0.0, 1.0, 1.0));
 /// ```
 #[macro_export]
 macro_rules! color {
     ($r:expr, $g:expr, $b:expr) => {
-        color!($r, $g, $b, 1.0)
+        $crate::color!($r, $g, $b, 1.0)
     };
     ($r:expr, $g:expr, $b:expr, $a:expr) => {{
         let r = $r as f32 / 255.0;
@@ -261,29 +260,18 @@ macro_rules! color {
         $crate::Color { r, g, b, a: $a }
     }};
     ($hex:expr) => {{
-        color!($hex, 1.0)
+        $crate::color!($hex, 1.0)
     }};
     ($hex:expr, $a:expr) => {{
         let hex = $hex as u32;
 
-        if hex <= 0xfff {
-            let r = (hex & 0xf00) >> 8;
-            let g = (hex & 0x0f0) >> 4;
-            let b = (hex & 0x00f);
+        debug_assert!(hex <= 0xffffff, "color! value must not exceed 0xffffff");
 
-            color!((r << 4 | r), (g << 4 | g), (b << 4 | b), $a)
-        } else {
-            debug_assert!(
-                hex <= 0xffffff,
-                "color! value must not exceed 0xffffff"
-            );
+        let r = (hex & 0xff0000) >> 16;
+        let g = (hex & 0xff00) >> 8;
+        let b = (hex & 0xff);
 
-            let r = (hex & 0xff0000) >> 16;
-            let g = (hex & 0xff00) >> 8;
-            let b = (hex & 0xff);
-
-            color!(r, g, b, $a)
-        }
+        $crate::color!(r, g, b, $a)
     }};
 }
 


### PR DESCRIPTION
We'd need to use `stringify!` and `str::len` to properly support the short-hand notation; however, we want the macro to work in `const` contexts.

Fixes #2591.
