### PR TITLE
Add select_range operation/helpers for `TextInput`

### DIFF
--- a/core/src/widget/operation/text_input.rs
+++ b/core/src/widget/operation/text_input.rs
@@ -13,6 +13,8 @@ pub trait TextInput {
     fn move_cursor_to(&mut self, position: usize);
     /// Selects all the content of the text input.
     fn select_all(&mut self);
+    /// Selects a range of text in the text input.
+    fn select_range(&mut self, start: usize, end: usize);
 }
 
 /// Produces an [`Operation`] that moves the cursor of the widget with the given [`Id`] to the
@@ -123,11 +125,11 @@ pub fn move_cursor_to<T>(target: Id, position: usize) -> impl Operation<T> {
 
 /// Produces an [`Operation`] that selects all the content of the widget with the given [`Id`].
 pub fn select_all<T>(target: Id) -> impl Operation<T> {
-    struct MoveCursor {
+    struct SelectAll {
         target: Id,
     }
 
-    impl<T> Operation<T> for MoveCursor {
+    impl<T> Operation<T> for SelectAll {
         fn text_input(
             &mut self,
             id: Option<&Id>,
@@ -152,5 +154,41 @@ pub fn select_all<T>(target: Id) -> impl Operation<T> {
         }
     }
 
-    MoveCursor { target }
+    SelectAll { target }
+}
+
+/// Produces an [`Operation`] that selects a range of text in the widget with the given [`Id`].
+pub fn select_range<T>(target: Id, start: usize, end: usize) -> impl Operation<T> {
+    struct SelectRange {
+        target: Id,
+        start: usize,
+        end: usize,
+    }
+
+    impl<T> Operation<T> for SelectRange {
+        fn text_input(
+            &mut self,
+            id: Option<&Id>,
+            _bounds: Rectangle,
+            state: &mut dyn TextInput,
+        ) {
+            match id {
+                Some(id) if id == &self.target => {
+                    state.select_range(self.start, self.end);
+                }
+                _ => {}
+            }
+        }
+
+        fn container(
+            &mut self,
+            _id: Option<&Id>,
+            _bounds: Rectangle,
+            operate_on_children: &mut dyn FnMut(&mut dyn Operation<T>),
+        ) {
+            operate_on_children(self);
+        }
+    }
+
+    SelectRange { target, start, end }
 }

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -1533,6 +1533,15 @@ pub fn select_all<T>(id: impl Into<Id>) -> Task<T> {
     )))
 }
 
+/// Produces a [`Task`] that selects a range of text in the [`TextInput`] with the given [`Id`].
+pub fn select_range<T>(id: impl Into<Id>, start: usize, end: usize) -> Task<T> {
+    task::effect(Action::widget(operation::text_input::select_range(
+        id.into().0,
+        start,
+        end,
+    )))
+}
+
 /// The state of a [`TextInput`].
 #[derive(Debug, Default, Clone)]
 pub struct State<P: text::Paragraph> {
@@ -1615,6 +1624,11 @@ impl<P: text::Paragraph> State<P> {
     pub fn select_all(&mut self) {
         self.cursor.select_range(0, usize::MAX);
     }
+
+    /// Selects a range of text in the [`TextInput`].
+    pub fn select_range(&mut self, start: usize, end: usize) {
+        self.cursor.select_range(start, end);
+    }
 }
 
 impl<P: text::Paragraph> operation::Focusable for State<P> {
@@ -1646,6 +1660,10 @@ impl<P: text::Paragraph> operation::TextInput for State<P> {
 
     fn select_all(&mut self) {
         State::select_all(self);
+    }
+
+    fn select_range(&mut self, start: usize, end: usize) {
+        State::select_range(self, start, end);
     }
 }
 


### PR DESCRIPTION
https://github.com/user-attachments/assets/29559378-0202-4887-a5a5-a4d61a977ef6

I have a use case for select_range. Currently, I'm wrapping a TextInput in a component, providing tab completion in the wrapper component, which is then selected after the value is replaced by the autocompleted text.

https://github.com/user-attachments/assets/1ff0a5b4-a9e8-4898-8de7-1ec8130bfe39

I'd like to select only the text that is autocompleted, so that the user is able to manipulate it without additional input to reposition their cursor in the widget.

This is clearly cargo culted, but straightforward and appears complete/working as intended.

I hope you consider merging it.
