### PR TITLE
Use strong reference when sending `Paragraph` and `Editor` to the ren…

### DIFF
--- a/graphics/src/text.rs
+++ b/graphics/src/text.rs
@@ -11,7 +11,9 @@ pub use cosmic_text;
 
 use crate::core::alignment;
 use crate::core::font::{self, Font};
-use crate::core::text::{Alignment, Shaping, Wrapping};
+use crate::core::text::{
+    Alignment, Editor as _, Paragraph as _, Shaping, Wrapping,
+};
 use crate::core::{Color, Pixels, Point, Rectangle, Size, Transformation};
 
 use std::borrow::Cow;
@@ -24,7 +26,7 @@ pub enum Text {
     /// A paragraph.
     #[allow(missing_docs)]
     Paragraph {
-        paragraph: paragraph::Weak,
+        paragraph: Paragraph,
         position: Point,
         color: Color,
         clip_bounds: Rectangle,
@@ -33,7 +35,7 @@ pub enum Text {
     /// An editor.
     #[allow(missing_docs)]
     Editor {
-        editor: editor::Weak,
+        editor: Editor,
         position: Point,
         color: Color,
         clip_bounds: Rectangle,
@@ -81,11 +83,11 @@ impl Text {
                 transformation,
                 ..
             } => (
-                Rectangle::new(*position, paragraph.min_bounds)
+                Rectangle::new(*position, paragraph.min_bounds())
                     .intersection(clip_bounds)
                     .map(|bounds| bounds * *transformation),
-                paragraph.align_x,
-                Some(paragraph.align_y),
+                paragraph.align_x(),
+                Some(paragraph.align_y()),
             ),
             Text::Editor {
                 editor,
@@ -94,7 +96,7 @@ impl Text {
                 transformation,
                 ..
             } => (
-                Rectangle::new(*position, editor.bounds)
+                Rectangle::new(*position, editor.bounds())
                     .intersection(clip_bounds)
                     .map(|bounds| bounds * *transformation),
                 Alignment::Default,

--- a/graphics/src/text/editor.rs
+++ b/graphics/src/text/editor.rs
@@ -14,7 +14,7 @@ use std::fmt;
 use std::sync::{self, Arc, RwLock};
 
 /// A multi-line text editor.
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Editor(Option<Arc<Internal>>);
 
 struct Internal {

--- a/tiny_skia/src/engine.rs
+++ b/tiny_skia/src/engine.rs
@@ -1,5 +1,6 @@
 use crate::Primitive;
 use crate::core::renderer::Quad;
+use crate::core::text::{Editor, Paragraph};
 use crate::core::{
     Background, Color, Gradient, Rectangle, Size, Transformation, Vector,
 };
@@ -345,7 +346,7 @@ impl Engine {
                 let transformation = transformation * *local_transformation;
 
                 let physical_bounds =
-                    Rectangle::new(*position, paragraph.min_bounds)
+                    Rectangle::new(*position, paragraph.min_bounds())
                         * transformation;
 
                 if !clip_bounds.intersects(&physical_bounds) {
@@ -374,7 +375,7 @@ impl Engine {
                 let transformation = transformation * *local_transformation;
 
                 let physical_bounds =
-                    Rectangle::new(*position, editor.bounds) * transformation;
+                    Rectangle::new(*position, editor.bounds()) * transformation;
 
                 if !clip_bounds.intersects(&physical_bounds) {
                     return;

--- a/tiny_skia/src/layer.rs
+++ b/tiny_skia/src/layer.rs
@@ -41,7 +41,7 @@ impl Layer {
         transformation: Transformation,
     ) {
         let paragraph = Text::Paragraph {
-            paragraph: paragraph.downgrade(),
+            paragraph: paragraph.clone(),
             position,
             color,
             clip_bounds,
@@ -60,7 +60,7 @@ impl Layer {
         transformation: Transformation,
     ) {
         let editor = Text::Editor {
-            editor: editor.downgrade(),
+            editor: editor.clone(),
             position,
             color,
             clip_bounds,

--- a/tiny_skia/src/text.rs
+++ b/tiny_skia/src/text.rs
@@ -4,9 +4,9 @@ use crate::core::{
     Color, Font, Pixels, Point, Rectangle, Size, Transformation,
 };
 use crate::graphics::text::cache::{self, Cache};
-use crate::graphics::text::editor;
+use crate::graphics::text::editor::Editor;
 use crate::graphics::text::font_system;
-use crate::graphics::text::paragraph;
+use crate::graphics::text::paragraph::Paragraph;
 
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::borrow::Cow;
@@ -40,7 +40,7 @@ impl Pipeline {
 
     pub fn draw_paragraph(
         &mut self,
-        paragraph: &paragraph::Weak,
+        paragraph: &Paragraph,
         position: Point,
         color: Color,
         pixels: &mut tiny_skia::PixmapMut<'_>,
@@ -48,10 +48,6 @@ impl Pipeline {
         transformation: Transformation,
     ) {
         use crate::core::text::Paragraph as _;
-
-        let Some(paragraph) = paragraph.upgrade() else {
-            return;
-        };
 
         let mut font_system = font_system().write().expect("Write font system");
 
@@ -71,7 +67,7 @@ impl Pipeline {
 
     pub fn draw_editor(
         &mut self,
-        editor: &editor::Weak,
+        editor: &Editor,
         position: Point,
         color: Color,
         pixels: &mut tiny_skia::PixmapMut<'_>,
@@ -79,10 +75,6 @@ impl Pipeline {
         transformation: Transformation,
     ) {
         use crate::core::text::Editor as _;
-
-        let Some(editor) = editor.upgrade() else {
-            return;
-        };
 
         let mut font_system = font_system().write().expect("Write font system");
 

--- a/wgpu/src/layer.rs
+++ b/wgpu/src/layer.rs
@@ -58,7 +58,7 @@ impl Layer {
         transformation: Transformation,
     ) {
         let paragraph = Text::Paragraph {
-            paragraph: paragraph.downgrade(),
+            paragraph: paragraph.clone(),
             position,
             color,
             clip_bounds,
@@ -77,7 +77,7 @@ impl Layer {
         transformation: Transformation,
     ) {
         let editor = Text::Editor {
-            editor: editor.downgrade(),
+            editor: editor.clone(),
             position,
             color,
             clip_bounds,

--- a/wgpu/src/text.rs
+++ b/wgpu/src/text.rs
@@ -467,10 +467,10 @@ fn prepare(
         .iter()
         .map(|section| match section {
             Text::Paragraph { paragraph, .. } => {
-                paragraph.upgrade().map(Allocation::Paragraph)
+                Some(Allocation::Paragraph(paragraph.clone()))
             }
             Text::Editor { editor, .. } => {
-                editor.upgrade().map(Allocation::Editor)
+                Some(Allocation::Editor(editor.clone()))
             }
             Text::Cached {
                 content,


### PR DESCRIPTION
I'm working on the `bevy_iced` plugin for Bevy that integrates Iced into Bevy. Since Bevy is using pipelined rendering and Iced assumes non-pipelined rendering, some things don't work. For instance, when typing into a text input widget, the text will often disappear for a frame when a letter is typed resulting in blinking, and is reported in #2318. I started a thread in [Discord](https://discourse.iced.rs/t/how-to-support-pipelined-rendering/931) to discuss this problem more generically.

This PR fixes the race condition that causes the flashing text.

The following PR is also required to get `bevy_iced` to work with the main branch of iced:
- https://github.com/iced-rs/iced/pull/2693