### PR TITLE
refactor scroll_to

### DIFF
--- a/core/src/widget/operation/scrollable.rs
+++ b/core/src/widget/operation/scrollable.rs
@@ -8,7 +8,12 @@ pub trait Scrollable {
     fn snap_to(&mut self, offset: RelativeOffset);
 
     /// Scroll the widget to the given [`AbsoluteOffset`] along the horizontal & vertical axis.
-    fn scroll_to(&mut self, offset: AbsoluteOffset);
+    fn scroll_to(
+        &mut self,
+        offset: AbsoluteOffset,
+        bounds: Rectangle,
+        content_bounds: Rectangle,
+    );
 
     /// Scroll the widget by the given [`AbsoluteOffset`] along the horizontal & vertical axis.
     fn scroll_by(
@@ -75,13 +80,13 @@ pub fn scroll_to<T>(target: Id, offset: AbsoluteOffset) -> impl Operation<T> {
         fn scrollable(
             &mut self,
             id: Option<&Id>,
-            _bounds: Rectangle,
-            _content_bounds: Rectangle,
+            bounds: Rectangle,
+            content_bounds: Rectangle,
             _translation: Vector,
             state: &mut dyn Scrollable,
         ) {
             if Some(&self.target) == id {
-                state.scroll_to(self.offset);
+                state.scroll_to(self.offset, bounds, content_bounds);
             }
         }
     }


### PR DESCRIPTION
This PR unifies the `scroll_to` and `scroll_by` implementations. Before, only the `scroll_by` implementation did a check weather the `offset` is out of bounds. Therefore another check existed in the offset getter. So in case of `scroll_by`, two checks where done.

I decided to remove the check in the offset getter and adding one in the `scroll_to` implementation. While doing that I added additional parameters to the `scroll_to` operation of the scrollable. Having bounds the the `scroll_to` of the operation further enables other widgets implementing that trait to access the bounds. (I have that use case for a custom widget of mine)