### PR TITLE
fix: add an initial state to the `system_information` example

### DIFF
--- a/examples/system_information/src/main.rs
+++ b/examples/system_information/src/main.rs
@@ -7,7 +7,7 @@ pub fn main() -> iced::Result {
         Example::update,
         Example::view,
     )
-    .run()
+    .run_with(Example::new)
 }
 
 #[derive(Default)]
@@ -28,6 +28,10 @@ enum Message {
 }
 
 impl Example {
+    fn new() -> (Self, Task<Message>) {
+        (Self::Loading, Task::done(Message::Refresh))
+    }
+    
     fn update(&mut self, message: Message) -> Task<Message> {
         match message {
             Message::Refresh => {

--- a/examples/system_information/src/main.rs
+++ b/examples/system_information/src/main.rs
@@ -29,23 +29,27 @@ enum Message {
 
 impl Example {
     fn new() -> (Self, Task<Message>) {
-        (Self::Loading, Task::done(Message::Refresh))
+        (
+            Self::Loading,
+            system::fetch_information().map(Message::InformationReceived),
+        )
     }
-    
+
     fn update(&mut self, message: Message) -> Task<Message> {
         match message {
             Message::Refresh => {
-                *self = Self::Loading;
+                let (state, refresh) = Self::new();
 
-                return system::fetch_information()
-                    .map(Message::InformationReceived);
+                *self = state;
+
+                refresh
             }
             Message::InformationReceived(information) => {
                 *self = Self::Loaded { information };
+
+                Task::none()
             }
         }
-
-        Task::none()
     }
 
     fn view(&self) -> Element<Message> {


### PR DESCRIPTION
**FYI:** The `system_information` example was eternally stuck at the loading screen (tested on macOS).

Fix on my system:
Create an initial state of `(Example::Loading, Task<Message::Refresh>)` using `run_with` on the `Application` builder.