### PR TITLE
Fix the preedit text placement on scrolled content

### DIFF
--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -753,7 +753,7 @@ where
                     if let InputMethod::Open { position, .. } =
                         shell.input_method_mut()
                     {
-                        *position = *position + translation;
+                        *position = *position - translation;
                     }
                 }
             };


### PR DESCRIPTION
@hecrj We missed this on testing on PR.

|Before|
|-|
|![Screenshot_2025-02-07_23-49-31](https://github.com/user-attachments/assets/9879181d-35f0-4df0-8576-2b81fd92e0c3)|

|After|
|-|
|![Screenshot_2025-02-07_23-48-34](https://github.com/user-attachments/assets/811e3356-18dd-47a3-92d4-7e11af66aea9)|

