### PR TITLE
Allow the user of `iced_wgpu::Engine` to submit the queue themself

### DIFF
--- a/wgpu/src/engine.rs
+++ b/wgpu/src/engine.rs
@@ -71,8 +71,18 @@ impl Engine {
         queue: &wgpu::Queue,
         encoder: wgpu::CommandEncoder,
     ) -> wgpu::SubmissionIndex {
-        self.staging_belt.finish();
+        self.finish();
         let index = queue.submit(Some(encoder.finish()));
+        self.end_frame();
+
+        index
+    }
+
+    pub fn finish(&mut self) {
+        self.staging_belt.finish();
+    }
+
+    pub fn end_frame(&mut self) {
         self.staging_belt.recall();
 
         self.quad_pipeline.end_frame();
@@ -81,7 +91,5 @@ impl Engine {
 
         #[cfg(any(feature = "image", feature = "svg"))]
         self.image_pipeline.end_frame();
-
-        index
     }
 }


### PR DESCRIPTION
The [iced integration for bevy](https://github.com/tasgon/bevy_iced/pull/33) needs to let Bevy take care of submitting the queue, so it can't call `Engine::submit`. But it still needs to call `finish/recall` on the staging belt and `end_frame` on all the pipelines.
This adds two additional methods to do that.

Note: The naming might be a bit confusing, I couldn't think of a better one :thinking: