### PR TITLE
Fix the initial candidate window position

### DIFF
--- a/core/src/shell.rs
+++ b/core/src/shell.rs
@@ -27,7 +27,7 @@ impl<'a, Message> Shell<'a, Message> {
             redraw_request: window::RedrawRequest::Wait,
             is_layout_invalid: false,
             are_widgets_invalid: false,
-            input_method: InputMethod::None,
+            input_method: InputMethod::Disabled,
         }
     }
 

--- a/runtime/src/user_interface.rs
+++ b/runtime/src/user_interface.rs
@@ -189,7 +189,7 @@ where
 
         let mut outdated = false;
         let mut redraw_request = window::RedrawRequest::Wait;
-        let mut input_method = InputMethod::None;
+        let mut input_method = InputMethod::Disabled;
 
         let mut manual_overlay = ManuallyDrop::new(
             self.root

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -729,7 +729,7 @@ where
                     _ => mouse::Cursor::Unavailable,
                 };
 
-                let had_input_method = shell.input_method().is_open();
+                let had_input_method = shell.input_method().is_enabled();
 
                 let translation =
                     state.translation(self.direction, bounds, content_bounds);
@@ -750,7 +750,7 @@ where
                 );
 
                 if !had_input_method {
-                    if let InputMethod::Open { position, .. } =
+                    if let InputMethod::Enabled { position, .. } =
                         shell.input_method_mut()
                     {
                         *position = *position - translation;

--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -339,10 +339,6 @@ where
             return InputMethod::Disabled;
         };
 
-        let Some(preedit) = &state.preedit else {
-            return InputMethod::Allowed;
-        };
-
         let bounds = layout.bounds();
         let internal = self.content.0.borrow_mut();
 
@@ -363,10 +359,10 @@ where
         let position =
             cursor + translation + Vector::new(0.0, f32::from(line_height));
 
-        InputMethod::Open {
+        InputMethod::Enabled {
             position,
             purpose: input_method::Purpose::Normal,
-            preedit: Some(preedit.as_ref()),
+            preedit: state.preedit.as_ref().map(input_method::Preedit::as_ref),
         }
     }
 }

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -1319,23 +1319,24 @@ where
                 let state = state::<Renderer>(tree);
 
                 if let Some(focus) = &mut state.is_focused {
-                    if focus.is_window_focused
-                        && matches!(
+                    if focus.is_window_focused {
+                        if matches!(
                             state.cursor.state(&self.value),
                             cursor::State::Index(_)
-                        )
-                    {
-                        focus.now = *now;
+                        ) {
+                            focus.now = *now;
 
-                        let millis_until_redraw = CURSOR_BLINK_INTERVAL_MILLIS
-                            - (*now - focus.updated_at).as_millis()
-                                % CURSOR_BLINK_INTERVAL_MILLIS;
+                            let millis_until_redraw =
+                                CURSOR_BLINK_INTERVAL_MILLIS
+                                    - (*now - focus.updated_at).as_millis()
+                                        % CURSOR_BLINK_INTERVAL_MILLIS;
 
-                        shell.request_redraw_at(
-                            *now + Duration::from_millis(
-                                millis_until_redraw as u64,
-                            ),
-                        );
+                            shell.request_redraw_at(
+                                *now + Duration::from_millis(
+                                    millis_until_redraw as u64,
+                                ),
+                            );
+                        }
 
                         shell.request_input_method(&self.input_method(
                             state,

--- a/winit/src/program/window_manager.rs
+++ b/winit/src/program/window_manager.rs
@@ -234,6 +234,8 @@ where
 
                         self.preedit = Some(overlay);
                     }
+                } else {
+                    self.preedit = None;
                 }
             }
         }

--- a/winit/src/program/window_manager.rs
+++ b/winit/src/program/window_manager.rs
@@ -75,6 +75,7 @@ where
                 mouse_interaction: mouse::Interaction::None,
                 redraw_at: None,
                 preedit: None,
+                ime_state: None,
             },
         );
 
@@ -166,6 +167,7 @@ where
     pub renderer: P::Renderer,
     pub redraw_at: Option<Instant>,
     preedit: Option<Preedit<P::Renderer>>,
+    ime_state: Option<(Point, input_method::Purpose)>,
 }
 
 impl<P, C> Window<P, C>
