### PR TITLE
Fix Rectangle::is_within inconsistency

### DIFF
--- a/core/src/rectangle.rs
+++ b/core/src/rectangle.rs
@@ -137,6 +137,7 @@ impl Rectangle<f32> {
     }
 
     /// Returns true if the given [`Point`] is contained in the [`Rectangle`].
+    /// Excludes the right and bottom edges.
     pub fn contains(&self, point: Point) -> bool {
         self.x <= point.x
             && point.x < self.x + self.width
@@ -182,13 +183,13 @@ impl Rectangle<f32> {
         )
     }
 
-    /// Returns true if the current [`Rectangle`] is completely within the given
-    /// `container`.
+    /// Returns true if the current [`Rectangle`] is within the given
+    /// `container`. Includes the right and bottom edges.
     pub fn is_within(&self, container: &Rectangle) -> bool {
-        container.contains(self.position())
-            && container.contains(
-                self.position() + Vector::new(self.width, self.height),
-            )
+        self.x >= container.x
+            && self.y >= container.y
+            && self.x + self.width <= container.x + container.width
+            && self.y + self.height <= container.y + container.height
     }
 
     /// Computes the intersection with the given [`Rectangle`].


### PR DESCRIPTION
Fixes #2965 

Also documents the current behavior of `Rectangle::contains` .