### PR TITLE
Adjust preedit position in text input not to overlap cursor

### DIFF
--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -431,7 +431,8 @@ where
         );
 
         let x = (text_bounds.x + cursor_x).floor() - scroll_offset
-            + alignment_offset;
+            + alignment_offset
+            + 1.0;
 
         InputMethod::Open {
             position: Point::new(x, text_bounds.y + text_bounds.height),


### PR DESCRIPTION
## Problem

Currently the preedit window overlaps the cursor as follows.


https://github.com/user-attachments/assets/0d04ffed-2545-4b2b-98cd-eaa137bad497

## Solution

This PR adjusts the preedit position not to overwrap the cursor.

https://github.com/user-attachments/assets/49ea9dc4-0d93-4bf7-9953-a870074d19a0


