### PR TITLE
Fix render pass viewport in `custom_shader` example

### DIFF
--- a/examples/custom_shader/src/scene/camera.rs
+++ b/examples/custom_shader/src/scene/camera.rs
@@ -33,9 +33,7 @@ pub const OPENGL_TO_WGPU_MATRIX: glam::Mat4 = mat4(
 
 impl Camera {
     pub fn build_view_proj_matrix(&self, bounds: Rectangle) -> glam::Mat4 {
-        //TODO looks distorted without padding; base on surface texture size instead?
-        let aspect_ratio = bounds.width / (bounds.height + 150.0);
-
+        let aspect_ratio = bounds.width / (bounds.height);
         let view = glam::Mat4::look_at_rh(self.eye, self.target, self.up);
         let proj = glam::Mat4::perspective_rh(
             self.fov_y,

--- a/examples/custom_shader/src/scene/pipeline.rs
+++ b/examples/custom_shader/src/scene/pipeline.rs
@@ -358,7 +358,7 @@ impl Pipeline {
         &self,
         target: &wgpu::TextureView,
         encoder: &mut wgpu::CommandEncoder,
-        viewport: Rectangle<u32>,
+        clip_bounds: Rectangle<u32>,
         num_cubes: u32,
         show_depth: bool,
     ) {
@@ -390,11 +390,13 @@ impl Pipeline {
                     occlusion_query_set: None,
                 });
 
-            pass.set_scissor_rect(
-                viewport.x,
-                viewport.y,
-                viewport.width,
-                viewport.height,
+            pass.set_viewport(
+                clip_bounds.x as f32,
+                clip_bounds.y as f32,
+                clip_bounds.width as f32,
+                clip_bounds.height as f32,
+                0.0,
+                1.0,
             );
             pass.set_pipeline(&self.pipeline);
             pass.set_bind_group(0, &self.uniform_bind_group, &[]);
@@ -404,7 +406,7 @@ impl Pipeline {
         }
 
         if show_depth {
-            self.depth_pipeline.render(encoder, target, viewport);
+            self.depth_pipeline.render(encoder, target, clip_bounds);
         }
     }
 }
@@ -562,7 +564,7 @@ impl DepthPipeline {
         &self,
         encoder: &mut wgpu::CommandEncoder,
         target: &wgpu::TextureView,
-        viewport: Rectangle<u32>,
+        clip_bounds: Rectangle<u32>,
     ) {
         let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
             label: Some("cubes.pipeline.depth_pass"),
@@ -585,11 +587,13 @@ impl DepthPipeline {
             occlusion_query_set: None,
         });
 
-        pass.set_scissor_rect(
-            viewport.x,
-            viewport.y,
-            viewport.width,
-            viewport.height,
+        pass.set_viewport(
+            clip_bounds.x as f32,
+            clip_bounds.y as f32,
+            clip_bounds.width as f32,
+            clip_bounds.height as f32,
+            0.0,
+            1.0,
         );
         pass.set_pipeline(&self.pipeline);
         pass.set_bind_group(0, &self.bind_group, &[]);


### PR DESCRIPTION
Fix the shader widget render pass viewport by setting it to the clip bounds of the shader widget in the `custom_shader` example.

Without setting the viewport explicitly for the render pass, the viewport default is the entire bounds of the render target i.e. whole surface texture.
