### PR TITLE
Add blurring on MacOS, Windows and Linux (setup dependent)

### DIFF
--- a/core/src/window/settings.rs
+++ b/core/src/window/settings.rs
@@ -62,6 +62,21 @@ pub struct Settings {
     /// Whether the window should be transparent.
     pub transparent: bool,
 
+    /// Whether the window should have a blurred background.
+    ///
+    /// Note that the blurry effect is only applied to transparent windows. You need to enable
+    /// [`Settings::transparent`] and set a proper opacity value to the background color with
+    /// `Application::style`.
+    ///
+    /// On Windows, it sets the [backdrop][winit_backdrop] to `TransientWindow`, making the window [acrylic][acrylic].
+    ///
+    /// On MacOS and Linux, it uses `set_blur`. For more details, please refer to the [winit documentation][winit_set_blur].
+    ///
+    /// [winit_backdrop]: https://docs.rs/winit/latest/winit/platform/windows/enum.BackdropType.html
+    /// [winit_set_blur]: https://docs.rs/winit/latest/winit/window/struct.Window.html#method.set_blur
+    /// [acrylic]: https://learn.microsoft.com/en-us/windows/apps/design/style/acrylic
+    pub blur: bool,
+
     /// The window [`Level`].
     pub level: Level,
 
@@ -95,6 +110,7 @@ impl Default for Settings {
             resizable: true,
             decorations: true,
             transparent: false,
+            blur: false,
             level: Level::default(),
             icon: None,
             exit_on_close_request: true,

--- a/src/application.rs
+++ b/src/application.rs
@@ -295,6 +295,17 @@ impl<P: Program> Application<P> {
         }
     }
 
+    /// Sets the [`window::Settings::blur`] of the [`Application`].
+    pub fn blur(self, blur: bool) -> Self {
+        Self {
+            window: window::Settings {
+                blur,
+                ..self.window
+            },
+            ..self
+        }
+    }
+
     /// Sets the [`window::Settings::level`] of the [`Application`].
     pub fn level(self, level: window::Level) -> Self {
         Self {

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -40,6 +40,7 @@ pub fn window_attributes(
         .with_decorations(settings.decorations)
         .with_transparent(settings.transparent)
         .with_window_icon(settings.icon.and_then(icon))
+        .with_blur(settings.blur)
         .with_window_level(window_level(settings.level))
         .with_visible(settings.visible);
 
@@ -79,6 +80,7 @@ pub fn window_attributes(
 
     #[cfg(target_os = "windows")]
     {
+        use winit::platform::windows::BackdropType;
         use winit::platform::windows::WindowAttributesExtWindows;
 
         attributes = attributes
@@ -90,6 +92,11 @@ pub fn window_attributes(
         attributes = attributes.with_undecorated_shadow(
             settings.platform_specific.undecorated_shadow,
         );
+
+        if settings.blur {
+            attributes =
+                attributes.with_system_backdrop(BackdropType::TransientWindow)
+        }
     }
 
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
Extends #2728 to support Windows in addition to MacOS and Linux.