### PR TITLE
Suppress two clippy false-positives which are only valid when some features are disabled

### DIFF
--- a/core/src/theme.rs
+++ b/core/src/theme.rs
@@ -162,6 +162,7 @@ impl Theme {
     }
 }
 
+#[allow(clippy::derivable_impls)]
 impl Default for Theme {
     fn default() -> Self {
         #[cfg(feature = "auto-detect-theme")]

--- a/wgpu/src/layer.rs
+++ b/wgpu/src/layer.rs
@@ -287,6 +287,7 @@ impl Default for Layer {
             triangles: triangle::Batch::default(),
             primitives: primitive::Batch::default(),
             text: text::Batch::default(),
+            #[allow(clippy::default_constructed_unit_structs)]
             images: image::Batch::default(),
             pending_meshes: Vec::new(),
             pending_text: Vec::new(),


### PR DESCRIPTION
This PR suppresses two false-positives from clippy.

- clippy complains about not using `#[default]` for `Theme` enum but it is only valid when `auto-detect-theme` feature is disabled.
  ```
  warning: this `impl` can be derived
     --> core/src/theme.rs:165:1
      |
  165 | / impl Default for Theme {
  166 | |     fn default() -> Self {
  167 | |         #[cfg(feature = "auto-detect-theme")]
  168 | |         {
  ...   |
  187 | |     }
  188 | | }
      | |_^
  ```
- clippy complains about constructing a unit tuple with `default()` constructor but it is only valid when both `image` and `svg` features are disabled.
  ```
  warning: use of `default` to create a unit struct
     --> wgpu/src/layer.rs:290:33
      |
  290 |             images: image::Batch::default(),
      |                                 ^^^^^^^^^^^ help: remove this call to `default`
      |
  ```