### PR TITLE
Mouse interaction to hide system cursor

### DIFF
--- a/core/src/mouse/interaction.rs
+++ b/core/src/mouse/interaction.rs
@@ -4,6 +4,7 @@
 pub enum Interaction {
     #[default]
     None,
+    Hidden,
     Idle,
     Pointer,
     Grab,

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -427,10 +427,13 @@ pub fn mode(mode: Option<winit::window::Fullscreen>) -> window::Mode {
 /// [`winit`]: https://github.com/rust-windowing/winit
 pub fn mouse_interaction(
     interaction: mouse::Interaction,
-) -> winit::window::CursorIcon {
+) -> Option<winit::window::CursorIcon> {
     use mouse::Interaction;
 
-    match interaction {
+    let icon = match interaction {
+        Interaction::Hidden => {
+            return None;
+        }
         Interaction::None | Interaction::Idle => {
             winit::window::CursorIcon::Default
         }
@@ -457,7 +460,9 @@ pub fn mouse_interaction(
         Interaction::Move => winit::window::CursorIcon::Move,
         Interaction::Copy => winit::window::CursorIcon::Copy,
         Interaction::Help => winit::window::CursorIcon::Help,
-    }
+    };
+
+    Some(icon)
 }
 
 /// Converts a `MouseButton` from [`winit`] to an [`iced`] mouse button.

--- a/winit/src/program.rs
+++ b/winit/src/program.rs
@@ -881,11 +881,18 @@ async fn run_instance<P, C>(
                         debug.draw_finished();
 
                         if new_mouse_interaction != window.mouse_interaction {
-                            window.raw.set_cursor(
-                                conversion::mouse_interaction(
-                                    new_mouse_interaction,
-                                ),
-                            );
+                            if let Some(icon) = conversion::mouse_interaction(
+                                new_mouse_interaction,
+                            ) {
+                                window.raw.set_cursor(icon);
+                                if window.mouse_interaction
+                                    == mouse::Interaction::Hidden
+                                {
+                                    window.raw.set_cursor_visible(true);
+                                }
+                            } else {
+                                window.raw.set_cursor_visible(false);
+                            }
 
                             window.mouse_interaction = new_mouse_interaction;
                         }


### PR DESCRIPTION
Adds support for hiding the system cursor via `mouse::Interaction`.
- Adds `mouse::Interaction::Hidden` variant
- Returns `Option<CursorIcon>` from `conversion::mouse_interaction`, where `None` denotes the cursor should be hidden
- Calls `set_cursor_visible` only when the interaction changes to/from `mouse::Interaction::Hidden`