### PR TITLE
Use float total_cmp instead of partial_cmp to get a total order.

### DIFF
--- a/graphics/src/damage.rs
+++ b/graphics/src/damage.rs
@@ -45,15 +45,12 @@ pub fn list<T>(
 /// Groups the given damage regions that are close together inside the given
 /// bounds.
 pub fn group(mut damage: Vec<Rectangle>, bounds: Rectangle) -> Vec<Rectangle> {
-    use std::cmp::Ordering;
-
     const AREA_THRESHOLD: f32 = 20_000.0;
 
     damage.sort_by(|a, b| {
         a.center()
             .distance(Point::ORIGIN)
-            .partial_cmp(&b.center().distance(Point::ORIGIN))
-            .unwrap_or(Ordering::Equal)
+            .total_cmp(&b.center().distance(Point::ORIGIN))
     });
 
     let mut output = Vec::new();


### PR DESCRIPTION
Since Rust version 1.81, sort_by will panic if the provided comparison function does not implement a total order.
See https://github.com/rust-lang/rust/issues/129561 for more details. Fixes #2650, and potentially addresses https://github.com/pop-os/cosmic-epoch/issues/1016

I ran `cargo test` and `cargo clippy`