### PR TITLE
Implement `Debug` for `Task`

### DIFF
--- a/runtime/src/task.rs
+++ b/runtime/src/task.rs
@@ -17,7 +17,6 @@ pub use sipper::{Never, Sender, Sipper, Straw, sipper, stream};
 /// A set of concurrent actions to be performed by the iced runtime.
 ///
 /// A [`Task`] _may_ produce a bunch of values of type `T`.
-#[allow(missing_debug_implementations)]
 #[must_use = "`Task` must be returned to the runtime to take effect; normally in your `update` or `new` functions."]
 pub struct Task<T> {
     stream: Option<BoxStream<Action<T>>>,
@@ -275,6 +274,17 @@ impl<T> Task<T> {
     /// Returns the amount of work "units" of the [`Task`].
     pub fn units(&self) -> usize {
         self.units
+    }
+}
+
+impl<T: std::fmt::Debug> std::fmt::Debug for Task<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Task<{}>, units={}",
+            std::any::type_name::<T>(),
+            self.units
+        )
     }
 }
 

--- a/runtime/src/task.rs
+++ b/runtime/src/task.rs
@@ -279,12 +279,9 @@ impl<T> Task<T> {
 
 impl<T> std::fmt::Debug for Task<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "Task<{}>, units={}",
-            std::any::type_name::<T>(),
-            self.units
-        )
+        f.debug_struct(&format!("Task<{}>", std::any::type_name::<T>()))
+            .field("units", &self.units)
+            .finish()
     }
 }
 

--- a/runtime/src/task.rs
+++ b/runtime/src/task.rs
@@ -277,7 +277,7 @@ impl<T> Task<T> {
     }
 }
 
-impl<T: std::fmt::Debug> std::fmt::Debug for Task<T> {
+impl<T> std::fmt::Debug for Task<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,


### PR DESCRIPTION
Just a small quality-of-life thing: implementing Debug for `Task` so that it's easy to to use in, say, an enum returned by `update` and to be able to derive Debug on that enum.
