### PR TITLE
Time Travel Debugging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2453,6 +2453,7 @@ version = "0.14.0-dev"
 dependencies = [
  "iced_beacon",
  "iced_core",
+ "iced_futures",
  "log",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,6 +2464,7 @@ dependencies = [
  "iced_debug",
  "iced_program",
  "iced_widget",
+ "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,8 @@ markdown = ["iced_widget/markdown"]
 lazy = ["iced_widget/lazy"]
 # Enables a debug view in native platforms (press F12)
 debug = ["iced_winit/debug", "iced_devtools"]
+# Enables time-travel debugging (very experimental!)
+time-travel = ["debug", "iced_devtools/time-travel"]
 # Enables the `thread-pool` futures executor as the `executor::Default` on native platforms
 thread-pool = ["iced_futures/thread-pool"]
 # Enables `tokio` as the `executor::Default` on native platforms

--- a/beacon/src/client.rs
+++ b/beacon/src/client.rs
@@ -1,10 +1,12 @@
+use crate::Error;
 use crate::core::time::{Duration, SystemTime};
 use crate::span;
 use crate::theme;
 
+use futures::{FutureExt, select};
 use semver::Version;
 use serde::{Deserialize, Serialize};
-use tokio::io::{self, AsyncWriteExt};
+use tokio::io::{self, AsyncReadExt, AsyncWriteExt};
 use tokio::net;
 use tokio::sync::mpsc;
 use tokio::time;
@@ -17,7 +19,7 @@ pub const SERVER_ADDRESS: &str = "127.0.0.1:9167";
 
 #[derive(Debug, Clone)]
 pub struct Client {
-    sender: mpsc::Sender<Message>,
+    sender: mpsc::Sender<Action>,
     is_connected: Arc<AtomicBool>,
     _handle: Arc<thread::JoinHandle<()>>,
 }
@@ -43,17 +45,17 @@ pub enum Event {
     ThemeChanged(theme::Palette),
     SpanStarted(span::Stage),
     SpanFinished(span::Stage, Duration),
-    MessageLogged(String),
+    MessageLogged { number: usize, message: String },
     CommandsSpawned(usize),
     SubscriptionsTracked(usize),
 }
 
 impl Client {
     pub fn log(&self, event: Event) {
-        let _ = self.sender.try_send(Message::EventLogged {
+        let _ = self.sender.try_send(Action::Send(Message::EventLogged {
             at: SystemTime::now(),
             event,
-        });
+        }));
     }
 
     pub fn is_connected(&self) -> bool {
@@ -61,21 +63,28 @@ impl Client {
     }
 
     pub fn quit(&self) {
-        let _ = self.sender.try_send(Message::Quit {
+        let _ = self.sender.try_send(Action::Send(Message::Quit {
             at: SystemTime::now(),
-        });
+        }));
+    }
+
+    pub fn subscribe(&self) -> mpsc::Receiver<Command> {
+        let (sender, receiver) = mpsc::channel(100);
+        let _ = self.sender.try_send(Action::Forward(sender));
+
+        receiver
     }
 }
 
 #[must_use]
 pub fn connect(name: String) -> Client {
-    let (sender, receiver) = mpsc::channel(100);
+    let (sender, receiver) = mpsc::channel(10_000);
     let is_connected = Arc::new(AtomicBool::new(false));
 
     let handle = {
         let is_connected = is_connected.clone();
 
-        std::thread::spawn(move || run(name, is_connected.clone(), receiver))
+        std::thread::spawn(move || run(name, is_connected, receiver))
     };
 
     Client {
@@ -85,16 +94,30 @@ pub fn connect(name: String) -> Client {
     }
 }
 
+enum Action {
+    Send(Message),
+    Forward(mpsc::Sender<Command>),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Command {
+    RewindTo { message: usize },
+}
+
 #[tokio::main]
 async fn run(
     name: String,
     is_connected: Arc<AtomicBool>,
-    mut receiver: mpsc::Receiver<Message>,
+    mut receiver: mpsc::Receiver<Action>,
 ) {
     let version = semver::Version::parse(env!("CARGO_PKG_VERSION"))
         .expect("Parse package version");
 
+    let mut buffer = Vec::new();
+
     loop {
+        let mut command_sender = None;
+
         match _connect().await {
             Ok(mut stream) => {
                 is_connected.store(true, atomic::Ordering::Relaxed);
@@ -109,16 +132,37 @@ async fn run(
                 )
                 .await;
 
-                while let Some(output) = receiver.recv().await {
-                    match send(&mut stream, output).await {
-                        Ok(()) => {}
-                        Err(error) => {
-                            if error.kind() != io::ErrorKind::BrokenPipe {
-                                log::warn!(
-                                    "Error sending message to server: {error}"
-                                );
+                loop {
+                    select! {
+                        action = receiver.recv().fuse() => {
+                            let Some(action) = action else { break; };
+
+                            match action {
+                                Action::Send(message) => {
+                                    match send(&mut stream, message).await {
+                                        Ok(()) => {}
+                                        Err(error) => {
+                                            if error.kind() != io::ErrorKind::BrokenPipe
+                                            {
+                                                log::warn!(
+                                                    "Error sending message to server: {error}"
+                                                );
+                                            }
+                                            break;
+                                        }
+                                    }
+                                }
+                                Action::Forward(sender) => {
+                                    command_sender = Some(sender);
+                                }
                             }
-                            break;
+                        }
+                        command = receive(&mut stream, &mut buffer).fuse() => {
+                            let Ok(command) = command else { continue; };
+
+                            if let Some(sender) = command_sender.as_mut() {
+                                let _ = sender.send(command).await;
+                            }
                         }
                     }
                 }
@@ -153,4 +197,19 @@ async fn send(
     stream.flush().await?;
 
     Ok(())
+}
+
+async fn receive(
+    stream: &mut net::TcpStream,
+    buffer: &mut Vec<u8>,
+) -> Result<Command, Error> {
+    let size = stream.read_u64().await? as usize;
+
+    if buffer.len() < size {
+        buffer.resize(size, 0);
+    }
+
+    let _n = stream.read_exact(&mut buffer[..size]).await?;
+
+    Ok(bincode::deserialize(buffer)?)
 }

--- a/beacon/src/client.rs
+++ b/beacon/src/client.rs
@@ -99,9 +99,10 @@ enum Action {
     Forward(mpsc::Sender<Command>),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub enum Command {
     RewindTo { message: usize },
+    GoLive,
 }
 
 #[tokio::main]

--- a/beacon/src/error.rs
+++ b/beacon/src/error.rs
@@ -1,0 +1,9 @@
+use std::io;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("input/output operation failed: {0}")]
+    IOFailed(#[from] io::Error),
+    #[error("decoding failed: {0}")]
+    DecodingFailed(#[from] Box<bincode::ErrorKind>),
+}

--- a/beacon/src/span.rs
+++ b/beacon/src/span.rs
@@ -8,7 +8,8 @@ pub enum Span {
     Update {
         number: usize,
         message: String,
-        commands_spawned: usize,
+        tasks: usize,
+        subscriptions: usize,
     },
     View {
         window: window::Id,

--- a/beacon/src/span.rs
+++ b/beacon/src/span.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 pub enum Span {
     Boot,
     Update {
+        number: usize,
         message: String,
         commands_spawned: usize,
     },

--- a/core/src/animation.rs
+++ b/core/src/animation.rs
@@ -90,15 +90,17 @@ where
         self
     }
 
-    /// Transitions the [`Animation`] from its current state to the given new state.
-    pub fn go(mut self, new_state: T) -> Self {
-        self.go_mut(new_state);
+    /// Transitions the [`Animation`] from its current state to the given new state
+    /// at the given time.
+    pub fn go(mut self, new_state: T, at: Instant) -> Self {
+        self.go_mut(new_state, at);
         self
     }
 
-    /// Transitions the [`Animation`] from its current state to the given new state, by reference.
-    pub fn go_mut(&mut self, new_state: T) {
-        self.raw.transition(new_state, Instant::now());
+    /// Transitions the [`Animation`] from its current state to the given new state
+    /// at the given time, by reference.
+    pub fn go_mut(&mut self, new_state: T, at: Instant) {
+        self.raw.transition(new_state, at);
     }
 
     /// Returns true if the [`Animation`] is currently in progress.

--- a/core/src/renderer/null.rs
+++ b/core/src/renderer/null.rs
@@ -31,6 +31,7 @@ impl text::Renderer for () {
     type Paragraph = ();
     type Editor = ();
 
+    const MONOSPACE_FONT: Font = Font::MONOSPACE;
     const ICON_FONT: Font = Font::DEFAULT;
     const CHECKMARK_ICON: char = '0';
     const ARROW_DOWN_ICON: char = '0';

--- a/core/src/text.rs
+++ b/core/src/text.rs
@@ -232,6 +232,11 @@ pub trait Renderer: crate::Renderer {
     /// The [`Editor`] of this [`Renderer`].
     type Editor: Editor<Font = Self::Font> + 'static;
 
+    /// A monospace font.
+    ///
+    /// It may be used by devtools.
+    const MONOSPACE_FONT: Self::Font;
+
     /// The icon font of the backend.
     const ICON_FONT: Self::Font;
 

--- a/core/src/theme.rs
+++ b/core/src/theme.rs
@@ -5,6 +5,7 @@ pub use palette::Palette;
 
 use crate::Color;
 
+use std::borrow::Cow;
 use std::fmt;
 use std::sync::Arc;
 
@@ -87,14 +88,17 @@ impl Theme {
     ];
 
     /// Creates a new custom [`Theme`] from the given [`Palette`].
-    pub fn custom(name: String, palette: Palette) -> Self {
+    pub fn custom(
+        name: impl Into<Cow<'static, str>>,
+        palette: Palette,
+    ) -> Self {
         Self::custom_with_fn(name, palette, palette::Extended::generate)
     }
 
     /// Creates a new custom [`Theme`] from the given [`Palette`], with
     /// a custom generator of a [`palette::Extended`].
     pub fn custom_with_fn(
-        name: String,
+        name: impl Into<Cow<'static, str>>,
         palette: Palette,
         generate: impl FnOnce(Palette) -> palette::Extended,
     ) -> Self {
@@ -220,7 +224,7 @@ impl fmt::Display for Theme {
 /// A [`Theme`] with a customized [`Palette`].
 #[derive(Debug, Clone, PartialEq)]
 pub struct Custom {
-    name: String,
+    name: Cow<'static, str>,
     palette: Palette,
     extended: palette::Extended,
 }
@@ -234,12 +238,12 @@ impl Custom {
     /// Creates a [`Custom`] theme from the given [`Palette`] with
     /// a custom generator of a [`palette::Extended`].
     pub fn with_fn(
-        name: String,
+        name: impl Into<Cow<'static, str>>,
         palette: Palette,
         generate: impl FnOnce(Palette) -> palette::Extended,
     ) -> Self {
         Self {
-            name,
+            name: name.into(),
             palette,
             extended: generate(palette),
         }

--- a/debug/Cargo.toml
+++ b/debug/Cargo.toml
@@ -15,6 +15,7 @@ enable = ["dep:iced_beacon"]
 
 [dependencies]
 iced_core.workspace = true
+iced_futures.workspace = true
 log.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/debug/src/lib.rs
+++ b/debug/src/lib.rs
@@ -7,8 +7,6 @@ use crate::futures::Subscription;
 
 pub use internal::Span;
 
-use std::io;
-
 #[derive(Debug, Clone, Copy)]
 pub enum Primitive {
     Quad,
@@ -36,8 +34,8 @@ pub fn init(name: &str) {
     internal::init(name);
 }
 
-pub fn toggle_comet() -> Result<(), io::Error> {
-    internal::toggle_comet()
+pub fn quit() -> bool {
+    internal::quit()
 }
 
 pub fn theme_changed(f: impl FnOnce() -> Option<theme::Palette>) {
@@ -118,8 +116,6 @@ mod internal {
     use beacon::client::{self, Client};
     use beacon::span;
 
-    use std::io;
-    use std::process;
     use std::sync::atomic::{self, AtomicBool, AtomicUsize};
     use std::sync::{LazyLock, RwLock};
 
@@ -129,25 +125,13 @@ mod internal {
         name.clone_into(&mut NAME.write().expect("Write application name"));
     }
 
-    pub fn toggle_comet() -> Result<(), io::Error> {
+    pub fn quit() -> bool {
         if BEACON.is_connected() {
             BEACON.quit();
 
-            Ok(())
+            true
         } else {
-            let _ = process::Command::new("iced_comet")
-                .stdin(process::Stdio::null())
-                .stdout(process::Stdio::null())
-                .stderr(process::Stdio::null())
-                .spawn()?;
-
-            if let Some(palette) =
-                LAST_PALETTE.read().expect("Read last palette").as_ref()
-            {
-                log(client::Event::ThemeChanged(*palette));
-            }
-
-            Ok(())
+            false
         }
     }
 
@@ -323,8 +307,8 @@ mod internal {
 
     pub fn init(_name: &str) {}
 
-    pub fn toggle_comet() -> Result<(), io::Error> {
-        Ok(())
+    pub fn quit() -> bool {
+        false
     }
 
     pub fn theme_changed(_f: impl FnOnce() -> Option<theme::Palette>) {}

--- a/devtools/Cargo.toml
+++ b/devtools/Cargo.toml
@@ -20,3 +20,5 @@ time-travel = ["iced_program/time-travel"]
 iced_debug.workspace = true
 iced_program.workspace = true
 iced_widget.workspace = true
+
+log.workspace = true

--- a/devtools/Cargo.toml
+++ b/devtools/Cargo.toml
@@ -13,6 +13,9 @@ rust-version.workspace = true
 [lints]
 workspace = true
 
+[features]
+time-travel = ["iced_program/time-travel"]
+
 [dependencies]
 iced_program.workspace = true
 iced_widget.workspace = true

--- a/devtools/Cargo.toml
+++ b/devtools/Cargo.toml
@@ -17,6 +17,6 @@ workspace = true
 time-travel = ["iced_program/time-travel"]
 
 [dependencies]
+iced_debug.workspace = true
 iced_program.workspace = true
 iced_widget.workspace = true
-iced_debug.workspace = true

--- a/devtools/src/comet.rs
+++ b/devtools/src/comet.rs
@@ -1,0 +1,108 @@
+use crate::executor;
+use crate::runtime::Task;
+
+use std::io;
+use std::process;
+use std::sync::Arc;
+
+pub const COMPATIBLE_REVISION: &str =
+    "69dd2283886dccdaa1ee6e1c274af62f7250bc38";
+
+pub fn launch() -> Task<Result<(), Error>> {
+    executor::try_spawn_blocking(|mut sender| {
+        let cargo_install = process::Command::new("cargo")
+            .args(["install", "--list"])
+            .output()?;
+
+        let installed_packages = String::from_utf8_lossy(&cargo_install.stdout);
+
+        for line in installed_packages.lines() {
+            if !line.starts_with("iced_comet ") {
+                continue;
+            }
+
+            let Some((_, revision)) = line.rsplit_once("?rev=") else {
+                return Err(Error::Outdated { revision: None });
+            };
+
+            let Some((revision, _)) = revision.rsplit_once("#") else {
+                return Err(Error::Outdated { revision: None });
+            };
+
+            if revision != COMPATIBLE_REVISION {
+                return Err(Error::Outdated {
+                    revision: Some(revision.to_owned()),
+                });
+            }
+
+            let _ = process::Command::new("iced_comet")
+                .stdin(process::Stdio::null())
+                .stdout(process::Stdio::null())
+                .stderr(process::Stdio::null())
+                .spawn()?;
+
+            let _ = sender.try_send(());
+            return Ok(());
+        }
+
+        Err(Error::NotFound)
+    })
+}
+
+pub fn install() -> Task<Result<Installation, Error>> {
+    executor::try_spawn_blocking(|mut sender| {
+        use std::io::{BufRead, BufReader};
+        use std::process::{Command, Stdio};
+
+        let install = Command::new("cargo")
+            .args([
+                "install",
+                "--locked",
+                "--git",
+                "https://github.com/iced-rs/comet.git",
+                "--rev",
+                COMPATIBLE_REVISION,
+            ])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .spawn()?;
+
+        let mut stderr =
+            BufReader::new(install.stderr.expect("stderr must be piped"));
+
+        let mut log = String::new();
+
+        while let Ok(n) = stderr.read_line(&mut log) {
+            if n == 0 {
+                break;
+            }
+
+            let _ = sender.try_send(Installation::Logged(log.clone()));
+            log.clear();
+        }
+
+        let _ = sender.try_send(Installation::Finished);
+
+        Ok(())
+    })
+}
+
+#[derive(Debug, Clone)]
+pub enum Installation {
+    Logged(String),
+    Finished,
+}
+
+#[derive(Debug, Clone)]
+pub enum Error {
+    NotFound,
+    Outdated { revision: Option<String> },
+    IoFailed(Arc<io::Error>),
+}
+
+impl From<io::Error> for Error {
+    fn from(error: io::Error) -> Self {
+        Self::IoFailed(Arc::new(error))
+    }
+}

--- a/devtools/src/executor.rs
+++ b/devtools/src/executor.rs
@@ -1,4 +1,6 @@
 use crate::futures::futures::channel::mpsc;
+use crate::futures::futures::channel::oneshot;
+use crate::futures::futures::stream::{self, StreamExt};
 use crate::runtime::Task;
 
 use std::thread;
@@ -16,4 +18,26 @@ where
     });
 
     Task::stream(receiver)
+}
+
+pub fn try_spawn_blocking<T, E>(
+    f: impl FnOnce(mpsc::Sender<T>) -> Result<(), E> + Send + 'static,
+) -> Task<Result<T, E>>
+where
+    T: Send + 'static,
+    E: Send + 'static,
+{
+    let (sender, receiver) = mpsc::channel(1);
+    let (error_sender, error_receiver) = oneshot::channel();
+
+    let _ = thread::spawn(move || {
+        if let Err(error) = f(sender) {
+            let _ = error_sender.send(Err(error));
+        }
+    });
+
+    Task::stream(stream::select(
+        receiver.map(Ok),
+        stream::once(error_receiver).filter_map(async |result| result.ok()),
+    ))
 }

--- a/devtools/src/lib.rs
+++ b/devtools/src/lib.rs
@@ -254,12 +254,10 @@ where
                 }
             },
             Event::Program(message) => {
-                {
-                    self.time_machine.push(&message);
+                self.time_machine.push(&message);
 
-                    if self.time_machine.is_rewinding() {
-                        debug::enable();
-                    }
+                if self.time_machine.is_rewinding() {
+                    debug::enable();
                 }
 
                 let span = debug::update(&message);

--- a/devtools/src/time_machine.rs
+++ b/devtools/src/time_machine.rs
@@ -1,0 +1,88 @@
+use crate::Program;
+
+#[cfg(feature = "time-travel")]
+pub struct TimeMachine<P>
+where
+    P: Program,
+{
+    state: Option<P::State>,
+    messages: Vec<P::Message>,
+}
+
+#[cfg(feature = "time-travel")]
+impl<P> TimeMachine<P>
+where
+    P: Program,
+{
+    pub fn new() -> Self {
+        Self {
+            state: None,
+            messages: Vec::new(),
+        }
+    }
+
+    pub fn is_rewinding(&self) -> bool {
+        self.state.is_some()
+    }
+
+    pub fn push(&mut self, message: &P::Message) {
+        self.messages.push(message.clone());
+    }
+
+    pub fn rewind(&mut self, program: &P, message: usize) {
+        let (mut state, _) = program.boot();
+
+        if message < self.messages.len() {
+            // TODO: Run concurrently (?)
+            for message in &self.messages[0..message] {
+                let _ = program.update(&mut state, message.clone());
+            }
+        }
+
+        self.state = Some(state);
+        crate::debug::disable();
+    }
+
+    pub fn go_to_present(&mut self) {
+        self.state = None;
+        crate::debug::enable();
+    }
+
+    pub fn state(&self) -> Option<&P::State> {
+        self.state.as_ref()
+    }
+}
+
+#[cfg(not(feature = "time-travel"))]
+pub struct TimeMachine<P>
+where
+    P: Program,
+{
+    _program: std::marker::PhantomData<P>,
+}
+
+#[cfg(not(feature = "time-travel"))]
+impl<P> TimeMachine<P>
+where
+    P: Program,
+{
+    pub fn new() -> Self {
+        Self {
+            _program: std::marker::PhantomData,
+        }
+    }
+
+    pub fn is_rewinding(&self) -> bool {
+        false
+    }
+
+    pub fn push(&mut self, _message: &P::Message) {}
+
+    pub fn rewind(&mut self, _program: &P, _message: usize) {}
+
+    pub fn go_to_present(&mut self) {}
+
+    pub fn state(&self) -> Option<&P::State> {
+        None
+    }
+}

--- a/examples/arc/src/main.rs
+++ b/examples/arc/src/main.rs
@@ -8,7 +8,7 @@ use iced::window;
 use iced::{Element, Fill, Point, Rectangle, Renderer, Subscription, Theme};
 
 pub fn main() -> iced::Result {
-    iced::application(Arc::default, Arc::update, Arc::view)
+    iced::application(Arc::new, Arc::update, Arc::view)
         .subscription(Arc::subscription)
         .theme(|_| Theme::Dark)
         .run()
@@ -25,6 +25,13 @@ enum Message {
 }
 
 impl Arc {
+    fn new() -> Self {
+        Arc {
+            start: Instant::now(),
+            cache: Cache::default(),
+        }
+    }
+
     fn update(&mut self, _: Message) {
         self.cache.clear();
     }
@@ -35,15 +42,6 @@ impl Arc {
 
     fn subscription(&self) -> Subscription<Message> {
         window::frames().map(|_| Message::Tick)
-    }
-}
-
-impl Default for Arc {
-    fn default() -> Self {
-        Arc {
-            start: Instant::now(),
-            cache: Cache::default(),
-        }
     }
 }
 

--- a/examples/clock/src/main.rs
+++ b/examples/clock/src/main.rs
@@ -11,7 +11,7 @@ use iced::{
 pub fn main() -> iced::Result {
     tracing_subscriber::fmt::init();
 
-    iced::application(Clock::default, Clock::update, Clock::view)
+    iced::application(Clock::new, Clock::update, Clock::view)
         .subscription(Clock::subscription)
         .theme(Clock::theme)
         .run()
@@ -28,6 +28,13 @@ enum Message {
 }
 
 impl Clock {
+    fn new() -> Self {
+        Self {
+            now: chrono::offset::Local::now(),
+            clock: Cache::default(),
+        }
+    }
+
     fn update(&mut self, message: Message) {
         match message {
             Message::Tick(local_time) => {
@@ -55,15 +62,6 @@ impl Clock {
     fn theme(&self) -> Theme {
         Theme::ALL[(self.now.timestamp() as usize / 10) % Theme::ALL.len()]
             .clone()
-    }
-}
-
-impl Default for Clock {
-    fn default() -> Self {
-        Self {
-            now: chrono::offset::Local::now(),
-            clock: Cache::default(),
-        }
     }
 }
 

--- a/examples/gallery/src/main.rs
+++ b/examples/gallery/src/main.rs
@@ -21,14 +21,15 @@ use iced::{
 use std::collections::HashMap;
 
 fn main() -> iced::Result {
-    iced::application(Gallery::new, Gallery::update, Gallery::view)
-        .window_size((
-            Preview::WIDTH as f32 * 4.0,
-            Preview::HEIGHT as f32 * 2.5,
-        ))
-        .subscription(Gallery::subscription)
-        .theme(Gallery::theme)
-        .run()
+    iced::application::timed(
+        Gallery::new,
+        Gallery::update,
+        Gallery::subscription,
+        Gallery::view,
+    )
+    .window_size((Preview::WIDTH as f32 * 4.0, Preview::HEIGHT as f32 * 2.5))
+    .theme(Gallery::theme)
+    .run()
 }
 
 struct Gallery {
@@ -48,7 +49,7 @@ enum Message {
     BlurhashDecoded(Id, civitai::Blurhash),
     Open(Id),
     Close,
-    Animate(Instant),
+    Animate,
 }
 
 impl Gallery {
@@ -76,13 +77,15 @@ impl Gallery {
             || self.viewer.is_animating(self.now);
 
         if is_animating {
-            window::frames().map(Message::Animate)
+            window::frames().map(|_| Message::Animate)
         } else {
             Subscription::none()
         }
     }
 
-    pub fn update(&mut self, message: Message) -> Task<Message> {
+    pub fn update(&mut self, message: Message, now: Instant) -> Task<Message> {
+        self.now = now;
+
         match message {
             Message::ImagesListed(Ok(images)) => {
                 self.images = images;
@@ -109,16 +112,16 @@ impl Gallery {
                 )
             }
             Message::ImageDownloaded(Ok(rgba)) => {
-                self.viewer.show(rgba);
+                self.viewer.show(rgba, self.now);
 
                 Task::none()
             }
             Message::ThumbnailDownloaded(id, Ok(rgba)) => {
                 let thumbnail = if let Some(preview) = self.previews.remove(&id)
                 {
-                    preview.load(rgba)
+                    preview.load(rgba, self.now)
                 } else {
-                    Preview::ready(rgba)
+                    Preview::ready(rgba, self.now)
                 };
 
                 let _ = self.previews.insert(id, thumbnail);
@@ -127,7 +130,7 @@ impl Gallery {
             }
             Message::ThumbnailHovered(id, is_hovered) => {
                 if let Some(preview) = self.previews.get_mut(&id) {
-                    preview.toggle_zoom(is_hovered);
+                    preview.toggle_zoom(is_hovered, self.now);
                 }
 
                 Task::none()
@@ -136,7 +139,7 @@ impl Gallery {
                 if !self.previews.contains_key(&id) {
                     let _ = self
                         .previews
-                        .insert(id, Preview::loading(blurhash.rgba));
+                        .insert(id, Preview::loading(blurhash.rgba, self.now));
                 }
 
                 Task::none()
@@ -151,7 +154,7 @@ impl Gallery {
                     return Task::none();
                 };
 
-                self.viewer.open();
+                self.viewer.open(self.now);
 
                 Task::perform(
                     image.download(Size::Original),
@@ -159,15 +162,11 @@ impl Gallery {
                 )
             }
             Message::Close => {
-                self.viewer.close();
+                self.viewer.close(self.now);
 
                 Task::none()
             }
-            Message::Animate(now) => {
-                self.now = now;
-
-                Task::none()
-            }
+            Message::Animate => Task::none(),
             Message::ImagesListed(Err(error))
             | Message::ImageDownloaded(Err(error))
             | Message::ThumbnailDownloaded(_, Err(error)) => {
@@ -293,13 +292,13 @@ impl Preview {
     const WIDTH: u32 = 320;
     const HEIGHT: u32 = 410;
 
-    fn loading(rgba: Rgba) -> Self {
+    fn loading(rgba: Rgba, now: Instant) -> Self {
         Self::Loading {
             blurhash: Blurhash {
                 fade_in: Animation::new(false)
                     .duration(milliseconds(700))
                     .easing(animation::Easing::EaseIn)
-                    .go(true),
+                    .go(true, now),
                 handle: image::Handle::from_rgba(
                     rgba.width,
                     rgba.height,
@@ -309,27 +308,27 @@ impl Preview {
         }
     }
 
-    fn ready(rgba: Rgba) -> Self {
+    fn ready(rgba: Rgba, now: Instant) -> Self {
         Self::Ready {
             blurhash: None,
-            thumbnail: Thumbnail::new(rgba),
+            thumbnail: Thumbnail::new(rgba, now),
         }
     }
 
-    fn load(self, rgba: Rgba) -> Self {
+    fn load(self, rgba: Rgba, now: Instant) -> Self {
         let Self::Loading { blurhash } = self else {
             return self;
         };
 
         Self::Ready {
             blurhash: Some(blurhash),
-            thumbnail: Thumbnail::new(rgba),
+            thumbnail: Thumbnail::new(rgba, now),
         }
     }
 
-    fn toggle_zoom(&mut self, enabled: bool) {
+    fn toggle_zoom(&mut self, enabled: bool, now: Instant) {
         if let Self::Ready { thumbnail, .. } = self {
-            thumbnail.zoom.go_mut(enabled);
+            thumbnail.zoom.go_mut(enabled, now);
         }
     }
 
@@ -357,14 +356,14 @@ impl Preview {
 }
 
 impl Thumbnail {
-    pub fn new(rgba: Rgba) -> Self {
+    pub fn new(rgba: Rgba, now: Instant) -> Self {
         Self {
             handle: image::Handle::from_rgba(
                 rgba.width,
                 rgba.height,
                 rgba.pixels,
             ),
-            fade_in: Animation::new(false).slow().go(true),
+            fade_in: Animation::new(false).slow().go(true, now),
             zoom: Animation::new(false)
                 .quick()
                 .easing(animation::Easing::EaseInOut),
@@ -391,24 +390,24 @@ impl Viewer {
         }
     }
 
-    fn open(&mut self) {
+    fn open(&mut self, now: Instant) {
         self.image = None;
-        self.background_fade_in.go_mut(true);
+        self.background_fade_in.go_mut(true, now);
     }
 
-    fn show(&mut self, rgba: Rgba) {
+    fn show(&mut self, rgba: Rgba, now: Instant) {
         self.image = Some(image::Handle::from_rgba(
             rgba.width,
             rgba.height,
             rgba.pixels,
         ));
-        self.background_fade_in.go_mut(true);
-        self.image_fade_in.go_mut(true);
+        self.background_fade_in.go_mut(true, now);
+        self.image_fade_in.go_mut(true, now);
     }
 
-    fn close(&mut self) {
-        self.background_fade_in.go_mut(false);
-        self.image_fade_in.go_mut(false);
+    fn close(&mut self, now: Instant) {
+        self.background_fade_in.go_mut(false, now);
+        self.image_fade_in.go_mut(false, now);
     }
 
     fn is_animating(&self, now: Instant) -> bool {

--- a/examples/markdown/src/main.rs
+++ b/examples/markdown/src/main.rs
@@ -18,11 +18,15 @@ use std::io;
 use std::sync::Arc;
 
 pub fn main() -> iced::Result {
-    iced::application(Markdown::new, Markdown::update, Markdown::view)
-        .font(icon::FONT)
-        .subscription(Markdown::subscription)
-        .theme(Markdown::theme)
-        .run()
+    iced::application::timed(
+        Markdown::new,
+        Markdown::update,
+        Markdown::subscription,
+        Markdown::view,
+    )
+    .font(icon::FONT)
+    .theme(Markdown::theme)
+    .run()
 }
 
 struct Markdown {
@@ -58,7 +62,7 @@ enum Message {
     ImageDownloaded(markdown::Url, Result<image::Handle, Error>),
     ToggleStream(bool),
     NextToken,
-    Animate(Instant),
+    Tick,
 }
 
 impl Markdown {
@@ -78,7 +82,9 @@ impl Markdown {
         )
     }
 
-    fn update(&mut self, message: Message) -> Task<Message> {
+    fn update(&mut self, message: Message, now: Instant) -> Task<Message> {
+        self.now = now;
+
         match message {
             Message::Edit(action) => {
                 let is_edit = action.is_edit();
@@ -119,7 +125,7 @@ impl Markdown {
                             fade_in: Animation::new(false)
                                 .quick()
                                 .easing(animation::Easing::EaseInOut)
-                                .go(true),
+                                .go(true, self.now),
                         })
                         .unwrap_or_else(Image::Errored),
                 );
@@ -164,11 +170,7 @@ impl Markdown {
 
                 Task::none()
             }
-            Message::Animate(now) => {
-                self.now = now;
-
-                Task::none()
-            }
+            Message::Tick => Task::none(),
         }
     }
 
@@ -230,7 +232,7 @@ impl Markdown {
             });
 
             if is_animating {
-                window::frames().map(Message::Animate)
+                window::frames().map(|_| Message::Tick)
             } else {
                 Subscription::none()
             }

--- a/examples/multitouch/src/main.rs
+++ b/examples/multitouch/src/main.rs
@@ -23,7 +23,7 @@ struct Multitouch {
     fingers: HashMap<touch::Finger, Point>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 enum Message {
     FingerPressed { id: touch::Finger, position: Point },
     FingerLifted { id: touch::Finger },

--- a/examples/solar_system/src/main.rs
+++ b/examples/solar_system/src/main.rs
@@ -21,31 +21,36 @@ use std::time::Instant;
 pub fn main() -> iced::Result {
     tracing_subscriber::fmt::init();
 
-    iced::application(
-        SolarSystem::default,
+    iced::application::timed(
+        SolarSystem::new,
         SolarSystem::update,
+        SolarSystem::subscription,
         SolarSystem::view,
     )
-    .subscription(SolarSystem::subscription)
     .theme(SolarSystem::theme)
     .run()
 }
 
-#[derive(Default)]
 struct SolarSystem {
     state: State,
 }
 
 #[derive(Debug, Clone, Copy)]
 enum Message {
-    Tick(Instant),
+    Tick,
 }
 
 impl SolarSystem {
-    fn update(&mut self, message: Message) {
+    fn new() -> Self {
+        Self {
+            state: State::new(),
+        }
+    }
+
+    fn update(&mut self, message: Message, now: Instant) {
         match message {
-            Message::Tick(instant) => {
-                self.state.update(instant);
+            Message::Tick => {
+                self.state.update(now);
             }
         }
     }
@@ -59,7 +64,7 @@ impl SolarSystem {
     }
 
     fn subscription(&self) -> Subscription<Message> {
-        window::frames().map(Message::Tick)
+        window::frames().map(|_| Message::Tick)
     }
 }
 
@@ -105,10 +110,7 @@ impl State {
     }
 
     pub fn update(&mut self, now: Instant) {
-        if self.start > now {
-            self.start = now;
-        }
-
+        self.start = self.start.min(now);
         self.now = now;
         self.system_cache.clear();
     }
@@ -204,11 +206,5 @@ impl<Message> canvas::Program<Message> for State {
         });
 
         vec![background, system]
-    }
-}
-
-impl Default for State {
-    fn default() -> Self {
-        Self::new()
     }
 }

--- a/examples/solar_system/src/main.rs
+++ b/examples/solar_system/src/main.rs
@@ -105,6 +105,10 @@ impl State {
     }
 
     pub fn update(&mut self, now: Instant) {
+        if self.start > now {
+            self.start = now;
+        }
+
         self.now = now;
         self.system_cache.clear();
     }

--- a/examples/the_matrix/src/main.rs
+++ b/examples/the_matrix/src/main.rs
@@ -1,5 +1,5 @@
 use iced::mouse;
-use iced::time::{self, Instant, milliseconds};
+use iced::time::{self, milliseconds};
 use iced::widget::canvas;
 use iced::{
     Color, Element, Fill, Font, Point, Rectangle, Renderer, Subscription, Theme,
@@ -22,13 +22,13 @@ struct TheMatrix {
 
 #[derive(Debug, Clone, Copy)]
 enum Message {
-    Tick(Instant),
+    Tick,
 }
 
 impl TheMatrix {
     fn update(&mut self, message: Message) {
         match message {
-            Message::Tick(_now) => {
+            Message::Tick => {
                 self.tick += 1;
             }
         }
@@ -39,7 +39,7 @@ impl TheMatrix {
     }
 
     fn subscription(&self) -> Subscription<Message> {
-        time::every(milliseconds(50)).map(Message::Tick)
+        time::every(milliseconds(50)).map(|_| Message::Tick)
     }
 }
 

--- a/examples/todos/Cargo.toml
+++ b/examples/todos/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 iced.workspace = true
-iced.features = ["tokio", "debug"]
+iced.features = ["tokio", "debug", "time-travel"]
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/futures/src/subscription.rs
+++ b/futures/src/subscription.rs
@@ -285,6 +285,11 @@ impl<T> Subscription<T> {
                 .collect(),
         }
     }
+
+    /// Returns the amount of recipe units in this [`Subscription`].
+    pub fn units(&self) -> usize {
+        self.recipes.len()
+    }
 }
 
 /// Creates a [`Subscription`] from a [`Recipe`] describing it.

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -10,9 +10,12 @@ categories.workspace = true
 keywords.workspace = true
 rust-version.workspace = true
 
+[lints]
+workspace = true
+
+[features]
+time-travel = []
+
 [dependencies]
 iced_graphics.workspace = true
 iced_runtime.workspace = true
-
-[lints]
-workspace = true

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -22,7 +22,7 @@ pub trait Program: Sized {
     type State;
 
     /// The message of the program.
-    type Message: Send + std::fmt::Debug + 'static;
+    type Message: Message + 'static;
 
     /// The theme of the program.
     type Theme: Default + theme::Base;
@@ -642,3 +642,17 @@ impl<P: Program> Instance<P> {
         self.program.scale_factor(&self.state, window)
     }
 }
+
+/// A trait alias for the [`Message`](Program::Message) of a [`Program`].
+#[cfg(feature = "time-travel")]
+pub trait Message: Send + std::fmt::Debug + Clone {}
+
+#[cfg(feature = "time-travel")]
+impl<T: Send + std::fmt::Debug + Clone> Message for T {}
+
+/// A trait alias for the [`Message`](Program::Message) of a [`Program`].
+#[cfg(not(feature = "time-travel"))]
+pub trait Message: Send + std::fmt::Debug {}
+
+#[cfg(not(feature = "time-travel"))]
+impl<T: Send + std::fmt::Debug> Message for T {}

--- a/renderer/src/fallback.rs
+++ b/renderer/src/fallback.rs
@@ -84,6 +84,7 @@ where
     type Paragraph = A::Paragraph;
     type Editor = A::Editor;
 
+    const MONOSPACE_FONT: Self::Font = A::MONOSPACE_FONT;
     const ICON_FONT: Self::Font = A::ICON_FONT;
     const CHECKMARK_ICON: char = A::CHECKMARK_ICON;
     const ARROW_DOWN_ICON: char = A::ARROW_DOWN_ICON;

--- a/src/application.rs
+++ b/src/application.rs
@@ -40,6 +40,10 @@ use crate::{
 
 use std::borrow::Cow;
 
+pub mod timed;
+
+pub use timed::timed;
+
 /// Creates an iced [`Application`] given its boot, update, and view logic.
 ///
 /// # Example

--- a/src/application.rs
+++ b/src/application.rs
@@ -75,7 +75,7 @@ pub fn application<State, Message, Theme, Renderer>(
 ) -> Application<impl Program<State = State, Message = Message, Theme = Theme>>
 where
     State: 'static,
-    Message: Send + std::fmt::Debug + 'static,
+    Message: program::Message + 'static,
     Theme: Default + theme::Base,
     Renderer: program::Renderer,
 {
@@ -94,7 +94,7 @@ where
     impl<State, Message, Theme, Renderer, Boot, Update, View> Program
         for Instance<State, Message, Theme, Renderer, Boot, Update, View>
     where
-        Message: Send + std::fmt::Debug + 'static,
+        Message: program::Message + 'static,
         Theme: Default + theme::Base,
         Renderer: program::Renderer,
         Boot: self::Boot<State, Message>,

--- a/src/application/timed.rs
+++ b/src/application/timed.rs
@@ -1,0 +1,178 @@
+//! An [`Application`] that receives an [`Instant`] in update logic.
+use crate::application::{Application, Boot, View};
+use crate::program;
+use crate::theme;
+use crate::time::Instant;
+use crate::window;
+use crate::{Element, Program, Settings, Subscription, Task};
+
+/// Creates an [`Application`] with an `update` function that also
+/// takes the [`Instant`] of each `Message`.
+///
+/// This constructor is useful to create animated applications that
+/// are _pure_ (e.g. without relying on side-effect calls like [`Instant::now`]).
+///
+/// Purity is needed when you want your application to end up in the
+/// same exact state given the same history of messages. This property
+/// enables proper time traveling debugging with [`comet`].
+///
+/// [`comet`]: https://github.com/iced-rs/comet
+pub fn timed<State, Message, Theme, Renderer>(
+    boot: impl Boot<State, Message>,
+    update: impl Update<State, Message>,
+    subscription: impl Fn(&State) -> Subscription<Message>,
+    view: impl for<'a> View<'a, State, Message, Theme, Renderer>,
+) -> Application<
+    impl Program<State = State, Message = (Message, Instant), Theme = Theme>,
+>
+where
+    State: 'static,
+    Message: program::Message + 'static,
+    Theme: Default + theme::Base + 'static,
+    Renderer: program::Renderer + 'static,
+{
+    use std::marker::PhantomData;
+
+    struct Instance<
+        State,
+        Message,
+        Theme,
+        Renderer,
+        Boot,
+        Update,
+        Subscription,
+        View,
+    > {
+        boot: Boot,
+        update: Update,
+        subscription: Subscription,
+        view: View,
+        _state: PhantomData<State>,
+        _message: PhantomData<Message>,
+        _theme: PhantomData<Theme>,
+        _renderer: PhantomData<Renderer>,
+    }
+
+    impl<State, Message, Theme, Renderer, Boot, Update, Subscription, View>
+        Program
+        for Instance<
+            State,
+            Message,
+            Theme,
+            Renderer,
+            Boot,
+            Update,
+            Subscription,
+            View,
+        >
+    where
+        Message: program::Message + 'static,
+        Theme: Default + theme::Base + 'static,
+        Renderer: program::Renderer + 'static,
+        Boot: self::Boot<State, Message>,
+        Update: self::Update<State, Message>,
+        Subscription: Fn(&State) -> self::Subscription<Message>,
+        View: for<'a> self::View<'a, State, Message, Theme, Renderer>,
+    {
+        type State = State;
+        type Message = (Message, Instant);
+        type Theme = Theme;
+        type Renderer = Renderer;
+        type Executor = iced_futures::backend::default::Executor;
+
+        fn name() -> &'static str {
+            let name = std::any::type_name::<State>();
+
+            name.split("::").next().unwrap_or("a_cool_application")
+        }
+
+        fn boot(&self) -> (State, Task<Self::Message>) {
+            let (state, task) = self.boot.boot();
+
+            (state, task.map(|message| (message, Instant::now())))
+        }
+
+        fn update(
+            &self,
+            state: &mut Self::State,
+            (message, now): Self::Message,
+        ) -> Task<Self::Message> {
+            self.update
+                .update(state, message, now)
+                .into()
+                .map(|message| (message, Instant::now()))
+        }
+
+        fn view<'a>(
+            &self,
+            state: &'a Self::State,
+            _window: window::Id,
+        ) -> Element<'a, Self::Message, Self::Theme, Self::Renderer> {
+            self.view
+                .view(state)
+                .into()
+                .map(|message| (message, Instant::now()))
+        }
+
+        fn subscription(
+            &self,
+            state: &Self::State,
+        ) -> self::Subscription<Self::Message> {
+            (self.subscription)(state).map(|message| (message, Instant::now()))
+        }
+    }
+
+    Application {
+        raw: Instance {
+            boot,
+            update,
+            subscription,
+            view,
+            _state: PhantomData,
+            _message: PhantomData,
+            _theme: PhantomData,
+            _renderer: PhantomData,
+        },
+        settings: Settings::default(),
+        window: window::Settings::default(),
+    }
+}
+
+/// The update logic of some timed [`Application`].
+///
+/// This is like [`application::Update`](super::Update),
+/// but it also takes an [`Instant`].
+pub trait Update<State, Message> {
+    /// Processes the message and updates the state of the [`Application`].
+    fn update(
+        &self,
+        state: &mut State,
+        message: Message,
+        now: Instant,
+    ) -> impl Into<Task<Message>>;
+}
+
+impl<State, Message> Update<State, Message> for () {
+    fn update(
+        &self,
+        _state: &mut State,
+        _message: Message,
+        _now: Instant,
+    ) -> impl Into<Task<Message>> {
+    }
+}
+
+impl<T, State, Message, C> Update<State, Message> for T
+where
+    T: Fn(&mut State, Message, Instant) -> C,
+    C: Into<Task<Message>>,
+{
+    fn update(
+        &self,
+        state: &mut State,
+        message: Message,
+        now: Instant,
+    ) -> impl Into<Task<Message>> {
+        self(state, message, now)
+    }
+}

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -25,7 +25,7 @@ pub fn daemon<State, Message, Theme, Renderer>(
 ) -> Daemon<impl Program<State = State, Message = Message, Theme = Theme>>
 where
     State: 'static,
-    Message: Send + std::fmt::Debug + 'static,
+    Message: program::Message + 'static,
     Theme: Default + theme::Base,
     Renderer: program::Renderer,
 {
@@ -44,7 +44,7 @@ where
     impl<State, Message, Theme, Renderer, Boot, Update, View> Program
         for Instance<State, Message, Theme, Renderer, Boot, Update, View>
     where
-        Message: Send + std::fmt::Debug + 'static,
+        Message: program::Message + 'static,
         Theme: Default + theme::Base,
         Renderer: program::Renderer,
         Boot: application::Boot<State, Message>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -535,7 +535,7 @@ pub use alignment::Vertical::{Bottom, Top};
 
 pub mod debug {
     //! Debug your applications.
-    pub use iced_debug::{Span, skip_next_timing, time, time_with};
+    pub use iced_debug::{Span, time, time_with};
 }
 
 pub mod task {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -343,7 +343,7 @@
 //! use iced::window;
 //! use iced::{Size, Subscription};
 //!
-//! #[derive(Debug)]
+//! #[derive(Debug, Clone)]
 //! enum Message {
 //!     WindowResized(Size),
 //! }
@@ -387,7 +387,7 @@
 //! #         pub fn update(&mut self, message: Message) -> Action { unimplemented!() }
 //! #         pub fn view(&self) -> Element<Message> { unimplemented!() }
 //! #     }
-//! #     #[derive(Debug)]
+//! #     #[derive(Debug, Clone)]
 //! #     pub enum Message {}
 //! #     pub enum Action { None, Run(Task<Message>), Chat(()) }
 //! # }
@@ -399,7 +399,7 @@
 //! #         pub fn update(&mut self, message: Message) -> Task<Message> { unimplemented!() }
 //! #         pub fn view(&self) -> Element<Message> { unimplemented!() }
 //! #     }
-//! #     #[derive(Debug)]
+//! #     #[derive(Debug, Clone)]
 //! #     pub enum Message {}
 //! # }
 //! use contacts::Contacts;
@@ -697,7 +697,7 @@ pub fn run<State, Message, Theme, Renderer>(
 ) -> Result
 where
     State: Default + 'static,
-    Message: std::fmt::Debug + Send + 'static,
+    Message: program::Message + 'static,
     Theme: Default + theme::Base + 'static,
     Renderer: program::Renderer + 'static,
 {

--- a/tiny_skia/src/lib.rs
+++ b/tiny_skia/src/lib.rs
@@ -235,6 +235,7 @@ impl core::text::Renderer for Renderer {
     type Paragraph = Paragraph;
     type Editor = Editor;
 
+    const MONOSPACE_FONT: Font = Font::MONOSPACE;
     const ICON_FONT: Font = Font::with_name("Iced-Icons");
     const CHECKMARK_ICON: char = '\u{f00c}';
     const ARROW_DOWN_ICON: char = '\u{e800}';

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -643,6 +643,7 @@ impl core::text::Renderer for Renderer {
     type Paragraph = Paragraph;
     type Editor = Editor;
 
+    const MONOSPACE_FONT: Font = Font::MONOSPACE;
     const ICON_FONT: Font = Font::with_name("Iced-Icons");
     const CHECKMARK_ICON: char = '\u{f00c}';
     const ARROW_DOWN_ICON: char = '\u{e800}';

--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -1069,10 +1069,7 @@ fn update<P: Program, E: Executor>(
     P::Theme: theme::Base,
 {
     for message in messages.drain(..) {
-        let update_span = debug::update(&message);
         let task = runtime.enter(|| program.update(message));
-        debug::tasks_spawned(task.units());
-        update_span.finish();
 
         if let Some(stream) = runtime::task::into_stream(task) {
             runtime.run(stream);
@@ -1082,7 +1079,6 @@ fn update<P: Program, E: Executor>(
     let subscription = runtime.enter(|| program.subscription());
     let recipes = subscription::into_recipes(subscription.map(Action::Output));
 
-    debug::subscriptions_tracked(recipes.len());
     runtime.track(recipes);
 }
 


### PR DESCRIPTION
# Introducing Comet

I never properly introduced [`comet`], so please let me.

[`comet`] is a new companion debugging tool that can be summoned by pressing F12 when the `debug` feature is enabled—replacing the old (and hideous) debug overlay.

https://github.com/user-attachments/assets/5afb74f5-65e6-4fac-9124-6c64bf496304

[`comet`]: https://github.com/iced-rs/comet

When the `debug` feature is enabled, an `iced` application will send performance metrics through a socket to any server implementing the `iced_beacon` protocol.

[`comet`] is one of such servers. It is built with iced itself and you can find the code over here: https://github.com/iced-rs/comet

Of course, this all means you could build your own custom debugger if you wanted to! It should all be reusable enough.

# Custom Performance Metrics

As I introduced in #2891, you can decorate any piece of code with [`debug::time`](https://docs.iced.rs/iced/debug/fn.time.html) and [`debug::time_with`](https://docs.iced.rs/iced/debug/fn.time_with.html) to time and visualize different parts of your app.

https://github.com/user-attachments/assets/0d47b8b6-3ead-4561-a0f6-00faf5877c28

# Time Traveling

As you know, iced uses the Elm Architecture. One of the advantages of this architecture is that application state can only be mutated in a single place: `update`—and only in response of a `Message`. Furthermore, impure side effects are encouraged to happen inside `Task` and `Subscription` which are run indirectly by the runtime.

Effectively, this means that if we have an initial state and a list of messages, then we should be able to replicate any state the application has been at _any_ point in time. In other words, we can __time travel__.

https://github.com/user-attachments/assets/2e49695c-0261-4b43-ac2e-8d7da5454c4b

https://github.com/user-attachments/assets/278953fe-d190-4a15-8847-520509a90482

https://github.com/user-attachments/assets/5ccf67e5-68cc-43a9-950b-f317bf4d1a6b

Pretty cool, huh? Time traveling can be enabled with the new `time-travel` feature. Activating it will force a `Clone` bound on your `Message` type.

It goes without saying but... the feature is very experimental! It will only work well if your `update` logic is _pure_; meaning it does not rely on external state (e.g. calling `Instant::now`).

Use it carefully, it may eat your laundry!