### PR TITLE
Include images and saved meshes when pasting `Frame`

### DIFF
--- a/tiny_skia/src/geometry.rs
+++ b/tiny_skia/src/geometry.rs
@@ -256,6 +256,7 @@ impl geometry::frame::Backend for Frame {
     fn paste(&mut self, frame: Self) {
         self.primitives.extend(frame.primitives);
         self.text.extend(frame.text);
+        self.images.extend(frame.images);
     }
 
     fn translate(&mut self, translation: Vector) {

--- a/wgpu/src/geometry.rs
+++ b/wgpu/src/geometry.rs
@@ -395,6 +395,7 @@ impl geometry::frame::Backend for Frame {
     }
 
     fn paste(&mut self, frame: Frame) {
+        self.meshes.extend(frame.meshes);
         self.meshes
             .extend(frame.buffers.into_meshes(frame.clip_bounds));
 


### PR DESCRIPTION
`tiny_skia::Frame` was ignoring images in `Frame::paste`, making images not show up when created in a `with_clip` context.

`wgpu::Frame` similarly did not pass through meshes in its paste method, that may have been saved from a nested `with_clip` call.

I'm not sure that nesting `with_clip` makes a lot of sense, because only the innermost clip region gets applied (should this be documented?), also it seems like images are not yet affected by clipping? Nevertheless, these fixes seem relevant.