### PR TITLE
Allow maximizing window when app starts

### DIFF
--- a/core/src/window/settings.rs
+++ b/core/src/window/settings.rs
@@ -44,6 +44,9 @@ pub struct Settings {
     /// The maximum size of the window.
     pub max_size: Option<Size>,
 
+    /// Whether the window should be maximized or not.
+    pub maximized: bool,
+
     /// Whether the window should be visible or not.
     pub visible: bool,
 
@@ -83,6 +86,7 @@ impl Default for Settings {
             position: Position::default(),
             min_size: None,
             max_size: None,
+            maximized: false,
             visible: true,
             resizable: true,
             decorations: true,

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -34,7 +34,8 @@ pub fn window_attributes(
         .with_transparent(settings.transparent)
         .with_window_icon(settings.icon.and_then(icon))
         .with_window_level(window_level(settings.level))
-        .with_visible(settings.visible);
+        .with_visible(settings.visible)
+        .with_maximized(settings.maximized);
 
     if let Some(position) =
         position(primary_monitor.as_ref(), settings.size, settings.position)


### PR DESCRIPTION
This PR adds the capability to start an application window in maximized state.

[`winit::window::WindowAttributes`](https://docs.rs/winit/latest/winit/window/struct.WindowAttributes.html#structfield.maximized) provides the attribute to maximize a window when creating it. However iced doesn't expose the functionality. This PR just exposes it by adding the same attribute to `iced::window::Settings`.