### PR TITLE
Adds the ability to disable `allows_automatic_window_tabbing` on macOS.

### DIFF
--- a/core/src/settings.rs
+++ b/core/src/settings.rs
@@ -33,6 +33,14 @@ pub struct Settings {
     ///
     /// By default, it is enabled.
     pub antialiasing: bool,
+
+    #[cfg(target_os = "macos")]
+    /// Set whether the system can automatically organize windows into tabs.
+    ///
+    /// <https://developer.apple.com/documentation/appkit/nswindow/1646657-allowsautomaticwindowtabbing>
+    ///
+    /// The default value is `true`
+    pub allows_automatic_window_tabbing: bool,
 }
 
 impl Default for Settings {
@@ -43,6 +51,9 @@ impl Default for Settings {
             default_font: Font::default(),
             default_text_size: Pixels(16.0),
             antialiasing: true,
+
+            #[cfg(target_os = "macos")]
+            allows_automatic_window_tabbing: true
         }
     }
 }

--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -26,6 +26,9 @@ pub use runtime::debug;
 pub use runtime::futures;
 pub use winit;
 
+#[cfg(target_os = "macos")]
+use winit::platform::macos::ActiveEventLoopExtMacOS;
+
 pub mod clipboard;
 pub mod conversion;
 
@@ -140,6 +143,9 @@ where
 
         #[cfg(target_arch = "wasm32")]
         canvas: Option<web_sys::HtmlCanvasElement>,
+
+        #[cfg(target_os = "macos")]
+        allows_automatic_window_tabbing: bool,
     }
 
     let runner = Runner {
@@ -152,6 +158,10 @@ where
 
         #[cfg(target_arch = "wasm32")]
         canvas: None,
+
+        #[cfg(target_os = "macos")]
+        allows_automatic_window_tabbing: settings
+            .allows_automatic_window_tabbing,
     };
 
     boot_span.finish();
@@ -164,8 +174,15 @@ where
     {
         fn resumed(
             &mut self,
+            #[cfg(not(target_os = "macos"))]
             _event_loop: &winit::event_loop::ActiveEventLoop,
+            #[cfg(target_os = "macos")]
+            event_loop: &winit::event_loop::ActiveEventLoop,
         ) {
+            #[cfg(target_os = "macos")]
+            event_loop.set_allows_automatic_window_tabbing(
+                self.allows_automatic_window_tabbing,
+            );
         }
 
         fn new_events(


### PR DESCRIPTION
macOS intrusively adds certain global menu items if a certain menu item is present and if the underlying feature of the `AppKit` is enabled. For example, if a `View` global menu item is present and the [`allowsAutomaticWindowTabbing`](https://developer.apple.com/documentation/appkit/nswindow/allowsAutomaticWindowTabbing) value is set to `true`, the `Show/Hide Tab Bar` item is added to the `View` submenu (see images). By default, `allowsAutomaticWindowTabbing` is set to `true`. This makes any application with a `View` menu item the ability to show/hide potentially useless tab bar. See attached images that show the described menu item and the tab bar in the window.

This PR exposes this setting in `settings::Settings` (`core/src/settings.rs`) and applies it in `iced_winit::run` function.

<img width="599" alt="tab_bar_visible" src="https://github.com/user-attachments/assets/4b827bbc-f8ad-4751-88f0-4806c1c5778e" />
<img width="596" alt="tab_bar_hidden" src="https://github.com/user-attachments/assets/a4c4e8e9-b0ba-4610-b80a-7e14a7eba502" />
