### PR TITLE
Avoids artifacts when drawing small arcs by casting `f32` to `f64`.

### DIFF
--- a/graphics/src/geometry/path/builder.rs
+++ b/graphics/src/geometry/path/builder.rs
@@ -116,7 +116,8 @@ impl Builder {
 
         let _ = self.raw.move_to(arc.sample(0.0));
 
-        arc.for_each_quadratic_bezier(&mut |curve| {
+        arc.cast::<f64>().for_each_quadratic_bezier(&mut |curve| {
+            let curve = curve.cast::<f32>();
             let _ = self.raw.quadratic_bezier_to(curve.ctrl, curve.to);
         });
     }


### PR DESCRIPTION
I ran into an `f32` related bug while drawing large phylogenetic trees that required subdividing a circle into ~400k sections (see images). The solution is an `f64` cast on the `lyon_geom::Arc` object before getting quadratic bezier curves (`for_each_quadratic_bezier`) before drawing.

<img width="757" alt="f32_artifacts" src="https://github.com/user-attachments/assets/07190203-ea5e-43a2-982e-3dddfb94ea9a" />
<img width="757" alt="f64" src="https://github.com/user-attachments/assets/496ccb96-76ed-4378-a18a-52756486bdfb" />
