### PR TITLE
Allow storage of pipelines in custom shaders for WASM target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1187,6 +1187,9 @@ name = "custom_shader"
 version = "0.1.0"
 dependencies = [
  "bytemuck",
+ "console_error_panic_hook",
+ "console_log",
+ "getrandom 0.2.15",
  "glam",
  "iced",
  "image",

--- a/examples/custom_shader/Cargo.toml
+++ b/examples/custom_shader/Cargo.toml
@@ -15,3 +15,10 @@ glam.workspace = true
 glam.features = ["bytemuck"]
 
 rand = "0.8.5"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+iced.workspace = true
+iced.features = ["debug", "image", "advanced", "webgl", "fira-sans"]
+getrandom = { version = "0.2", features = ["js"] }
+console_error_panic_hook = "0.1"
+console_log = "1.0"

--- a/examples/custom_shader/index.html
+++ b/examples/custom_shader/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Custom Shader - Iced</title>
+    <base data-trunk-public-url />
+</head>
+<body>
+<link data-trunk rel="rust" href="Cargo.toml" data-wasm-opt="z" data-bin="custom_shader" />
+</body>
+</html>

--- a/examples/custom_shader/src/main.rs
+++ b/examples/custom_shader/src/main.rs
@@ -9,6 +9,8 @@ use iced::window;
 use iced::{Center, Color, Element, Fill, Subscription};
 
 fn main() -> iced::Result {
+    #[cfg(target_arch = "wasm32")]
+    std::panic::set_hook(Box::new(console_error_panic_hook::hook));
     iced::application(IcedCubes::default, IcedCubes::update, IcedCubes::view)
         .subscription(IcedCubes::subscription)
         .run()

--- a/examples/custom_shader/src/scene/pipeline.rs
+++ b/examples/custom_shader/src/scene/pipeline.rs
@@ -499,13 +499,7 @@ impl DepthPipeline {
                         wgpu::PipelineCompilationOptions::default(),
                 },
                 primitive: wgpu::PrimitiveState::default(),
-                depth_stencil: Some(wgpu::DepthStencilState {
-                    format: wgpu::TextureFormat::Depth32Float,
-                    depth_write_enabled: false,
-                    depth_compare: wgpu::CompareFunction::Less,
-                    stencil: wgpu::StencilState::default(),
-                    bias: wgpu::DepthBiasState::default(),
-                }),
+                depth_stencil: None,
                 multisample: wgpu::MultisampleState::default(),
                 fragment: Some(wgpu::FragmentState {
                     module: &shader,
@@ -574,13 +568,7 @@ impl DepthPipeline {
                     store: wgpu::StoreOp::Store,
                 },
             })],
-            depth_stencil_attachment: Some(
-                wgpu::RenderPassDepthStencilAttachment {
-                    view: &self.depth_view,
-                    depth_ops: None,
-                    stencil_ops: None,
-                },
-            ),
+            depth_stencil_attachment: None,
             timestamp_writes: None,
             occlusion_query_set: None,
         });

--- a/examples/custom_shader/src/shaders/depth.wgsl
+++ b/examples/custom_shader/src/shaders/depth.wgsl
@@ -42,7 +42,7 @@ fn fs_main(input: Output) -> @location(0) vec4<f32> {
         discard;
     }
 
-    let c = 1.0 - depth;
+    let c = (1.0 - depth) * 10.0;
 
     return vec4<f32>(c, c, c, 1.0);
 }


### PR DESCRIPTION
I tried to add a custom shader component to my app (a boardgame with a web client and a local one) and ran into an error similar to this one:

> error[E0277]: `(dyn FnOnce(std::result::Result<(), BufferAccessError>) + 'static)` cannot be sent between threads safely
   --> examples/custom_shader/src/scene.rs:141:27
    |
141 |               storage.store(Pipeline::new(
    |  _____________________-----_^
    | |                     |
    | |                     required by a bound introduced by this call
142 | |                 device,
143 | |                 queue,
144 | |                 format,
145 | |                 viewport.physical_size(),
146 | |             ));

The traits to fix this are already available. To test it, I extended the custom shader example. Rebasing the first commit out will cause the error above.