### PR TITLE
Expose drawing cosmic_text::Buffer directly in text::Renderer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2522,6 +2522,7 @@ dependencies = [
  "approx",
  "bitflags 2.9.0",
  "bytes",
+ "cosmic-text",
  "dark-light",
  "glam",
  "lilt",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,6 +20,7 @@ advanced = []
 [dependencies]
 bitflags.workspace = true
 bytes.workspace = true
+cosmic-text.workspace = true
 glam.workspace = true
 lilt.workspace = true
 log.workspace = true

--- a/core/src/renderer/null.rs
+++ b/core/src/renderer/null.rs
@@ -1,3 +1,5 @@
+use std::sync::Weak;
+
 use crate::alignment;
 use crate::image::{self, Image};
 use crate::renderer::{self, Renderer};
@@ -66,6 +68,14 @@ impl text::Renderer for () {
         _paragraph: Text,
         _position: Point,
         _color: Color,
+        _clip_bounds: Rectangle,
+    ) {
+    }
+
+    fn fill_buffer(
+        &mut self,
+        _buffer: Weak<cosmic_text::Buffer>,
+        _position: Point,
         _clip_bounds: Rectangle,
     ) {
     }

--- a/core/src/text.rs
+++ b/core/src/text.rs
@@ -12,8 +12,11 @@ use crate::{
     Background, Border, Color, Padding, Pixels, Point, Rectangle, Size,
 };
 
+use cosmic_text::Buffer;
+
 use std::borrow::Cow;
 use std::hash::{Hash, Hasher};
+use std::sync::Weak;
 
 /// A paragraph.
 #[derive(Debug, Clone, Copy)]
@@ -278,6 +281,14 @@ pub trait Renderer: crate::Renderer {
         text: Text<String, Self::Font>,
         position: Point,
         color: Color,
+        clip_bounds: Rectangle,
+    );
+
+    /// Draws the given ['Buffer'] at the given position.
+    fn fill_buffer(
+        &mut self,
+        buffer: Weak<Buffer>,
+        position: Point,
         clip_bounds: Rectangle,
     );
 }

