### PR TITLE
iced_test: Add `Snapshot::into_inner()` fn

### DIFF
--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -539,6 +539,11 @@ impl Snapshot {
             Ok(true)
         }
     }
+
+    /// Returns the inner [`window::Screenshot`] of the [`Snapshot`].
+    pub fn into_inner(self) -> window::Screenshot {
+        self.screenshot
+    }
 }
 
 /// Returns the sequence of events of a click.


### PR DESCRIPTION
https://github.com/mitsuhiko/insta lately gained experimental support for binary snapshots. Unfortunately the `Snapshot` struct in the `iced_test` crate currently does not give access to the underlying binary data of the screenshot, so `insta` can't be used for this purpose.

This PR adds an `into_inner()` fn to the `Snapshot` struct to solve this problem. Let me know if you would prefer a `fn screenshot() -> &Screenshot` fn or something like that.