### PR TITLE
Remove unnecessary `Arc`

### DIFF
--- a/wgpu/src/image/atlas.rs
+++ b/wgpu/src/image/atlas.rs
@@ -23,7 +23,7 @@ pub struct Atlas {
     texture: wgpu::Texture,
     texture_view: wgpu::TextureView,
     texture_bind_group: wgpu::BindGroup,
-    texture_layout: Arc<wgpu::BindGroupLayout>,
+    texture_layout: wgpu::BindGroupLayout,
     layers: Vec<Layer>,
 }
 
@@ -31,7 +31,7 @@ impl Atlas {
     pub fn new(
         device: &wgpu::Device,
         backend: wgpu::Backend,
-        texture_layout: Arc<wgpu::BindGroupLayout>,
+        texture_layout: wgpu::BindGroupLayout,
     ) -> Self {
         let layers = match backend {
             // On the GL backend we start with 2 layers, to help wgpu figure

--- a/wgpu/src/image/cache.rs
+++ b/wgpu/src/image/cache.rs
@@ -16,7 +16,7 @@ impl Cache {
     pub fn new(
         device: &wgpu::Device,
         backend: wgpu::Backend,
-        layout: Arc<wgpu::BindGroupLayout>,
+        layout: wgpu::BindGroupLayout,
     ) -> Self {
         Self {
             atlas: Atlas::new(device, backend, layout),

--- a/wgpu/src/image/mod.rs
+++ b/wgpu/src/image/mod.rs
@@ -27,7 +27,7 @@ pub struct Pipeline {
     backend: wgpu::Backend,
     nearest_sampler: wgpu::Sampler,
     linear_sampler: wgpu::Sampler,
-    texture_layout: Arc<wgpu::BindGroupLayout>,
+    texture_layout: wgpu::BindGroupLayout,
     constant_layout: wgpu::BindGroupLayout,
 }
 
@@ -196,7 +196,7 @@ impl Pipeline {
             backend,
             nearest_sampler,
             linear_sampler,
-            texture_layout: Arc::new(texture_layout),
+            texture_layout,
             constant_layout,
         }
     }


### PR DESCRIPTION
Since `wgpu` 24, most types are ref-counted so this is not necessary anymore.


