### PR TITLE
Emit pane_grid::DragEvent::Canceled within deadband

### DIFF
--- a/widget/src/pane_grid.rs
+++ b/widget/src/pane_grid.rs
@@ -628,6 +628,10 @@ where
                                 };
 
                                 shell.publish(on_drag(event));
+                            } else {
+                                shell.publish(on_drag(DragEvent::Canceled {
+                                    pane,
+                                }));
                             }
                         }
                     }


### PR DESCRIPTION
My use case is that I want to know when a pane is being dragged so that I can disable some buttons/tooltips. However, if you click on a pane and release without moving the mouse, the `Canceled` event is never emitted, so I can't tell that the dragging stopped.

Before:

> https://github.com/user-attachments/assets/e32eafa1-f5ea-4c75-9475-9b8a3a8461e8

After:

> https://github.com/user-attachments/assets/6f8dfe33-95fe-4121-869d-a03a56d1c5b6
