### PR TITLE
removes .5 buffer from position in atlas

### DIFF
--- a/wgpu/src/image/mod.rs
+++ b/wgpu/src/image/mod.rs
@@ -605,8 +605,8 @@ fn add_instance(
         _rotation: rotation,
         _opacity: opacity,
         _position_in_atlas: [
-            (x as f32 + 0.5) / atlas::SIZE as f32,
-            (y as f32 + 0.5) / atlas::SIZE as f32,
+            (x as f32) / atlas::SIZE as f32,
+            (y as f32) / atlas::SIZE as f32,
         ],
         _size_in_atlas: [
             (width as f32 - 1.0) / atlas::SIZE as f32,


### PR DESCRIPTION
remove .5 buffer for position in atlas.

This fixes a bug where pixels towards the border of the image and image viewer widget are cut in half.
I did some tests on my own and it didn't seem to effect anything else, but I'm not entirely sure.

![Screenshot_2025-05-10_13-55-48](https://github.com/user-attachments/assets/0f48ed80-391f-47cb-a95d-281db932e1f9)
what it looks like before the change

![Screenshot_2025-05-10_13-54-54](https://github.com/user-attachments/assets/2b060b02-2dc5-4449-865c-bbf354aa4afc)
what it looks like after the change.
