### PR TITLE
Add `iced::window::get_monitor_size` to get the logical size of the current monitor

### DIFF
--- a/runtime/src/window.rs
+++ b/runtime/src/window.rs
@@ -175,6 +175,9 @@ pub enum Action {
 
     /// Set the window size increment.
     SetResizeIncrements(Id, Option<Size>),
+
+    /// Get the size of the monitor on which the window currently resides in logical dimensions.
+    GetMonitorSize(Id, oneshot::Sender<Option<Size>>),
 }
 
 /// Subscribes to the frames of the window of the running application.
@@ -478,4 +481,11 @@ pub fn enable_mouse_passthrough<Message>(id: Id) -> Task<Message> {
 /// from being passed to whatever is underneath.
 pub fn disable_mouse_passthrough<Message>(id: Id) -> Task<Message> {
     task::effect(crate::Action::Window(Action::DisableMousePassthrough(id)))
+}
+
+/// Get the size of the monitor on which the window currently resides in logical dimensions.
+pub fn get_monitor_size(id: Id) -> Task<Option<Size>> {
+    task::oneshot(move |channel| {
+        crate::Action::Window(Action::GetMonitorSize(id, channel))
+    })
 }

--- a/winit/src/program.rs
+++ b/winit/src/program.rs
@@ -1491,6 +1491,16 @@ fn run_action<P, C>(
                     let _ = window.raw.set_cursor_hittest(true);
                 }
             }
+            window::Action::GetMonitorSize(id, channel) => {
+                if let Some(window) = window_manager.get(id) {
+                    let size = window.raw.current_monitor().map(|monitor| {
+                        let factor = monitor.scale_factor();
+                        let size = monitor.size().to_logical(factor);
+                        Size::new(size.width, size.height)
+                    });
+                    let _ = channel.send(size);
+                }
+            }
         },
         Action::System(action) => match action {
             system::Action::QueryInformation(_channel) => {


### PR DESCRIPTION
This PR adds `iced::window::get_monitor_size` function to create a task to get the logical size of current monitor.

This function is useful to determine the size of window when resizing it. In my case, I want to resize a window to fit to its content. When the content is big, the window can overflow off the monitor. By calculating the window size based on the monitor size, I can prevent the overflow.