### PR TITLE
Update to wgpu 25.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,10 +883,11 @@ dependencies = [
 
 [[package]]
 name = "codespan-reporting"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
+ "serde",
  "termcolor",
  "unicode-width",
 ]
@@ -1144,7 +1145,7 @@ checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 [[package]]
 name = "cryoglyph"
 version = "0.1.0"
-source = "git+https://github.com/iced-rs/cryoglyph.git?rev=a456d1c17bbcf33afcca41d9e5e299f9f1193819#a456d1c17bbcf33afcca41d9e5e299f9f1193819"
+source = "git+https://github.com/sunsided/cryoglyph.git?rev=1b72c1fe9ec53c481f12fed847bbbc1dca13add7#1b72c1fe9ec53c481f12fed847bbbc1dca13add7"
 dependencies = [
  "cosmic-text",
  "etagere",
@@ -2121,6 +2122,7 @@ checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "num-traits",
 ]
 
 [[package]]
@@ -3163,9 +3165,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
 
 [[package]]
 name = "lyon"
@@ -3389,24 +3391,26 @@ checksum = "16cf681a23b4d0a43fc35024c176437f9dcd818db34e0f42ab456a0ee5ad497b"
 
 [[package]]
 name = "naga"
-version = "24.0.0"
+version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e380993072e52eef724eddfcde0ed013b0c023c3f0417336ed041aa9f076994e"
+checksum = "aab20c4fce5c7d2c161dc332b5eebbdba970dbacce925e130f16078d2533660e"
 dependencies = [
  "arrayvec",
  "bit-set",
  "bitflags 2.9.0",
  "cfg_aliases",
  "codespan-reporting",
+ "half",
+ "hashbrown",
  "hexf-parse",
  "indexmap",
  "log",
+ "num-traits",
  "rustc-hash 1.1.0",
  "spirv",
  "strum",
- "termcolor",
  "thiserror 2.0.12",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -4303,6 +4307,12 @@ dependencies = [
  "tracing",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
 name = "powerfmt"
@@ -6159,12 +6169,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6645,18 +6649,20 @@ checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 
 [[package]]
 name = "wgpu"
-version = "24.0.3"
+version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35904fb00ba2d2e0a4d002fcbbb6e1b89b574d272a50e5fc95f6e81cf281c245"
+checksum = "ca6049eb2014a0e0d8689f9b787605dd71d5bbfdc74095ead499f3cff705c229"
 dependencies = [
  "arrayvec",
  "bitflags 2.9.0",
  "cfg_aliases",
  "document-features",
+ "hashbrown",
  "js-sys",
  "log",
  "naga",
  "parking_lot",
+ "portable-atomic",
  "profiling",
  "raw-window-handle 0.6.2",
  "smallvec",
@@ -6671,34 +6677,77 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "24.0.2"
+version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671c25545d479b47d3f0a8e373aceb2060b67c6eb841b24ac8c32348151c7a0c"
+checksum = "a57f3472e6ea6682a9cbe53c835048c6625f07bfb2a258cdae8ce4b6fe4c0ddb"
 dependencies = [
  "arrayvec",
+ "bit-set",
  "bit-vec",
  "bitflags 2.9.0",
  "cfg_aliases",
  "document-features",
+ "hashbrown",
  "indexmap",
  "log",
  "naga",
  "once_cell",
  "parking_lot",
+ "portable-atomic",
  "profiling",
  "raw-window-handle 0.6.2",
  "rustc-hash 1.1.0",
  "smallvec",
  "thiserror 2.0.12",
+ "wgpu-core-deps-apple",
+ "wgpu-core-deps-emscripten",
+ "wgpu-core-deps-wasm",
+ "wgpu-core-deps-windows-linux-android",
  "wgpu-hal",
  "wgpu-types",
 ]
 
 [[package]]
-name = "wgpu-hal"
-version = "24.0.4"
+name = "wgpu-core-deps-apple"
+version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f112f464674ca69f3533248508ee30cb84c67cf06c25ff6800685f5e0294e259"
+checksum = "cfd488b3239b6b7b185c3b045c39ca6bf8af34467a4c5de4e0b1a564135d093d"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-emscripten"
+version = "25.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09ad7aceb3818e52539acc679f049d3475775586f3f4e311c30165cf2c00445"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-wasm"
+version = "25.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca8809ad123f6c7f2c5e01a2c7117c4fdfd02f70bd422ee2533f69dfa98756c"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-windows-linux-android"
+version = "25.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cba5fb5f7f9c98baa7c889d444f63ace25574833df56f5b817985f641af58e46"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "25.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8f6a308c20f59fb207660d3cdd6bb1b704e86c3917cf64d26c5f732597577ee"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -6707,6 +6756,7 @@ dependencies = [
  "bitflags 2.9.0",
  "block",
  "bytemuck",
+ "cfg-if",
  "cfg_aliases",
  "core-graphics-types 0.1.3",
  "glow",
@@ -6714,6 +6764,7 @@ dependencies = [
  "gpu-alloc",
  "gpu-allocator",
  "gpu-descriptor",
+ "hashbrown",
  "js-sys",
  "khronos-egl",
  "libc",
@@ -6723,14 +6774,13 @@ dependencies = [
  "naga",
  "ndk-sys 0.5.0+25.2.9519653",
  "objc",
- "once_cell",
  "ordered-float",
  "parking_lot",
+ "portable-atomic",
  "profiling",
  "range-alloc",
  "raw-window-handle 0.6.2",
  "renderdoc-sys",
- "rustc-hash 1.1.0",
  "smallvec",
  "thiserror 2.0.12",
  "wasm-bindgen",
@@ -6742,13 +6792,15 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "24.0.0"
+version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50ac044c0e76c03a0378e7786ac505d010a873665e2d51383dcff8dd227dc69c"
+checksum = "2aa49460c2a8ee8edba3fca54325540d904dd85b2e086ada762767e17d06e8bc"
 dependencies = [
  "bitflags 2.9.0",
+ "bytemuck",
  "js-sys",
  "log",
+ "thiserror 2.0.12",
  "web-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,7 +167,7 @@ cosmic-text = "0.14"
 dark-light = "2.0"
 futures = { version = "0.3", default-features = false }
 glam = "0.25"
-cryoglyph = { git = "https://github.com/iced-rs/cryoglyph.git", rev = "a456d1c17bbcf33afcca41d9e5e299f9f1193819" }
+cryoglyph = { git = "https://github.com/sunsided/cryoglyph.git", rev = "1b72c1fe9ec53c481f12fed847bbbc1dca13add7" }
 guillotiere = "0.6"
 half = "2.2"
 image = { version = "0.25", default-features = false }
@@ -204,7 +204,7 @@ wasm-bindgen-futures = "0.4"
 wasmtimer = "0.4.1"
 web-sys = "0.3.69"
 web-time = "1.1"
-wgpu = "24.0"
+wgpu = "25.0"
 window_clipboard = "0.4.1"
 winit = { git = "https://github.com/iced-rs/winit.git", rev = "11414b6aa45699f038114e61b4ddf5102b2d3b4b" }
 

--- a/examples/integration/src/main.rs
+++ b/examples/integration/src/main.rs
@@ -96,17 +96,14 @@ pub fn main() -> Result<(), winit::error::EventLoopError> {
                         let capabilities = surface.get_capabilities(&adapter);
 
                         let (device, queue) = adapter
-                            .request_device(
-                                &wgpu::DeviceDescriptor {
-                                    label: None,
-                                    required_features: adapter_features
-                                        & wgpu::Features::default(),
-                                    required_limits: wgpu::Limits::default(),
-                                    memory_hints:
-                                        wgpu::MemoryHints::MemoryUsage,
-                                },
-                                None,
-                            )
+                            .request_device(&wgpu::DeviceDescriptor {
+                                label: None,
+                                required_features: adapter_features
+                                    & wgpu::Features::default(),
+                                required_limits: wgpu::Limits::default(),
+                                memory_hints: wgpu::MemoryHints::MemoryUsage,
+                                trace: Default::default(),
+                            })
                             .await
                             .expect("Request device");
 

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -284,7 +284,7 @@ impl Renderer {
         let _ = self
             .engine
             .device
-            .poll(wgpu::Maintain::WaitForSubmissionIndex(index));
+            .poll(wgpu::PollType::WaitForSubmissionIndex(index));
 
         let mapped_buffer = slice.get_mapped_range();
 
@@ -818,21 +818,20 @@ impl renderer::Headless for Renderer {
                 force_fallback_adapter: false,
                 compatible_surface: None,
             })
-            .await?;
+            .await
+            .ok()?;
 
         let (device, queue) = adapter
-            .request_device(
-                &wgpu::DeviceDescriptor {
-                    label: Some("iced_wgpu [headless]"),
-                    required_features: wgpu::Features::empty(),
-                    required_limits: wgpu::Limits {
-                        max_bind_groups: 2,
-                        ..wgpu::Limits::default()
-                    },
-                    memory_hints: wgpu::MemoryHints::MemoryUsage,
+            .request_device(&wgpu::DeviceDescriptor {
+                label: Some("iced_wgpu [headless]"),
+                required_features: wgpu::Features::empty(),
+                required_limits: wgpu::Limits {
+                    max_bind_groups: 2,
+                    ..wgpu::Limits::default()
                 },
-                None,
-            )
+                memory_hints: wgpu::MemoryHints::MemoryUsage,
+                trace: Default::default(),
+            })
             .await
             .ok()?;
 

--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -96,7 +96,9 @@ impl Compositor {
         let adapter = instance
             .request_adapter(&adapter_options)
             .await
-            .ok_or(Error::NoAdapterFound(format!("{:?}", adapter_options)))?;
+            .map_err(|_| {
+                Error::NoAdapterFound(format!("{:?}", adapter_options))
+            })?;
 
         log::info!("Selected: {:#?}", adapter.get_info());
 
@@ -162,17 +164,15 @@ impl Compositor {
 
         for required_limits in limits {
             let result = adapter
-                .request_device(
-                    &wgpu::DeviceDescriptor {
-                        label: Some(
-                            "iced_wgpu::window::compositor device descriptor",
-                        ),
-                        required_features: wgpu::Features::empty(),
-                        required_limits: required_limits.clone(),
-                        memory_hints: wgpu::MemoryHints::MemoryUsage,
-                    },
-                    None,
-                )
+                .request_device(&wgpu::DeviceDescriptor {
+                    label: Some(
+                        "iced_wgpu::window::compositor device descriptor",
+                    ),
+                    required_features: wgpu::Features::empty(),
+                    required_limits: required_limits.clone(),
+                    memory_hints: wgpu::MemoryHints::MemoryUsage,
+                    trace: Default::default(),
+                })
                 .await;
 
             match result {


### PR DESCRIPTION
This pull request includes several updates and improvements to the `Cargo.toml` dependencies and various files in the `wgpu` integration. The main changes involve updating dependencies, refactoring code for better readability, and adding default trace values to device descriptors.

Requires https://github.com/iced-rs/cryoglyph/pull/2 - I currently based it against my own fork of cryptoglyph to get things going.

Dependency updates:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L170-R170): Updated the `cryoglyph` dependency to point to a new GitHub repository and revision.
* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L207-R207): Updated the `wgpu` dependency from version `24.0` to `25.0`.

Code refactoring and improvements:

* [`examples/integration/src/main.rs`](diffhunk://#diff-87c4c8cd379c3e1e7671a807ecd37878050259e895f5160bdb5a9746c0109dadL99-R106): Refactored the `request_device` method call to improve readability and added a default trace value to the `DeviceDescriptor`.
* [`wgpu/src/lib.rs`](diffhunk://#diff-69eb2a0461b18b418449129eaf12c15ee0a277bbaebb6860f2711de5fd6aa06aL287-R287): Changed `wgpu::Maintain::WaitForSubmissionIndex` to `wgpu::PollType::WaitForSubmissionIndex` in the `poll` method call.
* [`wgpu/src/lib.rs`](diffhunk://#diff-69eb2a0461b18b418449129eaf12c15ee0a277bbaebb6860f2711de5fd6aa06aL821-R834): Refactored the `request_device` method call in the `Headless` implementation to improve readability and added a default trace value to the `DeviceDescriptor`.
* [`wgpu/src/window/compositor.rs`](diffhunk://#diff-9ccb6c380f79bd90d45dc570827840d0e5de4491b306b319769c1eb3000831ceL99-R101): Improved error handling in the `request_adapter` method call and refactored the `request_device` method call to add a default trace value to the `DeviceDescriptor`. [[1]](diffhunk://#diff-9ccb6c380f79bd90d45dc570827840d0e5de4491b306b319769c1eb3000831ceL99-R101) [[2]](diffhunk://#diff-9ccb6c380f79bd90d45dc570827840d0e5de4491b306b319769c1eb3000831ceL165-R175)