### PR TITLE
feat: add a window drag resize task

### DIFF
--- a/core/src/window.rs
+++ b/core/src/window.rs
@@ -3,6 +3,7 @@ pub mod icon;
 pub mod screenshot;
 pub mod settings;
 
+mod direction;
 mod event;
 mod id;
 mod level;
@@ -11,6 +12,7 @@ mod position;
 mod redraw_request;
 mod user_attention;
 
+pub use direction::Direction;
 pub use event::Event;
 pub use icon::Icon;
 pub use id::Id;

--- a/core/src/window/direction.rs
+++ b/core/src/window/direction.rs
@@ -1,0 +1,27 @@
+/// The cardinal directions relative to the center of a window.
+#[derive(Debug, Clone, Copy)]
+pub enum Direction {
+    /// Points to the top edge of a window.
+    North,
+
+    /// Points to the bottom edge of a window.
+    South,
+
+    /// Points to the right edge of a window.
+    East,
+
+    /// Points to the left edge of a window.
+    West,
+
+    /// Points to the top-right corner of a window.
+    NorthEast,
+
+    /// Points to the top-left corner of a window.
+    NorthWest,
+
+    /// Points to the bottom-right corner of a window.
+    SouthEast,
+
+    /// Points to the bottom-left corner of a window.
+    SouthWest,
+}

--- a/runtime/src/window.rs
+++ b/runtime/src/window.rs
@@ -32,14 +32,14 @@ pub enum Action {
     /// Move the window with the left mouse button until the button is
     /// released.
     ///
-    /// There’s no guarantee that this will work unless the left mouse
+    /// There's no guarantee that this will work unless the left mouse
     /// button was pressed immediately before this function is called.
     Drag(Id),
 
     /// Resize the window with the left mouse button until the button is
     /// released.
     ///
-    /// There’s no guarantee that this will work unless the left mouse
+    /// There's no guarantee that this will work unless the left mouse
     /// button was pressed immediately before this function is called.
     DragResize(Id, Direction),
 

--- a/runtime/src/window.rs
+++ b/runtime/src/window.rs
@@ -1,7 +1,8 @@
 //! Build window-based GUI applications.
 use crate::core::time::Instant;
 use crate::core::window::{
-    Event, Icon, Id, Level, Mode, Screenshot, Settings, UserAttention,
+    Direction, Event, Icon, Id, Level, Mode, Screenshot, Settings,
+    UserAttention,
 };
 use crate::core::{Point, Size};
 use crate::futures::event;
@@ -34,6 +35,13 @@ pub enum Action {
     /// There’s no guarantee that this will work unless the left mouse
     /// button was pressed immediately before this function is called.
     Drag(Id),
+
+    /// Resize the window with the left mouse button until the button is
+    /// released.
+    ///
+    /// There’s no guarantee that this will work unless the left mouse
+    /// button was pressed immediately before this function is called.
+    DragResize(Id, Direction),
 
     /// Resize the window to the given logical dimensions.
     Resize(Id, Size),
@@ -270,6 +278,11 @@ pub fn get_latest() -> Task<Option<Id>> {
 /// Begins dragging the window while the left mouse button is held.
 pub fn drag<T>(id: Id) -> Task<T> {
     task::effect(crate::Action::Window(Action::Drag(id)))
+}
+
+/// Begins resizing the window while the left mouse button is held.
+pub fn drag_resize<T>(id: Id, direction: Direction) -> Task<T> {
+    task::effect(crate::Action::Window(Action::DragResize(id, direction)))
 }
 
 /// Resizes the window to the given logical dimensions.

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -1136,9 +1136,7 @@ pub fn user_attention(
     }
 }
 
-/// Converts some [`ResizeDirection`] into its `winit` counterpart.
-///
-/// [`ResizeDirection`]: window::ResizeDirection
+/// Converts some [`window::Direction`] into a [`winit::window::ResizeDirection`].
 pub fn resize_direction(
     resize_direction: window::Direction,
 ) -> winit::window::ResizeDirection {

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -1120,7 +1120,7 @@ pub fn native_key_code(
     }
 }
 
-/// Converts some [`UserAttention`] into it's `winit` counterpart.
+/// Converts some [`UserAttention`] into its `winit` counterpart.
 ///
 /// [`UserAttention`]: window::UserAttention
 pub fn user_attention(
@@ -1132,6 +1132,32 @@ pub fn user_attention(
         }
         window::UserAttention::Informational => {
             winit::window::UserAttentionType::Informational
+        }
+    }
+}
+
+/// Converts some [`ResizeDirection`] into its `winit` counterpart.
+///
+/// [`ResizeDirection`]: window::ResizeDirection
+pub fn resize_direction(
+    resize_direction: window::Direction,
+) -> winit::window::ResizeDirection {
+    match resize_direction {
+        window::Direction::North => winit::window::ResizeDirection::North,
+        window::Direction::South => winit::window::ResizeDirection::South,
+        window::Direction::East => winit::window::ResizeDirection::East,
+        window::Direction::West => winit::window::ResizeDirection::West,
+        window::Direction::NorthEast => {
+            winit::window::ResizeDirection::NorthEast
+        }
+        window::Direction::NorthWest => {
+            winit::window::ResizeDirection::NorthWest
+        }
+        window::Direction::SouthEast => {
+            winit::window::ResizeDirection::SouthEast
+        }
+        window::Direction::SouthWest => {
+            winit::window::ResizeDirection::SouthWest
         }
     }
 }

--- a/winit/src/program.rs
+++ b/winit/src/program.rs
@@ -1265,6 +1265,13 @@ fn run_action<P, C>(
                     let _ = window.raw.drag_window();
                 }
             }
+            window::Action::DragResize(id, direction) => {
+                if let Some(window) = window_manager.get_mut(id) {
+                    let _ = window.raw.drag_resize_window(
+                        conversion::resize_direction(direction),
+                    );
+                }
+            }
             window::Action::Resize(id, size) => {
                 if let Some(window) = window_manager.get_mut(id) {
                     let _ = window.raw.request_inner_size(


### PR DESCRIPTION
When implementing a custom title bar, most things are straight forward: minimizing, maximizing, closing, dragging, and the context menu. 
However, there is one small issue: resizing. Since you have to turn off decorations, the border also gets disabled, and there is no easy way to specifically enable that through winit ( afaik ).

This PR exposes `winit`'s `drag_resize_window` to give an easier time to resize the window, which is especially useful for the case I mentioned above.

Hopefully everything is up to standard!