### PR TITLE
Create a shared window handle struct that implements both window and display traits.

### DIFF
--- a/winit/src/program.rs
+++ b/winit/src/program.rs
@@ -23,6 +23,7 @@ use crate::graphics;
 use crate::graphics::{Compositor, compositor};
 use crate::runtime::Debug;
 use crate::runtime::user_interface::{self, UserInterface};
+use crate::runtime::window::Handle;
 use crate::runtime::{self, Action, Task};
 use crate::{Clipboard, Error, Proxy, Settings};
 
@@ -1461,13 +1462,18 @@ fn run_action<P, C>(
                 }
             }
             window::Action::RunWithHandle(id, f) => {
+                use window::raw_window_handle::HasDisplayHandle;
                 use window::raw_window_handle::HasWindowHandle;
 
-                if let Some(handle) = window_manager
-                    .get_mut(id)
-                    .and_then(|window| window.raw.window_handle().ok())
+                if let Some((Some(window), Some(display))) =
+                    window_manager.get_mut(id).map(|window| {
+                        (
+                            window.raw.window_handle().ok(),
+                            window.raw.display_handle().ok(),
+                        )
+                    })
                 {
-                    f(handle);
+                    f(Handle { window, display });
                 }
             }
             window::Action::Screenshot(id, channel) => {


### PR DESCRIPTION
This is required to use a library like rfd now, where linux support requires the display handle as well, which is always apart of a window anyways. The handle struct prevents exposing the internal window.