### PR TITLE
Incremental `markdown` parsing and various fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2640,6 +2640,7 @@ dependencies = [
  "iced_highlighter",
  "iced_renderer",
  "iced_runtime",
+ "log",
  "num-traits",
  "ouroboros",
  "pulldown-cmark",

--- a/examples/markdown/Cargo.toml
+++ b/examples/markdown/Cargo.toml
@@ -7,6 +7,6 @@ publish = false
 
 [dependencies]
 iced.workspace = true
-iced.features = ["markdown", "highlighter", "debug"]
+iced.features = ["markdown", "highlighter", "tokio", "debug"]
 
 open = "5.3"

--- a/examples/markdown/src/main.rs
+++ b/examples/markdown/src/main.rs
@@ -74,7 +74,7 @@ impl Markdown {
                 if enable_stream {
                     self.mode = Mode::Stream {
                         pending: self.content.text(),
-                        parsed: markdown::Content::parse(""),
+                        parsed: markdown::Content::new(),
                     };
 
                     scrollable::snap_to(

--- a/examples/markdown/src/main.rs
+++ b/examples/markdown/src/main.rs
@@ -1,23 +1,37 @@
 use iced::highlighter;
-use iced::widget::{self, markdown, row, scrollable, text_editor};
-use iced::{Element, Fill, Font, Task, Theme};
+use iced::time::{self, milliseconds};
+use iced::widget::{
+    self, hover, markdown, right, row, scrollable, text_editor, toggler,
+};
+use iced::{Element, Fill, Font, Subscription, Task, Theme};
 
 pub fn main() -> iced::Result {
     iced::application("Markdown - Iced", Markdown::update, Markdown::view)
+        .subscription(Markdown::subscription)
         .theme(Markdown::theme)
         .run_with(Markdown::new)
 }
 
 struct Markdown {
     content: text_editor::Content,
-    items: Vec<markdown::Item>,
+    mode: Mode,
     theme: Theme,
+}
+
+enum Mode {
+    Oneshot(Vec<markdown::Item>),
+    Stream {
+        pending: String,
+        parsed: markdown::Content,
+    },
 }
 
 #[derive(Debug, Clone)]
 enum Message {
     Edit(text_editor::Action),
     LinkClicked(markdown::Url),
+    ToggleStream(bool),
+    NextToken,
 }
 
 impl Markdown {
@@ -29,7 +43,7 @@ impl Markdown {
         (
             Self {
                 content: text_editor::Content::with_text(INITIAL_CONTENT),
-                items: markdown::parse(INITIAL_CONTENT).collect(),
+                mode: Mode::Oneshot(markdown::parse(INITIAL_CONTENT).collect()),
                 theme,
             },
             widget::focus_next(),
@@ -44,13 +58,48 @@ impl Markdown {
                 self.content.perform(action);
 
                 if is_edit {
-                    self.items =
-                        markdown::parse(&self.content.text()).collect();
+                    self.mode = match self.mode {
+                        Mode::Oneshot(_) => Mode::Oneshot(
+                            markdown::parse(&self.content.text()).collect(),
+                        ),
+                        Mode::Stream { .. } => Mode::Stream {
+                            pending: self.content.text(),
+                            parsed: markdown::Content::parse(""),
+                        },
+                    }
                 }
             }
             Message::LinkClicked(link) => {
                 let _ = open::that_in_background(link.to_string());
             }
+            Message::ToggleStream(enable_stream) => {
+                self.mode = if enable_stream {
+                    Mode::Stream {
+                        pending: self.content.text(),
+                        parsed: markdown::Content::parse(""),
+                    }
+                } else {
+                    Mode::Oneshot(
+                        markdown::parse(&self.content.text()).collect(),
+                    )
+                };
+            }
+            Message::NextToken => match &mut self.mode {
+                Mode::Oneshot(_) => {}
+                Mode::Stream { pending, parsed } => {
+                    if pending.is_empty() {
+                        self.mode = Mode::Oneshot(parsed.items().to_vec());
+                    } else {
+                        let mut tokens = pending.split(' ');
+
+                        if let Some(token) = tokens.next() {
+                            parsed.push_str(&format!("{token} "));
+                        }
+
+                        *pending = tokens.collect::<Vec<_>>().join(" ");
+                    }
+                }
+            },
         }
     }
 
@@ -63,20 +112,45 @@ impl Markdown {
             .font(Font::MONOSPACE)
             .highlight("markdown", highlighter::Theme::Base16Ocean);
 
+        let items = match &self.mode {
+            Mode::Oneshot(items) => items.as_slice(),
+            Mode::Stream { parsed, .. } => parsed.items(),
+        };
+
         let preview = markdown(
-            &self.items,
+            items,
             markdown::Settings::default(),
             markdown::Style::from_palette(self.theme.palette()),
         )
         .map(Message::LinkClicked);
 
-        row![editor, scrollable(preview).spacing(10).height(Fill)]
-            .spacing(10)
-            .padding(10)
-            .into()
+        row![
+            editor,
+            hover(
+                scrollable(preview).spacing(10).width(Fill).height(Fill),
+                right(
+                    toggler(matches!(self.mode, Mode::Stream { .. }))
+                        .label("Stream")
+                        .on_toggle(Message::ToggleStream)
+                )
+                .padding([0, 20])
+            )
+        ]
+        .spacing(10)
+        .padding(10)
+        .into()
     }
 
     fn theme(&self) -> Theme {
         self.theme.clone()
+    }
+
+    fn subscription(&self) -> Subscription<Message> {
+        match self.mode {
+            Mode::Oneshot(_) => Subscription::none(),
+            Mode::Stream { .. } => {
+                time::every(milliseconds(20)).map(|_| Message::NextToken)
+            }
+        }
     }
 }

--- a/widget/Cargo.toml
+++ b/widget/Cargo.toml
@@ -33,6 +33,7 @@ iced_renderer.workspace = true
 iced_runtime.workspace = true
 
 num-traits.workspace = true
+log.workspace = true
 rustc-hash.workspace = true
 thiserror.workspace = true
 unicode-segmentation.workspace = true

--- a/widget/src/container.rs
+++ b/widget/src/container.rs
@@ -107,8 +107,8 @@ where
     }
 
     /// Sets the [`Id`] of the [`Container`].
-    pub fn id(mut self, id: Id) -> Self {
-        self.id = Some(id);
+    pub fn id(mut self, id: impl Into<Id>) -> Self {
+        self.id = Some(id.into());
         self
     }
 
@@ -480,9 +480,17 @@ impl From<Id> for widget::Id {
     }
 }
 
+impl From<&'static str> for Id {
+    fn from(value: &'static str) -> Self {
+        Id::new(value)
+    }
+}
+
 /// Produces a [`Task`] that queries the visible screen bounds of the
 /// [`Container`] with the given [`Id`].
-pub fn visible_bounds(id: Id) -> Task<Option<Rectangle>> {
+pub fn visible_bounds(id: impl Into<Id>) -> Task<Option<Rectangle>> {
+    let id = id.into();
+
     struct VisibleBounds {
         target: widget::Id,
         depth: usize,

--- a/widget/src/markdown.rs
+++ b/widget/src/markdown.rs
@@ -344,7 +344,16 @@ pub fn parse(markdown: &str) -> impl Iterator<Item = Item> + '_ {
                         }));
                 }
 
-                None
+                let prev = if spans.is_empty() {
+                    None
+                } else {
+                    produce(
+                        &mut lists,
+                        Item::Paragraph(Text::new(spans.drain(..).collect())),
+                    )
+                };
+
+                prev
             }
             pulldown_cmark::Tag::MetadataBlock(_) => {
                 metadata = true;

--- a/widget/src/markdown.rs
+++ b/widget/src/markdown.rs
@@ -735,7 +735,7 @@ where
         .into(),
     });
 
