### PR TITLE
make `iced_wgpu::mesh::Indexed` use `Arc<[_]>` instead of `Vec<_>`

### DIFF
--- a/examples/geometry/src/main.rs
+++ b/examples/geometry/src/main.rs
@@ -83,7 +83,7 @@ mod rainbow {
 
             let mesh = Mesh::Solid {
                 buffers: mesh::Indexed {
-                    vertices: vec![
+                    vertices: [
                         SolidVertex2D {
                             position: posn_center,
                             color: color::pack([1.0, 1.0, 1.0, 1.0]),
@@ -120,8 +120,9 @@ mod rainbow {
                             position: posn_l,
                             color: color::pack(color_v),
                         },
-                    ],
-                    indices: vec![
+                    ]
+                    .into(),
+                    indices: [
                         0, 1, 2, // TL
                         0, 2, 3, // T
                         0, 3, 4, // TR
@@ -130,7 +131,8 @@ mod rainbow {
                         0, 6, 7, // B
                         0, 7, 8, // BL
                         0, 8, 1, // L
-                    ],
+                    ]
+                    .into(),
                 },
                 transformation: Transformation::IDENTITY,
                 clip_bounds: Rectangle::INFINITE,

--- a/graphics/src/mesh.rs
+++ b/graphics/src/mesh.rs
@@ -4,6 +4,7 @@ use crate::core::{Rectangle, Transformation};
 use crate::gradient;
 
 use bytemuck::{Pod, Zeroable};
+use std::sync::Arc;
 
 /// A low-level primitive to render a mesh of triangles.
 #[derive(Debug, Clone, PartialEq)]
@@ -70,12 +71,12 @@ impl Mesh {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Indexed<T> {
     /// The vertices of the mesh
-    pub vertices: Vec<T>,
+    pub vertices: Arc<[T]>,
 
     /// The list of vertex indices that defines the triangles of the mesh.
     ///
     /// Therefore, this list should always have a length that is a multiple of 3.
-    pub indices: Vec<u32>,
+    pub indices: Arc<[u32]>,
 }
 
 /// A two-dimensional vertex with a color.

--- a/wgpu/src/geometry.rs
+++ b/wgpu/src/geometry.rs
@@ -527,8 +527,8 @@ impl BufferStack {
                 Buffer::Solid(buffer) if !buffer.indices.is_empty() => {
                     Some(Mesh::Solid {
                         buffers: mesh::Indexed {
-                            vertices: buffer.vertices,
-                            indices: buffer.indices,
+                            vertices: Arc::from(buffer.vertices),
+                            indices: Arc::from(buffer.indices),
                         },
                         clip_bounds,
                         transformation: Transformation::IDENTITY,
@@ -537,8 +537,8 @@ impl BufferStack {
                 Buffer::Gradient(buffer) if !buffer.indices.is_empty() => {
                     Some(Mesh::Gradient {
                         buffers: mesh::Indexed {
-                            vertices: buffer.vertices,
-                            indices: buffer.indices,
+                            vertices: Arc::from(buffer.vertices),
+                            indices: Arc::from(buffer.indices),
                         },
                         clip_bounds,
                         transformation: Transformation::IDENTITY,


### PR DESCRIPTION
My use case for this is that I have a very large mesh that is very expensive to clone, whose vertices and indices never 
change, that I would like to be able to move, scale and clip cheaply within a custom widget.

This should have negiligible performance impact, since `Arc::from<Vec<_>>` doesn't clone the `Vec<_>`, and only allocates four words for a ref counted slice.