### PR TITLE
Implement `time::repeat` and simplify `Subscription::run_with`

### DIFF
--- a/core/src/time.rs
+++ b/core/src/time.rs
@@ -2,3 +2,28 @@
 
 pub use web_time::Duration;
 pub use web_time::Instant;
+
+/// Creates a [`Duration`] representing the given amount of milliseconds.
+pub fn milliseconds(milliseconds: u64) -> Duration {
+    Duration::from_millis(milliseconds)
+}
+
+/// Creates a [`Duration`] representing the given amount of seconds.
+pub fn seconds(seconds: u64) -> Duration {
+    Duration::from_secs(seconds)
+}
+
+/// Creates a [`Duration`] representing the given amount of minutes.
+pub fn minutes(minutes: u64) -> Duration {
+    seconds(minutes * 60)
+}
+
+/// Creates a [`Duration`] representing the given amount of hours.
+pub fn hours(hours: u64) -> Duration {
+    minutes(hours * 60)
+}
+
+/// Creates a [`Duration`] representing the given amount of days.
+pub fn days(days: u64) -> Duration {
+    hours(days * 24)
+}

--- a/examples/arc/src/main.rs
+++ b/examples/arc/src/main.rs
@@ -4,6 +4,7 @@ use iced::mouse;
 use iced::widget::canvas::{
     self, stroke, Cache, Canvas, Geometry, Path, Stroke,
 };
+use iced::window;
 use iced::{Element, Fill, Point, Rectangle, Renderer, Subscription, Theme};
 
 pub fn main() -> iced::Result {
@@ -34,8 +35,7 @@ impl Arc {
     }
 
     fn subscription(&self) -> Subscription<Message> {
-        iced::time::every(std::time::Duration::from_millis(10))
-            .map(|_| Message::Tick)
+        window::frames().map(|_| Message::Tick)
     }
 }
 

--- a/examples/clock/src/main.rs
+++ b/examples/clock/src/main.rs
@@ -1,5 +1,5 @@
 use iced::mouse;
-use iced::time;
+use iced::time::{self, milliseconds};
 use iced::widget::canvas::{stroke, Cache, Geometry, LineCap, Path, Stroke};
 use iced::widget::{canvas, container};
 use iced::{alignment, Radians};
@@ -49,7 +49,7 @@ impl Clock {
     }
 
     fn subscription(&self) -> Subscription<Message> {
-        time::every(time::Duration::from_millis(500))
+        time::every(milliseconds(500))
             .map(|_| Message::Tick(chrono::offset::Local::now()))
     }
 

--- a/examples/game_of_life/src/main.rs
+++ b/examples/game_of_life/src/main.rs
@@ -5,12 +5,11 @@ mod preset;
 use grid::Grid;
 use preset::Preset;
 
-use iced::time;
+use iced::time::{self, milliseconds};
 use iced::widget::{
     button, checkbox, column, container, pick_list, row, slider, text,
 };
 use iced::{Center, Element, Fill, Subscription, Task, Theme};
