### PR TITLE
Set correct text size for preedit window

### DIFF
--- a/core/src/input_method.rs
+++ b/core/src/input_method.rs
@@ -40,14 +40,11 @@ pub struct Preedit<T = String> {
 
 impl<T> Preedit<T> {
     /// Creates a new empty [`Preedit`].
-    pub fn new(text_size: Option<impl Into<Pixels>>) -> Self
+    pub fn new() -> Self
     where
         T: Default,
     {
-        Self {
-            text_size: text_size.map(Into::into),
-            ..Default::default()
-        }
+        Self::default()
     }
 
     /// Turns a [`Preedit`] into its owned version.

--- a/core/src/input_method.rs
+++ b/core/src/input_method.rs
@@ -1,5 +1,5 @@
 //! Listen to input method events.
-use crate::Point;
+use crate::{Pixels, Point};
 
 use std::ops::Range;
 
@@ -34,15 +34,20 @@ pub struct Preedit<T = String> {
     pub content: T,
     /// The selected range of the content.
     pub selection: Option<Range<usize>>,
+    /// The text size of the content.
+    pub text_size: Option<Pixels>,
 }
 
 impl<T> Preedit<T> {
     /// Creates a new empty [`Preedit`].
-    pub fn new() -> Self
+    pub fn new(text_size: Option<impl Into<Pixels>>) -> Self
     where
         T: Default,
     {
-        Self::default()
+        Self {
+            text_size: text_size.map(Into::into),
+            ..Default::default()
+        }
     }
 
     /// Turns a [`Preedit`] into its owned version.
@@ -53,6 +58,7 @@ impl<T> Preedit<T> {
         Preedit {
             content: self.content.as_ref().to_owned(),
             selection: self.selection.clone(),
+            text_size: self.text_size,
         }
     }
 }
@@ -63,6 +69,7 @@ impl Preedit {
         Preedit {
             content: &self.content,
             selection: self.selection.clone(),
+            text_size: self.text_size,
         }
     }
 }
@@ -90,13 +97,13 @@ impl InputMethod {
     /// let open = InputMethod::Open {
     ///     position: Point::ORIGIN,
     ///     purpose: Purpose::Normal,
-    ///     preedit: Some(Preedit { content: "1".to_owned(), selection: None }),
+    ///     preedit: Some(Preedit { content: "1".to_owned(), selection: None, text_size: None }),
     /// };
     ///
     /// let open_2 = InputMethod::Open {
     ///     position: Point::ORIGIN,
     ///     purpose: Purpose::Secure,
-    ///     preedit: Some(Preedit { content: "2".to_owned(), selection: None }),
+    ///     preedit: Some(Preedit { content: "2".to_owned(), selection: None, text_size: None }),
     /// };
     ///
     /// let mut ime = InputMethod::Disabled;

--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -753,14 +753,18 @@ where
                 }
                 Update::InputMethod(update) => match update {
                     Ime::Toggle(is_open) => {
-                        state.preedit =
-                            is_open.then(input_method::Preedit::new);
+                        state.preedit = is_open.then(|| {
+                            input_method::Preedit::new(self.text_size)
+                        });
 
                         shell.request_redraw();
                     }
                     Ime::Preedit { content, selection } => {
-                        state.preedit =
-                            Some(input_method::Preedit { content, selection });
+                        state.preedit = Some(input_method::Preedit {
+                            content,
+                            selection,
+                            text_size: self.text_size,
+                        });
 
                         shell.request_redraw();
                     }

--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -753,11 +753,8 @@ where
                 }
                 Update::InputMethod(update) => match update {
                     Ime::Toggle(is_open) => {
-                        state.preedit = is_open.then(|| {
-                            let mut preedit = input_method::Preedit::new();
-                            preedit.text_size = self.text_size;
-                            preedit
-                        });
+                        state.preedit =
+                            is_open.then(input_method::Preedit::new);
 
                         shell.request_redraw();
                     }

--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -754,7 +754,9 @@ where
                 Update::InputMethod(update) => match update {
                     Ime::Toggle(is_open) => {
                         state.preedit = is_open.then(|| {
-                            input_method::Preedit::new(self.text_size)
+                            let mut preedit = input_method::Preedit::new();
+                            preedit.text_size = self.text_size;
+                            preedit
                         });
 
                         shell.request_redraw();

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -1261,8 +1261,13 @@ where
                     let state = state::<Renderer>(tree);
 
                     state.is_ime_open =
-                        matches!(event, input_method::Event::Opened)
-                            .then(|| input_method::Preedit::new(self.size));
+                        matches!(event, input_method::Event::Opened).then(
+                            || {
+                                let mut preedit = input_method::Preedit::new();
+                                preedit.text_size = self.size;
+                                preedit
+                            },
+                        );
 
                     shell.request_redraw();
                 }

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -1262,7 +1262,7 @@ where
 
                     state.is_ime_open =
                         matches!(event, input_method::Event::Opened)
-                            .then(input_method::Preedit::new);
+                            .then(|| input_method::Preedit::new(self.size));
 
                     shell.request_redraw();
                 }
@@ -1273,6 +1273,7 @@ where
                         state.is_ime_open = Some(input_method::Preedit {
                             content: content.to_owned(),
                             selection: selection.clone(),
+                            text_size: self.size,
                         });
 
                         shell.request_redraw();

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -1261,13 +1261,8 @@ where
                     let state = state::<Renderer>(tree);
 
                     state.is_ime_open =
-                        matches!(event, input_method::Event::Opened).then(
-                            || {
-                                let mut preedit = input_method::Preedit::new();
-                                preedit.text_size = self.size;
-                                preedit
-                            },
-                        );
+                        matches!(event, input_method::Event::Opened)
+                            .then(input_method::Preedit::new);
 
                     shell.request_redraw();
                 }

--- a/winit/src/program/window_manager.rs
+++ b/winit/src/program/window_manager.rs
@@ -322,7 +322,9 @@ where
             self.content = Renderer::Paragraph::with_spans(Text {
                 content: &spans,
                 bounds: Size::INFINITY,
-                size: renderer.default_size(),
+                size: preedit
+                    .text_size
+                    .unwrap_or_else(|| renderer.default_size()),
                 line_height: text::LineHeight::default(),
                 font: renderer.default_font(),
                 horizontal_alignment: alignment::Horizontal::Left,


### PR DESCRIPTION
## Problem

Currently the text size of preedit window is fixed to `renderer.default_size()`. However the text size of text input and text editor can be changed by user. Using same size for preedit window is more natural.

https://github.com/user-attachments/assets/8e3bb738-4f9a-4648-9005-29893241a102

## Solution

This PR propagates the text size from the widget which requests IME to the window manager which manages the event loop. The propagated text size is used when the preedit window is rendered if available.

https://github.com/user-attachments/assets/5629c1ea-0c5a-4f5f-b941-66ff6f9d57f9


