### PR TITLE
make `Layout::children` return an `ExactSizeIterator`

### DIFF
--- a/core/src/layout.rs
+++ b/core/src/layout.rs
@@ -54,7 +54,9 @@ impl<'a> Layout<'a> {
     }
 
     /// Returns an iterator over the [`Layout`] of the children of a [`Node`].
-    pub fn children(self) -> impl DoubleEndedIterator<Item = Layout<'a>> {
+    pub fn children(
+        self,
+    ) -> impl DoubleEndedIterator<Item = Layout<'a>> + ExactSizeIterator {
         self.node.children().iter().map(move |node| {
             Layout::with_offset(
                 Vector::new(self.position.x, self.position.y),


### PR DESCRIPTION
I found myself wanting to use `.rposition(..)` on the children of a layout, this change makes that possible.