### PR TITLE
Change lifetime of markdown IntoIterator Item, as it does not need to live as long as the returned Element

### DIFF
--- a/widget/src/markdown.rs
+++ b/widget/src/markdown.rs
@@ -613,8 +613,8 @@ impl Style {
 ///     }
 /// }
 /// ```
-pub fn view<'a, Theme, Renderer>(
-    items: impl IntoIterator<Item = &'a Item>,
+pub fn view<'a, 'b, Theme, Renderer>(
+    items: impl IntoIterator<Item = &'b Item>,
     settings: Settings,
     style: Style,
 ) -> Element<'a, Url, Theme, Renderer>


### PR DESCRIPTION
The original lifetime of Item indicated that the Items yielded by an iterator must live as long as the returned Element, which is not required.

This made it difficult to work with data wrapped in a `Mutex` or `RwLock` as an iterator, as the guard creates a temporary variable which the compiler thinks needs to be held for the lifetime of the Element.

This adds another lifetime to indicate that `Item`'s yielded by`IntoIterator` only need to last as long as the view function itself.