### PR TITLE
Remove `surface` argument of `Compositor::screenshot`

### DIFF
--- a/graphics/src/compositor.rs
+++ b/graphics/src/compositor.rs
@@ -90,7 +90,6 @@ pub trait Compositor: Sized {
     fn screenshot<T: AsRef<str>>(
         &mut self,
         renderer: &mut Self::Renderer,
-        surface: &mut Self::Surface,
         viewport: &Viewport,
         background_color: Color,
         overlay: &[T],
@@ -201,7 +200,6 @@ impl Compositor for () {
     fn screenshot<T: AsRef<str>>(
         &mut self,
         _renderer: &mut Self::Renderer,
-        _surface: &mut Self::Surface,
         _viewport: &Viewport,
         _background_color: Color,
         _overlay: &[T],

--- a/renderer/src/fallback.rs
+++ b/renderer/src/fallback.rs
@@ -353,34 +353,27 @@ where
     fn screenshot<T: AsRef<str>>(
         &mut self,
         renderer: &mut Self::Renderer,
-        surface: &mut Self::Surface,
         viewport: &graphics::Viewport,
         background_color: Color,
         overlay: &[T],
     ) -> Vec<u8> {
-        match (self, renderer, surface) {
-            (
-                Self::Primary(compositor),
-                Renderer::Primary(renderer),
-                Surface::Primary(surface),
-            ) => compositor.screenshot(
-                renderer,
-                surface,
-                viewport,
-                background_color,
-                overlay,
-            ),
-            (
-                Self::Secondary(compositor),
-                Renderer::Secondary(renderer),
-                Surface::Secondary(surface),
-            ) => compositor.screenshot(
-                renderer,
-                surface,
-                viewport,
-                background_color,
-                overlay,
-            ),
+        match (self, renderer) {
+            (Self::Primary(compositor), Renderer::Primary(renderer)) => {
+                compositor.screenshot(
+                    renderer,
+                    viewport,
+                    background_color,
+                    overlay,
+                )
+            }
+            (Self::Secondary(compositor), Renderer::Secondary(renderer)) => {
+                compositor.screenshot(
+                    renderer,
+                    viewport,
+                    background_color,
+                    overlay,
+                )
+            }
             _ => unreachable!(),
         }
     }

--- a/tiny_skia/src/window/compositor.rs
+++ b/tiny_skia/src/window/compositor.rs
@@ -121,12 +121,11 @@ impl crate::graphics::Compositor for Compositor {
     fn screenshot<T: AsRef<str>>(
         &mut self,
         renderer: &mut Self::Renderer,
-        surface: &mut Self::Surface,
         viewport: &Viewport,
         background_color: Color,
         overlay: &[T],
     ) -> Vec<u8> {
-        screenshot(renderer, surface, viewport, background_color, overlay)
+        screenshot(renderer, viewport, background_color, overlay)
     }
 }
 
@@ -212,7 +211,6 @@ pub fn present<T: AsRef<str>>(
 
 pub fn screenshot<T: AsRef<str>>(
     renderer: &mut Renderer,
-    surface: &mut Surface,
     viewport: &Viewport,
     background_color: Color,
     overlay: &[T],
@@ -222,6 +220,9 @@ pub fn screenshot<T: AsRef<str>>(
     let mut offscreen_buffer: Vec<u32> =
         vec![0; size.width as usize * size.height as usize];
 
+    let mut clip_mask = tiny_skia::Mask::new(size.width, size.height)
+        .expect("Create clip mask");
+
     renderer.draw(
         &mut tiny_skia::PixmapMut::from_bytes(
             bytemuck::cast_slice_mut(&mut offscreen_buffer),
@@ -229,7 +230,7 @@ pub fn screenshot<T: AsRef<str>>(
             size.height,
         )
         .expect("Create offscreen pixel map"),
-        &mut surface.clip_mask,
+        &mut clip_mask,
         viewport,
         &[Rectangle::with_size(Size::new(
             size.width as f32,

--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -370,7 +370,6 @@ impl graphics::Compositor for Compositor {
     fn screenshot<T: AsRef<str>>(
         &mut self,
         renderer: &mut Self::Renderer,
-        _surface: &mut Self::Surface,
         viewport: &Viewport,
         background_color: Color,
         overlay: &[T],

--- a/winit/src/program.rs
+++ b/winit/src/program.rs
@@ -1456,7 +1456,6 @@ fn run_action<P, C>(
                 if let Some(window) = window_manager.get_mut(id) {
                     let bytes = compositor.screenshot(
                         &mut window.renderer,
-                        &mut window.surface,
                         window.state.viewport(),
                         window.state.background_color(),
                         &debug.overlay(),


### PR DESCRIPTION
This argument was completely ignored by the wgpu renderer, and used only for the `clip_mask` by the `tiny_skia` renderer. I believe creating a new clip mask is correct.

This way it's possible to render offscreen without needing a surface.