### PR TITLE
Make `Color::from_rgb8` and `Color::from_rgba8` const

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust: [stable, beta, "1.81"]
+        rust: [stable, beta, "1.82"]
     steps:
     - uses: hecrj/setup-rust-action@v2
       with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,7 @@ repository = "https://github.com/iced-rs/iced"
 homepage = "https://iced.rs"
 categories = ["gui"]
 keywords = ["gui", "ui", "graphics", "interface", "widgets"]
-rust-version = "1.81"
+rust-version = "1.82"
 
 [workspace.dependencies]
 iced = { version = "0.14.0-dev", path = "." }

--- a/core/src/color.rs
+++ b/core/src/color.rs
@@ -74,16 +74,16 @@ impl Color {
     }
 
     /// Creates a [`Color`] from its RGB8 components.
-    pub fn from_rgb8(r: u8, g: u8, b: u8) -> Color {
+    pub const fn from_rgb8(r: u8, g: u8, b: u8) -> Color {
         Color::from_rgba8(r, g, b, 1.0)
     }
 
     /// Creates a [`Color`] from its RGB8 components and an alpha value.
-    pub fn from_rgba8(r: u8, g: u8, b: u8, a: f32) -> Color {
+    pub const fn from_rgba8(r: u8, g: u8, b: u8, a: f32) -> Color {
         Color {
-            r: f32::from(r) / 255.0,
-            g: f32::from(g) / 255.0,
-            b: f32::from(b) / 255.0,
+            r: r as f32 / 255.0,
+            g: g as f32 / 255.0,
+            b: b as f32 / 255.0,
             a,
         }
     }

--- a/core/src/color.rs
+++ b/core/src/color.rs
@@ -42,22 +42,18 @@ impl Color {
     ///
     /// In debug mode, it will panic if the values are not in the correct
     /// range: 0.0 - 1.0
-    pub fn new(r: f32, g: f32, b: f32, a: f32) -> Color {
+    const fn new(r: f32, g: f32, b: f32, a: f32) -> Color {
         debug_assert!(
-            (0.0..=1.0).contains(&r),
-            "Red component must be on [0, 1]"
+            r >= 0.0 && r <= 1.0,
+            "Red component must be in [0, 1] range."
         );
         debug_assert!(
-            (0.0..=1.0).contains(&g),
-            "Green component must be on [0, 1]"
+            g >= 0.0 && g <= 1.0,
+            "Green component must be in [0, 1] range."
         );
         debug_assert!(
-            (0.0..=1.0).contains(&b),
-            "Blue component must be on [0, 1]"
-        );
-        debug_assert!(
-            (0.0..=1.0).contains(&a),
-            "Alpha component must be on [0, 1]"
+            b >= 0.0 && b <= 1.0,
+            "Blue component must be in [0, 1] range."
         );
 
         Color { r, g, b, a }
@@ -70,7 +66,7 @@ impl Color {
 
     /// Creates a [`Color`] from its RGBA components.
     pub const fn from_rgba(r: f32, g: f32, b: f32, a: f32) -> Color {
-        Color { r, g, b, a }
+        Color::new(r, g, b, a)
     }
 
     /// Creates a [`Color`] from its RGB8 components.
@@ -80,12 +76,7 @@ impl Color {
 
     /// Creates a [`Color`] from its RGB8 components and an alpha value.
     pub const fn from_rgba8(r: u8, g: u8, b: u8, a: f32) -> Color {
-        Color {
-            r: r as f32 / 255.0,
-            g: g as f32 / 255.0,
-            b: b as f32 / 255.0,
-            a,
-        }
+        Color::new(r as f32 / 255.0, g as f32 / 255.0, b as f32 / 255.0, a)
     }
 
     /// Creates a [`Color`] from its linear RGBA components.
@@ -234,30 +225,10 @@ impl From<[f32; 4]> for Color {
 #[macro_export]
 macro_rules! color {
     ($r:expr, $g:expr, $b:expr) => {
-        $crate::color!($r, $g, $b, 1.0)
+        $crate::Color::from_rgb8($r, $g, $b)
     };
     ($r:expr, $g:expr, $b:expr, $a:expr) => {{
-        let r = $r as f32 / 255.0;
-        let g = $g as f32 / 255.0;
-        let b = $b as f32 / 255.0;
-
-        #[allow(clippy::manual_range_contains)]
-        {
-            debug_assert!(
-                r >= 0.0 && r <= 1.0,
-                "R channel must be in [0, 255] range."
-            );
-            debug_assert!(
-                g >= 0.0 && g <= 1.0,
-                "G channel must be in [0, 255] range."
-            );
-            debug_assert!(
-                b >= 0.0 && b <= 1.0,
-                "B channel must be in [0, 255] range."
-            );
-        }
-
-        $crate::Color { r, g, b, a: $a }
+        $crate::Color::from_rgba8($r, $g, $b, $a)
     }};
     ($hex:expr) => {{
         $crate::color!($hex, 1.0)
@@ -271,7 +242,7 @@ macro_rules! color {
         let g = (hex & 0xff00) >> 8;
         let b = (hex & 0xff);
 
-        $crate::color!(r, g, b, $a)
+        $crate::color!(r as u8, g as u8, b as u8, $a)
     }};
 }
 

--- a/core/src/theme/palette.rs
+++ b/core/src/theme/palette.rs
@@ -29,20 +29,20 @@ impl Palette {
     pub const LIGHT: Self = Self {
         background: Color::WHITE,
         text: Color::BLACK,
-        primary: Color::from_rgb8(0x5E, 0x7C, 0xE2),
-        success: Color::from_rgb8(0x12, 0x66, 0x4F),
-        warning: Color::from_rgb8(0xFF, 0xC1, 0x4E),
-        danger: Color::from_rgb8(0xC3, 0x42, 0x3F),
+        primary: color!(0x5e7ce2),
+        success: color!(0x12664f),
+        warning: color!(0xffc14e),
+        danger: color!(0xc3423f),
     };
 
     /// The built-in dark variant of a [`Palette`].
     pub const DARK: Self = Self {
-        background: Color::from_rgb8(0x20, 0x22, 0x25),
+        background: color!(0x202225),
         text: Color::from_rgb(0.90, 0.90, 0.90),
-        primary: Color::from_rgb8(0x5E, 0x7C, 0xE2),
-        success: Color::from_rgb8(0x12, 0x66, 0x4F),
-        warning: Color::from_rgb8(0xFF, 0xC1, 0x4E),
-        danger: Color::from_rgb8(0xC3, 0x42, 0x3F),
+        primary: color!(0x5e7ce2),
+        success: color!(0x12664f),
+        warning: color!(0xffc14e),
+        danger: color!(0xc3423f),
     };
 
     /// The built-in [Dracula] variant of a [`Palette`].

--- a/core/src/theme/palette.rs
+++ b/core/src/theme/palette.rs
@@ -29,56 +29,20 @@ impl Palette {
     pub const LIGHT: Self = Self {
         background: Color::WHITE,
         text: Color::BLACK,
-        primary: Color::from_rgb(
-            0x5E as f32 / 255.0,
-            0x7C as f32 / 255.0,
-            0xE2 as f32 / 255.0,
-        ),
-        success: Color::from_rgb(
-            0x12 as f32 / 255.0,
-            0x66 as f32 / 255.0,
-            0x4F as f32 / 255.0,
-        ),
-        warning: Color::from_rgb(
-            0xFF as f32 / 255.0,
-            0xC1 as f32 / 255.0,
-            0x4E as f32 / 255.0,
-        ),
-        danger: Color::from_rgb(
-            0xC3 as f32 / 255.0,
-            0x42 as f32 / 255.0,
-            0x3F as f32 / 255.0,
-        ),
+        primary: Color::from_rgb8(0x5E, 0x7C, 0xE2),
+        success: Color::from_rgb8(0x12, 0x66, 0x4F),
+        warning: Color::from_rgb8(0xFF, 0xC1, 0x4E),
+        danger: Color::from_rgb8(0xC3, 0x42, 0x3F),
     };
 
     /// The built-in dark variant of a [`Palette`].
     pub const DARK: Self = Self {
-        background: Color::from_rgb(
-            0x20 as f32 / 255.0,
-            0x22 as f32 / 255.0,
-            0x25 as f32 / 255.0,
-        ),
+        background: Color::from_rgb8(0x20, 0x22, 0x25),
         text: Color::from_rgb(0.90, 0.90, 0.90),
-        primary: Color::from_rgb(
-            0x5E as f32 / 255.0,
-            0x7C as f32 / 255.0,
-            0xE2 as f32 / 255.0,
-        ),
-        success: Color::from_rgb(
-            0x12 as f32 / 255.0,
-            0x66 as f32 / 255.0,
-            0x4F as f32 / 255.0,
-        ),
-        warning: Color::from_rgb(
-            0xFF as f32 / 255.0,
-            0xC1 as f32 / 255.0,
-            0x4E as f32 / 255.0,
-        ),
-        danger: Color::from_rgb(
-            0xC3 as f32 / 255.0,
-            0x42 as f32 / 255.0,
-            0x3F as f32 / 255.0,
-        ),
+        primary: Color::from_rgb8(0x5E, 0x7C, 0xE2),
+        success: Color::from_rgb8(0x12, 0x66, 0x4F),
+        warning: Color::from_rgb8(0xFF, 0xC1, 0x4E),
+        danger: Color::from_rgb8(0xC3, 0x42, 0x3F),
     };
 
     /// The built-in [Dracula] variant of a [`Palette`].

--- a/examples/gradient/src/main.rs
+++ b/examples/gradient/src/main.rs
@@ -3,7 +3,7 @@ use iced::theme;
 use iced::widget::{
     checkbox, column, container, horizontal_space, row, slider, text,
 };
-use iced::{Center, Color, Element, Fill, Radians, Theme};
+use iced::{color, Center, Color, Element, Fill, Radians, Theme};
 
 pub fn main() -> iced::Result {
     tracing_subscriber::fmt::init();
@@ -34,7 +34,7 @@ impl Gradient {
     fn new() -> Self {
         Self {
             start: Color::WHITE,
-            end: Color::new(0.0, 0.0, 1.0, 1.0),
+            end: color!(0x0000ff),
             angle: Radians(0.0),
             transparent: false,
         }

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -414,7 +414,7 @@ impl Renderer {
                     renderer.fill_text(
                         text.clone(),
                         Point::new(11.0, 11.0 + 25.0 * i as f32),
-                        Color::new(0.9, 0.9, 0.9, 1.0),
+                        Color::from_rgba(0.9, 0.9, 0.9, 1.0),
                         Rectangle::with_size(Size::INFINITY),
                     );
 


### PR DESCRIPTION
### Problem

I want to use `Color::from_rgb8` and `Color::from_rgba8` for constants to define my own color palette. However they are not `const fn`.

### Solution

They are not `const fn` because `From::from` is not const. This PR replaces it with `as` operator which is equivalent to it. As a bonus, the implementation of `LIGHT` and `DARK` palettes can be simplified.