### PR TITLE
improve argument names in `Widget` trait

### DIFF
--- a/core/src/widget.rs
+++ b/core/src/widget.rs
@@ -101,7 +101,7 @@ where
     /// Applies an [`Operation`] to the [`Widget`].
     fn operate(
         &self,
-        _state: &mut Tree,
+        _tree: &mut Tree,
         _layout: Layout<'_>,
         _renderer: &Renderer,
         _operation: &mut dyn Operation,
@@ -113,7 +113,7 @@ where
     /// By default, it does nothing.
     fn update(
         &mut self,
-        _state: &mut Tree,
+        _tree: &mut Tree,
         _event: Event,
         _layout: Layout<'_>,
         _cursor: mouse::Cursor,
@@ -129,7 +129,7 @@ where
     /// By default, it returns [`mouse::Interaction::Idle`].
     fn mouse_interaction(
         &self,
-        _state: &Tree,
+        _tree: &Tree,
         _layout: Layout<'_>,
         _cursor: mouse::Cursor,
         _viewport: &Rectangle,
@@ -141,7 +141,7 @@ where
     /// Returns the overlay of the [`Widget`], if there is any.
     fn overlay<'a>(
         &'a mut self,
-        _state: &'a mut Tree,
+        _tree: &'a mut Tree,
         _layout: Layout<'_>,
         _renderer: &Renderer,
         _translation: Vector,


### PR DESCRIPTION
This removes the underscores in front of the argument names in provided `Widget` methods, in order to make an IDE-autofilled method signature more useful. This was done in a similar manner to https://github.com/Smithay/smithay/blob/bc1d7320f95cdf17f9e7aa6867cccc5903548032/src/xwayland/xwm/mod.rs#L330-L356

It also renames all instances where the `Tree` argument was named `state`, as `Tree` has a `state` field. This has led to confusion on my part a few times, with the IDE-autofilled method signature clashing with my own naming, in which case I assumed `state` was the widget's (downcasted) state, not the widget's tree. I can't think of any reasoning as to why it was named `tree` vs `state` in different methods, so it makes sense to me to make it consistent everywhere.