### PR TITLE
chore: make the functions of devtools all public

### DIFF
--- a/devtools/src/lib.rs
+++ b/devtools/src/lib.rs
@@ -144,7 +144,7 @@ impl<P> DevTools<P>
 where
     P: Program + 'static,
 {
-    fn new(state: P::State) -> (Self, Task<Message>) {
+    pub fn new(state: P::State) -> (Self, Task<Message>) {
         (
             Self {
                 state,
@@ -160,11 +160,11 @@ where
         )
     }
 
-    fn title(&self, program: &P, window: window::Id) -> String {
+    pub fn title(&self, program: &P, window: window::Id) -> String {
         program.title(&self.state, window)
     }
 
-    fn update(&mut self, program: &P, event: Event<P>) -> Task<Event<P>> {
+    pub fn update(&mut self, program: &P, event: Event<P>) -> Task<Event<P>> {
         match event {
             Event::Message(message) => match message {
                 Message::HideNotification => {
@@ -290,7 +290,7 @@ where
         }
     }
 
-    fn view(
+    pub fn view(
         &self,
         program: &P,
         window: window::Id,
@@ -361,7 +361,7 @@ where
             .into()
     }
 
-    fn subscription(&self, program: &P) -> Subscription<Event<P>> {
+    pub fn subscription(&self, program: &P) -> Subscription<Event<P>> {
         let subscription =
             program.subscription(&self.state).map(Event::Program);
         debug::subscriptions_tracked(subscription.units());
@@ -380,19 +380,19 @@ where
         Subscription::batch([subscription, hotkeys, commands])
     }
 
-    fn theme(&self, program: &P, window: window::Id) -> P::Theme {
+    pub fn theme(&self, program: &P, window: window::Id) -> P::Theme {
         program.theme(self.state(), window)
     }
 
-    fn style(&self, program: &P, theme: &P::Theme) -> theme::Style {
+    pub fn style(&self, program: &P, theme: &P::Theme) -> theme::Style {
         program.style(self.state(), theme)
     }
 
-    fn scale_factor(&self, program: &P, window: window::Id) -> f64 {
+    pub fn scale_factor(&self, program: &P, window: window::Id) -> f64 {
         program.scale_factor(self.state(), window)
     }
 
-    fn state(&self) -> &P::State {
+    pub fn state(&self) -> &P::State {
         self.time_machine.state().unwrap_or(&self.state)
     }
 }


### PR DESCRIPTION
I am mading a iced platform plugin, and now I have already figure out how to reuse the iced_program::Program, now I want to expose all needed functions of DevTools to public

commit is here: https://github.com/waycrate/exwlshelleventloop/commit/6708037a8663e5a9d2f59ca97d661a8faf036c1b

I just made a fork to test my idea, and it works

The core team is busy and does not have time to mentor nor babysit new contributors. If a member of the core team thinks that reviewing and understanding your work will take more time and effort than writing it from scratch by themselves, your contribution will be dismissed. It is your responsibility to communicate and figure out how to reduce the likelihood of this!

Read the contributing guidelines for more details: https://github.com/iced-rs/iced/blob/master/CONTRIBUTING.md
