### PR TITLE
Add `menu_height` method to `PickList` and `ComboBox` widgets.

### DIFF
--- a/widget/src/combo_box.rs
+++ b/widget/src/combo_box.rs
@@ -154,6 +154,7 @@ pub struct ComboBox<
     menu_class: <Theme as menu::Catalog>::Class<'a>,
     padding: Padding,
     size: Option<f32>,
+    menu_height: Length,
 }
 
 impl<'a, T, Message, Theme, Renderer> ComboBox<'a, T, Message, Theme, Renderer>
@@ -190,6 +191,7 @@ where
             menu_class: <Theme as Catalog>::default_menu(),
             padding: text_input::DEFAULT_PADDING,
             size: None,
+            menu_height: Length::Shrink,
         }
     }
 
@@ -270,6 +272,12 @@ where
             text_input: self.text_input.width(width),
             ..self
         }
+    }
+
+    /// ciao
+    pub fn menu_height(mut self, menu_height: impl Into<Length>) -> Self {
+        self.menu_height = menu_height.into();
+        self
     }
 
     /// Sets the style of the input of the [`ComboBox`].
@@ -890,12 +898,11 @@ where
                     menu = menu.text_size(size);
                 }
 
-                Some(
-                    menu.overlay(
-                        layout.position() + translation,
-                        bounds.height,
-                    ),
-                )
+                Some(menu.overlay(
+                    layout.position() + translation,
+                    bounds.height,
+                    self.menu_height,
+                ))
             }
         } else {
             None

--- a/widget/src/combo_box.rs
+++ b/widget/src/combo_box.rs
@@ -274,7 +274,7 @@ where
         }
     }
 
-    /// ciao
+    /// Sets the height of the menu of the [`ComboBox`].
     pub fn menu_height(mut self, menu_height: impl Into<Length>) -> Self {
         self.menu_height = menu_height.into();
         self

--- a/widget/src/overlay/menu.rs
+++ b/widget/src/overlay/menu.rs
@@ -128,11 +128,13 @@ where
         self,
         position: Point,
         target_height: f32,
+        menu_height: Length,
     ) -> overlay::Element<'a, Message, Theme, Renderer> {
         overlay::Element::new(Box::new(Overlay::new(
             position,
             self,
             target_height,
+            menu_height,
         )))
     }
 }
@@ -182,6 +184,7 @@ where
         position: Point,
         menu: Menu<'a, 'b, T, Message, Theme, Renderer>,
         target_height: f32,
+        menu_height: Length,
     ) -> Self
     where
         T: Clone + ToString,
@@ -212,7 +215,8 @@ where
             text_shaping,
             padding,
             class,
-        });
+        })
+        .height(menu_height);
 
         state.tree.diff(&list as &dyn Widget<_, _, _>);
 

--- a/widget/src/pick_list.rs
+++ b/widget/src/pick_list.rs
@@ -227,7 +227,7 @@ where
         self
     }
 
-    /// ciao
+    /// Sets the height of the [`Menu`].
     pub fn menu_height(mut self, menu_height: impl Into<Length>) -> Self {
         self.menu_height = menu_height.into();
         self

--- a/widget/src/pick_list.rs
+++ b/widget/src/pick_list.rs
@@ -174,6 +174,7 @@ pub struct PickList<
     class: <Theme as Catalog>::Class<'a>,
     menu_class: <Theme as menu::Catalog>::Class<'a>,
     last_status: Option<Status>,
+    menu_height: Length,
 }
 
 impl<'a, T, L, V, Message, Theme, Renderer>
@@ -210,6 +211,7 @@ where
             class: <Theme as Catalog>::default(),
             menu_class: <Theme as Catalog>::default_menu(),
             last_status: None,
+            menu_height: Length::Shrink,
         }
     }
 
@@ -222,6 +224,12 @@ where
     /// Sets the width of the [`PickList`].
     pub fn width(mut self, width: impl Into<Length>) -> Self {
         self.width = width.into();
+        self
+    }
+
+    /// ciao
+    pub fn menu_height(mut self, menu_height: impl Into<Length>) -> Self {
+        self.menu_height = menu_height.into();
         self
     }
 
@@ -721,7 +729,11 @@ where
                 menu = menu.text_size(text_size);
             }
 
-            Some(menu.overlay(layout.position() + translation, bounds.height))
+            Some(menu.overlay(
+                layout.position() + translation,
+                bounds.height,
+                self.menu_height,
+            ))
         } else {
             None
         }


### PR DESCRIPTION
Add `menu_height` method to `PickList` and `ComboBox` widgets.

This is particularly useful to reduce the menu height in presence of a long list of options.

***

<div align="center">

_Before_

<img src="https://github.com/user-attachments/assets/1ad777c3-3a3a-42c7-8174-7b51e5b985a6" width=75%/>

</div>

***

<div align="center">

_After_

<img src="https://github.com/user-attachments/assets/3e0a76bd-f13f-4759-95fc-0b4e12925a18" width=75%/>

</div>

