### PR TITLE
Move `wgpu` re-export to root module

### DIFF
--- a/examples/custom_shader/src/main.rs
+++ b/examples/custom_shader/src/main.rs
@@ -3,7 +3,7 @@ mod scene;
 use scene::Scene;
 
 use iced::time::Instant;
-use iced::widget::shader::wgpu;
+use iced::wgpu;
 use iced::widget::{center, checkbox, column, row, shader, slider, text};
 use iced::window;
 use iced::{Center, Color, Element, Fill, Subscription};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -483,6 +483,9 @@ pub use iced_futures::stream;
 #[cfg(feature = "highlighter")]
 pub use iced_highlighter as highlighter;
 
+#[cfg(feature = "wgpu")]
+pub use iced_renderer::wgpu::wgpu;
+
 mod error;
 mod program;
 

--- a/widget/src/shader.rs
+++ b/widget/src/shader.rs
@@ -18,7 +18,6 @@ use crate::renderer::wgpu::primitive;
 use std::marker::PhantomData;
 
 pub use crate::graphics::Viewport;
-pub use crate::renderer::wgpu::wgpu;
 pub use primitive::{Primitive, Storage};
 
 /// A widget which can render custom shaders with Iced's `wgpu` backend.


### PR DESCRIPTION
`wgpu` takes a long time to document otherwise.