### PR TITLE
Floating Images

### DIFF
--- a/core/src/element.rs
+++ b/core/src/element.rs
@@ -368,12 +368,13 @@ where
         tree: &'b mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
+        viewport: &Rectangle,
         translation: Vector,
     ) -> Option<overlay::Element<'b, B, Theme, Renderer>> {
         let mapper = &self.mapper;
 
         self.widget
-            .overlay(tree, layout, renderer, translation)
+            .overlay(tree, layout, renderer, viewport, translation)
             .map(move |overlay| overlay.map(mapper))
     }
 }
@@ -519,10 +520,15 @@ where
         state: &'b mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
+        viewport: &Rectangle,
         translation: Vector,
     ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
-        self.element
-            .widget
-            .overlay(state, layout, renderer, translation)
+        self.element.widget.overlay(
+            state,
+            layout,
+            renderer,
+            viewport,
+            translation,
+        )
     }
 }

--- a/core/src/overlay.rs
+++ b/core/src/overlay.rs
@@ -101,6 +101,16 @@ where
     ) -> Option<Element<'a, Message, Theme, Renderer>> {
         None
     }
+
+    /// The index of the overlay.
+    ///
+    /// Overlays with a higher index will be rendered on top of overlays with
+    /// a lower index.
+    ///
+    /// By default, it returns `1.0`.
+    fn index(&self) -> f32 {
+        1.0
+    }
 }
 
 /// Returns a [`Group`] of overlay [`Element`] children.

--- a/core/src/overlay.rs
+++ b/core/src/overlay.rs
@@ -122,6 +122,7 @@ pub fn from_children<'a, Message, Theme, Renderer>(
     tree: &'a mut Tree,
     layout: Layout<'_>,
     renderer: &Renderer,
+    viewport: &Rectangle,
     translation: Vector,
 ) -> Option<Element<'a, Message, Theme, Renderer>>
 where
@@ -132,9 +133,13 @@ where
         .zip(&mut tree.children)
         .zip(layout.children())
         .filter_map(|((child, state), layout)| {
-            child
-                .as_widget_mut()
-                .overlay(state, layout, renderer, translation)
+            child.as_widget_mut().overlay(
+                state,
+                layout,
+                renderer,
+                viewport,
+                translation,
+            )
         })
         .collect::<Vec<_>>();
 

--- a/core/src/overlay/element.rs
+++ b/core/src/overlay/element.rs
@@ -23,6 +23,18 @@ where
         Self { overlay }
     }
 
+    /// Returns a reference to the [`Overlay`] of the [`Element`],
+    pub fn as_overlay(&self) -> &dyn Overlay<Message, Theme, Renderer> {
+        self.overlay.as_ref()
+    }
+
+    /// Returns a mutable reference to the [`Overlay`] of the [`Element`],
+    pub fn as_overlay_mut(
+        &mut self,
+    ) -> &mut dyn Overlay<Message, Theme, Renderer> {
+        self.overlay.as_mut()
+    }
+
     /// Applies a transformation to the produced message of the [`Element`].
     pub fn map<B>(
         self,
@@ -37,82 +49,6 @@ where
         Element {
             overlay: Box::new(Map::new(self.overlay, f)),
         }
-    }
-
-    /// Computes the layout of the [`Element`] in the given bounds.
-    pub fn layout(
-        &mut self,
-        renderer: &Renderer,
-        bounds: Size,
-    ) -> layout::Node {
-        self.overlay.layout(renderer, bounds)
-    }
-
-    /// Processes a runtime [`Event`].
-    pub fn update(
-        &mut self,
-        event: &Event,
-        layout: Layout<'_>,
-        cursor: mouse::Cursor,
-        renderer: &Renderer,
-        clipboard: &mut dyn Clipboard,
-        shell: &mut Shell<'_, Message>,
-    ) {
-        self.overlay
-            .update(event, layout, cursor, renderer, clipboard, shell);
-    }
-
-    /// Returns the current [`mouse::Interaction`] of the [`Element`].
-    pub fn mouse_interaction(
-        &self,
-        layout: Layout<'_>,
-        cursor: mouse::Cursor,
-        viewport: &Rectangle,
-        renderer: &Renderer,
-    ) -> mouse::Interaction {
-        self.overlay
-            .mouse_interaction(layout, cursor, viewport, renderer)
-    }
-
-    /// Draws the [`Element`] and its children using the given [`Layout`].
-    pub fn draw(
-        &self,
-        renderer: &mut Renderer,
-        theme: &Theme,
-        style: &renderer::Style,
-        layout: Layout<'_>,
-        cursor: mouse::Cursor,
-    ) {
-        self.overlay.draw(renderer, theme, style, layout, cursor);
-    }
-
-    /// Applies a [`widget::Operation`] to the [`Element`].
-    pub fn operate(
-        &mut self,
-        layout: Layout<'_>,
-        renderer: &Renderer,
-        operation: &mut dyn widget::Operation,
-    ) {
-        self.overlay.operate(layout, renderer, operation);
-    }
-
-    /// Returns true if the cursor is over the [`Element`].
-    pub fn is_over(
-        &self,
-        layout: Layout<'_>,
-        renderer: &Renderer,
-        cursor_position: Point,
-    ) -> bool {
-        self.overlay.is_over(layout, renderer, cursor_position)
-    }
-
-    /// Returns the nested overlay of the [`Element`], if there is any.
-    pub fn overlay<'b>(
-        &'b mut self,
-        layout: Layout<'_>,
-        renderer: &Renderer,
-    ) -> Option<Element<'b, Message, Theme, Renderer>> {
-        self.overlay.overlay(layout, renderer)
     }
 }
 

--- a/core/src/overlay/group.rs
+++ b/core/src/overlay/group.rs
@@ -39,15 +39,6 @@ where
         Group { children }
     }
 
-    /// Adds an [`overlay::Element`] to the [`Group`].
-    pub fn push(
-        mut self,
-        child: impl Into<overlay::Element<'a, Message, Theme, Renderer>>,
-    ) -> Self {
-        self.children.push(child.into());
-        self
-    }
-
     /// Turns the [`Group`] into an overlay [`overlay::Element`].
     pub fn overlay(self) -> overlay::Element<'a, Message, Theme, Renderer> {
         overlay::Element::new(Box::new(self))

