### PR TITLE
Remove `zbus` dependency in `dark-light`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,7 @@ bitflags = "2.0"
 bytemuck = { version = "1.0", features = ["derive"] }
 bytes = "1.6"
 cosmic-text = "0.12"
-dark-light = "1.0"
+dark-light = { git = "https://github.com/bbb651/rust-dark-light.git", rev = "192daa06be5a0bad927e71c05a1e2eb5d9061c54" }
 futures = "0.3"
 glam = "0.25"
 glyphon = { git = "https://github.com/hecrj/glyphon.git", rev = "0d7ba1bba4dd71eb88d2cface5ce649db2413cb7" }

--- a/core/src/theme.rs
+++ b/core/src/theme.rs
@@ -169,9 +169,8 @@ impl Default for Theme {
             static DEFAULT: Lazy<Theme> =
                 Lazy::new(|| match dark_light::detect() {
                     dark_light::Mode::Dark => Theme::Dark,
-                    dark_light::Mode::Light | dark_light::Mode::Default => {
-                        Theme::Light
-                    }
+                    dark_light::Mode::Light
+                    | dark_light::Mode::NoPreference => Theme::Light,
                 });
 
             DEFAULT.clone()


### PR DESCRIPTION
We should wait for upstream to see what happens with the pull request: https://github.com/frewsxcv/rust-dark-light/pull/40 (it also needs testing on macOS and windows).

Should I add a `auto-detect-theme-zbus` feature that activates `zbus` feature in `dark-light`? Afaik there's no other way for `dark-light` to know if `zbus` is used. The portal (which is the only usage of `zbus`) is only used as a fallback after DE specific methods, and this PR doesn't add support for the `subscribe` method that gives you a stream of theme yet (which does relay directly on portals and thus `zbus`), so it should very rarely be used anyway.