### PR TITLE
fix: Wgpu text bounds cutoff

### DIFF
--- a/wgpu/src/text.rs
+++ b/wgpu/src/text.rs
@@ -628,8 +628,8 @@ fn prepare(
                 bounds: cryoglyph::TextBounds {
                     left: clip_bounds.x as i32,
                     top: clip_bounds.y as i32,
-                    right: (clip_bounds.x + clip_bounds.width) as i32,
-                    bottom: (clip_bounds.y + clip_bounds.height) as i32,
+                    right: (clip_bounds.x + clip_bounds.width).round() as i32,
+                    bottom: (clip_bounds.y + clip_bounds.height).round() as i32,
                 },
                 default_color: to_color(color),
             })


### PR DESCRIPTION
Fixes #2963 

The current wgpu text bounds implementation casts the right and bottom bound to an integer without rounding, leading to letters not being displayed fully. 

In this example there is a combo box on the left with a `0.2px` vertical space and an input box on the right without a vertical space. The default font size is `16px`, leading to a default line height of `1.3 * 16px = 20.8px`. With a `0.2px` vertical space the bottom bound equals to a whole integer coordinate, so the letters are displayed correctly. On the right the bound is cast from `20.8px` to `20px`, loosing almost a pixel of all letters extending to the bottom line:

![Bildschirmfoto vom 2025-06-01 12-41-32](https://github.com/user-attachments/assets/0530c303-85b7-463c-9562-8f518f9e0988)

This PR matches the line bound calculation of [tinyskia](https://github.com/iced-rs/iced/blob/ca6d992d6751bb523eaf8f14a3d2678df77cea77/tiny_skia/src/text.rs#L226) and `round`s the text bounds:

![grafik](https://github.com/user-attachments/assets/94d4ba60-5405-4e47-a51e-bbce4ac69699)