--- a/core/src/overlay/group.rs
+++ b/core/src/overlay/group.rs
@@ -25,8 +25,17 @@ where
 
     /// Creates a [`Group`] with the given elements.
     pub fn with_children(
-        children: Vec<overlay::Element<'a, Message, Theme, Renderer>>,
+        mut children: Vec<overlay::Element<'a, Message, Theme, Renderer>>,
     ) -> Self {
+        use std::cmp;
+
+        children.sort_unstable_by(|a, b| {
+            a.as_overlay()
+                .index()
+                .partial_cmp(&b.as_overlay().index())
+                .unwrap_or(cmp::Ordering::Equal)
+        });
+
         Group { children }
     }
 
@@ -67,7 +76,7 @@ where
             bounds,
             self.children
                 .iter_mut()
-                .map(|child| child.layout(renderer, bounds))
+                .map(|child| child.as_overlay_mut().layout(renderer, bounds))
                 .collect(),
         )
     }
@@ -82,7 +91,9 @@ where
         shell: &mut Shell<'_, Message>,
     ) {
         for (child, layout) in self.children.iter_mut().zip(layout.children()) {
-            child.update(event, layout, cursor, renderer, clipboard, shell);
+            child
+                .as_overlay_mut()
+                .update(event, layout, cursor, renderer, clipboard, shell);
         }
     }
 
@@ -95,7 +106,9 @@ where
         cursor: mouse::Cursor,
     ) {
         for (child, layout) in self.children.iter().zip(layout.children()) {
-            child.draw(renderer, theme, style, layout, cursor);
+            child
+                .as_overlay()
+                .draw(renderer, theme, style, layout, cursor);
         }
     }
 
@@ -110,7 +123,9 @@ where
             .iter()
             .zip(layout.children())
             .map(|(child, layout)| {
-                child.mouse_interaction(layout, cursor, viewport, renderer)
+                child
+                    .as_overlay()
+                    .mouse_interaction(layout, cursor, viewport, renderer)
             })
             .max()
             .unwrap_or_default()
@@ -125,7 +140,7 @@ where
         operation.container(None, layout.bounds(), &mut |operation| {
             self.children.iter_mut().zip(layout.children()).for_each(
                 |(child, layout)| {
-                    child.operate(layout, renderer, operation);
+                    child.as_overlay_mut().operate(layout, renderer, operation);
                 },
             );
         });
@@ -141,7 +156,9 @@ where
             .iter()
             .zip(layout.children())
             .any(|(child, layout)| {
-                child.is_over(layout, renderer, cursor_position)
+                child
+                    .as_overlay()
+                    .is_over(layout, renderer, cursor_position)
             })
     }
 
@@ -154,10 +171,19 @@ where
             .children
             .iter_mut()
             .zip(layout.children())
-            .filter_map(|(child, layout)| child.overlay(layout, renderer))
+            .filter_map(|(child, layout)| {
+                child.as_overlay_mut().overlay(layout, renderer)
+            })
             .collect::<Vec<_>>();
 
         (!children.is_empty()).then(|| Group::with_children(children).overlay())
+    }
+
+    fn index(&self) -> f32 {
+        self.children
+            .first()
+            .map(|child| child.as_overlay().index())
+            .unwrap_or(1.0)
     }
 }
 

--- a/core/src/rectangle.rs
+++ b/core/src/rectangle.rs
@@ -160,25 +160,25 @@ impl Rectangle<f32> {
     /// Computes the offset that must be applied to the [`Rectangle`] to be placed
     /// inside the given `container`.
     pub fn offset(&self, container: &Rectangle) -> Vector {
-        if let Some(intersection) = self.intersection(container) {
-            let left = intersection.x - self.x;
-            let top = intersection.y - self.y;
+        let Some(intersection) = self.intersection(container) else {
+            return Vector::ZERO;
+        };
 
-            Vector::new(
-                if left > 0.0 {
-                    left
-                } else {
-                    intersection.x + intersection.width - self.x - self.width
-                },
-                if top > 0.0 {
-                    top
-                } else {
-                    intersection.y + intersection.height - self.y - self.height
-                },
-            )
-        } else {
-            Vector::ZERO
-        }
+        let left = intersection.x - self.x;
+        let top = intersection.y - self.y;
+
+        Vector::new(
+            if left > 0.0 {
+                left
+            } else {
+                intersection.x + intersection.width - self.x - self.width
+            },
+            if top > 0.0 {
+                top
+            } else {
+                intersection.y + intersection.height - self.y - self.height
+            },
+        )
     }
 
     /// Returns true if the current [`Rectangle`] is completely within the given

--- a/core/src/rectangle.rs
+++ b/core/src/rectangle.rs
@@ -157,6 +157,30 @@ impl Rectangle<f32> {
         distance_x.hypot(distance_y)
     }
 
+    /// Computes the offset that must be applied to the [`Rectangle`] to be placed
+    /// inside the given `container`.
+    pub fn offset(&self, container: &Rectangle) -> Vector {
+        if let Some(intersection) = self.intersection(container) {
+            let left = intersection.x - self.x;
+            let top = intersection.y - self.y;
+
+            Vector::new(
+                if left > 0.0 {
+                    left
+                } else {
+                    intersection.x + intersection.width - self.x - self.width
+                },
+                if top > 0.0 {
+                    top
+                } else {
+                    intersection.y + intersection.height - self.y - self.height
+                },
+            )
+        } else {
+            Vector::ZERO
+        }
+    }
+
     /// Returns true if the current [`Rectangle`] is completely within the given
     /// `container`.
     pub fn is_within(&self, container: &Rectangle) -> bool {
@@ -267,6 +291,17 @@ impl Rectangle<f32> {
         );
 
         Self::new(position, size)
+    }
+
+    /// Scales the [`Rectangle`] without changing its position, effectively
+    /// "zooming" it.
+    pub fn zoom(self, zoom: f32) -> Self {
+        Self {
+            x: self.x - (self.width * (zoom - 1.0)) / 2.0,
+            y: self.y - (self.height * (zoom - 1.0)) / 2.0,
+            width: self.width * zoom,
+            height: self.height * zoom,
+        }
     }
 }
 

