### PR TITLE
Fix flex layout of `Fill` elements in a `Shrink` cross axis

### DIFF
--- a/core/src/layout/flex.rs
+++ b/core/src/layout/flex.rs
@@ -79,10 +79,10 @@ where
     let max_cross = axis.cross(limits.max());
 
     let mut fill_main_sum = 0;
-    let mut cross = match axis {
-        Axis::Vertical if width == Length::Shrink => 0.0,
-        Axis::Horizontal if height == Length::Shrink => 0.0,
-        _ => max_cross,
+    let (mut cross, cross_compress) = match axis {
+        Axis::Vertical if width == Length::Shrink => (0.0, true),
+        Axis::Horizontal if height == Length::Shrink => (0.0, true),
+        _ => (max_cross, false),
     };
 
     let mut available = axis.main(limits.max()) - total_spacing;
@@ -97,7 +97,8 @@ where
             axis.pack(size.width.fill_factor(), size.height.fill_factor())
         };
 
-        if fill_main_factor == 0 {
+        if fill_main_factor == 0 && (!cross_compress || fill_cross_factor == 0)
+        {
             let (max_width, max_height) = axis.pack(
                 available,
                 if fill_cross_factor == 0 {
@@ -141,7 +142,7 @@ where
             axis.pack(size.width.fill_factor(), size.height.fill_factor())
         };
 
-        if fill_main_factor != 0 {
+        if fill_main_factor != 0 || (cross_compress && fill_cross_factor != 0) {
             let max_main =
                 remaining * fill_main_factor as f32 / fill_main_sum as f32;
 

--- a/examples/layout/src/main.rs
+++ b/examples/layout/src/main.rs
@@ -2,12 +2,12 @@ use iced::border;
 use iced::keyboard;
 use iced::mouse;
 use iced::widget::{
-    button, canvas, center, checkbox, column, container, horizontal_space,
-    pick_list, row, scrollable, text,
+    button, canvas, center, checkbox, column, container, horizontal_rule,
+    horizontal_space, pick_list, row, scrollable, text, vertical_rule,
 };
 use iced::{
     color, Center, Element, Fill, Font, Length, Point, Rectangle, Renderer,
-    Subscription, Theme,
+    Shrink, Subscription, Theme,
 };
 
 pub fn main() -> iced::Result {
@@ -147,6 +147,10 @@ impl Example {
             title: "Application",
             view: application,
         },
+        Self {
+            title: "Quotes",
+            view: quotes,
+        },
     ];
 
     fn is_first(self) -> bool {
@@ -273,6 +277,36 @@ fn application<'a>() -> Element<'a, Message> {
     .padding(10);
 
     column![header, row![sidebar, content]].into()
+}
+
+fn quotes<'a>() -> Element<'a, Message> {
+    fn quote<'a>(
+        content: impl Into<Element<'a, Message>>,
+    ) -> Element<'a, Message> {
+        row![vertical_rule(2), content.into()]
+            .spacing(10)
+            .height(Shrink)
+            .into()
+    }
+
+    fn reply<'a>(
+        original: impl Into<Element<'a, Message>>,
+        reply: impl Into<Element<'a, Message>>,
+    ) -> Element<'a, Message> {
+        column![quote(original), reply.into()].spacing(10).into()
+    }
+
+    column![
+        reply(
+            reply("This is the original message", "This is a reply"),
+            "This is another reply",
+        ),
+        horizontal_rule(1),
+        "A separator ↑",
+    ]
+    .width(Shrink)
+    .spacing(10)
+    .into()
 }
 
 fn square<'a>(size: impl Into<Length> + Copy) -> Element<'a, Message> {


### PR DESCRIPTION
Instead of collapsing, the `Fill` elements will fill the cross space allocated by the other `Shrink` elements present in the container.