### PR TITLE
feat: Pixel perfect quads

### DIFF
--- a/examples/custom_quad/src/main.rs
+++ b/examples/custom_quad/src/main.rs
@@ -107,6 +107,7 @@ enum Message {
     ShadowXOffsetChanged(f32),
     ShadowYOffsetChanged(f32),
     ShadowBlurRadiusChanged(f32),
+    None,
 }
 
 impl Example {
@@ -148,6 +149,7 @@ impl Example {
             Message::ShadowBlurRadiusChanged(s) => {
                 self.shadow.blur_radius = s;
             }
+            Message::None => {}
         }
     }
 
@@ -172,7 +174,7 @@ impl Example {
                 self.border_width,
                 self.shadow
             ),
-            text!("Radius: {top_left:.2}/{top_right:.2}/{bottom_right:.2}/{bottom_left:.2}"),
+            text!("Radius: {top_left:.2}/{top_right:.2}/{bottom_right:.2}/{bottom_left:.2} - {:.2}", self.border_width),
             slider(1.0..=100.0, top_left, Message::RadiusTopLeftChanged).step(0.01),
             slider(1.0..=100.0, top_right, Message::RadiusTopRightChanged).step(0.01),
             slider(1.0..=100.0, bottom_right, Message::RadiusBottomRightChanged)
@@ -188,6 +190,13 @@ impl Example {
                 .step(0.01),
             slider(0.0..=100.0, sr, Message::ShadowBlurRadiusChanged)
                 .step(0.01),
+            iced::widget::button("test")
+                .style(|theme, status| {
+                    let mut style = iced::widget::button::primary(theme, status);
+                    style.border.radius = iced::border::left(10.0);
+                    style
+                })
+                .on_press(Message::None)
         ]
         .padding(20)
         .spacing(20)

--- a/wgpu/src/shader/quad.wgsl
+++ b/wgpu/src/shader/quad.wgsl
@@ -16,6 +16,13 @@ fn distance_alg(
     return rounded_box_sdf(frag_coord - top_left - inner_half_size, inner_half_size, 0.0);
 }
 
