### PR TITLE
Expose setting to disable vsync if requested.

### DIFF
--- a/core/src/settings.rs
+++ b/core/src/settings.rs
@@ -33,6 +33,13 @@ pub struct Settings {
     ///
     /// By default, it is disabled.
     pub antialiasing: bool,
+
+    /// Whether or not to attempt to synchronize rendering when possible.
+    ///
+    /// Disabling it can improve rendering performance on some platforms.
+    ///
+    /// By default, it is enabled.
+    pub vsync: bool,
 }
 
 impl Default for Settings {
@@ -43,6 +50,7 @@ impl Default for Settings {
             default_font: Font::default(),
             default_text_size: Pixels(16.0),
             antialiasing: false,
+            vsync: true,
         }
     }
 }

--- a/graphics/src/settings.rs
+++ b/graphics/src/settings.rs
@@ -16,6 +16,11 @@ pub struct Settings {
     ///
     /// By default, it is `None`.
     pub antialiasing: Option<Antialiasing>,
+
+    /// Whether or not to synchronize frames.
+    ///
+    /// By default, it is `true`.
+    pub vsync: bool,
 }
 
 impl Default for Settings {
@@ -24,6 +29,7 @@ impl Default for Settings {
             default_font: Font::default(),
             default_text_size: Pixels(16.0),
             antialiasing: None,
+            vsync: true,
         }
     }
 }

--- a/src/program.rs
+++ b/src/program.rs
@@ -170,6 +170,7 @@ pub trait Program: Sized {
             } else {
                 None
             },
+            vsync: settings.vsync,
             ..crate::graphics::Settings::default()
         };
 
@@ -183,6 +184,7 @@ pub trait Program: Sized {
                 default_font: settings.default_font,
                 default_text_size: settings.default_text_size,
                 antialiasing: settings.antialiasing,
+                vsync: settings.vsync,
             }
             .into(),
             renderer_settings,

--- a/wgpu/src/settings.rs
+++ b/wgpu/src/settings.rs
@@ -44,6 +44,11 @@ impl Default for Settings {
 impl From<graphics::Settings> for Settings {
     fn from(settings: graphics::Settings) -> Self {
         Self {
+            present_mode: if settings.vsync {
+                wgpu::PresentMode::AutoVsync
+            } else {
+                wgpu::PresentMode::AutoNoVsync
+            },
             default_font: settings.default_font,
             default_text_size: settings.default_text_size,
             antialiasing: settings.antialiasing,


### PR DESCRIPTION
- This improves rendering performance on windows 10x and doesn't result in noticeable tearing. The user can decide if they want it anyways.