### PR TITLE
Guess image format on `image::Handle::Path` load

### DIFF
--- a/graphics/src/image.rs
+++ b/graphics/src/image.rs
@@ -85,7 +85,9 @@ pub fn load(
 
     let (width, height, pixels) = match handle {
         image::Handle::Path(_, path) => {
-            let image = ::image::open(path)?;
+            let image = ::image::io::Reader::open(path)?
+                .with_guessed_format()?
+                .decode()?;
 
             let operation = std::fs::File::open(path)
                 .ok()


### PR DESCRIPTION
Currently there is an inconsistency with image loading. If Image is loaded from bytes `image::Handle::from_bytes(bytes)` - format is guessed by content, but with `image::Handle::from_path(path)` it is guessed by file extension, which might not be present. 

In the comments it is said to examine the data in the file.
```rust
/// Creates an image [`Handle`] pointing to the image of the given path.
///
/// Makes an educated guess about the image format by examining the data in the file.
pub fn from_path<T: Into<PathBuf>>(path: T) -> Handle {
    let path = path.into();

    Self::Path(Id::path(&path), path)
}
```
So this PR fixes this inconsistency to guess the format by contents instead.