### PR TITLE
Fix updating spans cache for pre-edit content in window manager

### DIFF
--- a/winit/src/program/window_manager.rs
+++ b/winit/src/program/window_manager.rs
@@ -343,6 +343,10 @@ where
                 shaping: text::Shaping::Advanced,
                 wrapping: text::Wrapping::None,
             });
+
+            self.spans.clear();
+            self.spans
+                .extend(spans.into_iter().map(text::Span::to_static));
         }
     }
 


### PR DESCRIPTION
`window_manager::Preedit` caches the spans for checking if the content has been changed. However this field is actually not updated so it does not work as intended.

This PR updates the field correctly so that generating an overlay content can be skipped when the spans haven't changed.