### PR TITLE
Allow custom vertical spacing for wrapped rows

### DIFF
--- a/widget/src/row.rs
+++ b/widget/src/row.rs
@@ -167,7 +167,10 @@ where
     ///
     /// The original alignment of the [`Row`] is preserved per row wrapped.
     pub fn wrap(self) -> Wrapping<'a, Message, Theme, Renderer> {
-        Wrapping { row: self }
+        Wrapping {
+            row: self,
+            vertical_spacing: None,
+        }
     }
 }
 
@@ -372,6 +375,15 @@ pub struct Wrapping<
     Renderer = crate::Renderer,
 > {
     row: Row<'a, Message, Theme, Renderer>,
+    vertical_spacing: Option<f32>,
+}
+
+impl<Message, Theme, Renderer> Wrapping<'_, Message, Theme, Renderer> {
+    /// Sets the vertical spacing _between_ lines.
+    pub fn vertical_spacing(mut self, amount: impl Into<Pixels>) -> Self {
+        self.vertical_spacing = Some(amount.into().0);
+        self
+    }
 }
 
 impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer>
@@ -403,6 +415,7 @@ where
             .shrink(self.row.padding);
 
         let spacing = self.row.spacing;
+        let vertical_spacing = self.vertical_spacing.unwrap_or(spacing);
         let max_width = limits.max().width;
 
         let mut children: Vec<layout::Node> = Vec::new();
@@ -447,7 +460,7 @@ where
 
                 align(row_start..i, row_height, &mut children);
 
-                y += row_height + spacing;
+                y += row_height + vertical_spacing;
                 x = 0.0;
                 row_start = i;
                 row_height = 0.0;


### PR DESCRIPTION
I have a use case where I'd like the spacing between wrapped lines to be different than the spacing within each line.

| before (inherited spacing = 20) | after (overridden spacing = 0) |
| - | - |
| ![Screenshot 2025-03-20 182819](https://github.com/user-attachments/assets/deed25e8-1f9e-4595-a371-eac1590b4271) | ![Screenshot 2025-03-20 182953](https://github.com/user-attachments/assets/b61b4739-3d39-46fb-bf52-5d645850f443) |

My specific use case where I'd like to reduce the spacing:

> ![Screenshot 2025-03-20 182953](https://github.com/user-attachments/assets/11771fba-b01b-4276-95ee-02551a131966)