--- a/core/src/widget.rs
+++ b/core/src/widget.rs
@@ -146,6 +146,7 @@ where
         _state: &'a mut Tree,
         _layout: Layout<'_>,
         _renderer: &Renderer,
+        _viewport: &Rectangle,
         _translation: Vector,
     ) -> Option<overlay::Element<'a, Message, Theme, Renderer>> {
         None

--- a/examples/gallery/src/main.rs
+++ b/examples/gallery/src/main.rs
@@ -14,8 +14,8 @@ use iced::widget::{
 };
 use iced::window;
 use iced::{
-    Animation, ContentFit, Element, Fill, Function, Subscription, Task, Theme,
-    color,
+    Animation, Color, ContentFit, Element, Fill, Function, Shadow,
+    Subscription, Task, Theme, color,
 };
 
 use std::collections::HashMap;
@@ -210,6 +210,19 @@ fn card<'a>(
                     .content_fit(ContentFit::Cover)
                     .opacity(thumbnail.fade_in.interpolate(0.0, 1.0, now))
                     .scale(thumbnail.zoom.interpolate(1.0, 1.1, now))
+                    .float(true)
+                    .style(move |_theme| image::Style {
+                        shadow: Shadow {
+                            color: Color::BLACK.scale_alpha(
+                                thumbnail.zoom.interpolate(0.0, 1.0, now),
+                            ),
+                            blur_radius: thumbnail
+                                .zoom
+                                .interpolate(0.0, 20.0, now),
+                            ..Shadow::default()
+                        },
+                        ..image::Style::default()
+                    })
                     .into()
             } else {
                 horizontal_space().into()

--- a/examples/gallery/src/main.rs
+++ b/examples/gallery/src/main.rs
@@ -210,6 +210,12 @@ fn card<'a>(
                     .content_fit(ContentFit::Cover)
                     .opacity(thumbnail.fade_in.interpolate(0.0, 1.0, now))
                     .scale(thumbnail.zoom.interpolate(1.0, 1.1, now))
+                    .translate(move |bounds, viewport| {
+                        let final_bounds = bounds.zoom(1.1);
+
+                        final_bounds.offset(&viewport.shrink(10))
+                            * thumbnail.zoom.interpolate(0.0, 1.0, now)
+                    })
                     .float(true)
                     .style(move |_theme| image::Style {
                         shadow: Shadow {

--- a/examples/gallery/src/main.rs
+++ b/examples/gallery/src/main.rs
@@ -212,11 +212,9 @@ fn card<'a>(
                     .scale(thumbnail.zoom.interpolate(1.0, 1.1, now))
                     .translate(move |bounds, viewport| {
                         let final_bounds = bounds.zoom(1.1);
-
                         final_bounds.offset(&viewport.shrink(10))
                             * thumbnail.zoom.interpolate(0.0, 1.0, now)
                     })
-                    .float(true)
                     .style(move |_theme| image::Style {
                         shadow: Shadow {
                             color: Color::BLACK.scale_alpha(

--- a/examples/gallery/src/main.rs
+++ b/examples/gallery/src/main.rs
@@ -211,8 +211,7 @@ fn card<'a>(
                     .opacity(thumbnail.fade_in.interpolate(0.0, 1.0, now))
                     .scale(thumbnail.zoom.interpolate(1.0, 1.1, now))
                     .translate(move |bounds, viewport| {
-                        let final_bounds = bounds.zoom(1.1);
-                        final_bounds.offset(&viewport.shrink(10))
+                        bounds.zoom(1.1).offset(&viewport.shrink(10))
                             * thumbnail.zoom.interpolate(0.0, 1.0, now)
                     })
                     .style(move |_theme| image::Style {

--- a/examples/toast/src/main.rs
+++ b/examples/toast/src/main.rs
@@ -425,6 +425,7 @@ mod toast {
             state: &'b mut Tree,
             layout: Layout<'_>,
             renderer: &Renderer,
+            viewport: &Rectangle,
             translation: Vector,
         ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
             let instants = state.state.downcast_mut::<Vec<Option<Instant>>>();
@@ -435,6 +436,7 @@ mod toast {
                 &mut content_state[0],
                 layout,
                 renderer,
+                viewport,
                 translation,
             );
 

--- a/runtime/src/user_interface.rs
+++ b/runtime/src/user_interface.rs
@@ -190,6 +190,7 @@ where
         let mut outdated = false;
         let mut redraw_request = window::RedrawRequest::Wait;
         let mut input_method = InputMethod::Disabled;
+        let viewport = Rectangle::with_size(self.bounds);
 
         let mut manual_overlay = ManuallyDrop::new(
             self.root
@@ -198,6 +199,7 @@ where
                     &mut self.state,
                     Layout::new(&self.base),
                     renderer,
+                    &viewport,
                     Vector::ZERO,
                 )
                 .map(overlay::Nested::new),
@@ -242,6 +244,7 @@ where
                                 &mut self.state,
                                 Layout::new(&self.base),
                                 renderer,
+                                &viewport,
                                 Vector::ZERO,
                             )
                             .map(overlay::Nested::new),
@@ -443,6 +446,7 @@ where
                 &mut self.state,
                 Layout::new(&self.base),
                 renderer,
+                &viewport,
                 Vector::ZERO,
             )
             .map(overlay::Nested::new)
@@ -513,6 +517,7 @@ where
                         &mut self.state,
                         Layout::new(base),
                         renderer,
+                        &viewport,
                         Vector::ZERO,
                     )
                     .map(overlay::Nested::new)
@@ -558,6 +563,8 @@ where
         renderer: &Renderer,
         operation: &mut dyn widget::Operation,
     ) {
+        let viewport = Rectangle::with_size(self.bounds);
+
         self.root.as_widget().operate(
             &mut self.state,
             Layout::new(&self.base),
@@ -572,6 +579,7 @@ where
                 &mut self.state,
                 Layout::new(&self.base),
                 renderer,
+                &viewport,
                 Vector::ZERO,
             )
             .map(overlay::Nested::new)

--- a/widget/src/button.rs
+++ b/widget/src/button.rs
@@ -432,12 +432,14 @@ where
         tree: &'b mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
+        viewport: &Rectangle,
         translation: Vector,
     ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
         self.content.as_widget_mut().overlay(
             &mut tree.children[0],
             layout.children().next().unwrap(),
             renderer,
+            viewport,
             translation,
         )
     }

--- a/widget/src/column.rs
+++ b/widget/src/column.rs
@@ -338,6 +338,7 @@ where
         tree: &'b mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
+        viewport: &Rectangle,
         translation: Vector,
     ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
         overlay::from_children(
@@ -345,6 +346,7 @@ where
             tree,
             layout,
             renderer,
+            viewport,
             translation,
         )
     }

--- a/widget/src/combo_box.rs
+++ b/widget/src/combo_box.rs
@@ -832,6 +832,7 @@ where
         tree: &'b mut widget::Tree,
         layout: Layout<'_>,
         _renderer: &Renderer,
+        _viewport: &Rectangle,
         translation: Vector,
     ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
         let is_focused = {

--- a/widget/src/container.rs
+++ b/widget/src/container.rs
@@ -379,12 +379,14 @@ where
         tree: &'b mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
+        viewport: &Rectangle,
         translation: Vector,
     ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
         self.content.as_widget_mut().overlay(
             tree,
             layout.children().next().unwrap(),
             renderer,
+            viewport,
             translation,
         )
     }

--- a/widget/src/grid.rs
+++ b/widget/src/grid.rs
@@ -345,6 +345,7 @@ where
         tree: &'b mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
+        viewport: &Rectangle,
         translation: Vector,
     ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
         overlay::from_children(
@@ -352,6 +353,7 @@ where
             tree,
             layout,
             renderer,
+            viewport,
             translation,
         )
     }

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -694,6 +694,7 @@ where
             state: &'b mut core::widget::Tree,
             layout: core::Layout<'_>,
             renderer: &Renderer,
+            viewport: &Rectangle,
             translation: core::Vector,
         ) -> Option<core::overlay::Element<'b, Message, Theme, Renderer>>
         {
@@ -701,6 +702,7 @@ where
                 state,
                 layout,
                 renderer,
+                viewport,
                 translation,
             )
         }
@@ -948,6 +950,7 @@ where
             tree: &'b mut core::widget::Tree,
             layout: core::Layout<'_>,
             renderer: &Renderer,
+            viewport: &Rectangle,
             translation: core::Vector,
         ) -> Option<core::overlay::Element<'b, Message, Theme, Renderer>>
         {
@@ -959,6 +962,7 @@ where
                         tree,
                         layout,
                         renderer,
+                        viewport,
                         translation,
                     )
                 });

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -1844,7 +1844,12 @@ where
 /// ```
 /// <img src="https://github.com/iced-rs/iced/blob/9712b319bb7a32848001b96bd84977430f14b623/examples/resources/ferris.png?raw=true" width="300">
 #[cfg(feature = "image")]
