### PR TITLE
publicly re-export input_method on advanced

### DIFF
--- a/src/advanced.rs
+++ b/src/advanced.rs
@@ -16,6 +16,7 @@ pub mod widget {
 pub use crate::core::Shell;
 pub use crate::core::clipboard::{self, Clipboard};
 pub use crate::core::image;
+pub use crate::core::input_method;
 pub use crate::core::layout::{self, Layout};
 pub use crate::core::mouse;
 pub use crate::core::overlay::{self, Overlay};


### PR DESCRIPTION
Re-exports the `input_method` module under the `advanced` feature, which might be useful for anyone writing a custom widget with support for input method.
