### PR TITLE
Add in new convenience function for a hidden Scrollbar

### DIFF
--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -339,6 +339,12 @@ impl Scrollbar {
         Self::default()
     }
 
+    /// Create a [`Scrollbar`] with zero width to allow a [`Scrollable`] to scroll without a visible
+    /// scroller.
+    pub fn hidden() -> Self {
+        Self::default().width(0).scroller_width(0)
+    }
+
     /// Sets the scrollbar width of the [`Scrollbar`] .
     pub fn width(mut self, width: impl Into<Pixels>) -> Self {
         self.width = width.into().0.max(0.0);


### PR DESCRIPTION
**why**
- a `Scrollable` widget requires a `Direction`, which in turn requires a `Scrollbar`
- all of these are reasonably defaulted to a vertical-only scrollable with a sane 8px wide scrollbar
- sometimes you want to maintain the scrollable functionality but not display a scrollbar

**changes tl;dr**
- adding in convenience function `iced_widget::scrollable::Scrollbar::hidden()` that is simply `default()` with zero-width

example:
```rs
widget::scrollable(row![
    horizontal_space().width(Length::Fixed(600.0)),
    "hello",
    horizontal_space().width(Length::Fixed(600.0))
])
.direction(Direction::Horizontal(Scrollbar::hidden()))
// you can then control via methods eg iced::widget::scrollable::scroll_to(id, offset)
```

 