### PR TITLE
Implement division operation for `Rectangle`, `Size` and `Vector`

### DIFF
--- a/core/src/rectangle.rs
+++ b/core/src/rectangle.rs
@@ -283,6 +283,19 @@ impl std::ops::Mul<f32> for Rectangle<f32> {
     }
 }
 
+impl std::ops::Div<f32> for Rectangle<f32> {
+    type Output = Self;
+
+    fn div(self, scale: f32) -> Self {
+        Self {
+            x: self.x / scale,
+            y: self.y / scale,
+            width: self.width / scale,
+            height: self.height / scale,
+        }
+    }
+}
+
 impl From<Rectangle<u32>> for Rectangle<f32> {
     fn from(rectangle: Rectangle<u32>) -> Rectangle<f32> {
         Rectangle {
@@ -336,6 +349,22 @@ where
             y: self.y * scale.y,
             width: self.width * scale.x,
             height: self.height * scale.y,
+        }
+    }
+}
+
+impl<T> std::ops::Div<Vector<T>> for Rectangle<T>
+where
+    T: std::ops::Div<Output = T> + Copy,
+{
+    type Output = Rectangle<T>;
+
+    fn div(self, scale: Vector<T>) -> Self {
+        Rectangle {
+            x: self.x / scale.x,
+            y: self.y / scale.y,
+            width: self.width / scale.x,
+            height: self.height / scale.y,
         }
     }
 }

--- a/core/src/size.rs
+++ b/core/src/size.rs
@@ -141,6 +141,20 @@ where
     }
 }
 
+impl<T> std::ops::Div<T> for Size<T>
+where
+    T: std::ops::Div<Output = T> + Copy,
+{
+    type Output = Size<T>;
+
+    fn div(self, rhs: T) -> Self::Output {
+        Size {
+            width: self.width / rhs,
+            height: self.height / rhs,
+        }
+    }
+}
+
 impl<T> std::ops::Mul<Vector<T>> for Size<T>
 where
     T: std::ops::Mul<Output = T> + Copy,

--- a/core/src/vector.rs
+++ b/core/src/vector.rs
@@ -64,6 +64,17 @@ where
     }
 }
 
+impl<T> std::ops::Div<T> for Vector<T>
+where
+    T: std::ops::Div<Output = T> + Copy,
+{
+    type Output = Self;
+
+    fn div(self, scale: T) -> Self {
+        Self::new(self.x / scale, self.y / scale)
+    }
+}
+
 impl<T> Default for Vector<T>
 where
     T: Default,


### PR DESCRIPTION
Implement `std::ops::Div` for `Rectangle`, `Size` and `Vector` to complement existing multiplication operations.

This way users can avoid the roundabout `foo * (1.0 / scaling)` to scale a `Vector`, for example.

I thought `impl<T> std::ops::Div<Vector<T>> for Rectangle<T>` was a bit weird conceptually, but added it for consistency since we already had `impl<T> std::ops::Mul<Vector<T>> for Rectangle<T>`.