### PR TITLE
Prevent unintended keyboard input during focus.

### DIFF
--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -191,6 +191,8 @@ pub fn window_event(
                 }))
             }
         },
+        // Ignore keyboard presses/releases during window focus/unfocus
+        WindowEvent::KeyboardInput { is_synthetic, .. } if is_synthetic => None,
         WindowEvent::KeyboardInput { event, .. } => Some(Event::Keyboard({
             let key = {
                 #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
`winit` generates [`is_synthetic: true`](https://docs.rs/winit/latest/winit/event/enum.WindowEvent.html#variant.KeyboardInput.field.is_synthetic) `KeyboardInput` events whenever a window gains or loses focus, which is mistakenly picked up as a intentional input event. 

Fixes #2621.

### Prior Art

- Fixed in egui since https://github.com/emilk/egui/pull/4514
- Fixed in bevy since https://github.com/bevyengine/bevy/issues/13299
- Fixed in floem since https://github.com/lapce/floem/pull/387
- [Discussion about synthetic key events as a whole in winit](https://github.com/rust-windowing/winit/issues/3543)