### PR TITLE
Remove the placeholder text when IME is activated in text input

### DIFF
--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -582,7 +582,13 @@ where
         };
 
         let draw = |renderer: &mut Renderer, viewport| {
-            let paragraph = if text.is_empty() {
+            let paragraph = if text.is_empty()
+                && state
+                    .is_ime_open
+                    .as_ref()
+                    .map(|preedit| preedit.content.is_empty())
+                    .unwrap_or(true)
+            {
                 state.placeholder.raw()
             } else {
                 state.value.raw()


### PR DESCRIPTION
This PR fixes that the placeholder text is not removed when IME is activated.

## Problem

When the preedit window is opened, the placeholder text is not removed. This is weird because the text input is already editing the content but the placeholder text is still there.

https://github.com/user-attachments/assets/327be471-b662-41bf-af96-5515669cbf91

## Solution

This PR removes the placeholder text when the input method is activated even if the text input content is not committed. This is the same behavior as `<input>` element of web browsers.

https://github.com/user-attachments/assets/2d2bc50e-fcc6-4867-a48e-88e3c6179a23





