### PR TITLE
Fix scaling error of SVGs

### DIFF
--- a/tiny_skia/src/engine.rs
+++ b/tiny_skia/src/engine.rs
@@ -602,7 +602,7 @@ impl Engine {
                 self.vector_pipeline.draw(
                     &svg.handle,
                     svg.color,
-                    physical_bounds,
+                    *bounds,
                     svg.opacity,
                     _pixels,
                     transform,


### PR DESCRIPTION
This small pull-requests solves a problem when SVG are drawn with DPI scaling factor != 1.0 and tiny-skia. The problem is described in #2825.

In the `draw_image` function of `Engine` (in `tiny_skia/src/engine.rs`) the variable `pyhsical_bounds` is used, but it should be `*bounds` (same as in the `Image:Raster` arm).

```rust
                self.vector_pipeline.draw(
                    &svg.handle,
                    svg.color,
                    physical_bounds,  // <- *bounds is expected
                    svg.opacity,
                    _pixels,
                    transform,
                    clip_mask,
                );
```



