### PR TITLE
Fix scaling artifacts

### DIFF
--- a/tiny_skia/src/engine.rs
+++ b/tiny_skia/src/engine.rs
@@ -602,7 +602,7 @@ impl Engine {
                 self.vector_pipeline.draw(
                     &svg.handle,
                     svg.color,
-                    physical_bounds,
+                    *bounds,
                     svg.opacity,
                     _pixels,
                     transform,

--- a/tiny_skia/src/engine.rs
+++ b/tiny_skia/src/engine.rs
@@ -543,27 +543,27 @@ impl Engine {
     pub fn draw_image(
         &mut self,
         image: &Image,
-        _transformation: Transformation,
-        _pixels: &mut tiny_skia::PixmapMut<'_>,
-        _clip_mask: &mut tiny_skia::Mask,
-        _clip_bounds: Rectangle,
+        transformation: Transformation,
+        pixels: &mut tiny_skia::PixmapMut<'_>,
+        clip_mask: &mut tiny_skia::Mask,
+        clip_bounds: Rectangle,
     ) {
         match image {
             #[cfg(feature = "image")]
             Image::Raster(raster, bounds) => {
-                let physical_bounds = *bounds * _transformation;
+                let physical_bounds = *bounds * transformation;
 
-                if !_clip_bounds.intersects(&physical_bounds) {
+                if !clip_bounds.intersects(&physical_bounds) {
                     return;
                 }
 
-                let clip_mask = (!physical_bounds.is_within(&_clip_bounds))
-                    .then_some(_clip_mask as &_);
+                let clip_mask = (!physical_bounds.is_within(&clip_bounds))
+                    .then_some(clip_mask as &_);
 
                 let center = physical_bounds.center();
                 let radians = f32::from(raster.rotation);
 
-                let transform = into_transform(_transformation).post_rotate_at(
+                let transform = into_transform(transformation).post_rotate_at(
                     radians.to_degrees(),
                     center.x,
                     center.y,
@@ -574,26 +574,26 @@ impl Engine {
                     raster.filter_method,
                     *bounds,
                     raster.opacity,
-                    _pixels,
+                    pixels,
                     transform,
                     clip_mask,
                 );
             }
             #[cfg(feature = "svg")]
             Image::Vector(svg, bounds) => {
-                let physical_bounds = *bounds * _transformation;
+                let physical_bounds = *bounds * transformation;
 
-                if !_clip_bounds.intersects(&physical_bounds) {
+                if !clip_bounds.intersects(&physical_bounds) {
                     return;
                 }
 
-                let clip_mask = (!physical_bounds.is_within(&_clip_bounds))
-                    .then_some(_clip_mask as &_);
+                let clip_mask = (!physical_bounds.is_within(&clip_bounds))
+                    .then_some(clip_mask as &_);
 
                 let center = physical_bounds.center();
                 let radians = f32::from(svg.rotation);
 
-                let transform = into_transform(_transformation).post_rotate_at(
+                let transform = into_transform(transformation).post_rotate_at(
                     radians.to_degrees(),
                     center.x,
                     center.y,
@@ -604,7 +604,7 @@ impl Engine {
                     svg.color,
                     *bounds,
                     svg.opacity,
-                    _pixels,
+                    pixels,
                     transform,
                     clip_mask,
                 );

--- a/tiny_skia/src/vector.rs
+++ b/tiny_skia/src/vector.rs
@@ -42,17 +42,22 @@ impl Pipeline {
         if let Some(image) = self.cache.borrow_mut().draw(
             handle,
             color,
-            Size::new(bounds.width as u32, bounds.height as u32),
+            Size::new((bounds.width * transform.sx) as u32, (bounds.height * transform.sy) as u32),
+            //Size::new(bounds.width as u32, bounds.height as u32),
         ) {
+            let mut new_transform = transform.clone();
+            new_transform.sx = 1.0;
+            new_transform.sy = 1.0;
+
             pixels.draw_pixmap(
-                bounds.x as i32,
-                bounds.y as i32,
+                (bounds.x * transform.sx) as i32,
+                (bounds.y * transform.sy) as i32,
                 image,
                 &tiny_skia::PixmapPaint {
                     opacity,
                     ..tiny_skia::PixmapPaint::default()
                 },
-                transform,
+                new_transform,
                 clip_mask,
             );
         }

--- a/tiny_skia/src/vector.rs
+++ b/tiny_skia/src/vector.rs
@@ -43,12 +43,7 @@ impl Pipeline {
             handle,
             color,
             Size::new((bounds.width * transform.sx) as u32, (bounds.height * transform.sy) as u32),
-            //Size::new(bounds.width as u32, bounds.height as u32),
         ) {
-            let mut new_transform = transform.clone();
-            new_transform.sx = 1.0;
-            new_transform.sy = 1.0;
-
             pixels.draw_pixmap(
                 (bounds.x * transform.sx) as i32,
                 (bounds.y * transform.sy) as i32,
@@ -57,7 +52,7 @@ impl Pipeline {
                     opacity,
                     ..tiny_skia::PixmapPaint::default()
                 },
-                new_transform,
+                Transform::from_scale(1.0, 1.0),
                 clip_mask,
             );
         }


### PR DESCRIPTION
This pull request fixes two issues when tiny-skia is used andDPI scaling factor is unequal to 1.0.

* scaling factor of svg images is wrong (see issue #2825)
* svg images are getting pixelated when scaling (you also see it in issue #2825)

Changes done to fix these issues:
* Vector pipeline `.draw` gets `physical_bounds` but needs `*bounds`
* The SVG is rendered with size defined by logical size and then the pixmap is scaled up. Change this to rendering in physical size.
* Arguments with `_` prefix get the prefix removed, as the arguments are used.
