### PR TITLE
Make clipping of `pin`s content consistent for left/right and top/bottom

### DIFF
--- a/widget/src/pin.rs
+++ b/widget/src/pin.rs
@@ -146,13 +146,10 @@ where
     ) -> layout::Node {
         let limits = limits.width(self.width).height(self.height);
 
-        let available =
-            limits.max() - Size::new(self.position.x, self.position.y);
-
         let node = self
             .content
             .as_widget()
-            .layout(tree, renderer, &layout::Limits::new(Size::ZERO, available))
+            .layout(tree, renderer, &limits)
             .move_to(self.position);
 
         let size = limits.resolve(self.width, self.height, node.size());


### PR DESCRIPTION
The `pin` widget already implements clipping of then content in the `draw` function, so the additional logic in `layout` only made the behavior inconsistent when content started to exceed the bounds.

From the documentation of `pin`, it seems like it was not meant to handle drawing of content outside its boundaries, but with this small change, this works (as far as i can tell) to work just fine.

Here is a small demo of before and after, where i move a `text` widget past left/right bounds, to illustrate the behavior.


https://github.com/user-attachments/assets/e1be386f-e07f-429f-8828-7baa3a40b5fd


https://github.com/user-attachments/assets/76628445-3449-487e-a1ce-0a36b9953c16





