### PR TITLE
Expose shell to canvas::Program to match shader::Program.

### DIFF
--- a/examples/bezier_tool/Cargo.toml
+++ b/examples/bezier_tool/Cargo.toml
@@ -7,4 +7,4 @@ publish = false
 
 [dependencies]
 iced.workspace = true
-iced.features = ["canvas", "debug"]
+iced.features = ["canvas", "debug", "advanced"]

--- a/examples/bezier_tool/src/main.rs
+++ b/examples/bezier_tool/src/main.rs
@@ -56,6 +56,7 @@ impl Example {
 }
 
 mod bezier {
+    use iced::advanced::Shell;
     use iced::mouse;
     use iced::widget::canvas::event::{self, Event};
     use iced::widget::canvas::{self, Canvas, Frame, Geometry, Path, Stroke};
@@ -96,6 +97,7 @@ mod bezier {
             event: Event,
             bounds: Rectangle,
             cursor: mouse::Cursor,
+            _shell: &mut Shell<'_, Curve>,
         ) -> (event::Status, Option<Curve>) {
             let Some(cursor_position) = cursor.position_in(bounds) else {
                 return (event::Status::Ignored, None);

--- a/examples/game_of_life/Cargo.toml
+++ b/examples/game_of_life/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 iced.workspace = true
-iced.features = ["debug", "canvas", "tokio"]
+iced.features = ["debug", "canvas", "advanced", "tokio"]
 
 itertools = "0.12"
 rustc-hash.workspace = true

--- a/examples/game_of_life/src/main.rs
+++ b/examples/game_of_life/src/main.rs
@@ -189,6 +189,7 @@ fn view_controls<'a>(
 
 mod grid {
     use crate::Preset;
+    use iced::advanced::Shell;
     use iced::alignment;
     use iced::mouse;
     use iced::touch;
@@ -383,6 +384,7 @@ mod grid {
             event: Event,
             bounds: Rectangle,
             cursor: mouse::Cursor,
+            _shell: &mut Shell<'_, Message>,
         ) -> (event::Status, Option<Message>) {
             if let Event::Mouse(mouse::Event::ButtonReleased(_)) = event {
                 *interaction = Interaction::None;

--- a/examples/multitouch/Cargo.toml
+++ b/examples/multitouch/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 iced.workspace = true
-iced.features = ["debug", "canvas", "tokio"]
+iced.features = ["debug", "canvas", "tokio", "advanced"]
 
 tracing-subscriber = "0.3"
 voronator = "0.2"

--- a/examples/multitouch/src/main.rs
+++ b/examples/multitouch/src/main.rs
@@ -1,6 +1,7 @@
 //! This example shows how to use touch events in `Canvas` to draw
 //! a circle around each fingertip. This only works on touch-enabled
 //! computers like Microsoft Surface.
+use iced::advanced::Shell;
 use iced::mouse;
 use iced::touch;
 use iced::widget::canvas::event;
@@ -59,6 +60,7 @@ impl canvas::Program<Message> for Multitouch {
         event: event::Event,
         _bounds: Rectangle,
         _cursor: mouse::Cursor,
+        _shell: &mut Shell<'_, Message>,
     ) -> (event::Status, Option<Message>) {
         match event {
             event::Event::Touch(touch_event) => match touch_event {

--- a/examples/sierpinski_triangle/Cargo.toml
+++ b/examples/sierpinski_triangle/Cargo.toml
@@ -7,6 +7,6 @@ publish = false
 
 [dependencies]
 iced.workspace = true
-iced.features = ["debug", "canvas"]
+iced.features = ["debug", "canvas", "advanced"]
 
 rand = "0.8"

--- a/examples/sierpinski_triangle/src/main.rs
+++ b/examples/sierpinski_triangle/src/main.rs
@@ -1,3 +1,4 @@
+use iced::advanced::Shell;
 use iced::mouse;
 use iced::widget::canvas::event::{self, Event};
 use iced::widget::canvas::{self, Canvas, Geometry};
@@ -80,6 +81,7 @@ impl canvas::Program<Message> for SierpinskiGraph {
         event: Event,
         bounds: Rectangle,
         cursor: mouse::Cursor,
+        _shell: &mut Shell<'_, Message>,
     ) -> (event::Status, Option<Message>) {
         let Some(cursor_position) = cursor.position_in(bounds) else {
             return (event::Status::Ignored, None);

--- a/widget/src/canvas.rs
+++ b/widget/src/canvas.rs
@@ -239,7 +239,8 @@ where
             let state = tree.state.downcast_mut::<P::State>();
 
             let (event_status, message) =
-                self.program.update(state, canvas_event, bounds, cursor);
+                self.program
+                    .update(state, canvas_event, bounds, cursor, shell);
 
             if let Some(message) = message {
                 shell.publish(message);

--- a/widget/src/canvas/program.rs
+++ b/widget/src/canvas/program.rs
@@ -1,7 +1,7 @@
 use crate::canvas::event::{self, Event};
 use crate::canvas::mouse;
 use crate::canvas::Geometry;
-use crate::core::Rectangle;
+use crate::core::{Rectangle, Shell};
 use crate::graphics::geometry;
 
 /// The state and logic of a [`Canvas`].
@@ -34,6 +34,7 @@ where
         _event: Event,
         _bounds: Rectangle,
         _cursor: mouse::Cursor,
+        _shell: &mut Shell<'_, Message>,
     ) -> (event::Status, Option<Message>) {
         (event::Status::Ignored, None)
     }
@@ -84,8 +85,9 @@ where
         event: Event,
         bounds: Rectangle,
         cursor: mouse::Cursor,
+        shell: &mut Shell<'_, Message>,
     ) -> (event::Status, Option<Message>) {
-        T::update(self, state, event, bounds, cursor)
+        T::update(self, state, event, bounds, cursor, shell)
     }
 
     fn draw(


### PR DESCRIPTION
Allows a canvas program to schedule redraws as needed without managing it externally.

This matches the more powerful shader::Program update method now.