### PR TITLE
request redraw on mouse area hover change

### DIFF
--- a/widget/src/mouse_area.rs
+++ b/widget/src/mouse_area.rs
@@ -343,6 +343,10 @@ fn update<Message: Clone, Theme, Renderer>(
         state.cursor_position = cursor_position;
         state.bounds = bounds;
 
+        if widget.interaction.is_some() && state.is_hovered != was_hovered {
+            shell.request_redraw();
+        }
+
         match (
             widget.on_enter.as_ref(),
             widget.on_move.as_ref(),


### PR DESCRIPTION
Before, the mouse area's interaction wouldn't immediately change if it was set, since no redraw was requested when the cursor switched between being in the mouse area or outside of it.