-    Element::new(column(blocks).width(Length::Fill).spacing(text_size))
+    Element::new(column(blocks).spacing(spacing))
 }
 
 /// The theme catalog of Markdown items.

--- a/widget/src/markdown.rs
+++ b/widget/src/markdown.rs
@@ -313,18 +313,22 @@ impl Highlighter {
             Some(line) if line.0 == text => {}
             _ => {
                 if self.current + 1 < self.lines.len() {
-                    println!("Resetting...");
+                    log::debug!("Resetting highlighter...");
                     self.parser.reset();
                     self.lines.truncate(self.current);
 
                     for line in &self.lines {
-                        println!("Refeeding {n} lines", n = self.lines.len());
+                        log::debug!(
+                            "Refeeding {n} lines",
+                            n = self.lines.len()
+                        );
 
                         let _ = self.parser.highlight_line(&line.0);
                     }
                 }
 
-                println!("Parsing: {text}", text = text.trim_end());
+                log::trace!("Parsing: {text}", text = text.trim_end());
+
                 if self.current + 1 < self.lines.len() {
                     self.parser.commit();
                 }

--- a/widget/src/markdown.rs
+++ b/widget/src/markdown.rs
@@ -289,6 +289,7 @@ struct State {
 #[derive(Debug)]
 struct Highlighter {
     lines: Vec<(String, Vec<Span>)>,
+    language: String,
     parser: iced_highlighter::Stream,
     current: usize,
 }
@@ -304,6 +305,7 @@ impl Highlighter {
                     token: language.to_string(),
                 },
             ),
+            language: language.to_owned(),
             current: 0,
         }
     }