-pub fn image<Handle>(handle: impl Into<Handle>) -> crate::Image<Handle> {
+pub fn image<'a, Handle, Theme>(
+    handle: impl Into<Handle>,
+) -> crate::Image<'a, Handle, Theme>
+where
+    Theme: crate::image::Catalog,
+{
     crate::Image::new(handle.into())
 }
 

--- a/widget/src/image.rs
+++ b/widget/src/image.rs
@@ -19,14 +19,17 @@
 pub mod viewer;
 pub use viewer::Viewer;
 
+use crate::core;
+use crate::core::border;
 use crate::core::image;
 use crate::core::layout;
 use crate::core::mouse;
+use crate::core::overlay;
 use crate::core::renderer;
 use crate::core::widget::Tree;
 use crate::core::{
-    ContentFit, Element, Layout, Length, Point, Rectangle, Rotation, Size,
-    Vector, Widget,
+    ContentFit, Element, Layout, Length, Point, Rectangle, Rotation, Shadow,
+    Size, Vector, Widget,
 };
 
 pub use image::{FilterMethod, Handle};
@@ -55,7 +58,10 @@ pub fn viewer<Handle>(handle: Handle) -> Viewer<Handle> {
 /// ```
 /// <img src="https://github.com/iced-rs/iced/blob/9712b319bb7a32848001b96bd84977430f14b623/examples/resources/ferris.png?raw=true" width="300">
 #[derive(Debug)]
-pub struct Image<Handle = image::Handle> {
+pub struct Image<'a, Handle = image::Handle, Theme = crate::Theme>
+where
+    Theme: Catalog,
+{
     handle: Handle,
     width: Length,
     height: Length,
@@ -64,9 +70,14 @@ pub struct Image<Handle = image::Handle> {
     rotation: Rotation,
     opacity: f32,
     scale: f32,
+    float: bool,
+    class: Theme::Class<'a>,
 }
 
-impl<Handle> Image<Handle> {
+impl<'a, Handle, Theme> Image<'a, Handle, Theme>
+where
+    Theme: Catalog,
+{
     /// Creates a new [`Image`] with the given path.
     pub fn new(handle: impl Into<Handle>) -> Self {
         Image {
@@ -78,6 +89,8 @@ impl<Handle> Image<Handle> {
             rotation: Rotation::default(),
             opacity: 1.0,
             scale: 1.0,
+            float: false,
+            class: Theme::default(),
         }
     }
 
@@ -130,6 +143,35 @@ impl<Handle> Image<Handle> {
         self.scale = scale.into();
         self
     }
+
+    /// Sets whether an [`Image`] should float above other content when scaled up.
+    ///
+    /// By default, an [`Image`] has this flag set to `false`; meaning it
+    /// will be clipped or "framed" inside its bounds when scaled.
+    ///
+    /// Enabling this flag is useful to create cool hover effects!
+    pub fn float(mut self, float: bool) -> Self {
+        self.float = float;
+        self
+    }
+
+    /// Sets the style of the [`Image`].
+    #[must_use]
+    pub fn style(mut self, style: impl Fn(&Theme) -> Style + 'a) -> Self
+    where
+        Theme::Class<'a>: From<StyleFn<'a, Theme>>,
+    {
+        self.class = (Box::new(style) as StyleFn<'a, Theme>).into();
+        self
+    }
+
+    /// Sets the style class of the [`Image`].
+    #[cfg(feature = "advanced")]
+    #[must_use]
+    pub fn class(mut self, class: impl Into<Theme::Class<'a>>) -> Self {
+        self.class = class.into();
+        self
+    }
 }
 
 /// Computes the layout of an [`Image`].
@@ -174,26 +216,20 @@ where
     layout::Node::new(final_size)
 }
 
-/// Draws an [`Image`]
-pub fn draw<Renderer, Handle>(
-    renderer: &mut Renderer,
-    layout: Layout<'_>,
-    viewport: &Rectangle,
+fn drawing_bounds<Renderer, Handle>(
+    renderer: &Renderer,
+    bounds: Rectangle,
     handle: &Handle,
     content_fit: ContentFit,
-    filter_method: FilterMethod,
     rotation: Rotation,
-    opacity: f32,
     scale: f32,
-) where
+) -> Rectangle
+where
     Renderer: image::Renderer<Handle = Handle>,
-    Handle: Clone,
 {
     let Size { width, height } = renderer.measure_image(handle);
     let image_size = Size::new(width as f32, height as f32);
     let rotated_size = rotation.apply(image_size);
-
-    let bounds = layout.bounds();
     let adjusted_fit = content_fit.fit(rotated_size, bounds.size());
 
     let fit_scale = Vector::new(
@@ -214,36 +250,103 @@ pub fn draw<Renderer, Handle>(
         ),
     };
 
-    let drawing_bounds = Rectangle::new(position, final_size);
+    Rectangle::new(position, final_size)
+}
 
-    let render = |renderer: &mut Renderer| {
-        renderer.draw_image(
-            image::Image {
-                handle: handle.clone(),
-                filter_method,
-                rotation: rotation.radians(),
-                opacity,
-                snap: true,
-            },
-            drawing_bounds,
-        );
-    };
+fn must_clip(bounds: Rectangle, drawing_bounds: Rectangle) -> bool {
+    drawing_bounds.width > bounds.width || drawing_bounds.height > bounds.height
+}
 
-    if adjusted_fit.width > bounds.width || adjusted_fit.height > bounds.height
-    {
+/// Draws an [`Image`]
+pub fn draw<Renderer, Handle>(
+    renderer: &mut Renderer,
+    layout: Layout<'_>,
+    viewport: &Rectangle,
+    handle: &Handle,
+    content_fit: ContentFit,
+    filter_method: FilterMethod,
+    rotation: Rotation,
+    opacity: f32,
+    scale: f32,
+    float: bool,
+    style: Style,
+) where
+    Renderer: image::Renderer<Handle = Handle>,
+    Handle: Clone,
+{
+    let bounds = layout.bounds();
+    let drawing_bounds =
+        drawing_bounds(renderer, bounds, handle, content_fit, rotation, scale);
+
+    if must_clip(bounds, drawing_bounds) {
+        if scale > 1.0 && float {
+            return;
+        }
+
         if let Some(bounds) = bounds.intersection(viewport) {
-            renderer.with_layer(bounds, render);
+            renderer.with_layer(bounds, |renderer| {
+                render(
+                    renderer,
+                    handle,
+                    filter_method,
+                    rotation,
+                    opacity,
+                    drawing_bounds,
+                );
+            });
         }
     } else {
-        render(renderer);
+        render(
+            renderer,
+            handle,
+            filter_method,
+            rotation,
+            opacity,
+            drawing_bounds,
+        );
+    }
+
+    if style.shadow.color.a > 0.0 {
+        renderer.fill_quad(
+            renderer::Quad {
+                bounds: bounds.shrink(1.0),
+                shadow: style.shadow,
+                border: border::rounded(style.shadow_border_radius),
+            },
+            style.shadow.color,
+        );
     }
 }
 
+fn render<Renderer, Handle>(
+    renderer: &mut Renderer,
+    handle: &Handle,
+    filter_method: FilterMethod,
+    rotation: Rotation,
+    opacity: f32,
+    drawing_bounds: Rectangle,
+) where
+    Renderer: image::Renderer<Handle = Handle>,
+    Handle: Clone,
+{
+    renderer.draw_image(
+        image::Image {
+            handle: handle.clone(),
+            filter_method,
+            rotation: rotation.radians(),
+            opacity,
+            snap: true,
+        },
+        drawing_bounds,
+    );
+}
+
 impl<Message, Theme, Renderer, Handle> Widget<Message, Theme, Renderer>
-    for Image<Handle>
+    for Image<'_, Handle, Theme>
 where
     Renderer: image::Renderer<Handle = Handle>,
     Handle: Clone,
+    Theme: Catalog,
 {
     fn size(&self) -> Size<Length> {
         Size {
@@ -273,7 +376,7 @@ where
         &self,
         _state: &Tree,
         renderer: &mut Renderer,
-        _theme: &Theme,
+        theme: &Theme,
         _style: &renderer::Style,
         layout: Layout<'_>,
         _cursor: mouse::Cursor,
@@ -289,17 +392,179 @@ where
             self.rotation,
             self.opacity,
             self.scale,
+            self.float,
+            theme.style(&self.class),
         );
+    }
+
+    fn overlay<'a>(
+        &'a mut self,
+        _state: &'a mut Tree,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+        translation: Vector,
+    ) -> Option<overlay::Element<'a, Message, Theme, Renderer>> {
+        if !self.float || self.scale <= 1.0 {
+            return None;
+        }
+
+        let bounds = layout.bounds() + translation;
+        let drawing_bounds = drawing_bounds(
+            renderer,
+            bounds,
+            &self.handle,
+            self.content_fit,
+            self.rotation,
+            self.scale,
+        );
+
+        if must_clip(bounds, drawing_bounds) {
+            Some(overlay::Element::new(Box::new(Overlay {
+                image: self,
+                clip_bounds: bounds,
+                drawing_bounds,
+            })))
+        } else {
+            None
+        }
     }
 }
 
-impl<'a, Message, Theme, Renderer, Handle> From<Image<Handle>>
+impl<'a, Message, Theme, Renderer, Handle> From<Image<'a, Handle, Theme>>
     for Element<'a, Message, Theme, Renderer>
 where
     Renderer: image::Renderer<Handle = Handle>,
     Handle: Clone + 'a,
+    Theme: Catalog + 'a,
 {
-    fn from(image: Image<Handle>) -> Element<'a, Message, Theme, Renderer> {
+    fn from(
+        image: Image<'a, Handle, Theme>,
+    ) -> Element<'a, Message, Theme, Renderer> {
         Element::new(image)
+    }
+}
+
+/// The theme catalog of an [`Image`].
+///
+/// All themes that can be used with [`Image`]
+/// must implement this trait.
+pub trait Catalog {
+    /// The item class of the [`Catalog`].
+    type Class<'a>;
+
+    /// The default class produced by the [`Catalog`].
+    fn default<'a>() -> Self::Class<'a>;
+
+    /// The [`Style`] of a class with the given status.
+    fn style(&self, class: &Self::Class<'_>) -> Style;
+}
+
+/// A styling function for a [`Button`].
+pub type StyleFn<'a, Theme> = Box<dyn Fn(&Theme) -> Style + 'a>;
+
+impl Catalog for crate::Theme {
+    type Class<'a> = StyleFn<'a, Self>;
+
+    fn default<'a>() -> Self::Class<'a> {
+        Box::new(|_| Style::default())
+    }
+
+    fn style(&self, class: &Self::Class<'_>) -> Style {
+        class(self)
+    }
+}
+
+/// The style of an [`Image`].
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct Style {
+    /// The [`Shadow`] of the [`Image`].
+    pub shadow: Shadow,
+    /// The border radius of the shadow.
+    pub shadow_border_radius: border::Radius,
+}
+
+struct Overlay<'a, 'b, Handle, Theme>
+where
+    Theme: Catalog,
+{
+    image: &'a Image<'b, Handle, Theme>,
+    clip_bounds: Rectangle,
+    drawing_bounds: Rectangle,
+}
+
+impl<Message, Theme, Renderer, Handle> core::Overlay<Message, Theme, Renderer>
+    for Overlay<'_, '_, Handle, Theme>
+where
+    Renderer: image::Renderer<Handle = Handle>,
+    Handle: Clone,
+    Theme: Catalog,
+{
+    fn layout(&mut self, _renderer: &Renderer, _bounds: Size) -> layout::Node {
+        layout::Node::new(self.clip_bounds.size())
+            .move_to(self.clip_bounds.position())
+    }
+
+    fn is_over(
+        &self,
+        _layout: Layout<'_>,
+        _renderer: &Renderer,
+        _cursor_position: Point,
+    ) -> bool {
+        false
+    }
+
+    fn draw(
+        &self,
+        renderer: &mut Renderer,
+        theme: &Theme,
+        _style: &renderer::Style,
+        _layout: Layout<'_>,
+        _cursor: mouse::Cursor,
+    ) {
+        let clip_bounds = Rectangle {
+            x: self.clip_bounds.x
+                - (self.clip_bounds.width * self.image.scale
+                    - self.clip_bounds.width)
+                    / 2.0,
+            y: self.clip_bounds.y
+                - (self.clip_bounds.height * self.image.scale
+                    - self.clip_bounds.height)
+                    / 2.0,
+            width: self.clip_bounds.width * self.image.scale,
+            height: self.clip_bounds.height * self.image.scale,
+        };
+
+        let style = theme.style(&self.image.class);
+
+        if style.shadow.color.a > 0.0 {
+            renderer.with_layer(
+                clip_bounds.expand(style.shadow.blur_radius),
+                |renderer| {
+                    renderer.fill_quad(
+                        renderer::Quad {
+                            bounds: clip_bounds.shrink(1.0),
+                            shadow: style.shadow,
+                            border: border::rounded(style.shadow_border_radius),
+                        },
+                        style.shadow.color,
+                    );
+                },
+            );
+        }
+
+        renderer.with_layer(clip_bounds, |renderer| {
+            render(
+                renderer,
+                &self.image.handle,
+                self.image.filter_method,
+                self.image.rotation,
+                self.image.opacity,
+                self.drawing_bounds,
+            );
+        });
+    }
+
+    fn index(&self) -> f32 {
+        self.image.scale * 0.5
     }
 }

--- a/widget/src/image.rs
+++ b/widget/src/image.rs
@@ -536,11 +536,12 @@ where
     ) {
         let bounds = layout.bounds();
         let clip_bounds = bounds.zoom(self.image.scale);
-        let style = theme.style(&self.image.class);
 
-        let clip_bounds = clip_bounds
-            .intersection(&self.viewport)
-            .unwrap_or(self.viewport);
+        let Some(clip_bounds) = clip_bounds.intersection(&self.viewport) else {
+            return;
+        };
+
+        let style = theme.style(&self.image.class);
 
         if style.shadow.color.a > 0.0 {
             renderer.with_layer(

--- a/widget/src/image.rs
+++ b/widget/src/image.rs
@@ -538,6 +538,10 @@ where
         let clip_bounds = bounds.zoom(self.image.scale);
         let style = theme.style(&self.image.class);
 
+        let clip_bounds = clip_bounds
+            .intersection(&self.viewport)
+            .unwrap_or(self.viewport);
+
         if style.shadow.color.a > 0.0 {
             renderer.with_layer(
                 clip_bounds.expand(style.shadow.blur_radius),
@@ -557,10 +561,6 @@ where
                 },
             );
         }
-
-        let clip_bounds = clip_bounds
-            .intersection(&self.viewport)
-            .unwrap_or(self.viewport);
 
         renderer.with_layer(clip_bounds, |renderer| {
             render(

--- a/widget/src/keyed/column.rs
+++ b/widget/src/keyed/column.rs
@@ -369,6 +369,7 @@ where
         tree: &'b mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
+        viewport: &Rectangle,
         translation: Vector,
     ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
         overlay::from_children(
@@ -376,6 +377,7 @@ where
             tree,
             layout,
             renderer,
+            viewport,
             translation,
         )
     }

--- a/widget/src/lazy.rs
+++ b/widget/src/lazy.rs
@@ -267,6 +267,7 @@ where
         tree: &'b mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
+        viewport: &Rectangle,
         translation: Vector,
     ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
         let overlay = InnerBuilder {
@@ -283,7 +284,7 @@ where
             overlay_builder: |element, tree| {
                 element
                     .as_widget_mut()
-                    .overlay(tree, layout, renderer, translation)
+                    .overlay(tree, layout, renderer, viewport, translation)
                     .map(|overlay| RefCell::new(Nested::new(overlay)))
             },
         }

--- a/widget/src/lazy/component.rs
+++ b/widget/src/lazy/component.rs
@@ -447,6 +447,7 @@ where
         tree: &'b mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
+        viewport: &Rectangle,
         translation: Vector,
     ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
         self.rebuild_element_if_necessary();
@@ -469,6 +470,7 @@ where
                                 &mut tree.children[0],
                                 layout,
                                 renderer,
+                                viewport,
                                 translation,
                             )
                             .map(|overlay| RefCell::new(Nested::new(overlay)))

--- a/widget/src/lazy/responsive.rs
+++ b/widget/src/lazy/responsive.rs
@@ -283,6 +283,7 @@ where
         tree: &'b mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
+        viewport: &Rectangle,
         translation: Vector,
     ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
         use std::ops::DerefMut;
@@ -315,7 +316,13 @@ where
                 (
                     element
                         .as_widget_mut()
-                        .overlay(tree, content_layout, renderer, translation)
+                        .overlay(
+                            tree,
+                            content_layout,
+                            renderer,
+                            viewport,
+                            translation,
+                        )
                         .map(|overlay| RefCell::new(Nested::new(overlay))),
                     content_layout_node,
                 )

--- a/widget/src/mouse_area.rs
+++ b/widget/src/mouse_area.rs
@@ -296,12 +296,14 @@ where
         tree: &'b mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
+        viewport: &Rectangle,
         translation: Vector,
     ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
         self.content.as_widget_mut().overlay(
             &mut tree.children[0],
             layout,
             renderer,
+            viewport,
             translation,
         )
     }

--- a/widget/src/pane_grid.rs
+++ b/widget/src/pane_grid.rs
@@ -979,6 +979,7 @@ where
         tree: &'b mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
+        viewport: &Rectangle,
         translation: Vector,
     ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
         let children = self
@@ -997,7 +998,7 @@ where
                     return None;
                 }
 
-                content.overlay(state, layout, renderer, translation)
+                content.overlay(state, layout, renderer, viewport, translation)
             })
             .collect::<Vec<_>>();
 

--- a/widget/src/pane_grid/content.rs
+++ b/widget/src/pane_grid/content.rs
@@ -366,6 +366,7 @@ where
         tree: &'b mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
+        viewport: &Rectangle,
         translation: Vector,
     ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
         if let Some(title_bar) = self.title_bar.as_mut() {
@@ -380,6 +381,7 @@ where
                 title_bar_state,
                 title_bar_layout,
                 renderer,
+                viewport,
                 translation,
             ) {
                 Some(overlay) => Some(overlay),
@@ -387,6 +389,7 @@ where
                     body_state,
                     children.next()?,
                     renderer,
+                    viewport,
                     translation,
                 ),
             }
@@ -395,6 +398,7 @@ where
                 &mut tree.children[0],
                 layout,
                 renderer,
+                viewport,
                 translation,
             )
         }

