### PR TITLE
Add blurhash to gallery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -665,6 +665,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "blurhash"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79769241dcd44edf79a732545e8b5cec84c247ac060f5252cd51885d093a8fc"
+
+[[package]]
 name = "built"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1863,6 +1869,7 @@ dependencies = [
 name = "gallery"
 version = "0.1.0"
 dependencies = [
+ "blurhash",
  "bytes",
  "iced",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -200,6 +200,7 @@ unused_results = "deny"
 
 [workspace.lints.clippy]
 type-complexity = "allow"
+map-entry = "allow"
 semicolon_if_nothing_returned = "deny"
 trivially-copy-pass-by-ref = "deny"
 default_trait_access = "deny"

--- a/core/src/animation.rs
+++ b/core/src/animation.rs
@@ -13,6 +13,7 @@ where
     T: Clone + Copy + PartialEq + Float,
 {
     raw: lilt::Animated<T, Instant>,
+    duration: Duration, // TODO: Expose duration getter in `lilt`
 }
 
 impl<T> Animation<T>
@@ -23,6 +24,7 @@ where
     pub fn new(state: T) -> Self {
         Self {
             raw: lilt::Animated::new(state),
+            duration: Duration::from_millis(100),
         }
     }
 
@@ -58,6 +60,7 @@ where
     /// Sets the duration of the [`Animation`] to the given value.
     pub fn duration(mut self, duration: Duration) -> Self {
         self.raw = self.raw.duration(duration.as_secs_f32() * 1_000.0);
+        self.duration = duration;
         self
     }
 
@@ -132,5 +135,14 @@ impl Animation<bool> {
         I: Interpolable + Clone,
     {
         self.raw.animate_bool(start, end, at)
+    }
+
+    /// Returns the remaining [`Duration`] of the [`Animation`].
+    pub fn remaining(&self, at: Instant) -> Duration {
+        Duration::from_secs_f32(self.interpolate(
+            self.duration.as_secs_f32(),
+            0.0,
+            at,
+        ))
     }
 }

--- a/core/src/length.rs
+++ b/core/src/length.rs
@@ -77,8 +77,8 @@ impl From<f32> for Length {
     }
 }
 
-impl From<u16> for Length {
-    fn from(units: u16) -> Self {
-        Length::Fixed(f32::from(units))
+impl From<u32> for Length {
+    fn from(units: u32) -> Self {
+        Length::Fixed(units as f32)
     }
 }

--- a/core/src/pixels.rs
+++ b/core/src/pixels.rs
@@ -20,9 +20,9 @@ impl From<f32> for Pixels {
     }
 }
 
-impl From<u16> for Pixels {
-    fn from(amount: u16) -> Self {
-        Self(f32::from(amount))
+impl From<u32> for Pixels {
+    fn from(amount: u32) -> Self {
+        Self(amount as f32)
     }
 }
 

--- a/examples/gallery/Cargo.toml
+++ b/examples/gallery/Cargo.toml
@@ -19,5 +19,7 @@ bytes.workspace = true
 image.workspace = true
 tokio.workspace = true
 
+blurhash = "0.2.3"
+
 [lints]
 workspace = true

--- a/examples/gallery/src/civitai.rs
+++ b/examples/gallery/src/civitai.rs
@@ -71,7 +71,7 @@ impl Image {
                         if part.starts_with("width=") {
                             format!("width={width}")
                         } else {
-                            part.to_string()
+                            part.to_owned()
                         }
                     })
                     .collect::<Vec<_>>()

--- a/examples/gallery/src/civitai.rs
+++ b/examples/gallery/src/civitai.rs
@@ -69,7 +69,7 @@ impl Image {
                     .split("/")
                     .map(|part| {
                         if part.starts_with("width=") {
-                            format!("width={width}")
+                            format!("width={}", width * 2) // High DPI
                         } else {
                             part.to_owned()
                         }

--- a/examples/gallery/src/civitai.rs
+++ b/examples/gallery/src/civitai.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 pub struct Image {
     pub id: Id,
     url: String,
+    hash: String,
 }
 
 impl Image {
@@ -40,20 +41,37 @@ impl Image {
         Ok(response.items)
     }
 
+    pub async fn blurhash(
+        self,
+        width: u32,
+        height: u32,
+    ) -> Result<Rgba, Error> {
+        task::spawn_blocking(move || {
+            let pixels = blurhash::decode(&self.hash, width, height, 1.0)?;
+
+            Ok::<_, Error>(Rgba {
+                width,
+                height,
+                pixels: Bytes::from(pixels),
+            })
+        })
+        .await?
+    }
+
     pub async fn download(self, size: Size) -> Result<Rgba, Error> {
         let client = reqwest::Client::new();
 
         let bytes = client
             .get(match size {
                 Size::Original => self.url,
-                Size::Thumbnail => self
+                Size::Thumbnail { width } => self
                     .url
                     .split("/")
                     .map(|part| {
                         if part.starts_with("width=") {
-                            "width=640"
+                            format!("width={width}")
                         } else {
-                            part
+                            part.to_string()
                         }
                     })
                     .collect::<Vec<_>>()
@@ -107,7 +125,7 @@ impl fmt::Debug for Rgba {
 #[derive(Debug, Clone, Copy)]
 pub enum Size {
     Original,
-    Thumbnail,
+    Thumbnail { width: u16 },
 }
 
 #[derive(Debug, Clone)]
@@ -117,6 +135,7 @@ pub enum Error {
     IOFailed(Arc<io::Error>),
     JoinFailed(Arc<task::JoinError>),
     ImageDecodingFailed(Arc<image::ImageError>),
+    BlurhashDecodingFailed(Arc<blurhash::Error>),
 }
 
 impl From<reqwest::Error> for Error {
@@ -140,5 +159,11 @@ impl From<task::JoinError> for Error {
 impl From<image::ImageError> for Error {
     fn from(error: image::ImageError) -> Self {
         Self::ImageDecodingFailed(Arc::new(error))
+    }
+}
+
+impl From<blurhash::Error> for Error {
+    fn from(error: blurhash::Error) -> Self {
+        Self::BlurhashDecodingFailed(Arc::new(error))
     }
 }

--- a/examples/gallery/src/civitai.rs
+++ b/examples/gallery/src/civitai.rs
@@ -125,7 +125,7 @@ impl fmt::Debug for Rgba {
 #[derive(Debug, Clone, Copy)]
 pub enum Size {
     Original,
-    Thumbnail { width: u16 },
+    Thumbnail { width: u32 },
 }
 
 #[derive(Debug, Clone)]

--- a/examples/gallery/src/main.rs
+++ b/examples/gallery/src/main.rs
@@ -97,10 +97,7 @@ impl Gallery {
 
                 Task::batch(vec![
                     Task::perform(
-                        image.clone().blurhash(
-                            Preview::WIDTH as u32,
-                            Preview::HEIGHT as u32,
-                        ),
+                        image.clone().blurhash(Preview::WIDTH, Preview::HEIGHT),
                         move |result| Message::BlurhashDecoded(id, result),
                     ),
                     Task::perform(
@@ -313,8 +310,8 @@ enum Preview {
 }
 
 impl Preview {
-    const WIDTH: u16 = 320;
-    const HEIGHT: u16 = 410;
+    const WIDTH: u32 = 320;
+    const HEIGHT: u32 = 410;
 
     fn blurhash(rgba: Rgba) -> Self {
         Self::Blurhash(Blurhash {

--- a/examples/gallery/src/main.rs
+++ b/examples/gallery/src/main.rs
@@ -7,7 +7,7 @@ mod civitai;
 use crate::civitai::{Error, Id, Image, Rgba, Size};
 
 use iced::animation;
-use iced::time::Instant;
+use iced::time::{milliseconds, Instant};
 use iced::widget::{
     button, center_x, container, horizontal_space, image, mouse_area, opaque,
     pop, row, scrollable, stack,
@@ -290,7 +290,10 @@ impl Preview {
     fn loading(rgba: Rgba) -> Self {
         Self::Loading {
             blurhash: Blurhash {
-                fade_in: Animation::new(false).slow().go(true),
+                fade_in: Animation::new(false)
+                    .duration(milliseconds(700))
+                    .easing(animation::Easing::EaseIn)
+                    .go(true),
                 handle: image::Handle::from_rgba(
                     rgba.width,
                     rgba.height,

--- a/examples/scrollable/src/main.rs
+++ b/examples/scrollable/src/main.rs
@@ -21,9 +21,9 @@ pub fn main() -> iced::Result {
 
 struct ScrollableDemo {
     scrollable_direction: Direction,
-    scrollbar_width: u16,
-    scrollbar_margin: u16,
-    scroller_width: u16,
+    scrollbar_width: u32,
+    scrollbar_margin: u32,
+    scroller_width: u32,
     current_scroll_offset: scrollable::RelativeOffset,
     anchor: scrollable::Anchor,
 }
@@ -39,9 +39,9 @@ enum Direction {
 enum Message {
     SwitchDirection(Direction),
     AlignmentChanged(scrollable::Anchor),
-    ScrollbarWidthChanged(u16),
-    ScrollbarMarginChanged(u16),
-    ScrollerWidthChanged(u16),
+    ScrollbarWidthChanged(u32),
+    ScrollbarMarginChanged(u32),
+    ScrollerWidthChanged(u32),
     ScrollToBeginning,
     ScrollToEnd,
     Scrolled(scrollable::Viewport),

--- a/examples/tour/src/main.rs
+++ b/examples/tour/src/main.rs
@@ -24,12 +24,12 @@ pub struct Tour {
     screen: Screen,
     slider: u8,
     layout: Layout,
-    spacing: u16,
-    text_size: u16,
+    spacing: u32,
+    text_size: u32,
     text_color: Color,
     language: Option<Language>,
     toggler: bool,
-    image_width: u16,
+    image_width: u32,
     image_filter_method: image::FilterMethod,
     input_value: String,
     input_is_secure: bool,
@@ -43,11 +43,11 @@ pub enum Message {
     NextPressed,
     SliderChanged(u8),
     LayoutChanged(Layout),
-    SpacingChanged(u16),
-    TextSizeChanged(u16),
+    SpacingChanged(u32),
+    TextSizeChanged(u32),
     TextColorChanged(Color),
     LanguageSelected(Language),
-    ImageWidthChanged(u16),
+    ImageWidthChanged(u32),
     ImageUseNearestToggled(bool),
     InputChanged(String),
     ToggleSecureInput(bool),
@@ -537,7 +537,7 @@ impl Screen {
 }
 
 fn ferris<'a>(
-    width: u16,
+    width: u32,
     filter_method: image::FilterMethod,
 ) -> Container<'a, Message> {
     center_x(


### PR DESCRIPTION
Adds blurhash decoding in the `gallery` example and interpolates between the blurhash and thumbnail once that's loaded (a transition!):



https://github.com/user-attachments/assets/7e29ff70-a693-4495-844d-2c734db1360f



