### PR TITLE
Fix/pane grid continuity

### DIFF
--- a/widget/src/lazy/responsive.rs
+++ b/widget/src/lazy/responsive.rs
@@ -83,7 +83,10 @@ where
         new_size: Size,
         view: &dyn Fn(Size) -> Element<'a, Message, Theme, Renderer>,
     ) {
-        if self.size == new_size {
+        let is_tree_empty =
+            tree.tag == tree::Tag::stateless() && tree.children.is_empty();
+
+        if !is_tree_empty && self.size == new_size {
             return;
         }
 

--- a/widget/src/pane_grid/state.rs
+++ b/widget/src/pane_grid/state.rs
@@ -343,7 +343,7 @@ impl<T> State<T> {
 /// [`PaneGrid`]: super::PaneGrid
 #[derive(Debug, Clone)]
 pub struct Internal {
-    layout: Node,
+    pub(super) layout: Node,
     last_id: usize,
 }
 
@@ -397,11 +397,12 @@ impl Internal {
 /// The current action of a [`PaneGrid`].
 ///
 /// [`PaneGrid`]: super::PaneGrid
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub enum Action {
     /// The [`PaneGrid`] is idle.
     ///
     /// [`PaneGrid`]: super::PaneGrid
+    #[default]
     Idle,
     /// A [`Pane`] in the [`PaneGrid`] is being dragged.
     ///
@@ -441,9 +442,8 @@ impl Action {
     }
 }
 
-impl Internal {
-    /// The layout [`Node`] of the [`Internal`] state
-    pub fn layout(&self) -> &Node {
-        &self.layout
-    }
+#[derive(Default)]
+pub(super) struct Widget {
+    pub action: Action,
+    pub panes: Vec<Pane>,
 }

--- a/widget/src/pane_grid/state.rs
+++ b/widget/src/pane_grid/state.rs
@@ -228,8 +228,15 @@ impl<T> State<T> {
     ) {
         if let Some((state, _)) = self.close(pane) {
             if let Some((new_pane, _)) = self.split(axis, target, state) {
+                // Ensure new node corresponds to original `Pane` for state continuity
+                self.swap(pane, new_pane);
+                let _ = self
+                    .panes
+                    .remove(&new_pane)
+                    .and_then(|state| self.panes.insert(pane, state));
+
                 if swap {
-                    self.swap(target, new_pane);
+                    self.swap(target, pane);
                 }
             }
         }
@@ -262,7 +269,16 @@ impl<T> State<T> {
         swap: bool,
     ) {
         if let Some((state, _)) = self.close(pane) {
-            let _ = self.split_node(axis, None, state, swap);
+            if let Some((new_pane, _)) =
+                self.split_node(axis, None, state, swap)
+            {
+                // Ensure new node corresponds to original `Pane` for state continuity
+                self.swap(pane, new_pane);
+                let _ = self
+                    .panes
+                    .remove(&new_pane)
+                    .and_then(|state| self.panes.insert(pane, state));
+            }
         }
     }
 

--- a/widget/src/pane_grid/state.rs
+++ b/widget/src/pane_grid/state.rs
@@ -220,12 +220,8 @@ impl<T> State<T> {
     ) {
         if let Some((state, _)) = self.close(pane) {
             if let Some((new_pane, _)) = self.split(axis, target, state) {
-                // Ensure new node corresponds to original `Pane` for state continuity
-                self.swap(pane, new_pane);
-                let _ = self
-                    .panes
-                    .remove(&new_pane)
-                    .and_then(|state| self.panes.insert(pane, state));
+                // Ensure new node corresponds to original closed `Pane` for state continuity
+                self.relabel(new_pane, pane);
 
                 if swap {
                     self.swap(target, pane);
@@ -258,20 +254,25 @@ impl<T> State<T> {
         &mut self,
         axis: Axis,
         pane: Pane,
-        swap: bool,
+        inverse: bool,
     ) {
         if let Some((state, _)) = self.close(pane) {
             if let Some((new_pane, _)) =
-                self.split_node(axis, None, state, swap)
+                self.split_node(axis, None, state, inverse)
             {
-                // Ensure new node corresponds to original `Pane` for state continuity
-                self.swap(pane, new_pane);
-                let _ = self
-                    .panes
-                    .remove(&new_pane)
-                    .and_then(|state| self.panes.insert(pane, state));
+                // Ensure new node corresponds to original closed `Pane` for state continuity
+                self.relabel(new_pane, pane);
             }
         }
+    }
+
+    fn relabel(&mut self, target: Pane, label: Pane) {
+        self.swap(target, label);
+
+        let _ = self
+            .panes
+            .remove(&target)
+            .and_then(|state| self.panes.insert(label, state));
     }
 
     /// Swaps the position of the provided panes in the [`State`].

--- a/widget/src/pane_grid/state.rs
+++ b/widget/src/pane_grid/state.rs
@@ -6,7 +6,7 @@ use crate::pane_grid::{
     Axis, Configuration, Direction, Edge, Node, Pane, Region, Split, Target,
 };
 
-use rustc_hash::FxHashMap;
+use std::collections::BTreeMap;
 
 /// The state of a [`PaneGrid`].
 ///
@@ -25,7 +25,7 @@ pub struct State<T> {
     /// The panes of the [`PaneGrid`].
     ///
     /// [`PaneGrid`]: super::PaneGrid
-    pub panes: FxHashMap<Pane, T>,
+    pub panes: BTreeMap<Pane, T>,
 
     /// The internal state of the [`PaneGrid`].
     ///
@@ -52,7 +52,7 @@ impl<T> State<T> {
 
     /// Creates a new [`State`] with the given [`Configuration`].
     pub fn with_configuration(config: impl Into<Configuration<T>>) -> Self {
-        let mut panes = FxHashMap::default();
+        let mut panes = BTreeMap::default();
 
         let internal =
             Internal::from_configuration(&mut panes, config.into(), 0);
@@ -353,7 +353,7 @@ impl Internal {
     ///
     /// [`PaneGrid`]: super::PaneGrid
     pub fn from_configuration<T>(
-        panes: &mut FxHashMap<Pane, T>,
+        panes: &mut BTreeMap<Pane, T>,
         content: Configuration<T>,
         next_id: usize,
     ) -> Self {

--- a/widget/src/pane_grid/state.rs
+++ b/widget/src/pane_grid/state.rs
@@ -465,9 +465,3 @@ impl Action {
         }
     }
 }
-
-#[derive(Default)]
-pub(super) struct Widget {
-    pub action: Action,
-    pub panes: Vec<Pane>,
-}


### PR DESCRIPTION
Fixes issues w/ pane grid continuity of widget state when adding / removing panes, drag / dropping panes, or maximize / restoring panes. I've tested this fix with `halloy` and can confirm that scrollable offsets within each pane are perfectly retained when doing all the above operations. Previously the states would have gotten shuffled around relative to the panes which would cause the wrong scrollable offsets to get used for each pane (jump around).

For `maximize` / `restore`, we still need to build `view` for the hidden panes so diff'ing them doesn't break. This can be optimized to avoid calling `diff` on those hidden panes, allowing us to skip viewing them, but this adds additional complexity I didn't want to try and tackle here. The current approach allows us to naively zip all content, layout & state and then just applying a filter to return the maximized pane within each widget operation.