### PR TITLE
Update `cosmic-text` to `0.14`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1027,9 +1027,9 @@ dependencies = [
 
 [[package]]
 name = "cosmic-text"
-version = "0.13.2"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e418dd4f5128c3e93eab12246391c54a20c496811131f85754dc8152ee207892"
+checksum = "1db686e755000c93f73a3acc78be56a71e3efb83ed92886f45faea2b9485bad7"
 dependencies = [
  "bitflags 2.9.0",
  "fontdb 0.16.2",
@@ -1144,7 +1144,7 @@ checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 [[package]]
 name = "cryoglyph"
 version = "0.1.0"
-source = "git+https://github.com/iced-rs/cryoglyph.git?rev=be2defe4a13fd7c97c6f4c81e8e085463eb578dc#be2defe4a13fd7c97c6f4c81e8e085463eb578dc"
+source = "git+https://github.com/iced-rs/cryoglyph.git?rev=a456d1c17bbcf33afcca41d9e5e299f9f1193819#a456d1c17bbcf33afcca41d9e5e299f9f1193819"
 dependencies = [
  "cosmic-text",
  "etagere",
@@ -2115,9 +2115,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7db2ff139bba50379da6aa0766b52fdcb62cb5b263009b09ed58ba604e14bbd1"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -3100,9 +3100,9 @@ checksum = "2a385b1be4e5c3e362ad2ffa73c392e53f031eaa5b7d648e64cd87f27f6063d7"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -3319,9 +3319,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff70ce3e48ae43fa075863cef62e8b43b71a4f2382229920e0df362592919430"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -4842,7 +4842,7 @@ dependencies = [
  "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys 0.9.3",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 
@@ -7322,9 +7322,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
+checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
 dependencies = [
  "memchr",
 ]
@@ -7429,9 +7429,9 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xml-rs"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5b940ebc25896e71dd073bad2dbaa2abfe97b0a391415e22ad1326d9c54e3c4"
+checksum = "a62ce76d9b56901b19a74f19431b0d8b3bc7ca4ad685a746dfd78ca8f4fc6bda"
 
 [[package]]
 name = "xmlwriter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,11 +163,11 @@ bincode = "1.3"
 bitflags = "2.0"
 bytemuck = { version = "1.0", features = ["derive"] }
 bytes = "1.6"
-cosmic-text = "0.13"
+cosmic-text = "0.14"
 dark-light = "2.0"
 futures = { version = "0.3", default-features = false }
 glam = "0.25"
-cryoglyph = { git = "https://github.com/iced-rs/cryoglyph.git", rev = "be2defe4a13fd7c97c6f4c81e8e085463eb578dc" }
+cryoglyph = { git = "https://github.com/iced-rs/cryoglyph.git", rev = "a456d1c17bbcf33afcca41d9e5e299f9f1193819" }
 guillotiere = "0.6"
 half = "2.2"
 image = { version = "0.25", default-features = false }

--- a/graphics/src/geometry/text.rs
+++ b/graphics/src/geometry/text.rs
@@ -47,7 +47,7 @@ impl Text {
         let mut buffer = cosmic_text::BufferLine::new(
             &self.content,
             cosmic_text::LineEnding::default(),
-            cosmic_text::AttrsList::new(text::to_attributes(self.font)),
+            cosmic_text::AttrsList::new(&text::to_attributes(self.font)),
             text::to_shaping(self.shaping),
         );
 

--- a/graphics/src/settings.rs
+++ b/graphics/src/settings.rs
@@ -31,7 +31,15 @@ impl Default for Settings {
 impl From<core::Settings> for Settings {
     fn from(settings: core::Settings) -> Self {
         Self {
-            default_font: settings.default_font,
+            default_font: if cfg!(all(
+                target_arch = "wasm32",
+                feature = "fira-sans"
+            )) && settings.default_font == Font::default()
+            {
+                Font::with_name("Fira Sans")
+            } else {
+                settings.default_font
+            },
             default_text_size: settings.default_text_size,
             antialiasing: settings.antialiasing.then_some(Antialiasing::MSAAx4),
         }

--- a/graphics/src/text/cache.rs
+++ b/graphics/src/text/cache.rs
@@ -54,7 +54,7 @@ impl Cache {
             buffer.set_text(
                 font_system,
                 key.content,
-                text::to_attributes(key.font),
+                &text::to_attributes(key.font),
                 text::to_shaping(key.shaping),
             );
 

--- a/graphics/src/text/editor.rs
+++ b/graphics/src/text/editor.rs
@@ -73,7 +73,7 @@ impl editor::Editor for Editor {
         buffer.set_text(
             font_system.raw(),
             text,
-            cosmic_text::Attrs::new(),
+            &cosmic_text::Attrs::new(),
             cosmic_text::Shaping::Advanced,
         );
 
@@ -492,7 +492,7 @@ impl editor::Editor for Editor {
 
             for line in buffer.lines.iter_mut() {
                 let _ = line.set_attrs_list(cosmic_text::AttrsList::new(
-                    text::to_attributes(new_font),
+                    &text::to_attributes(new_font),
                 ));
             }
 
@@ -607,7 +607,7 @@ impl editor::Editor for Editor {
         for line in &mut buffer_mut_from_editor(&mut internal.editor).lines
             [current_line..=last_visible_line]
         {
-            let mut list = cosmic_text::AttrsList::new(attributes);
+            let mut list = cosmic_text::AttrsList::new(&attributes);
 
             for (range, highlight) in highlighter.highlight_line(line.text()) {
                 let format = format_highlight(&highlight);
@@ -615,12 +615,12 @@ impl editor::Editor for Editor {
                 if format.color.is_some() || format.font.is_some() {
                     list.add_span(
                         range,
-                        cosmic_text::Attrs {
+                        &cosmic_text::Attrs {
                             color_opt: format.color.map(text::to_color),
                             ..if let Some(font) = format.font {
                                 text::to_attributes(font)
                             } else {
-                                attributes
+                                attributes.clone()
                             }
                         },
                     );

--- a/graphics/src/text/paragraph.rs
+++ b/graphics/src/text/paragraph.rs
@@ -85,7 +85,7 @@ impl core::text::Paragraph for Paragraph {
         buffer.set_text(
             font_system.raw(),
             text.content,
-            text::to_attributes(text.font),
+            &text::to_attributes(text.font),
             text::to_shaping(text.shaping),
         );
 
@@ -154,7 +154,7 @@ impl core::text::Paragraph for Paragraph {
 
                 (span.text.as_ref(), attrs.metadata(i))
             }),
-            text::to_attributes(text.font),
+            &text::to_attributes(text.font),
             text::to_shaping(text.shaping),
             None,
         );


### PR DESCRIPTION
A small performance hit ~3% in our heavy dynamic text benchmark:

![image](https://github.com/user-attachments/assets/7a6f5c4e-ab45-4d26-8eea-3ff4deb0ed55)
