### PR TITLE
Smart Scrollbars

### DIFF
--- a/examples/tour/src/main.rs
+++ b/examples/tour/src/main.rs
@@ -168,19 +168,17 @@ impl Tour {
             Screen::End => self.end(),
         };
 
-        let content: Element<_> = column![screen, controls,]
-            .max_width(540)
-            .spacing(20)
-            .padding(20)
-            .into();
+        let content: Element<_> =
+            column![screen, controls].max_width(540).spacing(20).into();
 
         let scrollable = scrollable(center_x(if self.debug {
             content.explain(Color::BLACK)
         } else {
             content
-        }));
+        }))
+        .spacing(10);
 
-        center_y(scrollable).into()
+        center_y(scrollable).padding(10).into()
     }
 
     fn can_continue(&self) -> bool {

--- a/examples/websocket/src/main.rs
+++ b/examples/websocket/src/main.rs
@@ -104,6 +104,7 @@ impl WebSocket {
             )
             .id(MESSAGE_LOG.clone())
             .height(Fill)
+            .spacing(10)
             .into()
         };
 


### PR DESCRIPTION
This PR makes embedded scrollbars in a `scrollable` (i.e. when using `spacing`) only appear and take up space when needed.

We avoid constantly relayouting twice by remembering the scrollbar "status quo" and only recalculating if the content has grown longer or shorter. Chains of status quo changes should be very rare; therefore `layout` can still be considered single-pass.