### PR TITLE
0.13  multilang keybindings

### DIFF
--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -1025,7 +1025,7 @@ pub struct KeyPress {
     pub text: Option<SmolStr>,
     /// The current [`Status`] of the [`TextEditor`].
     pub status: Status,
-    ///
+    /// The physical key pressed.
     pub physical_key: Physical,
 }
 

--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -56,6 +56,7 @@ use std::fmt;
 use std::ops::DerefMut;
 use std::sync::Arc;
 
+use iced_runtime::keyboard::key::{Code, Physical};
 pub use text::editor::{Action, Edit, Motion};
 
 /// A multi-line text input.
@@ -1024,6 +1025,8 @@ pub struct KeyPress {
     pub text: Option<SmolStr>,
     /// The current [`Status`] of the [`TextEditor`].
     pub status: Status,
+    ///
+    pub physical_key: Physical,
 }
 
 impl<Message> Binding<Message> {
@@ -1034,68 +1037,72 @@ impl<Message> Binding<Message> {
             modifiers,
             text,
             status,
+            physical_key,
         } = event;
 
         if status != Status::Focused {
             return None;
         }
 
-        match key.as_ref() {
-            keyboard::Key::Named(key::Named::Enter) => Some(Self::Enter),
-            keyboard::Key::Named(key::Named::Backspace) => {
-                Some(Self::Backspace)
-            }
-            keyboard::Key::Named(key::Named::Delete) if text.is_none() => {
-                Some(Self::Delete)
-            }
-            keyboard::Key::Named(key::Named::Escape) => Some(Self::Unfocus),
-            keyboard::Key::Character("c") if modifiers.command() => {
+        match physical_key {
+            Physical::Code(Code::KeyC) if modifiers.command() => {
                 Some(Self::Copy)
             }
-            keyboard::Key::Character("x") if modifiers.command() => {
+            Physical::Code(Code::KeyX) if modifiers.command() => {
                 Some(Self::Cut)
             }
-            keyboard::Key::Character("v")
+            Physical::Code(Code::KeyV)
                 if modifiers.command() && !modifiers.alt() =>
             {
                 Some(Self::Paste)
             }
-            keyboard::Key::Character("a") if modifiers.command() => {
+            Physical::Code(Code::KeyA) if modifiers.command() => {
                 Some(Self::SelectAll)
             }
-            _ => {
-                if let Some(text) = text {
-                    let c = text.chars().find(|c| !c.is_control())?;
-
-                    Some(Self::Insert(c))
-                } else if let keyboard::Key::Named(named_key) = key.as_ref() {
-                    let motion = motion(named_key)?;
-
-                    let motion = if modifiers.macos_command() {
-                        match motion {
-                            Motion::Left => Motion::Home,
-                            Motion::Right => Motion::End,
-                            _ => motion,
-                        }
-                    } else {
-                        motion
-                    };
-
-                    let motion = if modifiers.jump() {
-                        motion.widen()
-                    } else {
-                        motion
-                    };
-
-                    Some(if modifiers.shift() {
-                        Self::Select(motion)
-                    } else {
-                        Self::Move(motion)
-                    })
-                } else {
-                    None
+            _ => match key.as_ref() {
+                keyboard::Key::Named(key::Named::Enter) => Some(Self::Enter),
+                keyboard::Key::Named(key::Named::Backspace) => {
+                    Some(Self::Backspace)
                 }
-            }
+                keyboard::Key::Named(key::Named::Delete) if text.is_none() => {
+                    Some(Self::Delete)
+                }
+                keyboard::Key::Named(key::Named::Escape) => Some(Self::Unfocus),
+                _ => {
+                    if let Some(text) = text {
+                        let c = text.chars().find(|c| !c.is_control())?;
+
+                        Some(Self::Insert(c))
+                    } else if let keyboard::Key::Named(named_key) = key.as_ref()
+                    {
+                        let motion = motion(named_key)?;
+
+                        let motion = if modifiers.macos_command() {
+                            match motion {
+                                Motion::Left => Motion::Home,
+                                Motion::Right => Motion::End,
+                                _ => motion,
+                            }
+                        } else {
+                            motion
+                        };
+
+                        let motion = if modifiers.jump() {
+                            motion.widen()
+                        } else {
+                            motion
+                        };
+
+                        Some(if modifiers.shift() {
+                            Self::Select(motion)
+                        } else {
+                            Self::Move(motion)
+                        })
+                    } else {
+                        None
+                    }
+                }
+            },
         }
     }
 }
@@ -1171,6 +1178,7 @@ impl<Message> Update<Message> {
                 key,
                 modifiers,
                 text,
+                physical_key,
                 ..
             }) => {
                 let status = if state.focus.is_some() {
@@ -1184,6 +1192,7 @@ impl<Message> Update<Message> {
                     modifiers,
                     text,
                     status,
+                    physical_key,
                 };
 
                 if let Some(key_binding) = key_binding {

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -173,6 +173,9 @@ where
         mut self,
         on_input: impl Fn(String) -> Message + 'a,
     ) -> Self {
+        panic!(
+            "The `on_input` method is deprecated. Use `on_input_maybe` instead."
+        );
         self.on_input = Some(Box::new(on_input));
         self
     }

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -36,6 +36,7 @@ mod value;
 pub mod cursor;
 
 pub use cursor::Cursor;
+use iced_runtime::keyboard::key::Code;
 pub use value::Value;
 
 use editor::Editor;
@@ -809,7 +810,7 @@ where
                 }
             }
             Event::Keyboard(keyboard::Event::KeyPressed {
-                key, text, ..
+                key, text, physical_key,..
             }) => {
                 let state = state::<Renderer>(tree);
 
@@ -817,8 +818,8 @@ where
                     let modifiers = state.keyboard_modifiers;
                     focus.updated_at = Instant::now();
 
-                    match key.as_ref() {
-                        keyboard::Key::Character("c")
+                    match physical_key {
+                        key::Physical::Code(Code::KeyC)
                             if state.keyboard_modifiers.command()
                                 && !self.is_secure =>
                         {
@@ -833,7 +834,7 @@ where
 
                             return event::Status::Captured;
                         }
-                        keyboard::Key::Character("x")
+                        key::Physical::Code(Code::KeyX)
                             if state.keyboard_modifiers.command()
                                 && !self.is_secure =>
                         {
@@ -861,7 +862,7 @@ where
 
                             return event::Status::Captured;
                         }
-                        keyboard::Key::Character("v")
+                        key::Physical::Code(Code::KeyV)
                             if state.keyboard_modifiers.command()
                                 && !state.keyboard_modifiers.alt() =>
                         {
@@ -901,10 +902,9 @@ where
 
                             return event::Status::Captured;
                         }
-                        keyboard::Key::Character("ф") |
-                        keyboard::Key::Character("a")
+                        key::Physical::Code(Code::KeyA)
                             if state.keyboard_modifiers.command() =>
-                        {
+                        {                        
                             state.cursor.select_all(&self.value);
 
                             return event::Status::Captured;

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -901,6 +901,7 @@ where
 
                             return event::Status::Captured;
                         }
+                        keyboard::Key::Character("ф") |
                         keyboard::Key::Character("a")
                             if state.keyboard_modifiers.command() =>
                         {

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -173,9 +173,6 @@ where
         mut self,
         on_input: impl Fn(String) -> Message + 'a,
     ) -> Self {
-        panic!(
-            "The `on_input` method is deprecated. Use `on_input_maybe` instead."
-        );
         self.on_input = Some(Box::new(on_input));
         self
     }
@@ -908,7 +905,6 @@ where
                         keyboard::Key::Character("a")
                             if state.keyboard_modifiers.command() =>
                         {
-                            panic!("Copying is not supported in this example");
                             state.cursor.select_all(&self.value);
 
                             return event::Status::Captured;

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -905,6 +905,7 @@ where
                         keyboard::Key::Character("a")
                             if state.keyboard_modifiers.command() =>
                         {
+                            panic!("Copying is not supported in this example");
                             state.cursor.select_all(&self.value);
 
                             return event::Status::Captured;


### PR DESCRIPTION
Replaced keyboard::Key::Character("...") with Physical::Code(Code::...) to ensure that keyboard shortcuts work independently of the current keyboard layout. This improves reliability for non-Latin layouts (e.g., Cyrillic).