@@ -484,6 +486,9 @@ fn parse_with<'a>(
                             .borrow_mut()
                             .highlighter
                             .take()
+                            .filter(|highlighter| {
+                                highlighter.language == _language.as_ref()
+                            })
                             .unwrap_or_else(|| Highlighter::new(&_language));
 
                         highlighter.prepare();

--- a/widget/src/markdown.rs
+++ b/widget/src/markdown.rs
@@ -66,13 +66,17 @@ pub use core::text::Highlight;
 pub use pulldown_cmark::HeadingLevel;
 pub use url::Url;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Content {
     items: Vec<Item>,
     state: State,
 }
 
 impl Content {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
     pub fn parse(markdown: &str) -> Self {
         let mut state = State::default();
         let items = parse_with(&mut state, markdown).collect();
@@ -595,15 +599,11 @@ fn parse_with<'a>(
         pulldown_cmark::Event::Text(text) if !metadata && !table => {
             #[cfg(feature = "highlighter")]
             if let Some(highlighter) = &mut highlighter {
-                let start = std::time::Instant::now();
-
                 for line in text.lines() {
                     spans.extend_from_slice(
                         highlighter.highlight_line(&format!("{line}\n")),
                     );
                 }
-
-                dbg!(start.elapsed());
 
                 return None;
             }

--- a/widget/src/markdown.rs
+++ b/widget/src/markdown.rs
@@ -527,6 +527,8 @@ pub struct Settings {
     pub h6_size: Pixels,
     /// The text size used in code blocks.
     pub code_size: Pixels,
+    /// The spacing to be used between elements.
+    pub spacing: Pixels,
 }
 
 impl Settings {
@@ -547,6 +549,7 @@ impl Settings {
             h5_size: text_size,
             h6_size: text_size,
             code_size: text_size * 0.75,
+            spacing: text_size * 0.875,
         }
     }
 }
@@ -649,9 +652,8 @@ where
         h5_size,
         h6_size,
         code_size,
+        spacing,
     } = settings;
-
-    let spacing = text_size * 0.625;
 
     let blocks = items.into_iter().enumerate().map(|(i, item)| match item {
         Item::Heading(level, heading) => {
@@ -675,11 +677,21 @@ where
         }
         Item::List { start: None, items } => {
             column(items.iter().map(|items| {
-                row![text("•").size(text_size), view(items, settings, style)]
-                    .spacing(spacing)
-                    .into()
+                row![
+                    text("•").size(text_size),
+                    view(
+                        items,
+                        Settings {
+                            spacing: settings.spacing * 0.6,
+                            ..settings
+                        },
+                        style
+                    )
+                ]
+                .spacing(spacing)
+                .into()
             }))
-            .spacing(spacing)
+            .spacing(spacing * 0.75)
             .into()
         }
         Item::List {
@@ -688,12 +700,19 @@ where
         } => column(items.iter().enumerate().map(|(i, items)| {
             row![
                 text!("{}.", i as u64 + *start).size(text_size),
-                view(items, settings, style)
+                view(
+                    items,
+                    Settings {
+                        spacing: settings.spacing * 0.6,
+                        ..settings
+                    },
+                    style
+                )
             ]
             .spacing(spacing)
             .into()
         }))
-        .spacing(spacing)
+        .spacing(spacing * 0.75)
         .into(),
         Item::CodeBlock(code) => container(
             scrollable(

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -144,8 +144,8 @@ where
     }
 
     /// Sets the [`Id`] of the [`Scrollable`].
-    pub fn id(mut self, id: Id) -> Self {
-        self.id = Some(id);
+    pub fn id(mut self, id: impl Into<Id>) -> Self {
+        self.id = Some(id.into());
         self
     }
 
@@ -1228,25 +1228,36 @@ impl From<Id> for widget::Id {
     }
 }
 
+impl From<&'static str> for Id {
+    fn from(id: &'static str) -> Self {
+        Self::new(id)
+    }
+}
+
 /// Produces a [`Task`] that snaps the [`Scrollable`] with the given [`Id`]
 /// to the provided [`RelativeOffset`].
-pub fn snap_to<T>(id: Id, offset: RelativeOffset) -> Task<T> {
-    task::effect(Action::widget(operation::scrollable::snap_to(id.0, offset)))
+pub fn snap_to<T>(id: impl Into<Id>, offset: RelativeOffset) -> Task<T> {
+    task::effect(Action::widget(operation::scrollable::snap_to(
+        id.into().0,
+        offset,
+    )))
 }
 
 /// Produces a [`Task`] that scrolls the [`Scrollable`] with the given [`Id`]
 /// to the provided [`AbsoluteOffset`].
-pub fn scroll_to<T>(id: Id, offset: AbsoluteOffset) -> Task<T> {
+pub fn scroll_to<T>(id: impl Into<Id>, offset: AbsoluteOffset) -> Task<T> {
     task::effect(Action::widget(operation::scrollable::scroll_to(
-        id.0, offset,
+        id.into().0,
+        offset,
     )))
 }
 
 /// Produces a [`Task`] that scrolls the [`Scrollable`] with the given [`Id`]
 /// by the provided [`AbsoluteOffset`].
-pub fn scroll_by<T>(id: Id, offset: AbsoluteOffset) -> Task<T> {
+pub fn scroll_by<T>(id: impl Into<Id>, offset: AbsoluteOffset) -> Task<T> {
     task::effect(Action::widget(operation::scrollable::scroll_by(
-        id.0, offset,
+        id.into().0,
+        offset,
     )))
 }
 

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -999,9 +999,9 @@ where
                             content_layout,
                             cursor,
                             &Rectangle {
-                                y: bounds.y + translation.y,
-                                x: bounds.x + translation.x,
-                                ..bounds
+                                y: visible_bounds.y + translation.y,
+                                x: visible_bounds.x + translation.x,
+                                ..visible_bounds
                             },
                         );
                     },
@@ -1103,9 +1103,9 @@ where
                 content_layout,
                 cursor,
                 &Rectangle {
-                    x: bounds.x + translation.x,
-                    y: bounds.y + translation.y,
-                    ..bounds
+                    x: visible_bounds.x + translation.x,
+                    y: visible_bounds.y + translation.y,
+                    ..visible_bounds
                 },
             );
         }

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -788,13 +788,7 @@ where
                                 (x, y)
                             };
 
-                            let is_vertical = match self.direction {
-                                Direction::Vertical(_) => true,
-                                Direction::Horizontal(_) => false,
-                                Direction::Both { .. } => !is_shift_pressed,
-                            };
-
-                            let movement = if is_vertical {
+                            let movement = if !is_shift_pressed {
                                 Vector::new(x, y)
                             } else {
                                 Vector::new(y, x)

--- a/widget/src/stack.rs
+++ b/widget/src/stack.rs
@@ -216,6 +216,8 @@ where
         viewport: &Rectangle,
     ) {
         let is_over = cursor.is_over(layout.bounds());
+        let is_mouse_movement =
+            matches!(event, Event::Mouse(mouse::Event::CursorMoved { .. }));
 
         for ((child, state), layout) in self
             .children
@@ -235,7 +237,10 @@ where
                 viewport,
             );
 
-            if is_over && cursor != mouse::Cursor::Unavailable {
+            if is_over
+                && !is_mouse_movement
+                && cursor != mouse::Cursor::Unavailable
+            {
                 let interaction = child.as_widget().mouse_interaction(
                     state, layout, cursor, viewport, renderer,
                 );

--- a/widget/src/text/rich.rs
+++ b/widget/src/text/rich.rs
@@ -395,8 +395,10 @@ where
                     .state
                     .downcast_mut::<State<Link, Renderer::Paragraph>>();
 
-                state.span_pressed = self.hovered_link;
-                shell.capture_event();
+                if self.hovered_link.is_some() {
+                    state.span_pressed = self.hovered_link;
+                    shell.capture_event();
+                }
             }
             Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) => {
                 let state = tree

--- a/widget/src/text/rich.rs
+++ b/widget/src/text/rich.rs
@@ -30,6 +30,7 @@ where
     align_y: alignment::Vertical,
     wrapping: Wrapping,
     class: Theme::Class<'a>,
+    hovered_link: Option<usize>,
 }
 
 impl<'a, Link, Theme, Renderer> Rich<'a, Link, Theme, Renderer>
@@ -52,6 +53,7 @@ where
             align_y: alignment::Vertical::Top,
             wrapping: Wrapping::default(),
             class: Theme::default(),
+            hovered_link: None,
         }
     }
 
