### PR TITLE
Use widget::Id directly instead of duplicated subclasses

### DIFF
--- a/core/src/widget/id.rs
+++ b/core/src/widget/id.rs
@@ -23,6 +23,18 @@ impl Id {
     }
 }
 
+impl From<&'static str> for Id {
+    fn from(id: &'static str) -> Self {
+        Self::new(id)
+    }
+}
+
+impl From<String> for Id {
+    fn from(id: String) -> Self {
+        Self::new(id)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 enum Internal {
     Unique(usize),

--- a/widget/src/container.rs
+++ b/widget/src/container.rs
@@ -284,7 +284,7 @@ where
         operation: &mut dyn Operation,
     ) {
         operation.container(
-            self.id.as_ref().map(|id| &id.0),
+            self.id.as_ref(),
             layout.bounds(),
             &mut |operation| {
                 self.content.as_widget().operate(
@@ -457,28 +457,7 @@ pub fn draw_background<Renderer>(
 }
 
 /// The identifier of a [`Container`].
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct Id(widget::Id);
-
-impl Id {
-    /// Creates a custom [`Id`].
-    pub fn new(id: impl Into<std::borrow::Cow<'static, str>>) -> Self {
-        Self(widget::Id::new(id))
-    }
-
-    /// Creates a unique [`Id`].
-    ///
-    /// This function produces a different [`Id`] every time it is called.
-    pub fn unique() -> Self {
-        Self(widget::Id::unique())
-    }
-}
-
-impl From<Id> for widget::Id {
-    fn from(id: Id) -> Self {
-        id.0
-    }
-}
+pub type Id = widget::Id;
 
 /// Produces a [`Task`] that queries the visible screen bounds of the
 /// [`Container`] with the given [`Id`].

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -487,25 +487,21 @@ where
             state.translation(self.direction, bounds, content_bounds);
 
         operation.scrollable(
-            self.id.as_ref().map(|id| &id.0),
+            self.id.as_ref(),
             bounds,
             content_bounds,
             translation,
             state,
         );
 
-        operation.container(
-            self.id.as_ref().map(|id| &id.0),
-            bounds,
-            &mut |operation| {
-                self.content.as_widget().operate(
-                    &mut tree.children[0],
-                    layout.children().next().unwrap(),
-                    renderer,
-                    operation,
-                );
-            },
-        );
+        operation.container(self.id.as_ref(), bounds, &mut |operation| {
+            self.content.as_widget().operate(
+                &mut tree.children[0],
+                layout.children().next().unwrap(),
+                renderer,
+                operation,
+            );
+        });
     }
 
     fn update(
@@ -1205,49 +1201,24 @@ where
 }
 
 /// The identifier of a [`Scrollable`].
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct Id(widget::Id);
-
-impl Id {
-    /// Creates a custom [`Id`].
-    pub fn new(id: impl Into<std::borrow::Cow<'static, str>>) -> Self {
-        Self(widget::Id::new(id))
-    }
-
-    /// Creates a unique [`Id`].
-    ///
-    /// This function produces a different [`Id`] every time it is called.
-    pub fn unique() -> Self {
-        Self(widget::Id::unique())
-    }
-}
-
-impl From<Id> for widget::Id {
-    fn from(id: Id) -> Self {
-        id.0
-    }
-}
+pub type Id = widget::Id;
 
 /// Produces a [`Task`] that snaps the [`Scrollable`] with the given [`Id`]
 /// to the provided [`RelativeOffset`].
 pub fn snap_to<T>(id: Id, offset: RelativeOffset) -> Task<T> {
-    task::effect(Action::widget(operation::scrollable::snap_to(id.0, offset)))
+    task::effect(Action::widget(operation::scrollable::snap_to(id, offset)))
 }
 
 /// Produces a [`Task`] that scrolls the [`Scrollable`] with the given [`Id`]
 /// to the provided [`AbsoluteOffset`].
 pub fn scroll_to<T>(id: Id, offset: AbsoluteOffset) -> Task<T> {
-    task::effect(Action::widget(operation::scrollable::scroll_to(
-        id.0, offset,
-    )))
+    task::effect(Action::widget(operation::scrollable::scroll_to(id, offset)))
 }
 
 /// Produces a [`Task`] that scrolls the [`Scrollable`] with the given [`Id`]
 /// by the provided [`AbsoluteOffset`].
 pub fn scroll_by<T>(id: Id, offset: AbsoluteOffset) -> Task<T> {
-    task::effect(Action::widget(operation::scrollable::scroll_by(
-        id.0, offset,
-    )))
+    task::effect(Action::widget(operation::scrollable::scroll_by(id, offset)))
 }
 
 fn notify_scroll<Message>(

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -623,17 +623,9 @@ where
     ) {
         let state = tree.state.downcast_mut::<State<Renderer::Paragraph>>();
 
-        operation.focusable(
-            self.id.as_ref().map(|id| &id.0),
-            layout.bounds(),
-            state,
-        );
+        operation.focusable(self.id.as_ref(), layout.bounds(), state);
 
-        operation.text_input(
-            self.id.as_ref().map(|id| &id.0),
-            layout.bounds(),
-            state,
-        );
+        operation.text_input(self.id.as_ref(), layout.bounds(), state);
     }
 
     fn update(
@@ -1338,51 +1330,18 @@ pub enum Side {
 }
 
 /// The identifier of a [`TextInput`].
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct Id(widget::Id);
-
-impl Id {
-    /// Creates a custom [`Id`].
-    pub fn new(id: impl Into<std::borrow::Cow<'static, str>>) -> Self {
-        Self(widget::Id::new(id))
-    }
-
-    /// Creates a unique [`Id`].
-    ///
-    /// This function produces a different [`Id`] every time it is called.
-    pub fn unique() -> Self {
-        Self(widget::Id::unique())
-    }
-}
-
-impl From<Id> for widget::Id {
-    fn from(id: Id) -> Self {
-        id.0
-    }
-}
-
-impl From<&'static str> for Id {
-    fn from(id: &'static str) -> Self {
-        Self::new(id)
-    }
-}
-
-impl From<String> for Id {
-    fn from(id: String) -> Self {
-        Self::new(id)
-    }
-}
+pub type Id = widget::Id;
 
 /// Produces a [`Task`] that focuses the [`TextInput`] with the given [`Id`].
 pub fn focus<T>(id: impl Into<Id>) -> Task<T> {
-    task::effect(Action::widget(operation::focusable::focus(id.into().0)))
+    task::effect(Action::widget(operation::focusable::focus(id.into())))
 }
 
 /// Produces a [`Task`] that moves the cursor of the [`TextInput`] with the given [`Id`] to the
 /// end.
 pub fn move_cursor_to_end<T>(id: impl Into<Id>) -> Task<T> {
     task::effect(Action::widget(operation::text_input::move_cursor_to_end(
-        id.into().0,
+        id.into(),
     )))
 }
 
@@ -1390,7 +1349,7 @@ pub fn move_cursor_to_end<T>(id: impl Into<Id>) -> Task<T> {
 /// front.
 pub fn move_cursor_to_front<T>(id: impl Into<Id>) -> Task<T> {
     task::effect(Action::widget(operation::text_input::move_cursor_to_front(
-        id.into().0,
+        id.into(),
     )))
 }
 
@@ -1398,16 +1357,14 @@ pub fn move_cursor_to_front<T>(id: impl Into<Id>) -> Task<T> {
 /// provided position.
 pub fn move_cursor_to<T>(id: impl Into<Id>, position: usize) -> Task<T> {
     task::effect(Action::widget(operation::text_input::move_cursor_to(
-        id.into().0,
+        id.into(),
         position,
     )))
 }
 
 /// Produces a [`Task`] that selects all the content of the [`TextInput`] with the given [`Id`].
 pub fn select_all<T>(id: impl Into<Id>) -> Task<T> {
-    task::effect(Action::widget(operation::text_input::select_all(
-        id.into().0,
-    )))
+    task::effect(Action::widget(operation::text_input::select_all(id.into())))
 }
 
 /// The state of a [`TextInput`].


### PR DESCRIPTION
There doesn't seem to be any benefit from encapsulating Id in widget specific types or to not allowing custom Ids for container and scrollable.

Keep the widget ::Id around as an alias for backwards compatibility and minimal diff.
