### PR TITLE
Fix Path::circle artifact

### DIFF
--- a/graphics/src/geometry/path.rs
+++ b/graphics/src/geometry/path.rs
@@ -61,7 +61,10 @@ impl Path {
     /// Creates a new [`Path`] representing a circle given its center
     /// coordinate and its radius.
     pub fn circle(center: Point, radius: f32) -> Self {
-        Self::new(|p| p.circle(center, radius))
+        Self::new(|p| {
+            p.circle(center, radius);
+            p.close();
+        })
     }
 
     /// Returns the internal [`lyon_path::Path`].


### PR DESCRIPTION
Fixes #2976 

The `Path::circle` helper function does not close the path after constructing the circle, leading to a small artifact on the right between the start and end point.

Before | After
--- | ---
![Bildschirmfoto vom 2025-06-03 15-00-59](https://github.com/user-attachments/assets/e9aaec54-8574-444c-86a9-5c73bc0f43a4) | ![Bildschirmfoto vom 2025-06-03 15-02-26](https://github.com/user-attachments/assets/cc620f1c-5196-4649-8774-7084361911ba)