@@ -236,7 +238,7 @@ where
         theme: &Theme,
         defaults: &renderer::Style,
         layout: Layout<'_>,
-        cursor: mouse::Cursor,
+        _cursor: mouse::Cursor,
         viewport: &Rectangle,
     ) {
         if !layout.bounds().intersects(viewport) {
@@ -249,13 +251,8 @@ where
 
         let style = theme.style(&self.class);
 
-        let hovered_span = cursor
-            .position_in(layout.bounds())
-            .and_then(|position| state.paragraph.hit_span(position));
-
         for (index, span) in self.spans.as_ref().as_ref().iter().enumerate() {
-            let is_hovered_link =
-                span.link.is_some() && Some(index) == hovered_span;
+            let is_hovered_link = Some(index) == self.hovered_link;
 
             if span.highlight.is_some()
                 || span.underline
@@ -369,53 +366,59 @@ where
         shell: &mut Shell<'_, Link>,
         _viewport: &Rectangle,
     ) {
+        let was_hovered = self.hovered_link.is_some();
+
+        if let Some(position) = cursor.position_in(layout.bounds()) {
+            let state = tree
+                .state
+                .downcast_ref::<State<Link, Renderer::Paragraph>>();
+
+            self.hovered_link =
+                state.paragraph.hit_span(position).and_then(|span| {
+                    if self.spans.as_ref().as_ref().get(span)?.link.is_some() {
+                        Some(span)
+                    } else {
+                        None
+                    }
+                });
+        } else {
+            self.hovered_link = None;
+        }
+
+        if was_hovered != self.hovered_link.is_some() {
+            shell.request_redraw();
+        }
+
         match event {
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) => {
-                if let Some(position) = cursor.position_in(layout.bounds()) {
-                    let state = tree
-                        .state
-                        .downcast_mut::<State<Link, Renderer::Paragraph>>();
+                let state = tree
+                    .state
+                    .downcast_mut::<State<Link, Renderer::Paragraph>>();
 
-                    if let Some(span) = state.paragraph.hit_span(position) {
-                        if self
-                            .spans
-                            .as_ref()
-                            .as_ref()
-                            .get(span)
-                            .is_some_and(|span| span.link.is_some())
-                        {
-                            state.span_pressed = Some(span);
-                            shell.capture_event();
-                        }
-                    }
-                }
+                state.span_pressed = self.hovered_link;
+                shell.capture_event();
             }
             Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) => {
                 let state = tree
                     .state
                     .downcast_mut::<State<Link, Renderer::Paragraph>>();
 
-                if let Some(span_pressed) = state.span_pressed {
-                    state.span_pressed = None;
-
-                    if let Some(position) = cursor.position_in(layout.bounds())
-                    {
-                        match state.paragraph.hit_span(position) {
-                            Some(span) if span == span_pressed => {
-                                if let Some(link) = self
-                                    .spans
-                                    .as_ref()
-                                    .as_ref()
-                                    .get(span)
-                                    .and_then(|span| span.link.clone())
-                                {
-                                    shell.publish(link);
-                                }
-                            }
-                            _ => {}
+                match state.span_pressed {
+                    Some(span) if Some(span) == self.hovered_link => {
+                        if let Some(link) = self
+                            .spans
+                            .as_ref()
+                            .as_ref()
+                            .get(span)
+                            .and_then(|span| span.link.clone())
+                        {
+                            shell.publish(link);
                         }
                     }
+                    _ => {}
                 }
+
+                state.span_pressed = None;
             }
             _ => {}
         }
@@ -423,29 +426,17 @@ where
 
     fn mouse_interaction(
         &self,
-        tree: &Tree,
-        layout: Layout<'_>,
-        cursor: mouse::Cursor,
+        _tree: &Tree,
+        _layout: Layout<'_>,
+        _cursor: mouse::Cursor,
         _viewport: &Rectangle,
         _renderer: &Renderer,
     ) -> mouse::Interaction {
-        if let Some(position) = cursor.position_in(layout.bounds()) {
-            let state = tree
-                .state
-                .downcast_ref::<State<Link, Renderer::Paragraph>>();
-
-            if let Some(span) = state
-                .paragraph
-                .hit_span(position)
-                .and_then(|span| self.spans.as_ref().as_ref().get(span))
-            {
-                if span.link.is_some() {
-                    return mouse::Interaction::Pointer;
-                }
-            }
+        if self.hovered_link.is_some() {
+            mouse::Interaction::Pointer
+        } else {
+            mouse::Interaction::None
         }
-
-        mouse::Interaction::None
     }
 }
 

--- a/widget/src/text/rich.rs
+++ b/widget/src/text/rich.rs
@@ -239,6 +239,10 @@ where
         cursor: mouse::Cursor,
         viewport: &Rectangle,
     ) {
+        if !layout.bounds().intersects(viewport) {
+            return;
+        }
+
         let state = tree
             .state
             .downcast_ref::<State<Link, Renderer::Paragraph>>();

--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -110,6 +110,8 @@ pub struct TextEditor<
     line_height: LineHeight,
     width: Length,
     height: Length,
+    min_height: f32,
+    max_height: f32,
     padding: Padding,
     wrapping: Wrapping,
     class: Theme::Class<'a>,
@@ -139,6 +141,8 @@ where
             line_height: LineHeight::default(),
             width: Length::Fill,
             height: Length::Shrink,
+            min_height: 0.0,
+            max_height: f32::INFINITY,
             padding: Padding::new(5.0),
             wrapping: Wrapping::default(),
             class: Theme::default(),
@@ -169,15 +173,27 @@ where
         self
     }
 
+    /// Sets the width of the [`TextEditor`].
+    pub fn width(mut self, width: impl Into<Pixels>) -> Self {
+        self.width = Length::from(width.into());
+        self
+    }
+
     /// Sets the height of the [`TextEditor`].
     pub fn height(mut self, height: impl Into<Length>) -> Self {
         self.height = height.into();
         self
     }
 
-    /// Sets the width of the [`TextEditor`].
-    pub fn width(mut self, width: impl Into<Pixels>) -> Self {
-        self.width = Length::from(width.into());
+    /// Sets the minimum height of the [`TextEditor`].
+    pub fn min_height(mut self, min_height: impl Into<Pixels>) -> Self {
+        self.min_height = min_height.into().0;
+        self
+    }
+
+    /// Sets the maximum height of the [`TextEditor`].
+    pub fn max_height(mut self, max_height: impl Into<Pixels>) -> Self {
+        self.max_height = max_height.into().0;
         self
     }
 
@@ -265,6 +281,8 @@ where
             line_height: self.line_height,
             width: self.width,
             height: self.height,
+            min_height: self.min_height,
+            max_height: self.max_height,
             padding: self.padding,
             wrapping: self.wrapping,
             class: self.class,
@@ -549,7 +567,11 @@ where
             state.highlighter_settings = self.highlighter_settings.clone();
         }
 
-        let limits = limits.width(self.width).height(self.height);
+        let limits = limits
+            .width(self.width)
+            .height(self.height)
+            .min_height(self.min_height)
+            .max_height(self.max_height);
 
         internal.editor.update(
             limits.shrink(self.padding).max(),

--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -768,6 +768,10 @@ where
                         }
                     }
 
+                    if !matches!(binding, Binding::Unfocus) {
+                        shell.capture_event();
+                    }
+
                     apply_binding(
                         binding,
                         self.content,
@@ -780,8 +784,6 @@ where
                     if let Some(focus) = &mut state.focus {
                         focus.updated_at = Instant::now();
                     }
-
-                    shell.capture_event();
                 }
             }
         }


### PR DESCRIPTION
This PR introduces a new `Content` type in the `markdown` module that allows users to incrementally parse Markdown—using its `push_str` method.

This is specially useful when you have potentially long Markdown streams—like an LLM reply in an AI chat application.

In fact, [`icebreaker`](https://github.com/hecrj/icebreaker) has been the main driver of this feature (see https://github.com/hecrj/icebreaker/pull/7):

https://github.com/user-attachments/assets/f3203d6f-3732-4374-919f-7dd2120c0bc6

These changes also fix a bunch of minor issues and improve some APIs:

- The `spacing` of Markdown items can be configured through `markdown::Settings`.
- Big Markdown items have been split into multiple smaller ones to aid diffing and layouting.
- Functions asking for a `container::Id` or `scrollable::Id` now uses `Into` generics. These types also implement `From<&'static str>` now.
- `text_editor` no longer captures unfocus events.
- `stack` now propagates mouse movements unconditionally to all layers. This allows widgets that are being interacted with to still work even when the mouse hovers layers on top.
- `rich_text` now requests redraws properly when a link is hovered.
- Horizontal scrolling with mouse wheel now requires `Shift` pressed.

And I think that's about it!