### PR TITLE
Add `font_maybe` Utility to `Text`

### DIFF
--- a/core/src/widget/text.rs
+++ b/core/src/widget/text.rs
@@ -100,6 +100,17 @@ where
         self
     }
 
+    /// Sets the [`Font`] of the [`Text`], if `Some`.
+    ///
+    /// [`Font`]: crate::text::Renderer::Font
+    pub fn font_maybe(
+        mut self,
+        font: Option<impl Into<Renderer::Font>>,
+    ) -> Self {
+        self.format.font = font.map(Into::into);
+        self
+    }
+
     /// Sets the width of the [`Text`] boundaries.
     pub fn width(mut self, width: impl Into<Length>) -> Self {
         self.format.width = width.into();


### PR DESCRIPTION
A small utility function to allow concise font setting when one has an `Option<Font>` instead of a `Font`, modeled after the `font_maybe` function for `Span` in `core/src/text.rs`.