### PR TITLE
Derive `Default` for `iced_wgpu::geometry::Cache`

### DIFF
--- a/wgpu/src/geometry.rs
+++ b/wgpu/src/geometry.rs
@@ -31,7 +31,7 @@ pub enum Geometry {
     Cached(Cache),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct Cache {
     pub meshes: Option<triangle::Cache>,
     pub images: Option<Arc<[Image]>>,


### PR DESCRIPTION
This enables deriving `Default` if holding a `Cache` in your widget state. `Cache::default()` then creates an empty `Cache`, instead of having to manually create it in a `Default` impl.