### PR TITLE
Make `text_input::State` `select_range` public

### DIFF
--- a/core/src/widget/operation/text_input.rs
+++ b/core/src/widget/operation/text_input.rs
@@ -13,6 +13,8 @@ pub trait TextInput {
     fn move_cursor_to(&mut self, position: usize);
     /// Selects all the content of the text input.
     fn select_all(&mut self);
+    /// Selects the given content range of the text input.
+    fn select_range(&mut self, start: usize, end: usize);
 }
 
 /// Produces an [`Operation`] that moves the cursor of the widget with the given [`Id`] to the
@@ -153,4 +155,44 @@ pub fn select_all<T>(target: Id) -> impl Operation<T> {
     }
 
     MoveCursor { target }
+}
+
+/// Produces an [`Operation`] that selects the given content range of the widget with the given [`Id`].
+pub fn select_range<T>(
+    target: Id,
+    start: usize,
+    end: usize,
+) -> impl Operation<T> {
+    struct SelectRange {
+        target: Id,
+        start: usize,
+        end: usize,
+    }
+
+    impl<T> Operation<T> for SelectRange {
+        fn text_input(
+            &mut self,
+            id: Option<&Id>,
+            _bounds: Rectangle,
+            state: &mut dyn TextInput,
+        ) {
+            match id {
+                Some(id) if id == &self.target => {
+                    state.select_range(self.start, self.end);
+                }
+                _ => {}
+            }
+        }
+
+        fn container(
+            &mut self,
+            _id: Option<&Id>,
+            _bounds: Rectangle,
+            operate_on_children: &mut dyn FnMut(&mut dyn Operation<T>),
+        ) {
+            operate_on_children(self);
+        }
+    }
+
+    SelectRange { target, start, end }
 }

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -1642,6 +1642,10 @@ impl<P: text::Paragraph> operation::TextInput for State<P> {
     fn select_all(&mut self) {
         State::select_all(self);
     }
+
+    fn select_range(&mut self, start: usize, end: usize) {
+        State::select_range(self, start, end);
+    }
 }
 
 fn offset<P: text::Paragraph>(

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -1605,6 +1605,11 @@ impl<P: text::Paragraph> State<P> {
     pub fn select_all(&mut self) {
         self.cursor.select_range(0, usize::MAX);
     }
+
+    /// Selects the given range of the content of the [`TextInput`].
+    pub fn select_range(&mut self, start: usize, end: usize) {
+        self.cursor.select_range(start, end);
+    }
 }
 
 impl<P: text::Paragraph> operation::Focusable for State<P> {


### PR DESCRIPTION
I would like to build a wrapper around a text_input that only allows selecting part of the content. This would allow me to do so.
