### PR TITLE
`operation::focusable::is_focused` & `text_input::is_focused`

### DIFF
--- a/core/src/widget/operation/focusable.rs
+++ b/core/src/widget/operation/focusable.rs
@@ -285,15 +285,15 @@ pub fn is_focused(target: Id) -> impl Operation<bool> {
             _bounds: Rectangle,
             operate_on_children: &mut dyn FnMut(&mut dyn Operation<bool>),
         ) {
+            if self.is_focused.is_some() {
+                return;
+            }
+
             operate_on_children(self);
         }
 
         fn finish(&self) -> Outcome<bool> {
-            if let Some(is_focused) = &self.is_focused {
-                Outcome::Some(*is_focused)
-            } else {
-                Outcome::None
-            }
+            self.is_focused.map_or(Outcome::None, Outcome::Some)
         }
     }
 

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -1481,6 +1481,11 @@ impl From<String> for Id {
     }
 }
 
+/// Produces a [`Task`] that returns whether the [`TextInput`] with the given [`Id`] is focused or not.
+pub fn is_focused(id: impl Into<Id>) -> Task<bool> {
+    task::widget(operation::focusable::is_focused(id.into().into()))
+}
+
 /// Produces a [`Task`] that focuses the [`TextInput`] with the given [`Id`].
 pub fn focus<T>(id: impl Into<Id>) -> Task<T> {
     task::effect(Action::widget(operation::focusable::focus(id.into().0)))


### PR DESCRIPTION
This PR consists of two additions:

1.  An `is_focused` function that produces an `Operation` that looks for a `focusable` widget by ID, and produces a `bool` that stores whether the widget is focused or not.  This function was modeled after the existing `find_focused`, and for my purposes was a means to implement the second addition.
2.  An `is_focused` function that produces a `Task` that looks for a `text_input` widget by ID, and produces a `bool` with whether the widget is focused or not.

Originally I tried to use the `find_focused` `Operation` for `text_input::is_focused`, but I couldn't figure out how to make it work as desired when there is no currently focused widget (and `find_focused` produces `Outcome::None`).