### PR TITLE
Add `window::Action::CursorGrab` and `mouse::Event::MouseMotion`

### DIFF
--- a/core/src/mouse/event.rs
+++ b/core/src/mouse/event.rs
@@ -1,4 +1,4 @@
-use crate::Point;
+use crate::{Point, Vector};
 
 use super::Button;
 
@@ -20,6 +20,21 @@ pub enum Event {
     CursorMoved {
         /// The new position of the mouse cursor
         position: Point,
+    },
+
+    /// The mouse was moved.
+    ///
+    /// This will fire in situations where [`CursorMoved`] might not,
+    /// such as the mouse being outside of the window or hitting the edge
+    /// of the monitor, and can be used to get the correct motion when
+    /// [`CursorGrab`] is set to something other than [`None`].
+    ///
+    /// [`CursorMoved`]: Event::CursorMoved
+    /// [`CursorGrab`]: super::super::window::CursorGrab
+    /// [`None`]: super::super::window::CursorGrab::None
+    MouseMotion {
+        /// The change in position of the mouse cursor
+        delta: Vector,
     },
 
     /// A mouse button was pressed.

--- a/core/src/point.rs
+++ b/core/src/point.rs
@@ -74,6 +74,16 @@ where
     }
 }
 
+impl<T> std::ops::AddAssign<Vector<T>> for Point<T>
+where
+    T: std::ops::AddAssign,
+{
+    fn add_assign(&mut self, vector: Vector<T>) {
+        self.x += vector.x;
+        self.y += vector.y;
+    }
+}
+
 impl<T> std::ops::Sub<Vector<T>> for Point<T>
 where
     T: std::ops::Sub<Output = T>,
@@ -88,6 +98,16 @@ where
     }
 }
 
+impl<T> std::ops::SubAssign<Vector<T>> for Point<T>
+where
+    T: std::ops::SubAssign,
+{
+    fn sub_assign(&mut self, vector: Vector<T>) {
+        self.x -= vector.x;
+        self.y -= vector.y;
+    }
+}
+
 impl<T> std::ops::Sub<Point<T>> for Point<T>
 where
     T: std::ops::Sub<Output = T>,
@@ -96,6 +116,16 @@ where
 
     fn sub(self, point: Self) -> Vector<T> {
         Vector::new(self.x - point.x, self.y - point.y)
+    }
+}
+
+impl<T> std::ops::SubAssign<Point<T>> for Point<T>
+where
+    T: std::ops::SubAssign,
+{
+    fn sub_assign(&mut self, point: Point<T>) {
+        self.x -= point.x;
+        self.y -= point.y;
     }
 }
 

--- a/core/src/vector.rs
+++ b/core/src/vector.rs
@@ -37,8 +37,18 @@ where
 {
     type Output = Self;
 
-    fn add(self, b: Self) -> Self {
-        Self::new(self.x + b.x, self.y + b.y)
+    fn add(self, rhs: Self) -> Self {
+        Self::new(self.x + rhs.x, self.y + rhs.y)
+    }
+}
+
+impl<T> std::ops::AddAssign for Vector<T>
+where
+    T: std::ops::AddAssign,
+{
+    fn add_assign(&mut self, rhs: Self) {
+        self.x += rhs.x;
+        self.y += rhs.y;
     }
 }
 
@@ -48,8 +58,18 @@ where
 {
     type Output = Self;
 
-    fn sub(self, b: Self) -> Self {
-        Self::new(self.x - b.x, self.y - b.y)
+    fn sub(self, rhs: Self) -> Self {
+        Self::new(self.x - rhs.x, self.y - rhs.y)
+    }
+}
+
+impl<T> std::ops::SubAssign for Vector<T>
+where
+    T: std::ops::SubAssign,
+{
+    fn sub_assign(&mut self, rhs: Self) {
+        self.x -= rhs.x;
+        self.y -= rhs.y;
     }
 }
 
@@ -61,6 +81,37 @@ where
 
     fn mul(self, scale: T) -> Self {
         Self::new(self.x * scale, self.y * scale)
+    }
+}
+
+impl<T> std::ops::MulAssign<T> for Vector<T>
+where
+    T: std::ops::MulAssign + Copy,
+{
+    fn mul_assign(&mut self, scale: T) {
+        self.x *= scale;
+        self.y *= scale;
+    }
+}
+
+impl<T> std::ops::Div<T> for Vector<T>
+where
+    T: std::ops::Div<Output = T> + Copy,
+{
+    type Output = Self;
+
+    fn div(self, scale: T) -> Self {
+        Self::new(self.x / scale, self.y / scale)
+    }
+}
+
+impl<T> std::ops::DivAssign<T> for Vector<T>
+where
+    T: std::ops::DivAssign + Copy,
+{
+    fn div_assign(&mut self, scale: T) {
+        self.x /= scale;
+        self.y /= scale;
     }
 }
 

--- a/core/src/window.rs
+++ b/core/src/window.rs
@@ -2,6 +2,7 @@
 pub mod icon;
 pub mod settings;
 
+mod cursor_grab;
 mod event;
 mod id;
 mod level;
@@ -10,6 +11,7 @@ mod position;
 mod redraw_request;
 mod user_attention;
 
+pub use cursor_grab::CursorGrab;
 pub use event::Event;
 pub use icon::Icon;
 pub use id::Id;

--- a/core/src/window/cursor_grab.rs
+++ b/core/src/window/cursor_grab.rs
@@ -1,0 +1,29 @@
+/// The behavior of cursor grabbing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CursorGrab {
+    /// No grabbing of the cursor is performed.
+    #[default]
+    None,
+
+    /// The cursor is confined to the window area.
+    ///
+    /// There's no guarantee that the cursor will be hidden. You should hide it by yourself if you
+    /// want to do so.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **macOS:** Not implemented.
+    /// - **iOS / Android / Web:** Unsupported.
+    Confined,
+
+    /// The cursor is locked inside the window area to the certain position.
+    ///
+    /// There's no guarantee that the cursor will be hidden. You should hide it by yourself if you
+    /// want to do so.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **X11 / Windows:** Not implemented.
+    /// - **iOS / Android:** Unsupported.
+    Locked,
+}