@@ -206,52 +208,39 @@ where
 
     pub fn request_input_method(&mut self, input_method: InputMethod) {
         match input_method {
-            InputMethod::None => {}
             InputMethod::Disabled => {
-                self.raw.set_ime_allowed(false);
+                self.disable_ime();
             }
-            InputMethod::Allowed | InputMethod::Open { .. } => {
-                self.raw.set_ime_allowed(true);
-            }
-        }
+            InputMethod::Enabled {
+                position,
+                purpose,
+                preedit,
+            } => {
+                self.enable_ime(position, purpose);
 
-        if let InputMethod::Open {
-            position,
-            purpose,
-            preedit,
-        } = input_method
-        {
-            self.raw.set_ime_cursor_area(
-                LogicalPosition::new(position.x, position.y),
-                LogicalSize::new(10, 10), // TODO?
-            );
+                if let Some(preedit) = preedit {
+                    if preedit.content.is_empty() {
+                        self.preedit = None;
+                    } else if let Some(overlay) = &mut self.preedit {
+                        overlay.update(
+                            position,
+                            &preedit,
+                            self.state.background_color(),
+                            &self.renderer,
+                        );
+                    } else {
+                        let mut overlay = Preedit::new();
+                        overlay.update(
+                            position,
+                            &preedit,
+                            self.state.background_color(),
+                            &self.renderer,
+                        );
 
-            self.raw.set_ime_purpose(conversion::ime_purpose(purpose));
-
-            if let Some(preedit) = preedit {
-                if preedit.content.is_empty() {
-                    self.preedit = None;
-                } else if let Some(overlay) = &mut self.preedit {
-                    overlay.update(
-                        position,
-                        &preedit,
-                        self.state.background_color(),
-                        &self.renderer,
-                    );
-                } else {
-                    let mut overlay = Preedit::new();
-                    overlay.update(
-                        position,
-                        &preedit,
-                        self.state.background_color(),
-                        &self.renderer,
-                    );
-
-                    self.preedit = Some(overlay);
+                        self.preedit = Some(overlay);
+                    }
                 }
             }
-        } else {
-            self.preedit = None;
         }
     }
 
@@ -267,6 +256,31 @@ where
                 ),
             );
         }
+    }
+
+    fn enable_ime(&mut self, position: Point, purpose: input_method::Purpose) {
+        if self.ime_state.is_none() {
+            self.raw.set_ime_allowed(true);
+        }
+
+        if self.ime_state != Some((position, purpose)) {
+            self.raw.set_ime_cursor_area(
+                LogicalPosition::new(position.x, position.y),
+                LogicalSize::new(10, 10), // TODO?
+            );
+            self.raw.set_ime_purpose(conversion::ime_purpose(purpose));
+
+            self.ime_state = Some((position, purpose));
+        }
+    }
+
+    fn disable_ime(&mut self) {
+        if self.ime_state.is_some() {
+            self.raw.set_ime_allowed(false);
+            self.ime_state = None;
+        }
+
+        self.preedit = None;
     }
 }
 

--- a/winit/src/program/window_manager.rs
+++ b/winit/src/program/window_manager.rs
@@ -221,15 +221,10 @@ where
                 if let Some(preedit) = preedit {
                     if preedit.content.is_empty() {
                         self.preedit = None;
-                    } else if let Some(overlay) = &mut self.preedit {
-                        overlay.update(
-                            position,
-                            &preedit,
-                            self.state.background_color(),
-                            &self.renderer,
-                        );
                     } else {
-                        let mut overlay = Preedit::new();
+                        let mut overlay =
+                            self.preedit.take().unwrap_or_else(Preedit::new);
+
                         overlay.update(
                             position,
                             &preedit,


### PR DESCRIPTION
Fixes #2792. Closes #2800.

The issue is that the candidate window is already open when `InputMethod::Open` event is handled in the window manager. Since `set_ime_cursor_area` is not called yet when the window is opened, the position of the window is at the top left corner.

To fix this, we need to call `set_ime_cursor_area` earlier before the window is opened. [winit's example](https://github.com/rust-windowing/winit/blob/2230e71093a110d959c245b639faf67a60dca135/examples/window.rs#L687-L690) calls the function just after calling `set_ime_allowed`.

This PR calls the function when allowing IME so `InputMethod::Allowed` event now has the position of the window.

Here is the video:

https://github.com/user-attachments/assets/c8d21b64-71f3-4ff5-80d4-3ddfa6b20718

