### PR TITLE
Add mailto as valid link scheme in markdown

### DIFF
--- a/widget/src/markdown.rs
+++ b/widget/src/markdown.rs
@@ -562,7 +562,8 @@ fn parse_with<'a>(
                 match Url::parse(&dest_url) {
                     Ok(url)
                         if url.scheme() == "http"
-                            || url.scheme() == "https" =>
+                            || url.scheme() == "https"
+                            || url.scheme() == "mailto" =>
                     {
                         link = Some(url);
                     }


### PR DESCRIPTION
Currently only link schemes "http" and "https" are valid. This pull requests adds "mailto" as valid link scheme.

Another question is, if the scheme should be checked here as it the verification could be left to the Message handler.