### PR TITLE
Use "outer" positions in all window-related operations

### DIFF
--- a/core/src/window/event.rs
+++ b/core/src/window/event.rs
@@ -9,8 +9,8 @@ pub enum Event {
     /// A window was opened.
     Opened {
         /// The position of the opened window. This is relative to the top-left corner of the desktop
-        /// the window is on, including virtual desktops. Refers to window's "inner" position,
-        /// or the client area, in logical pixels.
+        /// the window is on, including virtual desktops. Refers to window's "outer" position,
+        /// or the window area, in logical pixels.
         ///
         /// **Note**: Not available in Wayland.
         position: Option<Point>,

--- a/winit/src/program/window_manager.rs
+++ b/winit/src/program/window_manager.rs
@@ -165,7 +165,7 @@ where
 {
     pub fn position(&self) -> Option<Point> {
         self.raw
-            .inner_position()
+            .outer_position()
             .ok()
             .map(|position| position.to_logical(self.raw.scale_factor()))
             .map(|position| Point {


### PR DESCRIPTION
See https://docs.rs/winit/latest/winit/window/struct.WindowAttributes.html#method.with_position.

I think this is the best we can do until https://github.com/rust-windowing/winit/issues/2645 is addressed.