### PR TITLE
Add support for double click event to MouseArea

### DIFF
--- a/widget/src/mouse_area.rs
+++ b/widget/src/mouse_area.rs
@@ -56,7 +56,7 @@ impl<'a, Message, Theme, Renderer> MouseArea<'a, Message, Theme, Renderer> {
     ///
     /// The events stream will be: on_press -> on_release -> on_press
     /// -> on_double_click -> on_release -> on_press ...
-    /// 
+    ///
     /// [`on_press`]: Self::on_press
     /// [`on_release`]: Self::on_release
     #[must_use]

--- a/widget/src/mouse_area.rs
+++ b/widget/src/mouse_area.rs
@@ -22,6 +22,7 @@ pub struct MouseArea<
     content: Element<'a, Message, Theme, Renderer>,
     on_press: Option<Message>,
     on_release: Option<Message>,
+    on_double_click: Option<Message>,
     on_right_press: Option<Message>,
     on_right_release: Option<Message>,
     on_middle_press: Option<Message>,
@@ -45,6 +46,22 @@ impl<'a, Message, Theme, Renderer> MouseArea<'a, Message, Theme, Renderer> {
     #[must_use]
     pub fn on_release(mut self, message: Message) -> Self {
         self.on_release = Some(message);
+        self
+    }
+
+    /// The message to emit on a double click.
+    ///
+    /// If you use this with [`on_press`]/[`on_release`], those
+    /// event will be emit as normal.
+    ///
+    /// The events stream will be: on_press -> on_release -> on_press
+    /// -> on_double_click -> on_release -> on_press ...
+    /// 
+    /// [`on_press`]: Self::on_press
+    /// [`on_release`]: Self::on_release
+    #[must_use]
+    pub fn on_double_click(mut self, message: Message) -> Self {
+        self.on_double_click = Some(message);
         self
     }
 
@@ -121,6 +138,7 @@ struct State {
     is_hovered: bool,
     bounds: Rectangle,
     cursor_position: Option<Point>,
+    previous_click: Option<mouse::Click>,
 }
 
 impl<'a, Message, Theme, Renderer> MouseArea<'a, Message, Theme, Renderer> {
@@ -132,6 +150,7 @@ impl<'a, Message, Theme, Renderer> MouseArea<'a, Message, Theme, Renderer> {
             content: content.into(),
             on_press: None,
             on_release: None,
+            on_double_click: None,
             on_right_press: None,
             on_right_release: None,
             on_middle_press: None,
@@ -347,12 +366,37 @@ fn update<Message: Clone, Theme, Renderer>(
         return event::Status::Ignored;
     }
 
-    if let Some(message) = widget.on_press.as_ref() {
-        if let Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
-        | Event::Touch(touch::Event::FingerPressed { .. }) = event
-        {
-            shell.publish(message.clone());
+    if let Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
+    | Event::Touch(touch::Event::FingerPressed { .. }) = event
+    {
+        let mut captured = false;
 
+        if let Some(message) = widget.on_press.as_ref() {
+            captured = true;
+            shell.publish(message.clone());
+        }
+
+        if let Some(position) = cursor_position {
+            if let Some(message) = widget.on_double_click.as_ref() {
+                let new_click = mouse::Click::new(
+                    position,
+                    mouse::Button::Left,
+                    state.previous_click,
+                );
+
+                if matches!(new_click.kind(), mouse::click::Kind::Double) {
+                    shell.publish(message.clone());
+                }
+
+                state.previous_click = Some(new_click);
+
+                // Even if this is not a double click, but the press is nevertheless
+                // processed by us and should not be popup to parent widgets.
+                captured = true;
+            }
+        }
+
+        if captured {
             return event::Status::Captured;
         }
     }


### PR DESCRIPTION
This PR adds double_click support for the MouseArea widget.

Since `mouse::Click` exists, this PR directly uses it as the criterion for determining a "double-click," i.e., the position remains unchanged and the interval is less than 300ms.

Additionally, to minimize changes, this implementation is expected not to affect the emit of `on_press` and `on_release`. It can be understood as emit an `on_double_click` after the second `on_press`.

Furthermore, if only `on_double_click` is used (without `on_press`), a mouse **left press** (and touch) event which **do not** be cosidered as a double click will also be **marked as captured**. If not, a region that accepts double-clicks would trigger the parent component's on_press on some clicks, which seems counterintuitive. But It's not very clear should it do the same for release event...?

## Example

![GIF 2024-9-23 18-25-11](https://github.com/user-attachments/assets/14d876e9-4b09-4d04-9bbf-6e1e6f3f96c8)

## Example code

<details>
<summary>click to open...</summary>

<pre>
#[derive(Default)]
struct App {
    press: u64,
    double: u64,
}

#[derive(Debug, Copy, Clone, PartialEq, Eq)]
enum Message {
    Press,
    DoubleClick,
}

fn main() {
    fn update(app: &mut App, message: Message) {
        match message {
            Message::Press => app.press += 1,
            Message::DoubleClick => app.double += 1,
        }
    }

    fn view(app: &App) -> iced::Element<Message> {
        let s = format!(
            "press me {} times\ndouble click me {} times",
            app.press, app.double,
        );

        let label = iced::widget::mouse_area(iced::widget::text(s))
            .on_press(Message::Press)
            .on_double_click(Message::DoubleClick);

        iced::widget::container(label)
            .center_x(iced::Length::Fill)
            .center_y(iced::Length::Fill)
            .into()
    }

    iced::application("Double Click", update, view)
        .window_size((200.0, 100.0))
        .centered()
        .run()
        .unwrap();
}
</pre>
</details>
