### PR TITLE
feat: add an on_key_press method to TextInput

### DIFF
--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -831,7 +831,7 @@ where
                     focus.updated_at = Instant::now();
 
                     if let Some(on_key_press) = &self.on_key_press {
-                        let message: Message =
+                        let message =
                             (on_key_press)(key.clone(), modifiers.clone());
 
                         shell.publish(message);

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -226,8 +226,8 @@ where
         self
     }
 
-    /// Sets the message that should be produced when a key is pressed
-    /// when the [`TextInput`] is focused.
+    /// Sets the message that should be produced when the [`TextInput`] is
+    /// focused and a key is pressed.
     pub fn on_key_press(
         mut self,
         on_key_press: impl Fn(keyboard::Key, keyboard::Modifiers) -> Message + 'a,


### PR DESCRIPTION
Currently, the only way to listen for key presses involves setting up a subscription, which introduces some tedious boilerplate code: subscribe to the event, store the text input's ID, verify if it's focused, and so on. 

Adding a method to TextInput just simplifies it.

An example use case for this would be terminal-like text inputs, where you're scrolling through the input history with the up & down arrows.