### PR TITLE
Allow window size to be based on monitor resolution

### DIFF
--- a/core/src/window.rs
+++ b/core/src/window.rs
@@ -10,6 +10,7 @@ mod level;
 mod mode;
 mod position;
 mod redraw_request;
+mod size;
 mod user_attention;
 
 pub use direction::Direction;
@@ -22,4 +23,5 @@ pub use position::Position;
 pub use redraw_request::RedrawRequest;
 pub use screenshot::Screenshot;
 pub use settings::Settings;
+pub use size::Size;
 pub use user_attention::UserAttention;

--- a/core/src/window/settings.rs
+++ b/core/src/window/settings.rs
@@ -33,7 +33,7 @@ pub use platform::PlatformSpecific;
 #[derive(Debug, Clone)]
 pub struct Settings {
     /// The initial logical dimensions of the window.
-    pub size: Size,
+    pub size: crate::window::Size,
 
     /// Whether the window should start maximized.
     pub maximized: bool,
@@ -85,7 +85,7 @@ pub struct Settings {
 impl Default for Settings {
     fn default() -> Self {
         Self {
-            size: Size::new(1024.0, 768.0),
+            size: crate::window::Size::default(),
             maximized: false,
             fullscreen: false,
             position: Position::default(),

--- a/core/src/window/size.rs
+++ b/core/src/window/size.rs
@@ -1,0 +1,35 @@
+/// The size of a window upon creation.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Size {
+    /// Sets the size of the window directly.
+    Fixed(crate::Size),
+    /// Allows you to set the size of the window based on the monitors resolution
+    ///
+    /// The function receives the the monitor's resolution as input.
+    FromScreensize(fn(crate::Size) -> crate::Size),
+}
+
+impl Size {
+    /// Returns the default fixed windows size.
+    /// The output is an [`iced::Size`].
+    ///
+    /// If you want to populate the [`iced::window::Settings`], you can use the `default()` function instead.
+    pub fn default_window_size() -> crate::Size {
+        crate::Size::new(1024.0, 768.0)
+    }
+}
+
+impl Default for Size {
+    fn default() -> Self {
+        Self::Fixed(Self::default_window_size())
+    }
+}
+
+impl<Source> From<Source> for Size
+where
+    Source: Into<crate::Size>,
+{
+    fn from(value: Source) -> Self {
+        Self::Fixed(value.into())
+    }
+}

--- a/examples/solar_system/src/main.rs
+++ b/examples/solar_system/src/main.rs
@@ -89,7 +89,7 @@ impl State {
 
     pub fn new() -> State {
         let now = Instant::now();
-        let size = window::Settings::default().size;
+        let size = window::Size::default_window_size();
 
         State {
             sun: image::Handle::from_bytes(

--- a/src/application.rs
+++ b/src/application.rs
@@ -34,9 +34,7 @@ use crate::program::{self, Program};
 use crate::shell;
 use crate::theme;
 use crate::window;
-use crate::{
-    Element, Executor, Font, Result, Settings, Size, Subscription, Task,
-};
+use crate::{Element, Executor, Font, Result, Settings, Subscription, Task};
 
 use std::borrow::Cow;
 
@@ -253,7 +251,7 @@ impl<P: Program> Application<P> {
     }
 
     /// Sets the [`window::Settings::size`] of the [`Application`].
-    pub fn window_size(self, size: impl Into<Size>) -> Self {
+    pub fn window_size(self, size: impl Into<window::Size>) -> Self {
         Self {
             window: window::Settings {
                 size: size.into(),

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -167,7 +167,7 @@ where
         settings: Settings,
         element: impl Into<Element<'a, Message, Theme, Renderer>>,
     ) -> Self {
-        Self::with_size(settings, window::Settings::default().size, element)
+        Self::with_size(settings, window::Size::default_window_size(), element)
     }
 
     /// Creates a new [`Simulator`] with the given [`Settings`] and size.

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -20,10 +20,6 @@ pub fn window_attributes(
 
     attributes = attributes
         .with_title(title)
-        .with_inner_size(winit::dpi::LogicalSize {
-            width: settings.size.width,
-            height: settings.size.height,
-        })
         .with_maximized(settings.maximized)
         .with_fullscreen(
             settings
@@ -43,8 +39,17 @@ pub fn window_attributes(
         .with_window_level(window_level(settings.level))
         .with_visible(settings.visible);
 
+    let size = size(primary_monitor.as_ref(), settings.size);
+
+    if let Some(size) = size {
+        attributes = attributes.with_inner_size(winit::dpi::LogicalSize {
+            width: size.width,
+            height: size.height,
+        });
+    }
+
     if let Some(position) =
-        position(primary_monitor.as_ref(), settings.size, settings.position)
+        position(primary_monitor.as_ref(), size, settings.position)
     {
         attributes = attributes.with_position(position);
     }
@@ -334,12 +339,35 @@ pub fn window_level(level: window::Level) -> winit::window::WindowLevel {
     }
 }
 
+/// Converts a [`window::Size`] to an [`iced::Size`] for a given monitor.
+pub fn size(
+    monitor: Option<&winit::monitor::MonitorHandle>,
+    size: window::Size,
+) -> Option<crate::Size> {
+    match size {
+        window::Size::Fixed(size) => Some(size),
+        window::Size::FromScreensize(to_size) => {
+            if let Some(monitor) = monitor {
+                let resolution: winit::dpi::LogicalSize<f32> =
+                    monitor.size().to_logical(monitor.scale_factor());
+
+                let size =
+                    to_size(Size::new(resolution.width, resolution.height));
+
+                Some(size)
+            } else {
+                None
+            }
+        }
+    }
+}
+
 /// Converts a [`window::Position`] to a [`winit`] logical position for a given monitor.
 ///
 /// [`winit`]: https://github.com/rust-windowing/winit
 pub fn position(
     monitor: Option<&winit::monitor::MonitorHandle>,
-    size: Size,
+    size: Option<Size>,
     position: window::Position,
 ) -> Option<winit::dpi::Position> {
     match position {
@@ -352,53 +380,62 @@ pub fn position(
         }
         window::Position::SpecificWith(to_position) => {
             if let Some(monitor) = monitor {
-                let start = monitor.position();
+                if let Some(size) = size {
+                    let start = monitor.position();
 
-                let resolution: winit::dpi::LogicalSize<f32> =
-                    monitor.size().to_logical(monitor.scale_factor());
+                    let resolution: winit::dpi::LogicalSize<f32> =
+                        monitor.size().to_logical(monitor.scale_factor());
 
-                let position = to_position(
-                    size,
-                    Size::new(resolution.width, resolution.height),
-                );
+                    let position = to_position(
+                        size,
+                        Size::new(resolution.width, resolution.height),
+                    );
 
-                let centered: winit::dpi::PhysicalPosition<i32> =
-                    winit::dpi::LogicalPosition {
-                        x: position.x,
-                        y: position.y,
-                    }
-                    .to_physical(monitor.scale_factor());
+                    let centered: winit::dpi::PhysicalPosition<i32> =
+                        winit::dpi::LogicalPosition {
+                            x: position.x,
+                            y: position.y,
+                        }
+                        .to_physical(monitor.scale_factor());
 
-                Some(winit::dpi::Position::Physical(
-                    winit::dpi::PhysicalPosition {
-                        x: start.x + centered.x,
-                        y: start.y + centered.y,
-                    },
-                ))
+                    Some(winit::dpi::Position::Physical(
+                        winit::dpi::PhysicalPosition {
+                            x: start.x + centered.x,
+                            y: start.y + centered.y,
+                        },
+                    ))
+                } else {
+                    None
+                }
             } else {
                 None
             }
         }
         window::Position::Centered => {
             if let Some(monitor) = monitor {
-                let start = monitor.position();
+                if let Some(size) = size {
+                    let start = monitor.position();
 
-                let resolution: winit::dpi::LogicalSize<f64> =
-                    monitor.size().to_logical(monitor.scale_factor());
+                    let resolution: winit::dpi::LogicalSize<f64> =
+                        monitor.size().to_logical(monitor.scale_factor());
 
-                let centered: winit::dpi::PhysicalPosition<i32> =
-                    winit::dpi::LogicalPosition {
-                        x: (resolution.width - f64::from(size.width)) / 2.0,
-                        y: (resolution.height - f64::from(size.height)) / 2.0,
-                    }
-                    .to_physical(monitor.scale_factor());
+                    let centered: winit::dpi::PhysicalPosition<i32> =
+                        winit::dpi::LogicalPosition {
+                            x: (resolution.width - f64::from(size.width)) / 2.0,
+                            y: (resolution.height - f64::from(size.height))
+                                / 2.0,
+                        }
+                        .to_physical(monitor.scale_factor());
 
-                Some(winit::dpi::Position::Physical(
-                    winit::dpi::PhysicalPosition {
-                        x: start.x + centered.x,
-                        y: start.y + centered.y,
-                    },
-                ))
+                    Some(winit::dpi::Position::Physical(
+                        winit::dpi::PhysicalPosition {
+                            x: start.x + centered.x,
+                            y: start.y + centered.y,
+                        },
+                    ))
+                } else {
+                    None
+                }
             } else {
                 None
             }

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -379,63 +379,54 @@ pub fn position(
             }))
         }
         window::Position::SpecificWith(to_position) => {
-            if let Some(monitor) = monitor {
-                if let Some(size) = size {
-                    let start = monitor.position();
+            if let Some((monitor, size)) = monitor.zip(size) {
+                let start = monitor.position();
 
-                    let resolution: winit::dpi::LogicalSize<f32> =
-                        monitor.size().to_logical(monitor.scale_factor());
+                let resolution: winit::dpi::LogicalSize<f32> =
+                    monitor.size().to_logical(monitor.scale_factor());
 
-                    let position = to_position(
-                        size,
-                        Size::new(resolution.width, resolution.height),
-                    );
+                let position = to_position(
+                    size,
+                    Size::new(resolution.width, resolution.height),
+                );
 
-                    let centered: winit::dpi::PhysicalPosition<i32> =
-                        winit::dpi::LogicalPosition {
-                            x: position.x,
-                            y: position.y,
-                        }
-                        .to_physical(monitor.scale_factor());
+                let centered: winit::dpi::PhysicalPosition<i32> =
+                    winit::dpi::LogicalPosition {
+                        x: position.x,
+                        y: position.y,
+                    }
+                    .to_physical(monitor.scale_factor());
 
-                    Some(winit::dpi::Position::Physical(
-                        winit::dpi::PhysicalPosition {
-                            x: start.x + centered.x,
-                            y: start.y + centered.y,
-                        },
-                    ))
-                } else {
-                    None
-                }
+                Some(winit::dpi::Position::Physical(
+                    winit::dpi::PhysicalPosition {
+                        x: start.x + centered.x,
+                        y: start.y + centered.y,
+                    },
+                ))
             } else {
                 None
             }
         }
         window::Position::Centered => {
-            if let Some(monitor) = monitor {
-                if let Some(size) = size {
-                    let start = monitor.position();
+            if let Some((monitor, size)) = monitor.zip(size) {
+                let start = monitor.position();
 
-                    let resolution: winit::dpi::LogicalSize<f64> =
-                        monitor.size().to_logical(monitor.scale_factor());
+                let resolution: winit::dpi::LogicalSize<f64> =
+                    monitor.size().to_logical(monitor.scale_factor());
 
-                    let centered: winit::dpi::PhysicalPosition<i32> =
-                        winit::dpi::LogicalPosition {
-                            x: (resolution.width - f64::from(size.width)) / 2.0,
-                            y: (resolution.height - f64::from(size.height))
-                                / 2.0,
-                        }
-                        .to_physical(monitor.scale_factor());
+                let centered: winit::dpi::PhysicalPosition<i32> =
+                    winit::dpi::LogicalPosition {
+                        x: (resolution.width - f64::from(size.width)) / 2.0,
+                        y: (resolution.height - f64::from(size.height)) / 2.0,
+                    }
+                    .to_physical(monitor.scale_factor());
 
-                    Some(winit::dpi::Position::Physical(
-                        winit::dpi::PhysicalPosition {
-                            x: start.x + centered.x,
-                            y: start.y + centered.y,
-                        },
-                    ))
-                } else {
-                    None
-                }
+                Some(winit::dpi::Position::Physical(
+                    winit::dpi::PhysicalPosition {
+                        x: start.x + centered.x,
+                        y: start.y + centered.y,
+                    },
+                ))
             } else {
                 None
             }


### PR DESCRIPTION
When creating a window, it's already possible to set the position based on the window size and the monitor resolution.

e.g. to position a window at the top center of the screen:

```rs
window::Position::SpecificWith(|window_size, monitor_res| {
    let x = (monitor_res.width - window_size.width) / 2.0;
    iced::Point::new(x, 0.0)
})
```

This PR allows doing the same for the window Size:

```rs
window::Size::FromScreensize(|monitor_res| {
    iced::Size(monitor_res.width * 0.8, monitor_res.height * 0.8)
})
```

I implemented the `From` trait for all types that already are `Into<Size`, so this change should not break anything for most use cases.

I'm happy to help if any additional changes are needed.