### PR TITLE
fix: allow overlay mouse interaction outside its bounds

### DIFF
--- a/runtime/src/overlay/nested.rs
+++ b/runtime/src/overlay/nested.rs
@@ -271,12 +271,7 @@ where
             let mut layouts = layout.children();
 
             let layout = layouts.next()?;
-            let cursor_position = cursor.position()?;
             let overlay = element.as_overlay_mut();
-
-            if !overlay.is_over(layout, renderer, cursor_position) {
-                return None;
-            }
 
             Some(
                 overlay

--- a/runtime/src/user_interface.rs
+++ b/runtime/src/user_interface.rs
@@ -537,16 +537,7 @@ where
                             cursor,
                         );
 
-                        if cursor
-                            .position()
-                            .map(|cursor_position| {
-                                overlay.is_over(
-                                    Layout::new(layout),
-                                    renderer,
-                                    cursor_position,
-                                )
-                            })
-                            .unwrap_or_default()
+                        if overlay_interaction != mouse::Interaction::default()
                         {
                             overlay_interaction
                         } else {


### PR DESCRIPTION
This change is related to [this discussion](https://discord.com/channels/628993209984614400/1367863349114830848) on Discord.

This PR changes the overlay's `mouse_interaction` so that it can still call this function for all open overlays even if the mouse is not over the overlay bounds. This is useful when implementing any sort of drag ability on a widget on an overlay.

Currently if you try to have a widget like a slider that sets the `mouse_interaction` to `Interaction::Grabbing` when dragging the slider, this cursor wouldn't show as grabbing if you moved the mouse outside the overlay bounds while dragging. This doesn't seem to be the expected behavior, at lest not to me. I would expect the slider to keep moving and showing the correct cursor while I'm dragging it even if I move the mouse outside the overlay bounds. This PR fixes this.

The issue was that the `mouse_interaction` function wasn't even being called on an overlay if the mouse was outside it's borders. And even if it was there was still some code on the `user_interface.draw()` function that wouldn't let you have the `overlay_interaction` if the mouse wasn't over its bounds.

_The core team is busy and does not have time to mentor nor babysit new contributors. If a member of the core team thinks that reviewing and understanding your work will take more time and effort than writing it from scratch by themselves, your contribution will be dismissed. It is your responsibility to communicate and figure out how to reduce the likelihood of this!_

_Read the contributing guidelines for more details: https://github.com/iced-rs/iced/blob/master/CONTRIBUTING.md_
