### PR TITLE
Add an option for the wgpu feature to disable the default backends.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2510,6 +2510,7 @@ dependencies = [
  "iced_winit",
  "image",
  "thiserror 1.0.69",
+ "wgpu",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,9 @@ maintenance = { status = "actively-developed" }
 [features]
 default = ["wgpu", "tiny-skia", "auto-detect-theme"]
 # Enables the `wgpu` GPU-accelerated renderer backend
-wgpu = ["iced_renderer/wgpu", "iced_widget/wgpu"]
+wgpu = ["wgpu-without-backends", "wgpu/default"]
+# Enables the `wgpu` GPU-accelerated renderer backend without any default backend APIs.
+wgpu-without-backends = ["iced_renderer/wgpu", "iced_widget/wgpu", "dep:wgpu"]
 # Enables the `tiny-skia` software renderer backend
 tiny-skia = ["iced_renderer/tiny-skia"]
 # Enables the `image` widget
@@ -83,6 +85,9 @@ thiserror.workspace = true
 
 image.workspace = true
 image.optional = true
+
+wgpu.workspace = true
+wgpu.optional = true
 
 [dev-dependencies]
 criterion = "0.5"
@@ -188,7 +193,7 @@ wasm-bindgen-futures = "0.4"
 wasmtimer = "0.4.1"
 web-sys = "0.3.69"
 web-time = "1.1"
-wgpu = "23.0"
+wgpu = { version = "23.0", default-features = false, features = ["wgsl"] }
 window_clipboard = "0.4.1"
 winit = { git = "https://github.com/iced-rs/winit.git", rev = "11414b6aa45699f038114e61b4ddf5102b2d3b4b" }
 


### PR DESCRIPTION
- This allows the user to specify which backends they want enabled, just like how the `image-without-codecs` feature works.

Allows significant reduction in binary size on platforms with multiple backends.