--- a/runtime/src/window.rs
+++ b/runtime/src/window.rs
@@ -1,6 +1,7 @@
 //! Build window-based GUI applications.
 pub mod screenshot;
 
+use iced_core::window::CursorGrab;
 pub use screenshot::Screenshot;
 
 use crate::core::time::Instant;
@@ -159,6 +160,13 @@ pub enum Action {
     /// This enables mouse events for the window and stops mouse events
     /// from being passed to whatever is underneath.
     DisableMousePassthrough(Id),
+
+    /// Constraints the cursor in a window.
+    ///
+    /// ## Platform-specific
+    /// -- **Web / macOS:** [`CursorGrab::Confined`] unsupported.
+    /// -- **Windows / X11:** [`CursorGrab::Locked`] unsupported.
+    CursorGrab(Id, CursorGrab),
 }
 
 /// Subscribes to the frames of the window of the running application.
@@ -433,4 +441,9 @@ pub fn enable_mouse_passthrough<Message>(id: Id) -> Task<Message> {
 /// from being passed to whatever is underneath.
 pub fn disable_mouse_passthrough<Message>(id: Id) -> Task<Message> {
     task::effect(crate::Action::Window(Action::DisableMousePassthrough(id)))
+}
+
+/// Constraints the cursor in a window.
+pub fn cursor_grab<Message>(id: Id, cursor_grab: CursorGrab) -> Task<Message> {
+    task::effect(crate::Action::Window(Action::CursorGrab(id, cursor_grab)))
 }

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -6,7 +6,7 @@ use crate::core::keyboard;
 use crate::core::mouse;
 use crate::core::touch;
 use crate::core::window;
-use crate::core::{Event, Point, Size};
+use crate::core::{Event, Point, Size, Vector};
 
 /// Converts some [`window::Settings`] into some `WindowAttributes` from `winit`.
 pub fn window_attributes(
@@ -295,6 +295,25 @@ pub fn window_event(
                 position.to_logical(scale_factor);
 
             Some(Event::Window(window::Event::Moved(Point::new(x, y))))
+        }
+        _ => None,
+    }
+}
+
+/// Converts a winit device event into an iced event.
+pub fn device_event(
+    event: winit::event::DeviceEvent,
+    scale_factor: f64,
+) -> Option<Event> {
+    use winit::event::DeviceEvent;
+
+    match event {
+        DeviceEvent::MouseMotion { delta: (x, y) } => {
+            let x = (x / scale_factor) as f32;
+            let y = (y / scale_factor) as f32;
+            Some(Event::Mouse(mouse::Event::MouseMotion {
+                delta: Vector { x, y },
+            }))
         }
         _ => None,
     }
@@ -1133,6 +1152,19 @@ pub fn icon(icon: window::Icon) -> Option<winit::window::Icon> {
     let (pixels, size) = icon.into_raw();
 
     winit::window::Icon::from_rgba(pixels, size.width, size.height).ok()
+}
+
+/// Converts some [`CursorGrab`] into it's `winit` counterpart.
+///
+/// [`CursorGrab`]: window::CursorGrab
+pub fn cursor_grab(
+    cursor_grab: window::CursorGrab,
+) -> winit::window::CursorGrabMode {
+    match cursor_grab {
+        window::CursorGrab::None => winit::window::CursorGrabMode::None,
+        window::CursorGrab::Confined => winit::window::CursorGrabMode::Confined,
+        window::CursorGrab::Locked => winit::window::CursorGrabMode::Locked,
+    }
 }
 
 // See: https://en.wikipedia.org/wiki/Private_Use_Areas


### PR DESCRIPTION
Together they allow you to confine or lock the cursor, and still recive mouse events.
Corresponds to [`winit::window::CursorGrabMode`](https://docs.rs/winit/latest/winit/window/enum.CursorGrabMode.html) and [`winit::event::DeviceEvent::MouseMotion`](https://docs.rs/winit/latest/winit/event/enum.MouseButton.html) respectively.

Some use cases they allow are panning in viewports and inputs that can be dragged like sliders without a range, these can be implemented using the cursor position but lead to bad UX from the cursor exiting the window or hitting the edge of the monitor, making you have to stop the interaction and reposition the cursor. Blender is a good example of both of these behaviors.

Unfortunately, there are currently some pretty big limitations, stemming from winit (and potentially platform limitations):
- [`winit::event::DeviceEvent::MouseMotion`](https://docs.rs/winit/latest/winit/event/enum.DeviceEvent.html#variant.MouseMotion) uses raw (unaccelerated) mouse input. This really hurts usability and the reason this is a draft PR. I'm looking into solving this in winit, probably by adding a `winit::event::WindowEvent::MouseMotion` counterpart that is accelerated (and will also be specific to a window instead of being sent to all windows), this is very straight forward on wayland (the event is on a toplevel (window), and gives both accelerated and unaccelerated), but I'm not sure about other platforms.
- Platform support is not great for `CursorGrab`, it works out that there's exactly one mode that is guaranteed to work for each platform (on linux `CursorGrab::Confined` works for both wayland and x11).
- There's no ability to set a region in `CursorGrab::Confined`, which happens to be particularly useful for GUIs.