--- a/widget/src/pane_grid/title_bar.rs
+++ b/widget/src/pane_grid/title_bar.rs
@@ -570,6 +570,7 @@ where
         tree: &'b mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
+        viewport: &Rectangle,
         translation: Vector,
     ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
         let mut children = layout.children();
@@ -588,7 +589,7 @@ where
 
         content
             .as_widget_mut()
-            .overlay(title_state, title_layout, renderer, translation)
+            .overlay(title_state, title_layout, renderer, viewport, translation)
             .or_else(move || {
                 controls.as_mut().and_then(|controls| {
                     let controls_layout = children.next()?;
@@ -605,6 +606,7 @@ where
                                 compact_state,
                                 compact_layout,
                                 renderer,
+                                viewport,
                                 translation,
                             )
                         } else {
@@ -612,6 +614,7 @@ where
                                 controls_state,
                                 controls_layout,
                                 renderer,
+                                viewport,
                                 translation,
                             )
                         }
@@ -620,6 +623,7 @@ where
                             controls_state,
                             controls_layout,
                             renderer,
+                            viewport,
                             translation,
                         )
                     }

--- a/widget/src/pick_list.rs
+++ b/widget/src/pick_list.rs
@@ -690,6 +690,7 @@ where
         tree: &'b mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
+        _viewport: &Rectangle,
         translation: Vector,
     ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
         let state = tree.state.downcast_mut::<State<Renderer::Paragraph>>();

