### PR TITLE
refactor(checkbox): make label optional for checkbox

### DIFF
--- a/examples/checkbox/src/main.rs
+++ b/examples/checkbox/src/main.rs
@@ -39,11 +39,13 @@ impl Example {
     }
 
     fn view(&self) -> Element<Message> {
-        let default_checkbox = checkbox("Default", self.default)
+        let default_checkbox = checkbox(self.default)
+            .label("Default")
             .on_toggle(Message::DefaultToggled);
 
         let styled_checkbox = |label| {
-            checkbox(label, self.styled)
+            checkbox(self.styled)
+                .label(label)
                 .on_toggle_maybe(self.default.then_some(Message::StyledToggled))
         };
 
@@ -55,7 +57,8 @@ impl Example {
         ]
         .spacing(20);
 
-        let custom_checkbox = checkbox("Custom", self.custom)
+        let custom_checkbox = checkbox(self.custom)
+            .label("Custom")
             .on_toggle(Message::CustomToggled)
             .icon(checkbox::Icon {
                 font: ICON_FONT,

--- a/examples/custom_shader/src/main.rs
+++ b/examples/custom_shader/src/main.rs
@@ -77,7 +77,8 @@ impl IcedCubes {
                     .step(0.01)
                     .width(100),
             ),
-            checkbox("Show Depth Buffer", self.scene.show_depth_buffer)
+            checkbox(self.scene.show_depth_buffer)
+                .label("Show Depth Buffer")
                 .on_toggle(Message::ShowDepthBuffer),
         ]
         .spacing(40);

--- a/examples/ferris/src/main.rs
+++ b/examples/ferris/src/main.rs
@@ -153,7 +153,8 @@ impl Image {
                         self.rotation.degrees(),
                         Message::RotationChanged
                     ),
-                    checkbox("Spin!", self.spin)
+                    checkbox(self.spin)
+                        .label("Spin!")
                         .text_size(12)
                         .on_toggle(Message::SpinToggled)
                         .size(12)

--- a/examples/game_of_life/src/main.rs
+++ b/examples/game_of_life/src/main.rs
@@ -167,7 +167,9 @@ fn view_controls<'a>(
     row![
         playback_controls,
         speed_controls,
-        checkbox("Grid", is_grid_enabled).on_toggle(Message::ToggleGrid),
+        checkbox(is_grid_enabled)
+            .label("Grid")
+            .on_toggle(Message::ToggleGrid),
         row![
             pick_list(preset::ALL, Some(preset), Message::PresetPicked),
             button("Clear")

--- a/examples/gradient/src/main.rs
+++ b/examples/gradient/src/main.rs
@@ -80,7 +80,8 @@ impl Gradient {
         .align_y(Center);
 
         let transparency_toggle = iced::widget::Container::new(
-            checkbox("Transparent window", transparent)
+            checkbox(transparent)
+                .label("Transparent window")
                 .on_toggle(Message::TransparentToggled),
         )
         .padding(8);

--- a/examples/layout/src/main.rs
+++ b/examples/layout/src/main.rs
@@ -71,7 +71,8 @@ impl Layout {
         let header = row![
             text(self.example.title).size(20).font(Font::MONOSPACE),
             horizontal_space(),
-            checkbox("Explain", self.explain)
+            checkbox(self.explain)
+                .label("Explain")
                 .on_toggle(Message::ExplainToggled),
             pick_list(Theme::ALL, Some(&self.theme), Message::ThemeSelected),
         ]

--- a/examples/progress_bar/src/main.rs
+++ b/examples/progress_bar/src/main.rs
@@ -58,7 +58,8 @@ impl Progress {
                 )
             },
             center_x(
-                checkbox("Vertical", self.is_vertical)
+                checkbox(self.is_vertical)
+                    .label("Vertical")
                     .on_toggle(Message::ToggleVertical)
             ),
         ]

--- a/examples/styling/src/main.rs
+++ b/examples/styling/src/main.rs
@@ -102,7 +102,8 @@ impl Styling {
         .width(Fill)
         .height(100);
 
-        let checkbox = checkbox("Check me!", self.checkbox_value)
+        let checkbox = checkbox(self.checkbox_value)
+            .label("Check me!")
             .on_toggle(Message::CheckboxToggled);
 
         let toggler = toggler(self.toggler_value)

--- a/examples/svg/src/main.rs
+++ b/examples/svg/src/main.rs
@@ -42,9 +42,9 @@ impl Tiger {
                     },
                 });
 
-        let apply_color_filter =
-            checkbox("Apply a color filter", self.apply_color_filter)
-                .on_toggle(Message::ToggleColorFilter);
+        let apply_color_filter = checkbox(self.apply_color_filter)
+            .label("Apply a color filter")
+            .on_toggle(Message::ToggleColorFilter);
 
         center(column![svg, center_x(apply_color_filter)].spacing(20))
             .padding(20)

--- a/examples/todos/src/main.rs
+++ b/examples/todos/src/main.rs
@@ -336,7 +336,8 @@ impl Task {
     fn view(&self, i: usize) -> Element<TaskMessage> {
         match &self.state {
             TaskState::Idle => {
-                let checkbox = checkbox(&self.description, self.completed)
+                let checkbox = checkbox(self.completed)
+                    .label(&self.description)
                     .on_toggle(TaskMessage::Completed)
                     .width(Fill)
                     .size(17)

--- a/examples/tour/src/main.rs
+++ b/examples/tour/src/main.rs
@@ -398,11 +398,9 @@ impl Tour {
             .push(slider(100..=500, width, Message::ImageWidthChanged))
             .push(text!("Width: {width} px").width(Fill).align_x(Center))
             .push(
-                checkbox(
-                    "Use nearest interpolation",
-                    filter_method == image::FilterMethod::Nearest,
-                )
-                .on_toggle(Message::ImageUseNearestToggled),
+                checkbox(filter_method == image::FilterMethod::Nearest)
+                    .label("Use nearest interpolation")
+                    .on_toggle(Message::ImageUseNearestToggled),
             )
             .align_x(Center)
     }
@@ -453,11 +451,13 @@ impl Tour {
             .push("Use a text input to ask for different kinds of information.")
             .push(text_input.secure(is_secure))
             .push(
-                checkbox("Enable password mode", is_secure)
+                checkbox(is_secure)
+                    .label("Enable password mode")
                     .on_toggle(Message::ToggleSecureInput),
             )
             .push(
-                checkbox("Show icon", is_showing_icon)
+                checkbox(is_showing_icon)
+                    .label("Show icon")
                     .on_toggle(Message::ToggleTextInputIcon),
             )
             .push(
@@ -486,7 +486,8 @@ impl Tour {
                  see element boundaries.",
             )
             .push(
-                checkbox("Explain layout", self.debug)
+                checkbox(self.debug)
+                    .label("Explain layout")
                     .on_toggle(Message::DebugToggled),
             )
             .push("Feel free to go back and take a look.")

--- a/examples/vectorial_text/src/main.rs
+++ b/examples/vectorial_text/src/main.rs
@@ -61,7 +61,8 @@ impl VectorialText {
         column![
             canvas(&self.state).width(Fill).height(Fill),
             column![
-                checkbox("Use Japanese", self.state.use_japanese,)
+                checkbox(self.state.use_japanese,)
+                    .label("Use Japanese")
                     .on_toggle(Message::ToggleJapanese),
                 row![
                     slider_with_label(

--- a/widget/src/checkbox.rs
+++ b/widget/src/checkbox.rs
@@ -16,7 +16,8 @@
 //! }
 //!
 //! fn view(state: &State) -> Element<'_, Message> {
-//!     checkbox("Toggle me!", state.is_checked)
+//!     checkbox(state.is_checked)
+//!         .label("Toggle me!")
 //!         .on_toggle(Message::CheckboxToggled)
 //!         .into()
 //! }
@@ -63,7 +64,8 @@ use crate::core::{
 /// }
 ///
 /// fn view(state: &State) -> Element<'_, Message> {
-///     checkbox("Toggle me!", state.is_checked)
+///     checkbox(state.is_checked)
+///         .label("Toggle me!")
 ///         .on_toggle(Message::CheckboxToggled)
 ///         .into()
 /// }
@@ -89,7 +91,7 @@ pub struct Checkbox<
 {
     is_checked: bool,
     on_toggle: Option<Box<dyn Fn(bool) -> Message + 'a>>,
-    label: String,
+    label: Option<text::Fragment<'a>>,
     width: Length,
     size: f32,
     spacing: f32,
@@ -117,13 +119,12 @@ where
     /// Creates a new [`Checkbox`].
     ///
     /// It expects:
-    ///   * the label of the [`Checkbox`]
     ///   * a boolean describing whether the [`Checkbox`] is checked or not
-    pub fn new(label: impl Into<String>, is_checked: bool) -> Self {
+    pub fn new(is_checked: bool) -> Self {
         Checkbox {
             is_checked,
             on_toggle: None,
-            label: label.into(),
+            label: None,
             width: Length::Shrink,
             size: Self::DEFAULT_SIZE,
             spacing: Self::DEFAULT_SPACING,
@@ -142,6 +143,12 @@ where
             class: Theme::default(),
             last_status: None,
         }
+    }
+
+    /// Sets the label of the [`CheckBox`]
+    pub fn label(mut self, label: impl text::IntoFragment<'a>) -> Self {
+        self.label = Some(label.into_fragment());
+        self
     }
 
     /// Sets the function that will be called when the [`Checkbox`] is toggled.
@@ -279,25 +286,29 @@ where
             self.spacing,
             |_| layout::Node::new(Size::new(self.size, self.size)),
             |limits| {
-                let state = tree
+                if let Some(label) = self.label.as_deref() {
+                    let state = tree
                     .state
                     .downcast_mut::<widget::text::State<Renderer::Paragraph>>();
 
-                widget::text::layout(
-                    state,
-                    renderer,
-                    limits,
-                    self.width,
-                    Length::Shrink,
-                    &self.label,
-                    self.text_line_height,
-                    self.text_size,
-                    self.font,
-                    text::Alignment::Default,
-                    alignment::Vertical::Top,
-                    self.text_shaping,
-                    self.text_wrapping,
-                )
+                    widget::text::layout(
+                        state,
+                        renderer,
+                        limits,
+                        self.width,
+                        Length::Shrink,
+                        label,
+                        self.text_line_height,
+                        self.text_size,
+                        self.font,
+                        text::Alignment::Default,
+                        alignment::Vertical::Top,
+                        self.text_shaping,
+                        self.text_wrapping,
+                    )
+                } else {
+                    layout::Node::new(Size::ZERO)
+                }
             },
         )
     }
@@ -453,7 +464,9 @@ where
         _renderer: &Renderer,
         operation: &mut dyn widget::Operation,
     ) {
-        operation.text(None, layout.bounds(), &self.label);
+        if let Some(label) = self.label.as_deref() {
+            operation.text(None, layout.bounds(), label);
+        }
     }
 }
 

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -1230,7 +1230,8 @@ pub use crate::markdown::view as markdown;
 /// }
 ///
 /// fn view(state: &State) -> Element<'_, Message> {
-///     checkbox("Toggle me!", state.is_checked)
+///     checkbox(state.is_checked)
+///         .label("Toggle me!")
 ///         .on_toggle(Message::CheckboxToggled)
 ///         .into()
 /// }
@@ -1245,14 +1246,13 @@ pub use crate::markdown::view as markdown;
 /// ```
 /// ![Checkbox drawn by `iced_wgpu`](https://github.com/iced-rs/iced/blob/7760618fb112074bc40b148944521f312152012a/docs/images/checkbox.png?raw=true)
 pub fn checkbox<'a, Message, Theme, Renderer>(
-    label: impl Into<String>,
     is_checked: bool,
 ) -> Checkbox<'a, Message, Theme, Renderer>
 where
     Theme: checkbox::Catalog + 'a,
     Renderer: core::text::Renderer,
 {
-    Checkbox::new(label, is_checked)
+    Checkbox::new(is_checked)
 }
 
 /// Creates a new [`Radio`].


### PR DESCRIPTION
As discussed [here](https://discourse.iced.rs/t/shouldnt-checkbox-be-without-a-label), in this PR I made the label for `CheckBox` optional. I also removed it as parameter from the `checkbox` helper function and added a way to add the label with a builder pattern instead.

The documentation and examples are updated accordingly.