### PR TITLE
`keybind` widget

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2628,6 +2628,7 @@ dependencies = [
  "iced_highlighter",
  "iced_renderer",
  "iced_runtime",
+ "iced_test",
  "num-traits",
  "ouroboros",
  "pulldown-cmark",

--- a/core/src/keyboard.rs
+++ b/core/src/keyboard.rs
@@ -2,10 +2,12 @@
 pub mod key;
 
 mod event;
+mod hotkey;
 mod location;
 mod modifiers;
 
 pub use event::Event;
+pub use hotkey::Hotkey;
 pub use key::Key;
 pub use location::Location;
 pub use modifiers::Modifiers;

--- a/core/src/keyboard/event.rs
+++ b/core/src/keyboard/event.rs
@@ -29,6 +29,9 @@ pub enum Event {
 
         /// The text produced by the key press, if any.
         text: Option<SmolStr>,
+
+        /// Whether the key press is a key repeat event.
+        repeat: bool,
     },
 
     /// A keyboard key was released.

--- a/core/src/keyboard/hotkey.rs
+++ b/core/src/keyboard/hotkey.rs
@@ -1,0 +1,58 @@
+use crate::keyboard::key;
+use crate::keyboard::{Key, Location, Modifiers};
+
+/// A specific keyboard combination meant to trigger some action.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Hotkey {
+    /// The keyboard key.
+    pub key: Key,
+
+    /// The keyboard modifiers.
+    ///
+    /// By default, hotkeys are triggered with [`Modifiers::COMMAND`].
+    pub modifiers: Modifiers,
+
+    /// The keyboard location, if relevant.
+    ///
+    /// A `None` value will trigger the hotkey independently
+    /// of the actual keyboard location pressed by the user.
+    pub location: Option<Location>,
+}
+
+impl From<char> for Hotkey {
+    fn from(c: char) -> Self {
+        Self::from(Key::from(c))
+    }
+}
+
+impl From<&str> for Hotkey {
+    fn from(s: &str) -> Self {
+        Self::from(Key::from(s))
+    }
+}
+
+impl From<key::Named> for Hotkey {
+    fn from(key: key::Named) -> Self {
+        Self::from(Key::Named(key))
+    }
+}
+
+impl From<Key> for Hotkey {
+    fn from(key: Key) -> Self {
+        Self {
+            key,
+            modifiers: Modifiers::COMMAND,
+            location: None,
+        }
+    }
+}
+
+impl From<(Modifiers, Key)> for Hotkey {
+    fn from((modifiers, key): (Modifiers, Key)) -> Self {
+        Self {
+            key,
+            modifiers,
+            location: None,
+        }
+    }
+}

