### PR TITLE
Report cursor size to input method

### DIFF
--- a/core/src/input_method.rs
+++ b/core/src/input_method.rs
@@ -1,5 +1,5 @@
 //! Listen to input method events.
-use crate::{Pixels, Point};
+use crate::{Pixels, Rectangle};
 
 use std::ops::Range;
 
@@ -10,8 +10,8 @@ pub enum InputMethod<T = String> {
     Disabled,
     /// Input method is enabled.
     Enabled {
-        /// The position at which the input method dialog should be placed.
-        position: Point,
+        /// The area which the input method dialog should not cover.
+        cursor_position: Rectangle,
         /// The [`Purpose`] of the input method.
         purpose: Purpose,
         /// The preedit to overlay on top of the input method dialog, if needed.
@@ -130,11 +130,11 @@ impl<T> InputMethod<T> {
         match self {
             Self::Disabled => InputMethod::Disabled,
             Self::Enabled {
-                position,
+                cursor_position,
                 purpose,
                 preedit,
             } => InputMethod::Enabled {
-                position: *position,
+                cursor_position: *cursor_position,
                 purpose: *purpose,
                 preedit: preedit.as_ref().map(Preedit::to_owned),
             },

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -750,10 +750,11 @@ where
                 );
 
                 if !had_input_method {
-                    if let InputMethod::Enabled { position, .. } =
-                        shell.input_method_mut()
+                    if let InputMethod::Enabled {
+                        cursor_position, ..
+                    } = shell.input_method_mut()
                     {
-                        *position = *position - translation;
+                        *cursor_position = *cursor_position - translation;
                     }
                 }
             };

--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -356,11 +356,13 @@ where
             self.text_size.unwrap_or_else(|| renderer.default_size()),
         );
 
-        let position =
-            cursor + translation + Vector::new(0.0, f32::from(line_height));
+        let position = cursor + translation;
 
         InputMethod::Enabled {
-            position,
+            cursor_position: Rectangle::new(
+                position,
+                Size::new(0.0, f32::from(line_height)),
+            ),
             purpose: input_method::Purpose::Normal,
             preedit: state.preedit.as_ref().map(input_method::Preedit::as_ref),
         }

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -430,7 +430,10 @@ where
             + alignment_offset;
 
         InputMethod::Enabled {
-            position: Point::new(x, text_bounds.y + text_bounds.height),
+            cursor_position: Rectangle::new(
+                Point::new(x, text_bounds.y),
+                Size::new(0.0, text_bounds.height),
+            ),
             purpose: if self.is_secure {
                 input_method::Purpose::Secure
             } else {

--- a/winit/src/window.rs
+++ b/winit/src/window.rs
@@ -172,7 +172,7 @@ where
     pub renderer: P::Renderer,
     pub redraw_at: Option<Instant>,
     preedit: Option<Preedit<P::Renderer>>,
-    ime_state: Option<(Point, input_method::Purpose)>,
+    ime_state: Option<(Rectangle, input_method::Purpose)>,
 }
 
 impl<P, C> Window<P, C>
@@ -217,11 +217,11 @@ where
                 self.disable_ime();
             }
             InputMethod::Enabled {
-                position,
+                cursor_position,
                 purpose,
                 preedit,
             } => {
-                self.enable_ime(position, purpose);
+                self.enable_ime(cursor_position, purpose);
 
                 if let Some(preedit) = preedit {
                     if preedit.content.is_empty() {
@@ -231,7 +231,7 @@ where
                             self.preedit.take().unwrap_or_else(Preedit::new);
 
                         overlay.update(
-                            position,
+                            cursor_position.position(),
                             &preedit,
                             self.state.background_color(),
                             &self.renderer,
@@ -260,19 +260,23 @@ where
         }
     }
 
-    fn enable_ime(&mut self, position: Point, purpose: input_method::Purpose) {
+    fn enable_ime(
+        &mut self,
+        cursor: Rectangle,
+        purpose: input_method::Purpose,
+    ) {
         if self.ime_state.is_none() {
             self.raw.set_ime_allowed(true);
         }
 
-        if self.ime_state != Some((position, purpose)) {
+        if self.ime_state != Some((cursor, purpose)) {
             self.raw.set_ime_cursor_area(
-                LogicalPosition::new(position.x, position.y),
-                LogicalSize::new(10, 10), // TODO?
+                LogicalPosition::new(cursor.x, cursor.y),
+                LogicalSize::new(cursor.width, cursor.height),
             );
             self.raw.set_ime_purpose(conversion::ime_purpose(purpose));
 
-            self.ime_state = Some((position, purpose));
+            self.ime_state = Some((cursor, purpose));
         }
     }
 


### PR DESCRIPTION
This is a follow-up to https://discourse.iced.rs/t/better-input-method-suport-on-wayland/973 .

The input method may place a popup with suggestions on the screen. For this, it needs to know the area that should not be covered. That's the cursor rectangle in winit.

So far, the size of the rectangle has been hardcoded to 10x10px. This fills it with actual line height.

Testing: working on it (I am not aware of any input method that uses it yet, and I'm currently checking anvil's implementation).

This *does not* take preedit into account. Depending on the wishes of the reviewer, I can submit that in the same or separate MR once it's done.

Background for this change: I have NLNet support to make Wayland input method support awesome (or at least not suck as much). I need a toolkit where it works great, and I can pull iced to that level.