### PR TITLE
Fixed rendering in chromium

### DIFF
--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -52,15 +52,18 @@ impl Compositor {
         settings: Settings,
         compatible_window: Option<W>,
     ) -> Result<Self, Error> {
-        let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
-            backends: settings.backends,
-            flags: if cfg!(feature = "strict-assertions") {
-                wgpu::InstanceFlags::debugging()
-            } else {
-                wgpu::InstanceFlags::empty()
+        let instance = wgpu::util::new_instance_with_webgpu_detection(
+            &wgpu::InstanceDescriptor {
+                backends: settings.backends,
+                flags: if cfg!(feature = "strict-assertions") {
+                    wgpu::InstanceFlags::debugging()
+                } else {
+                    wgpu::InstanceFlags::empty()
+                },
+                ..Default::default()
             },
-            ..Default::default()
-        });
+        )
+        .await;
 
         log::info!("{settings:#?}");
 


### PR DESCRIPTION
I fixed issue of iced not rendering on chromium based browser. Previously chromium just showed error `Failed to create WebGPU Context Provider` even if webgl feature was enabled. Also the issue was similar to this wgpu issue https://github.com/gfx-rs/wgpu/issues/6490#issuecomment-2453016187