### PR TITLE
Relax Task::perform from Fn to more general FnOnce

### DIFF
--- a/runtime/src/task.rs
+++ b/runtime/src/task.rs
@@ -37,7 +37,7 @@ impl<T> Task<T> {
     /// output with the given closure.
     pub fn perform<A>(
         future: impl Future<Output = A> + MaybeSend + 'static,
-        f: impl Fn(A) -> T + MaybeSend + 'static,
+        f: impl FnOnce(A) -> T + MaybeSend + 'static,
     ) -> Self
     where
         T: MaybeSend + 'static,


### PR DESCRIPTION
`FutureExt::map` only requires the more generic `FnOnce` trait (a function capable of being called once) whereas `perform` currently requires a function capable of being called arbitrarily many times. Should be safe:
`Since both Fn and FnMut are subtraits of FnOnce, any instance of Fn or FnMut can be used where a FnOnce is expected.`
[source](https://doc.rust-lang.org/std/ops/trait.FnOnce.html)