### PR TITLE
Remove unused `winapi` crate from dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2652,7 +2652,6 @@ dependencies = [
  "tracing",
  "wasm-bindgen-futures",
  "web-sys",
- "winapi",
  "window_clipboard",
  "winit",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,7 +188,6 @@ wasm-timer = "0.2"
 web-sys = "0.3.69"
 web-time = "1.1"
 wgpu = "23.0"
-winapi = "0.3"
 window_clipboard = "0.4.1"
 winit = { git = "https://github.com/iced-rs/winit.git", rev = "11414b6aa45699f038114e61b4ddf5102b2d3b4b" }
 

--- a/winit/Cargo.toml
+++ b/winit/Cargo.toml
@@ -39,9 +39,6 @@ winit.workspace = true
 sysinfo.workspace = true
 sysinfo.optional = true
 
-[target.'cfg(target_os = "windows")'.dependencies]
-winapi.workspace = true
-
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys.workspace = true
 web-sys.features = ["Document", "Window", "HtmlCanvasElement"]


### PR DESCRIPTION
`winapi` crate is listed in dependencies but it is actually imported by no crate in this repository. I confirmed no error from `cargo check --target x86_64-pc-windows-msvc` as well.