### PR TITLE
animations: add go_at and go_at_mut

### DIFF
--- a/core/src/animation.rs
+++ b/core/src/animation.rs
@@ -96,9 +96,22 @@ where
         self
     }
 
+    /// Transitions the [`Animation`] from its current state to the given new state, starting from
+    /// the given start time.
+    pub fn go_at(mut self, new_state: T, at: Instant) -> Self {
+        self.go_at_mut(new_state, at);
+        self
+    }
+
     /// Transitions the [`Animation`] from its current state to the given new state, by reference.
     pub fn go_mut(&mut self, new_state: T) {
-        self.raw.transition(new_state, Instant::now());
+        self.go_at_mut(new_state, Instant::now());
+    }
+
+    /// Transitions the [`Animation`] from its current state to the given new state, starting from
+    /// the given start time, by reference.
+    pub fn go_at_mut(&mut self, new_state: T, at: Instant) {
+        self.raw.transition(new_state, at);
     }
 
     /// Returns true if the [`Animation`] is currently in progress.


### PR DESCRIPTION
I found myself calling `go` a lot when receiving `window::Event::RedrawRequested`, where I already have an instant provided to me, so to avoid potential desync issues and to save a bunch of libc calls I added these two functions. Additionally, I could see this being useful to start animations in the past, e.g. if you want to start in the middle of a transition state, which as far as I can tell wasn't possible before since the `Duration` used for animation delay is unsigned.