### PR TITLE
add warning status to toast

### DIFF
--- a/examples/toast/src/main.rs
+++ b/examples/toast/src/main.rs
@@ -189,11 +189,17 @@ mod toast {
         Secondary,
         Success,
         Danger,
+        Warning,
     }
 
     impl Status {
-        pub const ALL: &'static [Self] =
-            &[Self::Primary, Self::Secondary, Self::Success, Self::Danger];
+        pub const ALL: &'static [Self] = &[
+            Self::Primary,
+            Self::Secondary,
+            Self::Success,
+            Self::Danger,
+            Self::Warning,
+        ];
     }
 
     impl fmt::Display for Status {
@@ -203,6 +209,7 @@ mod toast {
                 Status::Secondary => "Secondary",
                 Status::Success => "Success",
                 Status::Danger => "Danger",
+                Status::Warning => "Warning",
             }
             .fmt(f)
         }
@@ -253,6 +260,7 @@ mod toast {
                             Status::Secondary => secondary,
                             Status::Success => success,
                             Status::Danger => danger,
+                            Status::Warning => warning,
                         }),
                         horizontal_rule(1),
                         container(text(toast.body.as_str()))
@@ -664,5 +672,11 @@ mod toast {
         let palette = theme.extended_palette();
 
         styled(palette.danger.weak)
+    }
+
+    fn warning(theme: &Theme) -> container::Style {
+        let palette = theme.extended_palette();
+
+        styled(palette.warning.weak)
     }
 }


### PR DESCRIPTION
This PR adds a Warning status to the toast example, which is probably missing because Extended::warning got added later
