### PR TITLE
get rid of palette dependency in iced-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2527,7 +2527,6 @@ dependencies = [
  "lilt",
  "log",
  "num-traits",
- "palette",
  "rustc-hash 2.1.1",
  "smol_str",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,7 +164,6 @@ lyon = "1.0"
 lyon_path = "1.0"
 num-traits = "0.2"
 ouroboros = "0.18"
-palette = "0.7"
 png = "0.17"
 pulldown-cmark = "0.12"
 qrcode = { version = "0.13", default-features = false }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -24,7 +24,6 @@ glam.workspace = true
 lilt.workspace = true
 log.workspace = true
 num-traits.workspace = true
-palette.workspace = true
 rustc-hash.workspace = true
 smol_str.workspace = true
 thiserror.workspace = true

--- a/core/src/color.rs
+++ b/core/src/color.rs
@@ -1,5 +1,3 @@
-use palette::rgb::{Srgb, Srgba};
-
 /// A color in the `sRGB` color space.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub struct Color {
@@ -242,70 +240,9 @@ macro_rules! color {
     }};
 }
 
-/// Converts from palette's `Rgba` type to a [`Color`].
-impl From<Srgba> for Color {
-    fn from(rgba: Srgba) -> Self {
-        Color::new(rgba.red, rgba.green, rgba.blue, rgba.alpha)
-    }
-}
-
-/// Converts from [`Color`] to palette's `Rgba` type.
-impl From<Color> for Srgba {
-    fn from(c: Color) -> Self {
-        Srgba::new(c.r, c.g, c.b, c.a)
-    }
-}
-
-/// Converts from palette's `Rgb` type to a [`Color`].
-impl From<Srgb> for Color {
-    fn from(rgb: Srgb) -> Self {
-        Color::new(rgb.red, rgb.green, rgb.blue, 1.0)
-    }
-}
-
-/// Converts from [`Color`] to palette's `Rgb` type.
-impl From<Color> for Srgb {
-    fn from(c: Color) -> Self {
-        Srgb::new(c.r, c.g, c.b)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use palette::blend::Blend;
-
-    #[test]
-    fn srgba_traits() {
-        let c = Color::from_rgb(0.5, 0.4, 0.3);
-        // Round-trip conversion to the palette::Srgba type
-        let s: Srgba = c.into();
-        let r: Color = s.into();
-        assert_eq!(c, r);
-    }
-
-    #[test]
-    fn color_manipulation() {
-        use approx::assert_relative_eq;
-
-        let c1 = Color::from_rgb(0.5, 0.4, 0.3);
-        let c2 = Color::from_rgb(0.2, 0.5, 0.3);
-
-        // Convert to linear color for manipulation
-        let l1 = Srgba::from(c1).into_linear();
-        let l2 = Srgba::from(c2).into_linear();
-
-        // Take the lighter of each of the sRGB components
-        let lighter = l1.lighten(l2);
-
-        // Convert back to our Color
-        let result: Color = Srgba::from_linear(lighter).into();
-
-        assert_relative_eq!(result.r, 0.5);
-        assert_relative_eq!(result.g, 0.5);
-        assert_relative_eq!(result.b, 0.3);
-        assert_relative_eq!(result.a, 1.0);
-    }
 
     #[test]
     fn parse() {

--- a/examples/color_palette/Cargo.toml
+++ b/examples/color_palette/Cargo.toml
@@ -9,4 +9,4 @@ publish = false
 iced.workspace = true
 iced.features = ["canvas"]
 
-palette.workspace = true
+palette = "0.7"


### PR DESCRIPTION
This brings iced-core down from 39 dependencies to 23.

Using `palette` here was overkill, and the crate constantly invalidated my incremental build cache which was annoying and the main reason I looked into this. Ran the tour example and everything looks correct to me, and tests pass locally as well, though I don't know whether anything tests screenshots etc.

I removed two of the tests, since they seemed to only exist to test conversions between iced `Color` and the `palette` types. Maybe the conversions could go behind a feature flag, but I left that out for now.