-use std::time::Duration;
 
 pub fn main() -> iced::Result {
     tracing_subscriber::fmt::init();
@@ -112,7 +111,7 @@ impl GameOfLife {
 
     fn subscription(&self) -> Subscription<Message> {
         if self.is_playing {
-            time::every(Duration::from_millis(1000 / self.speed as u64))
+            time::every(milliseconds(1000 / self.speed as u64))
                 .map(|_| Message::Tick)
         } else {
             Subscription::none()
@@ -191,6 +190,7 @@ mod grid {
     use crate::Preset;
     use iced::alignment;
     use iced::mouse;
+    use iced::time::{Duration, Instant};
     use iced::touch;
     use iced::widget::canvas;
     use iced::widget::canvas::{
@@ -202,7 +202,6 @@ mod grid {
     use rustc_hash::{FxHashMap, FxHashSet};
     use std::future::Future;
     use std::ops::RangeInclusive;
-    use std::time::{Duration, Instant};
 
     pub struct Grid {
         state: State,

--- a/examples/stopwatch/src/main.rs
+++ b/examples/stopwatch/src/main.rs
@@ -1,9 +1,7 @@
 use iced::keyboard;
-use iced::time;
+use iced::time::{self, milliseconds, Duration, Instant};
 use iced::widget::{button, center, column, row, text};
 use iced::{Center, Element, Subscription, Theme};
-
-use std::time::{Duration, Instant};
 
 pub fn main() -> iced::Result {
     iced::application("Stopwatch - Iced", Stopwatch::update, Stopwatch::view)
@@ -63,7 +61,7 @@ impl Stopwatch {
         let tick = match self.state {
             State::Idle => Subscription::none(),
             State::Ticking { .. } => {
-                time::every(Duration::from_millis(10)).map(Message::Tick)
+                time::every(milliseconds(10)).map(Message::Tick)
             }
         };
 

--- a/examples/the_matrix/src/main.rs
+++ b/examples/the_matrix/src/main.rs
@@ -1,5 +1,5 @@
 use iced::mouse;
-use iced::time::{self, Instant};
+use iced::time::{self, milliseconds, Instant};
 use iced::widget::canvas;
 use iced::{
     Color, Element, Fill, Font, Point, Rectangle, Renderer, Subscription, Theme,
@@ -40,7 +40,7 @@ impl TheMatrix {
     }
 
     fn subscription(&self) -> Subscription<Message> {
-        time::every(std::time::Duration::from_millis(50)).map(Message::Tick)
+        time::every(milliseconds(50)).map(Message::Tick)
     }
 }
 

--- a/examples/toast/src/main.rs
+++ b/examples/toast/src/main.rs
@@ -162,7 +162,6 @@ impl Default for App {
 
 mod toast {
     use std::fmt;
-    use std::time::{Duration, Instant};
 
     use iced::advanced::layout::{self, Layout};
     use iced::advanced::overlay;
@@ -171,6 +170,7 @@ mod toast {
     use iced::advanced::{Clipboard, Shell, Widget};
     use iced::mouse;
     use iced::theme;
+    use iced::time::{self, Duration, Instant};
     use iced::widget::{
         button, column, container, horizontal_rule, horizontal_space, row, text,
     };
@@ -502,9 +502,8 @@ mod toast {
                 self.instants.iter_mut().enumerate().for_each(
                     |(index, maybe_instant)| {
                         if let Some(instant) = maybe_instant.as_mut() {
-                            let remaining =
-                                Duration::from_secs(self.timeout_secs)
-                                    .saturating_sub(instant.elapsed());
+                            let remaining = time::seconds(self.timeout_secs)
+                                .saturating_sub(instant.elapsed());
 
                             if remaining == Duration::ZERO {
                                 maybe_instant.take();

--- a/futures/src/backend/native/tokio.rs
+++ b/futures/src/backend/native/tokio.rs
@@ -22,40 +22,25 @@ impl crate::Executor for Executor {
 
 pub mod time {
     //! Listen and react to time.
-    use crate::subscription::{self, Hasher, Subscription};
+    use crate::core::time::{Duration, Instant};
+    use crate::stream;
+    use crate::subscription::Subscription;
+    use crate::MaybeSend;
+
+    use futures::SinkExt;
+    use std::future::Future;
 
     /// Returns a [`Subscription`] that produces messages at a set interval.
     ///
     /// The first message is produced after a `duration`, and then continues to
     /// produce more messages every `duration` after that.
-    pub fn every(
-        duration: std::time::Duration,
-    ) -> Subscription<std::time::Instant> {
-        subscription::from_recipe(Every(duration))
-    }
-
-    #[derive(Debug)]
-    struct Every(std::time::Duration);
-
-    impl subscription::Recipe for Every {
-        type Output = std::time::Instant;
-
-        fn hash(&self, state: &mut Hasher) {
-            use std::hash::Hash;
-
-            std::any::TypeId::of::<Self>().hash(state);
-            self.0.hash(state);
-        }
-
-        fn stream(
-            self: Box<Self>,
-            _input: subscription::EventStream,
-        ) -> futures::stream::BoxStream<'static, Self::Output> {
+    pub fn every(duration: Duration) -> Subscription<Instant> {
+        Subscription::run_with(duration, |duration| {
             use futures::stream::StreamExt;
 
-            let start = tokio::time::Instant::now() + self.0;
+            let start = tokio::time::Instant::now() + *duration;
 
-            let mut interval = tokio::time::interval_at(start, self.0);
+            let mut interval = tokio::time::interval_at(start, *duration);
             interval.set_missed_tick_behavior(
                 tokio::time::MissedTickBehavior::Skip,
             );
@@ -67,6 +52,27 @@ pub mod time {
             };
 
             stream.map(tokio::time::Instant::into_std).boxed()
-        }
+        })
+    }
+
+    /// Returns a [`Subscription`] that runs the given async function at a
+    /// set interval; producing the result of the function as output.
+    pub fn repeat<F, T>(f: fn() -> F, interval: Duration) -> Subscription<T>
+    where
+        F: Future<Output = T> + MaybeSend + 'static,
+        T: MaybeSend + 'static,
+    {
+        Subscription::run_with((f, interval), |(f, interval)| {
+            let f = *f;
+            let interval = *interval;
+
+            stream::channel(1, move |mut output| async move {
+                loop {
+                    let _ = output.send(f().await).await;
+
+                    tokio::time::sleep(interval).await;
+                }
+            })
+        })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -365,9 +365,9 @@
 //!
 //! As with tasks, some modules expose convenient functions that build a [`Subscription`] for you—like
 //! [`time::every`] which can be used to listen to time, or [`keyboard::on_key_press`] which will notify you
-//! of any key presses. But you can also create your own with [`Subscription::run`] and [`run_with_id`].
+//! of any key presses. But you can also create your own with [`Subscription::run`] and [`run_with`].
 //!
-//! [`run_with_id`]: Subscription::run_with_id
+//! [`run_with`]: Subscription::run_with
 //!
 //! ## Scaling Applications
 //! The `update`, `view`, and `Message` triplet composes very nicely.

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,5 +1,5 @@
 //! Listen and react to time.
-pub use crate::core::time::{Duration, Instant};
+pub use crate::core::time::*;
 
 #[allow(unused_imports)]
 #[cfg_attr(


### PR DESCRIPTION
Let's say you have an async function to obtain the current weather:

```rust
async fn fetch_weather() -> Result<Weather, Error> {
    // ...
}
```

The new `time::repeat` function can be leveraged to turn this async function into a `Subscription` that runs it at a set interval:

```rust
use iced::time;

enum Message {
    WeatherFetched(Result<Weather, Error>),
}

fn subscription(state: &State) -> Subscription<Message> {
    time::repeat(fetch_weather, time::Duration::from_secs(5))
        .map(Message::WeatherFetched)
}
```