--- a/widget/src/pin.rs
+++ b/widget/src/pin.rs
@@ -244,12 +244,14 @@ where
         tree: &'b mut widget::Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
+        viewport: &Rectangle,
         translation: Vector,
     ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
         self.content.as_widget_mut().overlay(
             tree,
             layout.children().next().unwrap(),
             renderer,
+            viewport,
             translation,
         )
     }

--- a/widget/src/pop.rs
+++ b/widget/src/pop.rs
@@ -295,12 +295,14 @@ where
         tree: &'b mut Tree,
         layout: core::Layout<'_>,
         renderer: &Renderer,
+        viewport: &Rectangle,
         translation: core::Vector,
     ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
         self.content.as_widget_mut().overlay(
             &mut tree.children[0],
             layout,
             renderer,
+            viewport,
             translation,
         )
     }

--- a/widget/src/row.rs
+++ b/widget/src/row.rs
@@ -337,6 +337,7 @@ where
         tree: &'b mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
+        viewport: &Rectangle,
         translation: Vector,
     ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
         overlay::from_children(
@@ -344,6 +345,7 @@ where
             tree,
             layout,
             renderer,
+            viewport,
             translation,
         )
     }
@@ -546,9 +548,11 @@ where
         tree: &'b mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
+        viewport: &Rectangle,
         translation: Vector,
     ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
