### PR TITLE
Fix parsing of nested markdown lists without empty line

### DIFF
--- a/widget/src/markdown.rs
+++ b/widget/src/markdown.rs
@@ -305,12 +305,21 @@ pub fn parse(markdown: &str) -> impl Iterator<Item = Item> + '_ {
                 None
             }
             pulldown_cmark::Tag::List(first_item) if !metadata && !table => {
+                let prev = if spans.is_empty() {
+                    None
+                } else {
+                    produce(
+                        &mut lists,
+                        Item::Paragraph(Text::new(spans.drain(..).collect())),
+                    )
+                };
+
                 lists.push(List {
                     start: first_item,
                     items: Vec::new(),
                 });
 
-                None
+                prev
             }
             pulldown_cmark::Tag::Item => {
                 lists


### PR DESCRIPTION
Fixes #2640.

This change aligns the rendering of markdown more closely with other products (github, preview.md, etc.).

Testing markdown:
```markdown
**Expected**

- first
- second

    - nested first
    - nested second

- third


**Actual**

- first
- second
    - nested first
    - nested second
- third


**Third**

- first
-
    - nested first
    - nested second
- third
```

# Github
**Expected**

- first
- second

    - nested first
    - nested second

- third


**Actual**

- first
- second
    - nested first
    - nested second
- third


**Third**

- first
-
    - nested first
    - nested second
- third

# Iced
![image](https://github.com/user-attachments/assets/efec3e94-edcd-47ad-84f7-f59c55a33d95)
