### PR TITLE
Added State.program_mut.

### DIFF
--- a/runtime/src/program/state.rs
+++ b/runtime/src/program/state.rs
@@ -56,6 +56,11 @@ where
         &self.program
     }
 
+    /// Returns a mutable reference to the [`Program`] of the [`State`].
+    pub fn program_mut(&mut self) -> &mut P {
+        &mut self.program
+    }
+
     /// Queues an event in the [`State`] for processing during an [`update`].
     ///
     /// [`update`]: Self::update


### PR DESCRIPTION
I'm working on a non-standard application where iced is embedded in a game using sdl2 + wgpu. I need to be able to create multiple overlapping "pseudo-windows" (basically collection of widgets) and am using a modal-like approach for this. I need to be able to create new "pseudo-windows" dynamically based on the game state that can be triggered by events that iced will not receive. I've got it mainly working, but am having issues with the isolation that `iced_runtime::program::State` does around the program it is encapsulating.

Currently, it's possible to get an immutable program reference with `State.program`, however, it is not possible to get a mutable one. Simply adding the `State.program_mut`method would simplify all my code and logic without having to deal with messages that have to be `Send`.  This PR just adds `State.program_mut`. I have tested and the integration example works fine with it.