-        self.row.overlay(tree, layout, renderer, translation)
+        self.row
+            .overlay(tree, layout, renderer, viewport, translation)
     }
 }
 

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -1180,11 +1180,13 @@ where
         tree: &'b mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
+        viewport: &Rectangle,
         translation: Vector,
     ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
         let bounds = layout.bounds();
         let content_layout = layout.children().next().unwrap();
         let content_bounds = content_layout.bounds();
+        let visible_bounds = bounds.intersection(viewport).unwrap_or(*viewport);
 
         let offset = tree.state.downcast_ref::<State>().translation(
             self.direction,
@@ -1196,6 +1198,7 @@ where
             &mut tree.children[0],
             layout.children().next().unwrap(),
             renderer,
+            &visible_bounds,
             translation - offset,
         )
     }

--- a/widget/src/stack.rs
+++ b/widget/src/stack.rs
@@ -354,6 +354,7 @@ where
         tree: &'b mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
+        viewport: &Rectangle,
         translation: Vector,
     ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
         overlay::from_children(
@@ -361,6 +362,7 @@ where
             tree,
             layout,
             renderer,
+            viewport,
             translation,
         )
     }

--- a/widget/src/themer.rs
+++ b/widget/src/themer.rs
@@ -180,6 +180,7 @@ where
         tree: &'b mut Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
