### PR TITLE
Fix scrollable scrolling by touch

### DIFF
--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -842,8 +842,8 @@ where
                 }
                 Event::Touch(event)
                     if state.scroll_area_touched_at.is_some()
-                        || !mouse_over_y_scrollbar
-                            && !mouse_over_x_scrollbar =>
+                        && !mouse_over_y_scrollbar
+                        && !mouse_over_x_scrollbar =>
                 {
                     match event {
                         touch::Event::FingerPressed { .. } => {

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -841,19 +841,15 @@ where
                     }
                 }
                 Event::Touch(event)
-                    if state.scroll_area_touched_at.is_some()
-                        && !mouse_over_y_scrollbar
-                        && !mouse_over_x_scrollbar =>
+                    if !mouse_over_y_scrollbar && !mouse_over_x_scrollbar =>
                 {
                     match event {
                         touch::Event::FingerPressed { .. } => {
-                            let Some(cursor_position) = cursor.position()
-                            else {
+                            if cursor_over_scrollable.is_none() {
                                 return;
-                            };
+                            }
 
-                            state.scroll_area_touched_at =
-                                Some(cursor_position);
+                            state.scroll_area_touched_at = cursor.position();
                         }
                         touch::Event::FingerMoved { .. } => {
                             if let Some(scroll_box_touched_at) =


### PR DESCRIPTION
I ran into problem with scrollable by touch. The scrollable widget scrolled even when touch wasn't under the scroll area. This patch fixes the problem. And as I see it doesn't have side effects.