### PR TITLE
feat: 'Toggler' animation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "animations"
+version = "0.1.0"
+dependencies = [
+ "iced",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,8 @@ auto-detect-theme = ["iced_core/auto-detect-theme"]
 strict-assertions = ["iced_renderer/strict-assertions"]
 # Redraws on every runtime event, and not only when a widget requests it
 unconditional-rendering = ["iced_winit/unconditional-rendering"]
+# Enables widget animations
+animations = ["iced_widget/animations"]
 
 [dependencies]
 iced_core.workspace = true

--- a/core/src/animation.rs
+++ b/core/src/animation.rs
@@ -101,6 +101,17 @@ where
         self.raw.transition(new_state, Instant::now());
     }
 
+    /// Instantaneously transitions the [`Animation`] from its current state to the given new state.
+    pub fn force(mut self, new_state: T) -> Self {
+        self.force_mut(new_state);
+        self
+    }
+
+    /// Instantaneously transitions the [`Animation`] from its current state to the given new state, by reference.
+    pub fn force_mut(&mut self, new_state: T) {
+        self.raw.transition_instantaneous(new_state, Instant::now());
+    }
+
     /// Returns true if the [`Animation`] is currently in progress.
     ///
     /// An [`Animation`] is in progress when it is transitioning to a different state.

--- a/core/src/theme/palette.rs
+++ b/core/src/theme/palette.rs
@@ -631,7 +631,8 @@ fn lighten(color: Color, amount: f32) -> Color {
     from_hsl(hsl)
 }
 
-fn deviate(color: Color, amount: f32) -> Color {
+/// Lighten dark colors and darken light ones by the specefied amount.
+pub fn deviate(color: Color, amount: f32) -> Color {
     if is_dark(color) {
         lighten(color, amount)
     } else {
@@ -647,7 +648,8 @@ fn muted(color: Color) -> Color {
     from_hsl(hsl)
 }
 
-fn mix(a: Color, b: Color, factor: f32) -> Color {
+/// Mix with another color with the given ratio (from 0 to 1)
+pub fn mix(a: Color, b: Color, factor: f32) -> Color {
     let a_lin = Rgb::from(a).into_linear();
     let b_lin = Rgb::from(b).into_linear();
 

--- a/examples/animations/Cargo.toml
+++ b/examples/animations/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "animations"
+version = "0.1.0"
+authors = ["LazyTanuki"]
+edition = "2021"
+publish = false
+
+[dependencies]
+iced.workspace = true
+iced.features = ["animations"]

--- a/examples/animations/README.md
+++ b/examples/animations/README.md
@@ -1,0 +1,12 @@
+# Animations
+
+An application to showcase Iced widgets that have default animations.
+
+The __[`main`]__ file contains all the code of the example.
+
+You can run it with `cargo run`:
+```
+cargo run --package animations
+```
+
+[`main`]: src/main.rs

--- a/examples/animations/src/main.rs
+++ b/examples/animations/src/main.rs
@@ -1,0 +1,49 @@
+use iced::{
+    widget::{column, Toggler},
+    Element, Task, Theme,
+};
+
+pub fn main() -> iced::Result {
+    iced::application("Animated widgets", Animations::update, Animations::view)
+        .theme(Animations::theme)
+        .run()
+}
+
+#[derive(Default)]
+struct Animations {
+    toggled: bool,
+}
+
+#[derive(Debug, Clone)]
+enum Message {
+    Toggle(bool),
+}
+
+impl Animations {
+    fn update(&mut self, message: Message) -> Task<Message> {
+        match message {
+            Message::Toggle(t) => {
+                self.toggled = t;
+                Task::none()
+            }
+        }
+    }
+
+    fn view(&self) -> Element<Message> {
+        let main_text = iced::widget::text(
+            "You can find all widgets with default animations here.",
+        );
+        let toggle = Toggler::new(self.toggled)
+            .label("Toggle me!")
+            .on_toggle(Message::Toggle);
+        column![main_text, toggle]
+            .spacing(10)
+            .padding(50)
+            .max_width(800)
+            .into()
+    }
+
+    fn theme(&self) -> Theme {
+        Theme::Light
+    }
+}

--- a/widget/Cargo.toml
+++ b/widget/Cargo.toml
@@ -27,6 +27,7 @@ wgpu = ["iced_renderer/wgpu"]
 markdown = ["dep:pulldown-cmark", "dep:url"]
 highlighter = ["dep:iced_highlighter"]
 advanced = []
+animations = []
 
 [dependencies]
 iced_renderer.workspace = true

--- a/widget/src/toggler.rs
+++ b/widget/src/toggler.rs
@@ -450,7 +450,6 @@ where
 
         let mut children = layout.children();
         let toggler_layout = children.next().unwrap();
-        let state = tree.state.downcast_ref::<State<Renderer::Paragraph>>();
 
         if self.label.is_some() {
             let label_layout = children.next().unwrap();
@@ -496,7 +495,7 @@ where
             style.background,
         );
 
-        let x_ratio = state.transition.interpolate(0.0, 1.0, state.now);
+        let x_ratio = style.foreground_bounds_horizontal_progress;
         let toggler_foreground_bounds = Rectangle {
             x: bounds.x
                 + (2.0 * space + (x_ratio * (bounds.width - bounds.height))),
@@ -570,6 +569,8 @@ pub struct Style {
     pub foreground_border_width: f32,
     /// The [`Color`] of the foreground border of the toggler.
     pub foreground_border_color: Color,
+    /// The horizontal progress ratio of the foreground bounds of the toggler.
+    pub foreground_bounds_horizontal_progress: f32,
 }
 
 /// The theme catalog of a [`Toggler`].
@@ -658,6 +659,18 @@ pub fn default(theme: &Theme, status: Status) -> Style {
         Status::Disabled => palette.background.base.color,
     };
 
+    let foreground_bounds_horizontal_progress = match status {
+        Status::Active {
+            is_toggled: _,
+            animation_progress,
+        } => animation_progress,
+        Status::Hovered {
+            is_toggled: _,
+            animation_progress,
+        } => animation_progress,
+        Status::Disabled => 0.0,
+    };
+
     Style {
         background,
         foreground,
@@ -665,5 +678,6 @@ pub fn default(theme: &Theme, status: Status) -> Style {
         foreground_border_color: Color::TRANSPARENT,
         background_border_width: 0.0,
         background_border_color: Color::TRANSPARENT,
+        foreground_bounds_horizontal_progress,
     }
 }


### PR DESCRIPTION
Hi!

This is the continuation of #2483 for the 'Toggler' widget animation based on the recently merged #2757.

To respect the `animations` feature flag, we still use the animation code but the animation is just instantaneous, which IMO reduces the code complexity as opposed to having several features gates.

The toggler movement follows an "ease out" animation, and the background color smoothly transitions from one state to the other as well.

I've also included an example crate which is supposed to showcase all animated widgets as they land. ('cargo run -rp animations')

Thanks!

[Kooha-2025-02-02-20-08-42.webm](https://github.com/user-attachments/assets/06880b11-8083-4b97-86fd-5f3fb8d05ef0)
