### PR TITLE
Expand docs for on_link_click in Rich Text

### DIFF
--- a/widget/src/text/rich.rs
+++ b/widget/src/text/rich.rs
@@ -137,6 +137,9 @@ where
 
     /// Sets the message that will be produced when a link of the [`Rich`] text
     /// is clicked.
+    ///
+    /// If there is no link to click, you can call this method with
+    /// `on_link_clicked(never)`.
     pub fn on_link_click(
         mut self,
         on_link_clicked: impl Fn(Link) -> Message + 'a,


### PR DESCRIPTION
0.14-dev introduces the requirement to set `on_link_clicked` for any rich text. The behaviour was not very intuitive to me, and I don't fully understand all the intricacies. 

That said, I would not have come to the conclusion to call `on_link_clicked(never)` (primarily because it seems to hold a Some/None value, setting to a `Some(Box::new(never))` did not feel intuitive to me) without asking somebody else for help, so documenting this permanently somewhere can't hurt.

There's probably a better improvement that can be done somehow.