### PR TITLE
Fixed bug where delete key wasn't working in the text editor

### DIFF
--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -1045,7 +1045,9 @@ impl<Message> Binding<Message> {
             keyboard::Key::Named(key::Named::Backspace) => {
                 Some(Self::Backspace)
             }
-            keyboard::Key::Named(key::Named::Delete) if text.is_none() => {
+            keyboard::Key::Named(key::Named::Delete)
+                if text.is_none() || text.as_deref() == Some("\u{7f}") =>
+            {
                 Some(Self::Delete)
             }
             keyboard::Key::Named(key::Named::Escape) => Some(Self::Unfocus),


### PR DESCRIPTION
Fixes #2631.
When the delete key was pressed, it would only run the Delete binding if the content of the text editor was None. This was the source of the bug, I switched it to an is_some() check.

