### PR TITLE
Expose underlying mobile support from winit via cfg changes

### DIFF
--- a/winit/Cargo.toml
+++ b/winit/Cargo.toml
@@ -22,6 +22,8 @@ x11 = ["winit/x11"]
 wayland = ["winit/wayland"]
 wayland-dlopen = ["winit/wayland-dlopen"]
 wayland-csd-adwaita = ["winit/wayland-csd-adwaita"]
+android-native-activity = ["winit/android-native-activity"]
+android-game-activity = ["winit/android-game-activity"]
 unconditional-rendering = []
 
 [dependencies]

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -203,13 +203,25 @@ pub fn window_event(
         WindowEvent::KeyboardInput { is_synthetic, .. } if is_synthetic => None,
         WindowEvent::KeyboardInput { event, .. } => Some(Event::Keyboard({
             let key = {
-                #[cfg(not(target_arch = "wasm32"))]
+                #[cfg(any(
+                    target_os="windows",
+                    target_os="macos",
+                    all(feature = "x11", all(unix, not(any(target_os = "ios", target_os = "macos")), not(target_os = "android"), not(target_os = "emscripten")), not(target_os = "redox")),
+                    all(feature = "wayland", all(unix, not(any(target_os = "ios", target_os = "macos")), not(target_os = "android"), not(target_os = "emscripten")), not(target_os = "redox")),
+                    target_os="redox",
+                ))]
                 {
                     use winit::platform::modifier_supplement::KeyEventExtModifierSupplement;
                     event.key_without_modifiers()
                 }
 
-                #[cfg(target_arch = "wasm32")]
+                #[cfg(not(any(
+                    target_os="windows",
+                    target_os="macos",
+                    all(feature = "x11", all(unix, not(any(target_os = "ios", target_os = "macos")), not(target_os = "android"), not(target_os = "emscripten")), not(target_os = "redox")),
+                    all(feature = "wayland", all(unix, not(any(target_os = "ios", target_os = "macos")), not(target_os = "android"), not(target_os = "emscripten")), not(target_os = "redox")),
+                    target_os="redox",
+                )))]
                 {
                     // TODO: Fix inconsistent API on Wasm
                     event.logical_key.clone()
@@ -217,7 +229,13 @@ pub fn window_event(
             };
 
             let text = {
-                #[cfg(not(target_arch = "wasm32"))]
+                #[cfg(any(
+                    target_os="windows",
+                    target_os="macos",
+                    all(feature = "x11", all(unix, not(any(target_os = "ios", target_os = "macos")), not(target_os = "android"), not(target_os = "emscripten")), not(target_os = "redox")),
+                    all(feature = "wayland", all(unix, not(any(target_os = "ios", target_os = "macos")), not(target_os = "android"), not(target_os = "emscripten")), not(target_os = "redox")),
+                    target_os="redox",
+                ))]
                 {
                     use crate::core::SmolStr;
                     use winit::platform::modifier_supplement::KeyEventExtModifierSupplement;
@@ -225,7 +243,13 @@ pub fn window_event(
                     event.text_with_all_modifiers().map(SmolStr::new)
                 }
 
-                #[cfg(target_arch = "wasm32")]
+                #[cfg(not(any(
+                    target_os="windows",
+                    target_os="macos",
+                    all(feature = "x11", all(unix, not(any(target_os = "ios", target_os = "macos")), not(target_os = "android"), not(target_os = "emscripten")), not(target_os = "redox")),
+                    all(feature = "wayland", all(unix, not(any(target_os = "ios", target_os = "macos")), not(target_os = "android"), not(target_os = "emscripten")), not(target_os = "redox")),
+                    target_os="redox",
+                )))]
                 {
                     // TODO: Fix inconsistent API on Wasm
                     event.text


### PR DESCRIPTION
I understand mobile support is not a priority, and possibly even a detriment if it attracts more spurious bug reports.  But, with just 6 lines of code changes `iced` can expose underling `winit` android support.  This goes a long way to closing #302 with no ongoing maintenance from iced core team.

4 lines are cfg changes that more closely align with the underlying winit library

```diff
--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -203,13 +203,25 @@ pub fn window_event(
         WindowEvent::KeyboardInput { is_synthetic, .. } if is_synthetic => None,
         WindowEvent::KeyboardInput { event, .. } => Some(Event::Keyboard({
             let key = {
-                #[cfg(not(target_arch = "wasm32"))]
+                #[cfg(any(
+                    target_os="windows",
+                    target_os="macos",
+                    all(feature = "x11", all(unix, not(any(target_os = "ios", target_os = "macos")), not(target_os = "android"), not(target_os = "emscripten")), not(target_os = "redox")),
+                    all(feature = "wayland", all(unix, not(any(target_os = "ios", target_os = "macos")), not(target_os = "android"), not(target_os = "emscripten")), not(target_os = "redox")),
+                    target_os="redox",
+                ))]
```
Checking only for wasm32 let's unsupported platforms slip through the feature gate of KeyEventExtModifierSupplement, because the underlying core winit library uses a different set of platform checks.
    
This will allow more platform support transparently by matching the cfg of the underlying winit library.
    
`winit` 0.31 plans to remove config aliases in favor of raw cfg macros.  https://github.com/rust-windowing/winit/issues/3539

Lastly, re-exporting 2 `winit` features into the iced_winit workspace Cargo allows the underlying `winit` + `android-activity` to build when targeting `aarch64-linux-android`

```diff
--- a/winit/Cargo.toml
+++ b/winit/Cargo.toml
@@ -22,6 +22,8 @@ x11 = ["winit/x11"]
 wayland = ["winit/wayland"]
 wayland-dlopen = ["winit/wayland-dlopen"]
 wayland-csd-adwaita = ["winit/wayland-csd-adwaita"]
+android-native-activity = ["winit/android-native-activity"]
+android-game-activity = ["winit/android-game-activity"]
 unconditional-rendering = []
 ```

There are all the changes to allow successful building on android - fonts don't work, but that is another small pr.