### PR TITLE
make DEFAULT_PADDING public

### DIFF
--- a/widget/src/button.rs
+++ b/widget/src/button.rs
@@ -456,7 +456,7 @@ where
 }
 
 /// The default [`Padding`] of a [`Button`].
-pub(crate) const DEFAULT_PADDING: Padding = Padding {
+pub const DEFAULT_PADDING: Padding = Padding {
     top: 5.0,
     bottom: 5.0,
     right: 10.0,


### PR DESCRIPTION
This PR makes the DEFAULT_PADDING for a button public, like the one for text_input already is. 

https://docs.rs/iced/latest/iced/widget/text_input/constant.DEFAULT_PADDING.html
