### PR TITLE
fix docs for Limits.lose

### DIFF
--- a/core/src/layout/limits.rs
+++ b/core/src/layout/limits.rs
@@ -106,7 +106,7 @@ impl Limits {
         Limits { min, max }
     }
 
-    /// Removes the minimum width constraint for the current [`Limits`].
+    /// Removes the minimum constraint for the current [`Limits`].
     pub fn loose(&self) -> Limits {
         Limits {
             min: Size::ZERO,


### PR DESCRIPTION
Since `.loose` removes both width and height, saying it removes the width constraint is wrong. This PR removes just the word `width` from the docs.
