### PR TITLE
Document Wayland `File*` Events as Unsupported & Fix Typos

### DIFF
--- a/core/src/keyboard/key.rs
+++ b/core/src/keyboard/key.rs
@@ -203,7 +203,7 @@ pub enum Named {
     Standby,
     /// The WakeUp key. (`KEYCODE_WAKEUP`)
     WakeUp,
-    /// Initate the multi-candidate mode.
+    /// Initiate the multi-candidate mode.
     AllCandidates,
     Alphanumeric,
     /// Initiate the Code Input mode to allow characters to be entered by

--- a/core/src/keyboard/modifiers.rs
+++ b/core/src/keyboard/modifiers.rs
@@ -33,7 +33,7 @@ impl Modifiers {
     /// This is normally the main modifier to be used for hotkeys.
     ///
     /// On macOS, this is equivalent to `Self::LOGO`.
-    /// Ohterwise, this is equivalent to `Self::CTRL`.
+    /// Otherwise, this is equivalent to `Self::CTRL`.
     pub const COMMAND: Self = if cfg!(target_os = "macos") {
         Self::LOGO
     } else {

--- a/core/src/text.rs
+++ b/core/src/text.rs
@@ -411,13 +411,13 @@ impl<'a, Link, Font> Span<'a, Link, Font> {
         self
     }
 
-    /// Sets whether the [`Span`] shoud be underlined or not.
+    /// Sets whether the [`Span`] should be underlined or not.
     pub fn underline(mut self, underline: bool) -> Self {
         self.underline = underline;
         self
     }
 
-    /// Sets whether the [`Span`] shoud be struck through or not.
+    /// Sets whether the [`Span`] should be struck through or not.
     pub fn strikethrough(mut self, strikethrough: bool) -> Self {
         self.strikethrough = strikethrough;
         self

--- a/core/src/window/event.rs
+++ b/core/src/window/event.rs
@@ -46,17 +46,29 @@ pub enum Event {
     ///
     /// When the user hovers multiple files at once, this event will be emitted
     /// for each file separately.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **Wayland:** Not implemented.
     FileHovered(PathBuf),
 
     /// A file has been dropped into the window.
     ///
     /// When the user drops multiple files at once, this event will be emitted
     /// for each file separately.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **Wayland:** Not implemented.
     FileDropped(PathBuf),
 
     /// A file was hovered, but has exited the window.
     ///
     /// There will be a single `FilesHoveredLeft` event triggered even if
     /// multiple files were hovered.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **Wayland:** Not implemented.
     FilesHoveredLeft,
 }

--- a/graphics/src/compositor.rs
+++ b/graphics/src/compositor.rs
@@ -155,7 +155,7 @@ impl Compositor for () {
     async fn with_backend<W: Window + Clone>(
         _settings: Settings,
         _compatible_window: W,
-        _preffered_backend: Option<&str>,
+        _preferred_backend: Option<&str>,
     ) -> Result<Self, Error> {
         Ok(())
     }

--- a/runtime/src/system.rs
+++ b/runtime/src/system.rs
@@ -8,7 +8,7 @@ pub enum Action {
     QueryInformation(oneshot::Sender<Information>),
 }
 
-/// Contains informations about the system (e.g. system name, processor, memory, graphics adapter).
+/// Contains information about the system (e.g. system name, processor, memory, graphics adapter).
 #[derive(Clone, Debug)]
 pub struct Information {
     /// The operating system name

--- a/runtime/src/window.rs
+++ b/runtime/src/window.rs
@@ -220,7 +220,7 @@ pub fn resize_events() -> Subscription<(Id, Size)> {
     })
 }
 
-/// Subscribes to all [`Event::CloseRequested`] occurences in the running application.
+/// Subscribes to all [`Event::CloseRequested`] occurrences in the running application.
 pub fn close_requests() -> Subscription<Id> {
     event::listen_with(|event, _status, id| {
         if let crate::core::Event::Window(Event::CloseRequested) = event {

--- a/widget/src/button.rs
+++ b/widget/src/button.rs
@@ -477,9 +477,9 @@ pub struct Style {
     pub background: Option<Background>,
     /// The text [`Color`] of the button.
     pub text_color: Color,
-    /// The [`Border`] of the buton.
+    /// The [`Border`] of the button.
     pub border: Border,
-    /// The [`Shadow`] of the butoon.
+    /// The [`Shadow`] of the button.
     pub shadow: Shadow,
 }
 

--- a/widget/src/checkbox.rs
+++ b/widget/src/checkbox.rs
@@ -487,7 +487,7 @@ pub struct Style {
     pub background: Background,
     /// The icon [`Color`] of the checkbox.
     pub icon_color: Color,
-    /// The [`Border`] of hte checkbox.
+    /// The [`Border`] of the checkbox.
     pub border: Border,
     /// The text [`Color`] of the checkbox.
     pub text_color: Option<Color>,
@@ -600,7 +600,7 @@ pub fn success(theme: &Theme, status: Status) -> Style {
     }
 }
 
-/// A danger checkbox; denoting a negaive toggle.
+/// A danger checkbox; denoting a negative toggle.
 pub fn danger(theme: &Theme, status: Status) -> Style {
     let palette = theme.extended_palette();
 

--- a/widget/src/combo_box.rs
+++ b/widget/src/combo_box.rs
@@ -608,8 +608,8 @@ where
                     ..
                 }) = event
                 {
-                    let shift_modifer = modifiers.shift();
-                    match (named_key, shift_modifer) {
+                    let shift_modifier = modifiers.shift();
+                    match (named_key, shift_modifier) {
                         (key::Named::Enter, _) => {
                             if let Some(index) = &menu.hovered_option {
                                 if let Some(option) =

--- a/widget/src/markdown.rs
+++ b/widget/src/markdown.rs
@@ -1,6 +1,6 @@
 //! Markdown widgets can parse and display Markdown.
 //!
-//! You can enable the `highlighter` feature for syntax highligting
+//! You can enable the `highlighter` feature for syntax highlighting
 //! in code blocks.
 //!
 //! Only the variants of [`Item`] are currently supported.
@@ -72,7 +72,7 @@ pub enum Item {
     Paragraph(Text),
     /// A code block.
     ///
-    /// You can enable the `highlighter` feature for syntax highligting.
+    /// You can enable the `highlighter` feature for syntax highlighting.
     CodeBlock(Text),
     /// A list.
     List {

--- a/widget/src/text/rich.rs
+++ b/widget/src/text/rich.rs
@@ -72,7 +72,7 @@ where
         self
     }
 
-    /// Sets the defualt [`LineHeight`] of the [`Rich`] text.
+    /// Sets the default [`LineHeight`] of the [`Rich`] text.
     pub fn line_height(mut self, line_height: impl Into<LineHeight>) -> Self {
         self.line_height = line_height.into();
         self


### PR DESCRIPTION
Upstream winit issue: https://github.com/rust-windowing/winit/issues/1881
Partially fixes #1881 (converts it from a bug to an enhancement?).

[Typos](https://github.com/crate-ci/typos) can also be added to CI, although currently it has false positives on [lorem inpsum](https://github.com/crate-ci/typos/issues/815), [`ba` (blue-alpha) in shaders](https://github.com/crate-ci/typos/issues/1103), and on `@WailAbou` last name trying to correct it to "About" (they can be disabled in a config file, but `ba` seems pretty obnoxious, I think it would be nice to upstream it first).