+        viewport: &Rectangle,
         translation: Vector,
     ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
         struct Overlay<'a, Message, Theme, NewTheme, Renderer> {
@@ -287,7 +288,7 @@ where
 
         self.content
             .as_widget_mut()
-            .overlay(tree, layout, renderer, translation)
+            .overlay(tree, layout, renderer, viewport, translation)
             .map(|content| Overlay {
                 to_theme: &self.to_theme,
                 content,

--- a/widget/src/themer.rs
+++ b/widget/src/themer.rs
@@ -198,7 +198,7 @@ where
                 renderer: &Renderer,
                 bounds: Size,
             ) -> layout::Node {
-                self.content.layout(renderer, bounds)
+                self.content.as_overlay_mut().layout(renderer, bounds)
             }
 
             fn draw(
@@ -209,7 +209,7 @@ where
                 layout: Layout<'_>,
                 cursor: mouse::Cursor,
             ) {
-                self.content.draw(
+                self.content.as_overlay().draw(
                     renderer,
                     &(self.to_theme)(theme),
                     style,
@@ -228,6 +228,7 @@ where
                 shell: &mut Shell<'_, Message>,
             ) {
                 self.content
+                    .as_overlay_mut()
                     .update(event, layout, cursor, renderer, clipboard, shell);
             }
 
@@ -237,7 +238,9 @@ where
                 renderer: &Renderer,
                 operation: &mut dyn Operation,
             ) {
-                self.content.operate(layout, renderer, operation);
+                self.content
+                    .as_overlay_mut()
+                    .operate(layout, renderer, operation);
             }
 
             fn mouse_interaction(
@@ -248,6 +251,7 @@ where
                 renderer: &Renderer,
             ) -> mouse::Interaction {
                 self.content
+                    .as_overlay()
                     .mouse_interaction(layout, cursor, viewport, renderer)
             }
 
@@ -257,7 +261,11 @@ where
                 renderer: &Renderer,
                 cursor_position: Point,
             ) -> bool {
-                self.content.is_over(layout, renderer, cursor_position)
+                self.content.as_overlay().is_over(
+                    layout,
+                    renderer,
+                    cursor_position,
+                )
             }
 
             fn overlay<'b>(
@@ -267,6 +275,7 @@ where
             ) -> Option<overlay::Element<'b, Message, Theme, Renderer>>
             {
                 self.content
+                    .as_overlay_mut()
                     .overlay(layout, renderer)
                     .map(|content| Overlay {
                         to_theme: &self.to_theme,

--- a/widget/src/tooltip.rs
+++ b/widget/src/tooltip.rs
@@ -273,6 +273,7 @@ where
         tree: &'b mut widget::Tree,
         layout: Layout<'_>,
         renderer: &Renderer,
+        viewport: &Rectangle,
         translation: Vector,
     ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
         let state = tree.state.downcast_ref::<State>();
@@ -283,6 +284,7 @@ where
             children.next().unwrap(),
             layout,
             renderer,
+            viewport,
             translation,
         );
 


### PR DESCRIPTION
This PR introduces a new `translate` method for the `image` widget that can be used to make an image float above other content.

This method takes a closure that recieves the layout bounds of the image and its viewport and produces a `Vector` representing the translation that must be applied to the image.

Additionally, images can be styled with a `Shadow`.

Effectively, all of this can be combined with the already existing `scale` method to create cool animations using the `Animation` API (see #2757), like the `gallery` now showcases:

https://github.com/user-attachments/assets/ff9e2207-49ec-443c-8a3e-22917802fc4c

```rust
image(&thumbnail.handle)
    .width(Fill)
    .content_fit(ContentFit::Cover)
    .opacity(thumbnail.fade_in.interpolate(0.0, 1.0, now))
    .scale(thumbnail.zoom.interpolate(1.0, 1.1, now))
    .translate(move |bounds, viewport| {
        bounds.zoom(1.1).offset(&viewport.shrink(10))
            * thumbnail.zoom.interpolate(0.0, 1.0, now)
    })
    .style(move |_theme| image::Style {
        shadow: Shadow {
            color: Color::BLACK.scale_alpha(
                thumbnail.zoom.interpolate(0.0, 1.0, now),
            ),
            blur_radius: thumbnail
                .zoom
                .interpolate(0.0, 20.0, now),
            ..Shadow::default()
        },
        ..image::Style::default()
    })

```