### PR TITLE
Fix system informations `cpu_brand` always being empty

### DIFF
--- a/winit/src/system.rs
+++ b/winit/src/system.rs
@@ -17,7 +17,11 @@ pub(crate) fn information(
     let mut system = System::new_all();
     system.refresh_all();
 
-    let cpu = system.global_cpu_info();
+    let cpu_brand = system
+        .cpus()
+        .first()
+        .map(|cpu| cpu.brand().to_string())
+        .unwrap_or_default();
 
     let memory_used = sysinfo::get_current_pid()
         .and_then(|pid| system.process(pid).ok_or("Process not found"))
@@ -29,7 +33,7 @@ pub(crate) fn information(
         system_kernel: System::kernel_version(),
         system_version: System::long_os_version(),
         system_short_version: System::os_version(),
-        cpu_brand: cpu.brand().into(),
+        cpu_brand,
         cpu_cores: system.physical_core_count(),
         memory_total: system.total_memory(),
         memory_used,


### PR DESCRIPTION
This was caused by a misuse of the `global_cpu_info` function, which does not contain a valid `cpu_brand` field.

To fix this, we now get the first cpu and return it's brand instead.

Fixes #2794
