### PR TITLE
Fix `Color::new` was made private

### DIFF
--- a/core/src/color.rs
+++ b/core/src/color.rs
@@ -42,7 +42,7 @@ impl Color {
     ///
     /// In debug mode, it will panic if the values are not in the correct
     /// range: 0.0 - 1.0
-    const fn new(r: f32, g: f32, b: f32, a: f32) -> Color {
+    pub const fn new(r: f32, g: f32, b: f32, a: f32) -> Color {
         debug_assert!(
             r >= 0.0 && r <= 1.0,
             "Red component must be in [0, 1] range."


### PR DESCRIPTION
ce07acf6fedd705d6380739fbc5da40f95739e04 accidentally made `Color::new` private. This PR fixes the bug.