### PR TITLE
use `fn` for `Subscription::map`

### DIFF
--- a/futures/src/subscription.rs
+++ b/futures/src/subscription.rs
@@ -258,29 +258,17 @@ impl<T> Subscription<T> {
     }
 
     /// Transforms the [`Subscription`] output with the given function.
-    ///
-    /// # Panics
-    /// The closure provided must be a non-capturing closure. The method
-    /// will panic in debug mode otherwise.
-    pub fn map<F, A>(mut self, f: F) -> Subscription<A>
+    pub fn map<A>(mut self, f: fn(T) -> A) -> Subscription<A>
     where
         T: 'static,
-        F: Fn(T) -> A + MaybeSend + Clone + 'static,
         A: 'static,
     {
-        debug_assert!(
-            std::mem::size_of::<F>() == 0,
-            "the closure {} provided in `Subscription::map` is capturing",
-            std::any::type_name::<F>(),
-        );
-
         Subscription {
             recipes: self
                 .recipes
                 .drain(..)
                 .map(move |recipe| {
-                    Box::new(Map::new(recipe, f.clone()))
-                        as Box<dyn Recipe<Output = A>>
+                    Box::new(Map::new(recipe, f)) as Box<dyn Recipe<Output = A>>
                 })
                 .collect(),
         }


### PR DESCRIPTION
As per [rfc 1558](https://github.com/rust-lang/rfcs/blob/master/text/1558-closure-to-fn-coercion.md), any non-capturing closure can be coerced to a function pointer, so this replaces a runtime check for non-capturing-ness with a compile-time check.