### PR TITLE
add unfocus operation

### DIFF
--- a/core/src/widget/operation/focusable.rs
+++ b/core/src/widget/operation/focusable.rs
@@ -61,7 +61,7 @@ pub fn focus<T>(target: Id) -> impl Operation<T> {
     Focus { target }
 }
 
-/// Produces an [`Operation`] that unfocuses the focused widget
+/// Produces an [`Operation`] that unfocuses the focused widget.
 pub fn unfocus<T>() -> impl Operation<T> {
     struct Unfocus;
 

--- a/core/src/widget/operation/focusable.rs
+++ b/core/src/widget/operation/focusable.rs
@@ -61,6 +61,33 @@ pub fn focus<T>(target: Id) -> impl Operation<T> {
     Focus { target }
 }
 
+/// Produces an [`Operation`] that unfocuses the focused widget
+pub fn unfocus<T>() -> impl Operation<T> {
+    struct Unfocus;
+
+    impl<T> Operation<T> for Unfocus {
+        fn focusable(
+            &mut self,
+            _id: Option<&Id>,
+            _bounds: Rectangle,
+            state: &mut dyn Focusable,
+        ) {
+            state.unfocus();
+        }
+
+        fn container(
+            &mut self,
+            _id: Option<&Id>,
+            _bounds: Rectangle,
+            operate_on_children: &mut dyn FnMut(&mut dyn Operation<T>),
+        ) {
+            operate_on_children(self);
+        }
+    }
+
+    Unfocus
+}
+
 /// Produces an [`Operation`] that generates a [`Count`] and chains it with the
 /// provided function to build a new [`Operation`].
 pub fn count() -> impl Operation<Count> {


### PR DESCRIPTION
Adds an operation that unfocuses all focusable widgets. Previously this could be done by focusing a guaranteed-to-be-missing widget Id, however having it be its own thing is more intuitive. A use case for this would be to unfocus a `text_input` on submit.