### PR TITLE
fix: circular progress no longer skips

### DIFF
--- a/examples/loading_spinners/src/circular.rs
+++ b/examples/loading_spinners/src/circular.rs
@@ -139,8 +139,8 @@ impl Animation {
                 progress: 0.0,
                 rotation: rotation.wrapping_add(
                     BASE_ROTATION_SPEED.wrapping_add(
-                        (f64::from(WRAP_ANGLE / (2.0 * Radians::PI)) * f64::MAX)
-                            as u32,
+                        (f64::from(WRAP_ANGLE / (2.0 * Radians::PI))
+                            * u32::MAX as f64) as u32,
                     ),
                 ),
                 last: now,


### PR DESCRIPTION
Currently on master, the loading spinners example has a bug where the position of the active indicator (the highlighted part) skips ~90 degrees at the end of every animation cycle. This bug was introduced here:

https://github.com/iced-rs/iced/commit/b1932989b0146c1957ba5bc8a4b8fc1bbf037975#diff-7d796743c0a1456ea9a47db8034601be8cc1374f9846ea8a42368fbf0c8082d8

Since we're casting the number of circle rotations (radians / 2 PI) to a `u32`, we want to multiply by `u32::MAX`, not `f64::MAX`