### PR TITLE
Implement tinyskia text bounds

### DIFF
--- a/tiny_skia/src/engine.rs
+++ b/tiny_skia/src/engine.rs
@@ -339,10 +339,15 @@ impl Engine {
                 paragraph,
                 position,
                 color,
-                clip_bounds: _, // TODO
+                clip_bounds: local_clip_bounds,
                 transformation: local_transformation,
             } => {
                 let transformation = transformation * *local_transformation;
+                let Some(clip_bounds) =
+                    local_clip_bounds.intersection(&clip_bounds)
+                else {
+                    return;
+                };
 
                 let physical_bounds =
                     Rectangle::new(*position, paragraph.min_bounds)
@@ -352,8 +357,13 @@ impl Engine {
                     return;
                 }
 
-                let clip_mask = (!physical_bounds.is_within(&clip_bounds))
-                    .then_some(clip_mask as &_);
+                let clip_mask = match physical_bounds.is_within(&clip_bounds) {
+                    true => None,
+                    false => {
+                        adjust_clip_mask(clip_mask, clip_bounds);
+                        Some(clip_mask as &_)
+                    }
+                };
 
                 self.text_pipeline.draw_paragraph(
                     paragraph,
@@ -368,10 +378,15 @@ impl Engine {
                 editor,
                 position,
                 color,
-                clip_bounds: _, // TODO
+                clip_bounds: local_clip_bounds,
                 transformation: local_transformation,
             } => {
                 let transformation = transformation * *local_transformation;
+                let Some(clip_bounds) =
+                    local_clip_bounds.intersection(&clip_bounds)
+                else {
+                    return;
+                };
 
                 let physical_bounds =
                     Rectangle::new(*position, editor.bounds) * transformation;
@@ -380,8 +395,13 @@ impl Engine {
                     return;
                 }
 
-                let clip_mask = (!physical_bounds.is_within(&clip_bounds))
-                    .then_some(clip_mask as &_);
+                let clip_mask = match physical_bounds.is_within(&clip_bounds) {
+                    true => None,
+                    false => {
+                        adjust_clip_mask(clip_mask, clip_bounds);
+                        Some(clip_mask as &_)
+                    }
+                };
 
                 self.text_pipeline.draw_editor(
                     editor,
@@ -402,16 +422,21 @@ impl Engine {
                 align_x,
                 align_y,
                 shaping,
-                clip_bounds: text_bounds, // TODO
+                clip_bounds: local_clip_bounds,
             } => {
-                let physical_bounds = *text_bounds * transformation;
+                let physical_bounds = *local_clip_bounds * transformation;
 
                 if !clip_bounds.intersects(&physical_bounds) {
                     return;
                 }
 
-                let clip_mask = (!physical_bounds.is_within(&clip_bounds))
-                    .then_some(clip_mask as &_);
+                let clip_mask = match physical_bounds.is_within(&clip_bounds) {
+                    true => None,
+                    false => {
+                        adjust_clip_mask(clip_mask, clip_bounds);
+                        Some(clip_mask as &_)
+                    }
+                };
 
                 self.text_pipeline.draw_cached(
                     content,


### PR DESCRIPTION
Fixes #2740 

Paragraph clip bounds are currently marked todo in the tiny skia backend. This PR makes an effort to change this by:
1. Finding the intersection between the clip_bounds argument (layer bounds) and the clip_bounds of the paragraph
2. Adjusting the clip mask to the intersection bounds if the physical bounds extend past the clip_bounds, otherwise don't update the clip mask to avoid expensive clip mask drawing.

The original issue only mentions `text_input`, however `text_editor` and cached text have the same todo comment and are also handled by this PR.

### Before
![grafik](https://github.com/user-attachments/assets/16063e5b-9a52-4934-b3a0-0eaddd9173dd)


### After
![grafik](https://github.com/user-attachments/assets/e8580b2b-25e4-479d-8e9d-7aa783d625d1)