--- a/core/src/keyboard/key.rs
+++ b/core/src/keyboard/key.rs
@@ -6,7 +6,7 @@ use crate::SmolStr;
 /// This is mostly the `Key` type found in [`winit`].
 ///
 /// [`winit`]: https://docs.rs/winit/0.29.10/winit/keyboard/enum.Key.html
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Key<C = SmolStr> {
     /// A key with an established name.
     Named(Named),
@@ -35,6 +35,18 @@ impl Key {
 impl From<Named> for Key {
     fn from(named: Named) -> Self {
         Self::Named(named)
+    }
+}
+
+impl From<char> for Key {
+    fn from(c: char) -> Self {
+        Self::Character(SmolStr::from_iter([c]))
+    }
+}
+
+impl From<&str> for Key {
+    fn from(s: &str) -> Self {
+        Self::Character(SmolStr::new(s))
     }
 }
 

--- a/core/src/keyboard/location.rs
+++ b/core/src/keyboard/location.rs
@@ -1,5 +1,5 @@
 /// The location of a key on the keyboard.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Location {
     /// The standard group of keys on the keyboard.
     Standard,

--- a/examples/editor/src/main.rs
+++ b/examples/editor/src/main.rs
@@ -1,5 +1,4 @@
 use iced::highlighter;
-use iced::keyboard::Hotkey;
 use iced::widget::{
     self, button, center_x, column, container, horizontal_space, keybind,
     pick_list, row, text, text_editor, toggler, tooltip,
@@ -146,18 +145,25 @@ impl Editor {
 
     fn view(&self) -> Element<Message> {
         let controls = row![
-            action(new_icon(), "New file", 'n', Some(Message::NewFile)),
-            action(
-                open_icon(),
-                "Open file",
-                'o',
-                (!self.is_loading).then_some(Message::OpenFile)
+            keybind(
+                'n',
+                action(new_icon(), "New file", Some(Message::NewFile))
             ),
-            action(
-                save_icon(),
-                "Save file",
+            keybind(
+                'o',
+                action(
+                    open_icon(),
+                    "Open file",
+                    (!self.is_loading).then_some(Message::OpenFile)
+                )
+            ),
+            keybind(
                 's',
-                self.is_dirty.then_some(Message::SaveFile),
+                action(
+                    save_icon(),
+                    "Save file",
+                    self.is_dirty.then_some(Message::SaveFile),
+                )
             ),
             horizontal_space(),
             toggler(self.word_wrap)
@@ -284,14 +290,13 @@ async fn save_file(
 fn action<'a, Message: Clone + 'a>(
     content: impl Into<Element<'a, Message>>,
     label: &'a str,
-    hotkey: impl Into<Hotkey>,
     on_press: Option<Message>,
 ) -> Element<'a, Message> {
     let action = button(center_x(content).width(30));
 
     if let Some(on_press) = on_press {
         tooltip(
-            keybind(hotkey, action.on_press(on_press)),
+            action.on_press(on_press),
             label,
             tooltip::Position::FollowCursor,
         )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -568,7 +568,7 @@ pub mod event {
 pub mod keyboard {
     //! Listen and react to keyboard events.
     pub use crate::core::keyboard::key;
-    pub use crate::core::keyboard::{Event, Key, Location, Modifiers};
+    pub use crate::core::keyboard::{Event, Hotkey, Key, Location, Modifiers};
     pub use iced_futures::keyboard::{on_key_press, on_key_release};
 }
 

--- a/widget/Cargo.toml
+++ b/widget/Cargo.toml
@@ -51,3 +51,6 @@ iced_highlighter.optional = true
 
 url.workspace = true
 url.optional = true
+
+[dev-dependencies]
+iced_test.workspace = true

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -4,6 +4,7 @@ use crate::checkbox::{self, Checkbox};
 use crate::combo_box::{self, ComboBox};
 use crate::container::{self, Container};
 use crate::core;
+use crate::core::keyboard::Hotkey;
 use crate::core::widget::operation::{self, Operation};
 use crate::core::window;
 use crate::core::{Element, Length, Pixels, Widget};
@@ -24,7 +25,7 @@ use crate::text_input::{self, TextInput};
 use crate::toggler::{self, Toggler};
 use crate::tooltip::{self, Tooltip};
 use crate::vertical_slider::{self, VerticalSlider};
-use crate::{Column, MouseArea, Pin, Pop, Row, Space, Stack, Themer};
+use crate::{Column, Keybind, MouseArea, Pin, Pop, Row, Space, Stack, Themer};
 
 use std::borrow::Borrow;
 use std::ops::RangeInclusive;
@@ -1043,6 +1044,18 @@ where
     Renderer: core::Renderer,
 {
     Button::new(content)
+}
+
+/// A [`Keybind`] triggers a "click" on its target when a certain [`Hotkey`]
+/// combination is pressed.
+pub fn keybind<'a, Message, Theme, Renderer>(
+    hotkey: impl Into<Hotkey>,
+    target: impl Into<Element<'a, Message, Theme, Renderer>>,
+) -> Keybind<'a, Message, Theme, Renderer>
+where
+    Renderer: core::Renderer,
+{
+    Keybind::new(hotkey, target)
 }
 
 /// Creates a new [`Tooltip`] for the provided content with the given

--- a/widget/src/keybind.rs
+++ b/widget/src/keybind.rs
@@ -1,0 +1,237 @@
+//! Trigger elements with key combinations.
+use crate::core;
+use crate::core::keyboard;
+use crate::core::keyboard::Hotkey;
+use crate::core::layout;
+use crate::core::mouse;
+use crate::core::overlay;
+use crate::core::renderer;
+use crate::core::widget;
+use crate::core::{
+    Clipboard, Element, Event, Layout, Length, Rectangle, Shell, Size, Vector,
+    Widget,
+};
+
+/// A widget that triggers a "click" on its target when a certain hotkey combination
+/// is pressed.
+#[allow(missing_debug_implementations)]
+pub struct Keybind<
+    'a,
+    Message,
+    Theme = crate::Theme,
+    Renderer = crate::Renderer,
+> {
+    hotkey: Hotkey,
+    target: Element<'a, Message, Theme, Renderer>,
+    repeat: bool,
+}
+
+impl<'a, Message, Theme, Renderer> Keybind<'a, Message, Theme, Renderer> {
+    /// Creates a new [`Keybind`] with the given [`Hotkey`] and target.
+    pub fn new(
+        hotkey: impl Into<Hotkey>,
+        target: impl Into<Element<'a, Message, Theme, Renderer>>,
+    ) -> Self {
+        Self {
+            hotkey: hotkey.into(),
+            target: target.into(),
+            repeat: false,
+        }
+    }
+
+    /// Sets whether the [`Keybind`] should trigger on repeated key press events.
+    ///
+    /// By default, this is disabled. This means that a user holding down the [`Hotkey`]
+    /// will only trigger the [`Keybind`] once until any key is released.
+    pub fn repeat(mut self, repeat: bool) -> Self {
+        self.repeat = repeat;
+        self
+    }
+}
+
+impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer>
+    for Keybind<'_, Message, Theme, Renderer>
+where
+    Renderer: core::Renderer,
+{
+    fn update(
+        &mut self,
+        tree: &mut widget::Tree,
+        event: Event,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        renderer: &Renderer,
+        clipboard: &mut dyn Clipboard,
+        shell: &mut Shell<'_, Message>,
+        viewport: &Rectangle,
+    ) {
+        let key_pressed = match &event {
+            Event::Keyboard(keyboard::Event::KeyPressed {
+                modified_key,
+                modifiers,
+                location,
+                repeat,
+                ..
+            }) => {
+                modified_key.as_ref() == self.hotkey.key.as_ref()
+                    && *modifiers == self.hotkey.modifiers
+                    && self.hotkey.location.is_none_or(|hotkey_location| {
+                        *location == hotkey_location
+                    })
+                    && (!repeat || self.repeat)
+            }
+            _ => false,
+        };
+
+        self.target.as_widget_mut().update(
+            tree, event, layout, cursor, renderer, clipboard, shell, viewport,
+        );
+
+        if shell.is_event_captured() || !key_pressed {
+            return;
+        }
+
+        let click_events = [
+            Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)),
+            Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)),
+        ];
+
+        let mut local_messages = Vec::new();
+
+        for event in click_events {
+            let mut local_shell = Shell::new(&mut local_messages);
+
+            self.target.as_widget_mut().update(
+                tree,
+                event,
+                layout,
+                mouse::Cursor::Available(layout.bounds().center()),
+                renderer,
+                clipboard,
+                &mut local_shell,
+                viewport,
+            );
+
+            shell.merge(local_shell, std::convert::identity);
+        }
+    }
+
+    fn tag(&self) -> widget::tree::Tag {
+        self.target.as_widget().tag()
+    }
+
+    fn state(&self) -> widget::tree::State {
+        self.target.as_widget().state()
+    }
+
+    fn children(&self) -> Vec<widget::Tree> {
+        self.target.as_widget().children()
+    }
+
+    fn diff(&self, tree: &mut widget::Tree) {
+        self.target.as_widget().diff(tree);
+    }
+
+    fn size(&self) -> Size<Length> {
+        self.target.as_widget().size()
+    }
+
+    fn size_hint(&self) -> Size<Length> {
+        self.target.as_widget().size_hint()
+    }
+
+    fn layout(
+        &self,
+        tree: &mut widget::Tree,
+        renderer: &Renderer,
+        limits: &layout::Limits,
+    ) -> layout::Node {
+        self.target.as_widget().layout(tree, renderer, limits)
+    }
+
+    fn draw(
+        &self,
+        tree: &widget::Tree,
+        renderer: &mut Renderer,
+        theme: &Theme,
+        style: &renderer::Style,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+    ) {
+        self.target
+            .as_widget()
+            .draw(tree, renderer, theme, style, layout, cursor, viewport);
+    }
+
+    fn operate(
+        &self,
+        tree: &mut widget::Tree,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+        operation: &mut dyn widget::Operation,
+    ) {
+        self.target
+            .as_widget()
+            .operate(tree, layout, renderer, operation);
+    }
+
+    fn mouse_interaction(
+        &self,
+        tree: &widget::Tree,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+        renderer: &Renderer,
+    ) -> mouse::Interaction {
+        self.target
+            .as_widget()
+            .mouse_interaction(tree, layout, cursor, viewport, renderer)
+    }
+
+    fn overlay<'a>(
+        &'a mut self,
+        tree: &'a mut widget::Tree,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+        translation: Vector,
+    ) -> Option<overlay::Element<'a, Message, Theme, Renderer>> {
+        self.target
+            .as_widget_mut()
+            .overlay(tree, layout, renderer, translation)
+    }
+}
+
+impl<'a, Message, Theme, Renderer> From<Keybind<'a, Message, Theme, Renderer>>
+    for Element<'a, Message, Theme, Renderer>
+where
+    Message: 'a,
+    Theme: 'a,
+    Renderer: core::Renderer + 'a,
+{
+    fn from(keybind: Keybind<'a, Message, Theme, Renderer>) -> Self {
+        Element::new(keybind)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use crate::button;
+    use crate::core::event;
+
+    use iced_test::simulator;
+
+    #[test]
+    fn it_triggers_a_click() {
+        let keybind: Keybind<'_, _, crate::Theme> =
+            Keybind::new('s', button("Test!").on_press(42));
+
+        let mut ui = simulator(keybind);
+        let status = ui.tap_hotkey('s');
+
+        assert_eq!(status, event::Status::Captured);
+        assert_eq!(ui.into_messages().collect::<Vec<_>>(), vec![42]);
+    }
+}

--- a/widget/src/keybind.rs
+++ b/widget/src/keybind.rs
@@ -225,13 +225,18 @@ mod test {
 
     #[test]
     fn it_triggers_a_click() {
+        #[derive(Debug, Clone, PartialEq, Eq)]
+        enum Message {
+            Save,
+        }
+
         let keybind: Keybind<'_, _, crate::Theme> =
-            Keybind::new('s', button("Test!").on_press(42));
+            Keybind::new('s', button("Save").on_press(Message::Save));
 
         let mut ui = simulator(keybind);
         let status = ui.tap_hotkey('s');
 
         assert_eq!(status, event::Status::Captured);
-        assert_eq!(ui.into_messages().collect::<Vec<_>>(), vec![42]);
+        assert_eq!(ui.into_messages().collect::<Vec<_>>(), vec![Message::Save]);
     }
 }

--- a/widget/src/lib.rs
+++ b/widget/src/lib.rs
@@ -21,6 +21,7 @@ pub mod button;
 pub mod checkbox;
 pub mod combo_box;
 pub mod container;
+pub mod keybind;
 pub mod keyed;
 pub mod overlay;
 pub mod pane_grid;
@@ -58,6 +59,8 @@ pub use column::Column;
 pub use combo_box::ComboBox;
 #[doc(no_inline)]
 pub use container::Container;
+#[doc(no_inline)]
+pub use keybind::Keybind;
 #[doc(no_inline)]
 pub use mouse_area::MouseArea;
 #[doc(no_inline)]

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -235,6 +235,7 @@ pub fn window_event(
                 location,
                 logical_key,
                 physical_key,
+                repeat,
                 ..
             } = event;
 
@@ -265,6 +266,7 @@ pub fn window_event(
                         modifiers,
                         location,
                         text,
+                        repeat,
                     }
                 }
                 winit::event::ElementState::Released => {


### PR DESCRIPTION
This PR introduces a brand new widget: `keybind`.

A `keybind` widget can be used to trigger a click interaction on its contents when a certain `Hotkey` is pressed.

A `Hotkey` is a keyboard combination: a key, some modifiers, and an optional location. By default, hotkeys use `keyboard::Modifiers::COMMAND` as the trigger modifiers.

For instance:

```rust
keybind('s', button("Save").on_press(Message::Save))
```

This will display a save button that can be clicked with the mouse and also by pressing `Ctrl+S` (or `⌘+S` on macOS). In both instances, a `Save` message will be produced.