### PR TITLE
fix number of rows in grid when evenly distributed

### DIFF
--- a/widget/src/grid.rs
+++ b/widget/src/grid.rs
@@ -201,9 +201,7 @@ where
             Sizing::AspectRatio(ratio) => Some(cell_width / ratio),
             Sizing::EvenlyDistribute(Length::Shrink) => None,
             Sizing::EvenlyDistribute(_) => {
-                // (a + b - 1) / b = a / b, rounded up
-                let total_rows =
-                    (self.children.len() + cells_per_row - 1) / cells_per_row;
+                let total_rows = self.children.len().div_ceil(cells_per_row);
                 Some(
                     (available.height - self.spacing * (total_rows - 1) as f32)
                         / total_rows as f32,

--- a/widget/src/grid.rs
+++ b/widget/src/grid.rs
@@ -193,8 +193,6 @@ where
             Constraint::Amount(amount) => amount,
         };
 
-        let total_rows = self.children.len() / cells_per_row;
-
         let cell_width = (available.width
             - self.spacing * (cells_per_row - 1) as f32)
             / cells_per_row as f32;
@@ -202,10 +200,15 @@ where
         let cell_height = match self.height {
             Sizing::AspectRatio(ratio) => Some(cell_width / ratio),
             Sizing::EvenlyDistribute(Length::Shrink) => None,
-            Sizing::EvenlyDistribute(_) => Some(
-                (available.height - self.spacing * (total_rows - 1) as f32)
-                    / total_rows as f32,
-            ),
+            Sizing::EvenlyDistribute(_) => {
+                // (a + b - 1) / b = a / b, rounded up
+                let total_rows =
+                    (self.children.len() + cells_per_row - 1) / cells_per_row;
+                Some(
+                    (available.height - self.spacing * (total_rows - 1) as f32)
+                        / total_rows as f32,
+                )
+            }
         };
 
         let cell_limits = layout::Limits::new(
@@ -213,7 +216,7 @@ where
             Size::new(cell_width, cell_height.unwrap_or(available.height)),
         );
 
-        let mut nodes = Vec::new();
+        let mut nodes = Vec::with_capacity(self.children.len());
         let mut x = 0.0;
         let mut y = 0.0;
         let mut row_height = 0.0f32;


### PR DESCRIPTION
Fix calculation of number of rows in grid, which should be rounded up.
Also use `Vec::with_capacity` for nodes to potentially save some re-allocations.