### PR TITLE
fix combo-box panic after 6034a0c

### DIFF
--- a/widget/src/combo_box.rs
+++ b/widget/src/combo_box.rs
@@ -509,6 +509,10 @@ where
         vec![widget::Tree::new(&self.text_input as &dyn Widget<_, _, _>)]
     }
 
+    fn diff(&self, _tree: &mut widget::Tree) {
+        // do nothing so the children don't get cleared
+    }
+
     fn update(
         &mut self,
         tree: &mut widget::Tree,


### PR DESCRIPTION
Now that the default impl for `diff` clears all children, this would panic at line 481 when selecting the combo-box's text input.