+fn rounded_box_sdf2(p: vec2<f32>, size: vec2<f32>, corners: vec4<f32>) -> f32 {
+    var box_half = select(corners.yz, corners.xw, p.x > 0.0);
+    var corner = select(box_half.y, box_half.x, p.y > 0.0);
+    var q = abs(p) - size + corner;
+    return min(max(q.x, q.y), 0.0) + length(max(q, vec2(0.0))) - corner;
+}
+
 // Given a vector from a point to the center of a rounded rectangle of the given `size` and
 // border `radius`, determines the point's distance from the nearest edge of the rounded rectangle
 fn rounded_box_sdf(to_center: vec2<f32>, size: vec2<f32>, radius: f32) -> f32 {

--- a/wgpu/src/shader/quad.wgsl
+++ b/wgpu/src/shader/quad.wgsl
@@ -31,9 +31,9 @@ fn corner_pos(
 ) -> CornerPos {
     var base_pos = (position + vertex_position(vertex_index) * input_scale) * global_scale;
     var ret: CornerPos;
+    ret.pos = round(base_pos);
     switch vertex_index {
         case 0u, 5u: {
-            ret.pos = vec2(ceil(base_pos.x), ceil(base_pos.y));
             ret.with_shadow = ret.pos
                 + (vec2(
                     max(shadow_offset.x, 0.0),
@@ -42,7 +42,6 @@ fn corner_pos(
             ret.to_edge = vec2(0.5, 0.5);
         }
         case 1u: {
-            ret.pos = vec2(ceil(base_pos.x), floor(base_pos.y));
             ret.with_shadow = ret.pos
                 + (vec2(
                     max(shadow_offset.x, 0.0),
@@ -51,7 +50,6 @@ fn corner_pos(
             ret.to_edge = vec2(0.5, -0.5);
         }
         case 2u, 3u: {
-            ret.pos = vec2(floor(base_pos.x), floor(base_pos.y));
             ret.with_shadow = ret.pos
                 + (vec2(
                     min(shadow_offset.x, 0.0),
@@ -60,7 +58,6 @@ fn corner_pos(
             ret.to_edge = vec2(-0.5, -0.5);
         }
         case 4u: {
-            ret.pos = vec2(floor(base_pos.x), ceil(base_pos.y));
             ret.with_shadow = ret.pos
                 + (vec2(
                     min(shadow_offset.x, 0.0),

--- a/wgpu/src/shader/quad/solid.wgsl
+++ b/wgpu/src/shader/quad/solid.wgsl
@@ -24,67 +24,6 @@ struct SolidVertexOutput {
     @location(8) shadow_blur_radius: f32,
 }
 
-struct CornerPos {
-    pos: vec2<f32>,
-    with_shadow: vec2<f32>,
-    to_edge: vec2<f32>,
-}
-fn corner_pos(
-    vertex_index: u32,
-    input_scale: vec2<f32>,
-    position: vec2<f32>,
-    global_scale: f32,
-    shadow_offset: vec2<f32>,
-    shadow_blur_radius: f32,
-) -> CornerPos {
-    var base_pos = (position + vertex_position(vertex_index) * input_scale) * global_scale;
-    var ret: CornerPos;
-    switch vertex_index {
-        case 0u, 5u: {
-            ret.pos = vec2(ceil(base_pos.x), ceil(base_pos.y));
-            ret.with_shadow = ret.pos
-                + (vec2(
-                    max(shadow_offset.x, 0.0),
-                    max(shadow_offset.y, 0.0),
-                ) + vec2(shadow_blur_radius, shadow_blur_radius)) * global_scale;
-            ret.to_edge = vec2(0.5, 0.5);
-        }
-        case 1u: {
-            ret.pos = vec2(ceil(base_pos.x), floor(base_pos.y));
-            ret.with_shadow = ret.pos
-                + (vec2(
-                    max(shadow_offset.x, 0.0),
-                    min(shadow_offset.y, 0.0),
-                ) + vec2(shadow_blur_radius, -shadow_blur_radius)) * global_scale;
-            ret.to_edge = vec2(0.5, -0.5);
-        }
-        case 2u, 3u: {
-            ret.pos = vec2(floor(base_pos.x), floor(base_pos.y));
-            ret.with_shadow = ret.pos
-                + (vec2(
-                    min(shadow_offset.x, 0.0),
-                    min(shadow_offset.y, 0.0),
-                ) + vec2(-shadow_blur_radius, -shadow_blur_radius)) * global_scale;
-            ret.to_edge = vec2(-0.5, -0.5);
-        }
-        case 4u: {
-            ret.pos = vec2(floor(base_pos.x), ceil(base_pos.y));
-            ret.with_shadow = ret.pos
-                + (vec2(
-                    min(shadow_offset.x, 0.0),
-                    max(shadow_offset.y, 0.0),
-                ) + vec2(-shadow_blur_radius, shadow_blur_radius)) * global_scale;
-            ret.to_edge = vec2(-0.5, 0.5);
-        }
-        default: {
-            ret.pos = vec2<f32>();
-            ret.with_shadow = vec2<f32>();
-            ret.to_edge = vec2<f32>();
-        }
-    }
-    return ret;
-}
-
 @vertex
 fn solid_vs_main(input: SolidVertexInput) -> SolidVertexOutput {
     var out: SolidVertexOutput;
@@ -105,9 +44,6 @@ fn solid_vs_main(input: SolidVertexInput) -> SolidVertexOutput {
         input.shadow_offset,
         input.shadow_blur_radius,
     );
-    // #: 0 1 2 3 4 5
-    // x: 1 1 0 0 0 1
-    // y: 1 0 0 0 1 1
     var other_index: u32;
     switch input.vertex_index {
         case 0u, 5u: {

--- a/wgpu/src/shader/quad/solid.wgsl
+++ b/wgpu/src/shader/quad/solid.wgsl
@@ -24,21 +24,70 @@ struct SolidVertexOutput {
     @location(8) shadow_blur_radius: f32,
 }
 
+struct CornerPos {
+    pos: vec2<f32>,
+    with_shadow: vec2<f32>,
+    to_edge: vec2<f32>,
+}
+fn corner_pos(
+    vertex_index: u32,
+    input_scale: vec2<f32>,
+    position: vec2<f32>,
+    global_scale: f32,
+    shadow_offset: vec2<f32>,
+    shadow_blur_radius: f32,
+) -> CornerPos {
+    var base_pos = (position + vertex_position(vertex_index) * input_scale) * global_scale;
+    var ret: CornerPos;
+    switch vertex_index {
+        case 0u, 5u: {
+            ret.pos = vec2(ceil(base_pos.x), ceil(base_pos.y));
+            ret.with_shadow = ret.pos
+                + (vec2(
+                    max(shadow_offset.x, 0.0),
+                    max(shadow_offset.y, 0.0),
+                ) + vec2(shadow_blur_radius, shadow_blur_radius)) * global_scale;
+            ret.to_edge = vec2(0.5, 0.5);
+        }
+        case 1u: {
+            ret.pos = vec2(ceil(base_pos.x), floor(base_pos.y));
+            ret.with_shadow = ret.pos
+                + (vec2(
+                    max(shadow_offset.x, 0.0),
+                    min(shadow_offset.y, 0.0),
+                ) + vec2(shadow_blur_radius, -shadow_blur_radius)) * global_scale;
+            ret.to_edge = vec2(0.5, -0.5);
+        }
+        case 2u, 3u: {
+            ret.pos = vec2(floor(base_pos.x), floor(base_pos.y));
+            ret.with_shadow = ret.pos
+                + (vec2(
+                    min(shadow_offset.x, 0.0),
+                    min(shadow_offset.y, 0.0),
+                ) + vec2(-shadow_blur_radius, -shadow_blur_radius)) * global_scale;
+            ret.to_edge = vec2(-0.5, -0.5);
+        }
+        case 4u: {
+            ret.pos = vec2(floor(base_pos.x), ceil(base_pos.y));
+            ret.with_shadow = ret.pos
+                + (vec2(
+                    min(shadow_offset.x, 0.0),
+                    max(shadow_offset.y, 0.0),
+                ) + vec2(-shadow_blur_radius, shadow_blur_radius)) * global_scale;
+            ret.to_edge = vec2(-0.5, 0.5);
+        }
+        default: {
+            ret.pos = vec2<f32>();
+            ret.with_shadow = vec2<f32>();
+            ret.to_edge = vec2<f32>();
+        }
+    }
+    return ret;
+}
+
 @vertex
 fn solid_vs_main(input: SolidVertexInput) -> SolidVertexOutput {
     var out: SolidVertexOutput;
-
-    var pos: vec2<f32> = (input.pos + min(input.shadow_offset, vec2<f32>(0.0, 0.0)) - input.shadow_blur_radius) * globals.scale;
-    var scale: vec2<f32> = (input.scale + vec2<f32>(abs(input.shadow_offset.x), abs(input.shadow_offset.y)) + input.shadow_blur_radius * 2.0) * globals.scale;
-    var snap: vec2<f32> = vec2<f32>(0.0, 0.0);
-
-    if input.scale.x == 1.0 {
-        snap.x = round(pos.x) - pos.x;
-    }
-
-    if input.scale.y == 1.0 {
-        snap.y = round(pos.y) - pos.y;
-    }
 
     var min_border_radius = min(input.scale.x, input.scale.y) * 0.5;
     var border_radius: vec4<f32> = vec4<f32>(
@@ -48,18 +97,49 @@ fn solid_vs_main(input: SolidVertexInput) -> SolidVertexOutput {
         min(input.border_radius.w, min_border_radius)
     );
 
-    var transform: mat4x4<f32> = mat4x4<f32>(
-        vec4<f32>(scale.x + 1.0, 0.0, 0.0, 0.0),
-        vec4<f32>(0.0, scale.y + 1.0, 0.0, 0.0),
-        vec4<f32>(0.0, 0.0, 1.0, 0.0),
-        vec4<f32>(pos - vec2<f32>(0.5, 0.5) + snap, 0.0, 1.0)
+    var cpos = corner_pos(
+        input.vertex_index,
+        input.scale,
+        input.pos,
+        globals.scale,
+        input.shadow_offset,
+        input.shadow_blur_radius,
+    );
+    // #: 0 1 2 3 4 5
+    // x: 1 1 0 0 0 1
+    // y: 1 0 0 0 1 1
+    var other_index: u32;
+    switch input.vertex_index {
+        case 0u, 5u: {
+            other_index = 2;
+        }
+        case 1u: {
+            other_index = 4;
+        }
+        case 2u, 3u: {
+            other_index = 0;
+        }
+        case 4u: {
+            other_index = 1;
+        }
+        default: {
+            other_index = 0;
+        }
+    }
+    var other_cpos = corner_pos(
+        other_index,
+        input.scale,
+        input.pos,
+        globals.scale,
+        input.shadow_offset,
+        input.shadow_blur_radius,
     );
 
-    out.position = globals.transform * transform * vec4<f32>(vertex_position(input.vertex_index), 0.0, 1.0);
+    out.position = globals.transform * vec4<f32>(cpos.with_shadow + cpos.to_edge, 0.0, 1.0);
     out.color = premultiply(input.color);
     out.border_color = premultiply(input.border_color);
-    out.pos = input.pos * globals.scale + snap;
-    out.scale = input.scale * globals.scale;
+    out.pos = vec2(min(cpos.pos.x, other_cpos.pos.x), min(cpos.pos.y, other_cpos.pos.y)); // input.pos * globals.scale - cpos.difference;
+    out.scale = abs(cpos.pos - other_cpos.pos);
     out.border_radius = border_radius * globals.scale;
     out.border_width = input.border_width * globals.scale;
     out.shadow_color = premultiply(input.shadow_color);
@@ -75,55 +155,32 @@ fn solid_fs_main(
 ) -> @location(0) vec4<f32> {
     var mixed_color: vec4<f32> = input.color;
 
-    var border_radius = select_border_radius(
-        input.border_radius,
-        input.position.xy,
-        (input.pos + input.scale * 0.5).xy
-    );
+    var dist: f32 = rounded_box_sdf2(
+        -(input.position.xy - input.pos - input.scale/2.0) * 2.0,
+        input.scale,
+        input.border_radius * 2.0
+    ) / 2.0;
 
     if (input.border_width > 0.0) {
-        var internal_border: f32 = max(border_radius - input.border_width, 0.0);
-
-        var internal_distance: f32 = distance_alg(
-            input.position.xy,
-            input.pos + vec2<f32>(input.border_width, input.border_width),
-            input.scale - vec2<f32>(input.border_width * 2.0, input.border_width * 2.0),
-            internal_border
+        mixed_color = mix(
+            input.color,
+            input.border_color,
+            clamp(0.5 + dist + input.border_width, 0.0, 1.0)
         );
-
-        var border_mix: f32 = smoothstep(
-            max(internal_border - 0.5, 0.0),
-            internal_border + 0.5,
-            internal_distance
-        );
-
-        mixed_color = mix(input.color, input.border_color, border_mix);
     }
 
-    var dist: f32 = distance_alg(
-        vec2<f32>(input.position.x, input.position.y),
-        input.pos,
-        input.scale,
-        border_radius
-    );
 
-    var radius_alpha: f32 = 1.0 - smoothstep(
-        max(border_radius - 0.5, 0.0),
-        border_radius + 0.5,
-        dist
-    );
+    var radius_alpha: f32 = clamp(0.5-dist, 0.0, 1.0);
 
     let quad_color = mixed_color * radius_alpha;
 
     if input.shadow_color.a > 0.0 {
-        let shadow_radius = select_border_radius(
-            input.border_radius,
-            input.position.xy - input.shadow_offset,
-            (input.pos + input.scale * 0.5).xy
-        );
-
-        let shadow_distance = max(rounded_box_sdf(input.position.xy - input.pos - input.shadow_offset - (input.scale / 2.0), input.scale / 2.0, shadow_radius), 0.);
-        let shadow_alpha = 1.0 - smoothstep(-input.shadow_blur_radius, input.shadow_blur_radius, shadow_distance);
+        var shadow_dist: f32 = rounded_box_sdf2(
+            -(input.position.xy - input.pos - input.shadow_offset - input.scale/2.0) * 2.0,
+            input.scale,
+            input.border_radius * 2.0
+        ) / 2.0;
+        let shadow_alpha = 1.0 - smoothstep(-input.shadow_blur_radius, input.shadow_blur_radius, max(shadow_dist, 0.0));
 
         return mix(quad_color, input.shadow_color, (1.0 - radius_alpha) * shadow_alpha);
     } else {


### PR DESCRIPTION
Fixes #2894

This PR makes quads snap to the nearest pixel, and adapts the SDF method used to give consistent results in all situations.

This means that quads will no longer have blurry edges in almost all situations.

This has some drawbacks - quads don't have subpixel detail after this which means that while resizing or moving, they snap by one-pixel increments, which makes them a little less smooth. Other frameworks like Qt have this same issue however, so this is an acceptable tradeoff.

# TODO:
- [ ] Implement for gradients
- [ ] Clean up code
- [ ] Investigate whether using switch statements in shader code are necessary (could use a multiply-add approach)