--- a/graphics/src/text.rs
+++ b/graphics/src/text.rs
@@ -35,6 +35,7 @@ pub enum Text {
     Editor {
         editor: editor::Weak,
         position: Point,
+        bounds: Size,
         color: Color,
         clip_bounds: Rectangle,
         transformation: Transformation,
@@ -88,13 +89,13 @@ impl Text {
                 Some(paragraph.align_y),
             ),
             Text::Editor {
-                editor,
                 position,
+                bounds,
                 clip_bounds,
                 transformation,
                 ..
             } => (
-                Rectangle::new(*position, editor.bounds)
+                Rectangle::new(*position, *bounds)
                     .intersection(clip_bounds)
                     .map(|bounds| bounds * *transformation),
                 Alignment::Default,

--- a/graphics/src/text/editor.rs
+++ b/graphics/src/text/editor.rs
@@ -47,7 +47,6 @@ impl Editor {
 
         Weak {
             raw: Arc::downgrade(editor),
-            bounds: editor.bounds,
         }
     }
 
@@ -682,8 +681,6 @@ impl fmt::Debug for Internal {
 #[derive(Debug, Clone)]
 pub struct Weak {
     raw: sync::Weak<Internal>,
-    /// The bounds of the [`Editor`].
-    pub bounds: Size,
 }
 
 impl Weak {

--- a/renderer/src/fallback.rs
+++ b/renderer/src/fallback.rs
@@ -136,6 +136,19 @@ where
             renderer.fill_text(text, position, color, clip_bounds)
         );
     }
+
+    fn fill_buffer(
+        &mut self,
+        buffer: std::sync::Weak<iced_graphics::text::cosmic_text::Buffer>,
+        position: Point,
+        clip_bounds: Rectangle,
+    ) {
+        delegate!(
+            self,
+            renderer,
+            renderer.fill_buffer(buffer, position, clip_bounds)
+        );
+    }
 }
 
 impl<A, B> image::Renderer for Renderer<A, B>

--- a/tiny_skia/src/engine.rs
+++ b/tiny_skia/src/engine.rs
@@ -367,6 +367,7 @@ impl Engine {
             Text::Editor {
                 editor,
                 position,
+                bounds,
                 color,
                 clip_bounds: _, // TODO
                 transformation: local_transformation,
@@ -374,7 +375,7 @@ impl Engine {
                 let transformation = transformation * *local_transformation;
 
                 let physical_bounds =
-                    Rectangle::new(*position, editor.bounds) * transformation;
+                    Rectangle::new(*position, *bounds) * transformation;
 
                 if !clip_bounds.intersects(&physical_bounds) {
                     return;

--- a/tiny_skia/src/layer.rs
+++ b/tiny_skia/src/layer.rs
@@ -59,9 +59,12 @@ impl Layer {
         clip_bounds: Rectangle,
         transformation: Transformation,
     ) {
+        use crate::core::text::editor::Editor as _;
+
         let editor = Text::Editor {
             editor: editor.downgrade(),
             position,
+            bounds: editor.bounds(),
             color,
             clip_bounds,
             transformation,

--- a/tiny_skia/src/layer.rs
+++ b/tiny_skia/src/layer.rs
@@ -5,10 +5,11 @@ use crate::core::{
 };
 use crate::graphics::damage;
 use crate::graphics::layer;
-use crate::graphics::text::{Editor, Paragraph, Text};
+use crate::graphics::text::{Editor, Paragraph, Raw, Text};
 use crate::graphics::{self, Image};
 
 use std::rc::Rc;
+use std::sync::Weak;
 
 pub type Stack = layer::Stack<Layer>;
 
@@ -116,6 +117,24 @@ impl Layer {
     ) {
         self.text
             .push(Item::Cached(text, clip_bounds, transformation));
+    }
+
+    pub fn draw_buffer(
+        &mut self,
+        buffer: Weak<cosmic_text::Buffer>,
+        position: Point,
+        clip_bounds: Rectangle,
+        transformation: Transformation,
+    ) {
+        self.text.push(Item::Live(Text::Raw {
+            raw: Raw {
+                buffer: buffer.clone(),
+                position,
+                color: Color::WHITE,
+                clip_bounds,
+            },
+            transformation,
+        }));
     }
 
     pub fn draw_image(&mut self, image: Image, transformation: Transformation) {

--- a/tiny_skia/src/lib.rs
+++ b/tiny_skia/src/lib.rs
@@ -17,6 +17,8 @@ mod vector;
 #[cfg(feature = "geometry")]
 pub mod geometry;
 
+use std::sync::Weak;
+
 pub use iced_graphics as graphics;
 pub use iced_graphics::core;
 
@@ -312,6 +314,16 @@ impl core::text::Renderer for Renderer {
     ) {
         let (layer, transformation) = self.layers.current_mut();
         layer.draw_text(text, position, color, clip_bounds, transformation);
+    }
+
+    fn fill_buffer(
+        &mut self,
+        buffer: Weak<cosmic_text::Buffer>,
+        position: Point,
+        clip_bounds: Rectangle,
+    ) {
+        let (layer, transformation) = self.layers.current_mut();
+        layer.draw_buffer(buffer, position, clip_bounds, transformation);
     }
 }
 

--- a/wgpu/src/layer.rs
+++ b/wgpu/src/layer.rs
@@ -1,3 +1,5 @@
+use std::sync::Weak;
+
 use crate::core::{
     self, Background, Color, Point, Rectangle, Svg, Transformation, renderer,
 };
@@ -5,7 +7,7 @@ use crate::graphics;
 use crate::graphics::Mesh;
 use crate::graphics::color;
 use crate::graphics::layer;
-use crate::graphics::text::{Editor, Paragraph};
+use crate::graphics::text::{Editor, Paragraph, Raw};
 use crate::image::{self, Image};
 use crate::primitive::{self, Primitive};
 use crate::quad::{self, Quad};
@@ -112,6 +114,25 @@ impl Layer {
             clip_bounds: clip_bounds * transformation,
         };
 
+        self.pending_text.push(text);
+    }
+
+    pub fn draw_buffer(
+        &mut self,
+        buffer: Weak<glyphon::Buffer>,
+        position: Point,
+        clip_bounds: Rectangle,
+        transformation: Transformation,
+    ) {
+        let text = Text::Raw {
+            raw: Raw {
+                buffer: buffer.clone(),
+                position,
+                color: Color::WHITE,
+                clip_bounds,
+            },
+            transformation,
+        };
         self.pending_text.push(text);
     }
 

--- a/wgpu/src/layer.rs
+++ b/wgpu/src/layer.rs
@@ -119,7 +119,7 @@ impl Layer {
 
     pub fn draw_buffer(
         &mut self,
-        buffer: Weak<glyphon::Buffer>,
+        buffer: Weak<cryoglyph::Buffer>,
         position: Point,
         clip_bounds: Rectangle,
         transformation: Transformation,

--- a/wgpu/src/layer.rs
+++ b/wgpu/src/layer.rs
@@ -76,9 +76,12 @@ impl Layer {
         clip_bounds: Rectangle,
         transformation: Transformation,
     ) {
+        use crate::core::text::editor::Editor as _;
+
         let editor = Text::Editor {
             editor: editor.downgrade(),
             position,
+            bounds: editor.bounds(),
             color,
             clip_bounds,
             transformation,

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -535,7 +535,7 @@ impl core::text::Renderer for Renderer {
 
     fn fill_buffer(
         &mut self,
-        buffer: Weak<glyphon::Buffer>,
+        buffer: Weak<cryoglyph::Buffer>,
         position: Point,
         clip_bounds: Rectangle,
     ) {

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -45,6 +45,8 @@ mod image;
 #[path = "image/null.rs"]
 mod image;
 
+use std::sync::Weak;
+
 use buffer::Buffer;
 
 pub use iced_graphics as graphics;
@@ -529,6 +531,16 @@ impl core::text::Renderer for Renderer {
     ) {
         let (layer, transformation) = self.layers.current_mut();
         layer.draw_text(text, position, color, clip_bounds, transformation);
+    }
+
+    fn fill_buffer(
+        &mut self,
+        buffer: Weak<glyphon::Buffer>,
+        position: Point,
+        clip_bounds: Rectangle,
+    ) {
+        let (layer, transformation) = self.layers.current_mut();
+        layer.draw_buffer(buffer, position, clip_bounds, transformation);
     }
 }
 


### PR DESCRIPTION
Adds `fill_buffer` method to text::Renderer trait that takes in a Weak pointer to a cosmic_text::Buffer.
Allows for more advanced use cases on top of the existing helper methods.