### PR TITLE
Add PartialEq derives for widget styles

### DIFF
--- a/core/src/widget/text.rs
+++ b/core/src/widget/text.rs
@@ -389,7 +389,7 @@ where
 }
 
 /// The appearance of some text.
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub struct Style {
     /// The [`Color`] of the text.
     ///

--- a/widget/src/checkbox.rs
+++ b/widget/src/checkbox.rs
@@ -481,7 +481,7 @@ pub enum Status {
 }
 
 /// The style of a checkbox.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Style {
     /// The [`Background`] of the checkbox.
     pub background: Background,

--- a/widget/src/container.rs
+++ b/widget/src/container.rs
@@ -572,7 +572,7 @@ pub fn visible_bounds(id: Id) -> Task<Option<Rectangle>> {
 }
 
 /// The appearance of a container.
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub struct Style {
     /// The text [`Color`] of the container.
     pub text_color: Option<Color>,

--- a/widget/src/overlay/menu.rs
+++ b/widget/src/overlay/menu.rs
@@ -562,7 +562,7 @@ where
 }
 
 /// The appearance of a [`Menu`].
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Style {
     /// The [`Background`] of the menu.
     pub background: Background,

--- a/widget/src/pick_list.rs
+++ b/widget/src/pick_list.rs
@@ -828,7 +828,7 @@ pub enum Status {
 }
 
 /// The appearance of a pick list.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Style {
     /// The text [`Color`] of the pick list.
     pub text_color: Color,

--- a/widget/src/progress_bar.rs
+++ b/widget/src/progress_bar.rs
@@ -208,7 +208,7 @@ where
 }
 
 /// The appearance of a progress bar.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Style {
     /// The [`Background`] of the progress bar.
     pub background: Background,

--- a/widget/src/radio.rs
+++ b/widget/src/radio.rs
@@ -471,7 +471,7 @@ pub enum Status {
 }
 
 /// The appearance of a radio button.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Style {
     /// The [`Background`] of the radio button.
     pub background: Background,

--- a/widget/src/rule.rs
+++ b/widget/src/rule.rs
@@ -187,7 +187,7 @@ where
 }
 
 /// The appearance of a rule.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Style {
     /// The color of the rule.
     pub color: Color,
@@ -200,7 +200,7 @@ pub struct Style {
 }
 
 /// The fill mode of a rule.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum FillMode {
     /// Fill the whole length of the container.
     Full,

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -1856,7 +1856,7 @@ pub enum Status {
 }
 
 /// The appearance of a scrollable.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Style {
     /// The [`container::Style`] of a scrollable.
     pub container: container::Style,
@@ -1869,7 +1869,7 @@ pub struct Style {
 }
 
 /// The appearance of the scrollbar of a scrollable.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Rail {
     /// The [`Background`] of a scrollbar.
     pub background: Option<Background>,
@@ -1880,7 +1880,7 @@ pub struct Rail {
 }
 
 /// The appearance of the scroller of a scrollable.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Scroller {
     /// The [`Color`] of the scroller.
     pub color: Color,

--- a/widget/src/slider.rs
+++ b/widget/src/slider.rs
@@ -562,7 +562,7 @@ pub enum Status {
 }
 
 /// The appearance of a slider.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Style {
     /// The colors of the rail of the slider.
     pub rail: Rail,
@@ -582,7 +582,7 @@ impl Style {
 }
 
 /// The appearance of a slider rail
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Rail {
     /// The backgrounds of the rail of the slider.
     pub backgrounds: (Background, Background),
@@ -593,7 +593,7 @@ pub struct Rail {
 }
 
 /// The appearance of the handle of a slider.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Handle {
     /// The shape of the handle.
     pub shape: HandleShape,
@@ -606,7 +606,7 @@ pub struct Handle {
 }
 
 /// The shape of the handle of a slider.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum HandleShape {
     /// A circular handle.
     Circle {

--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -1226,7 +1226,7 @@ pub enum Status {
 }
 
 /// The appearance of a text input.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Style {
     /// The [`Background`] of the text input.
     pub background: Background,

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -1541,7 +1541,7 @@ pub enum Status {
 }
 
 /// The appearance of a text input.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Style {
     /// The [`Background`] of the text input.
     pub background: Background,

--- a/widget/src/toggler.rs
+++ b/widget/src/toggler.rs
@@ -489,7 +489,7 @@ pub enum Status {
 }
 
 /// The appearance of a toggler.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Style {
     /// The background [`Color`] of the toggler.
     pub background: Color,


### PR DESCRIPTION
This PR adds `PartialEq` support to all widget styles. This will allow comparison between styles, which will help for some animation-related work of tracking whether a style has changed due to changes to a widget's properties.