### PR TITLE
use wgpu's Backends::PRIMARY instead of Backends::all()

### DIFF
--- a/wgpu/src/settings.rs
+++ b/wgpu/src/settings.rs
@@ -33,7 +33,7 @@ impl Default for Settings {
     fn default() -> Settings {
         Settings {
             present_mode: wgpu::PresentMode::AutoVsync,
-            backends: wgpu::Backends::all(),
+            backends: wgpu::Backends::PRIMARY,
             default_font: Font::default(),
             default_text_size: Pixels(16.0),
             antialiasing: None,


### PR DESCRIPTION
Usage of `wgpu::Backends::PRIMARY` instead of `wgpu::Backends::all()` prevents SIGSEGV on quit of any application that uses wgpu for rendering (see https://github.com/gfx-rs/wgpu/issues/4650#issuecomment-1804907448)

This problem occurred in any application that uses iced (and wgpu) on Linux, Wayland (see https://github.com/iced-rs/iced/issues/2625)

Even if this PR is not accepted, i think we need a way to set custom `wgpu::Backends` from `iced` crate without need to use raw iced's core crates