### PR TITLE
Fix text damage calculation on tiny skia

### DIFF
--- a/graphics/src/text.rs
+++ b/graphics/src/text.rs
@@ -73,74 +73,32 @@ pub enum Text {
 impl Text {
     /// Returns the visible bounds of the [`Text`].
     pub fn visible_bounds(&self) -> Option<Rectangle> {
-        let (bounds, align_x, align_y) = match self {
+        match self {
             Text::Paragraph {
                 position,
                 paragraph,
                 clip_bounds,
                 transformation,
                 ..
-            } => (
-                Rectangle::new(*position, paragraph.min_bounds)
-                    .intersection(clip_bounds)
-                    .map(|bounds| bounds * *transformation),
-                paragraph.align_x,
-                Some(paragraph.align_y),
-            ),
+            } => Rectangle::new(*position, paragraph.min_bounds)
+                .intersection(clip_bounds)
+                .map(|bounds| bounds * *transformation),
             Text::Editor {
                 editor,
                 position,
                 clip_bounds,
                 transformation,
                 ..
-            } => (
-                Rectangle::new(*position, editor.bounds)
-                    .intersection(clip_bounds)
-                    .map(|bounds| bounds * *transformation),
-                Alignment::Default,
-                None,
-            ),
+            } => Rectangle::new(*position, editor.bounds)
+                .intersection(clip_bounds)
+                .map(|bounds| bounds * *transformation),
             Text::Cached {
                 bounds,
                 clip_bounds,
-                align_x: horizontal_alignment,
-                align_y: vertical_alignment,
                 ..
-            } => (
-                bounds.intersection(clip_bounds),
-                *horizontal_alignment,
-                Some(*vertical_alignment),
-            ),
-            Text::Raw { raw, .. } => {
-                (Some(raw.clip_bounds), Alignment::Default, None)
-            }
-        };
-
-        let mut bounds = bounds?;
-
-        match align_x {
-            Alignment::Default | Alignment::Left | Alignment::Justified => {}
-            Alignment::Center => {
-                bounds.x -= bounds.width / 2.0;
-            }
-            Alignment::Right => {
-                bounds.x -= bounds.width;
-            }
+            } => bounds.intersection(clip_bounds),
+            Text::Raw { raw, .. } => Some(raw.clip_bounds),
         }
-
-        if let Some(alignment) = align_y {
-            match alignment {
-                alignment::Vertical::Top => {}
-                alignment::Vertical::Center => {
-                    bounds.y -= bounds.height / 2.0;
-                }
-                alignment::Vertical::Bottom => {
-                    bounds.y -= bounds.height;
-                }
-            }
-        }
-
-        Some(bounds)
     }
 }
 


### PR DESCRIPTION
Fixes #2961 

Calculating the damage area of text on tiny skia uses the `Text::visible_bounds` method. This method applies text alignment, even though the bounds of the text have already been correctly aligned by using the `Rectangle::anchor` method before in the renderer code here: 
https://github.com/iced-rs/iced/blob/7c5a4bc465ca130cb54d856399e74d2cc962fee1/core/src/widget/text.rs#L336

This leads to the damage area being offset by half it's size, not rerendering the correct area:
![grafik](https://github.com/user-attachments/assets/705e159e-6a00-4b45-8287-0c608c6ced09)

Inspecting the center of text damage bounds in this example before and after with a window size of 1024px:
Before: `Point { x: 487.752, y: 10.4 }` 
After: `Point { x: 512.0, y: 10.4 }`

This PR removes the duplicate alignment from `Text::visible_bounds`, which is only used in one place in tinyskias layer code.