### PR TITLE
Don't fill out of viewport text

### DIFF
--- a/core/src/widget/text.rs
+++ b/core/src/widget/text.rs
@@ -334,10 +334,6 @@ pub fn draw<Renderer>(
 {
     let bounds = layout.bounds();
 
-    if !bounds.intersects(viewport) {
-        return;
-    }
-
     let x = match paragraph.horizontal_alignment() {
         alignment::Horizontal::Left => bounds.x,
         alignment::Horizontal::Center => bounds.center_x(),

--- a/core/src/widget/text.rs
+++ b/core/src/widget/text.rs
@@ -334,6 +334,10 @@ pub fn draw<Renderer>(
 {
     let bounds = layout.bounds();
 
+    if !bounds.intersects(viewport) {
+        return;
+    }
+
     let x = match paragraph.horizontal_alignment() {
         alignment::Horizontal::Left => bounds.x,
         alignment::Horizontal::Center => bounds.center_x(),

--- a/widget/src/column.rs
+++ b/widget/src/column.rs
@@ -320,24 +320,21 @@ where
         viewport: &Rectangle,
     ) {
         if let Some(clipped_viewport) = layout.bounds().intersection(viewport) {
+            let viewport = if self.clip {
+                &clipped_viewport
+            } else {
+                viewport
+            };
+
             for ((child, state), layout) in self
                 .children
                 .iter()
                 .zip(&tree.children)
                 .zip(layout.children())
+                .filter(|(_, layout)| layout.bounds().intersects(viewport))
             {
                 child.as_widget().draw(
-                    state,
-                    renderer,
-                    theme,
-                    style,
-                    layout,
-                    cursor,
-                    if self.clip {
-                        &clipped_viewport
-                    } else {
-                        viewport
-                    },
+                    state, renderer, theme, style, layout, cursor, viewport,
                 );
             }
         }

--- a/widget/src/row.rs
+++ b/widget/src/row.rs
@@ -316,24 +316,21 @@ where
         viewport: &Rectangle,
     ) {
         if let Some(clipped_viewport) = layout.bounds().intersection(viewport) {
+            let viewport = if self.clip {
+                &clipped_viewport
+            } else {
+                viewport
+            };
+
             for ((child, state), layout) in self
                 .children
                 .iter()
                 .zip(&tree.children)
                 .zip(layout.children())
+                .filter(|(_, layout)| layout.bounds().intersects(viewport))
             {
                 child.as_widget().draw(
-                    state,
-                    renderer,
-                    theme,
-                    style,
-                    layout,
-                    cursor,
-                    if self.clip {
-                        &clipped_viewport
-                    } else {
-                        viewport
-                    },
+                    state, renderer, theme, style, layout, cursor, viewport,
                 );
             }
         }


### PR DESCRIPTION
Super smol optimization. There's no need to submit this rendering operation when text is out of viewport. In `halloy` we leverage this optimization and it has a huge impact on primitive generation timings when dealing w/ lots of text in a scrollable.