### PR TITLE
[Scrollable] Added the ability of not to change a specific direction offset

### DIFF
--- a/core/src/widget/operation/scrollable.rs
+++ b/core/src/widget/operation/scrollable.rs
@@ -125,29 +125,33 @@ pub fn scroll_by<T>(target: Id, offset: AbsoluteOffset) -> impl Operation<T> {
 }
 
 /// The amount of absolute offset in each direction of a [`Scrollable`].
+/// 
+/// A value of `None` indicates the direction offset position is preserved.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub struct AbsoluteOffset {
     /// The amount of horizontal offset
-    pub x: f32,
+    pub x: Option<f32>,
     /// The amount of vertical offset
-    pub y: f32,
+    pub y: Option<f32>,
 }
 
 /// The amount of relative offset in each direction of a [`Scrollable`].
 ///
 /// A value of `0.0` means start, while `1.0` means end.
+/// 
+/// A value of `None` indicates the direction offset position is preserved.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub struct RelativeOffset {
     /// The amount of horizontal offset
-    pub x: f32,
+    pub x: Option<f32>,
     /// The amount of vertical offset
-    pub y: f32,
+    pub y: Option<f32>,
 }
 
 impl RelativeOffset {
     /// A relative offset that points to the top-left of a [`Scrollable`].
-    pub const START: Self = Self { x: 0.0, y: 0.0 };
+    pub const START: Self = Self { x: Some(0.0), y: Some(0.0) };
 
     /// A relative offset that points to the bottom-right of a [`Scrollable`].
-    pub const END: Self = Self { x: 1.0, y: 1.0 };
+    pub const END: Self = Self { x: Some(1.0), y: Some(1.0) };
 }

--- a/examples/scrollable/src/main.rs
+++ b/examples/scrollable/src/main.rs
@@ -305,16 +305,16 @@ impl ScrollableDemo {
 
         let progress_bars: Element<Message> = match self.scrollable_direction {
             Direction::Vertical => {
-                progress_bar(0.0..=1.0, self.current_scroll_offset.y).into()
+                progress_bar(0.0..=1.0, self.current_scroll_offset.y.unwrap()).into()
             }
             Direction::Horizontal => {
-                progress_bar(0.0..=1.0, self.current_scroll_offset.x)
+                progress_bar(0.0..=1.0, self.current_scroll_offset.x.unwrap())
                     .style(progress_bar_custom_style)
                     .into()
             }
             Direction::Multi => column![
-                progress_bar(0.0..=1.0, self.current_scroll_offset.y),
-                progress_bar(0.0..=1.0, self.current_scroll_offset.x)
+                progress_bar(0.0..=1.0, self.current_scroll_offset.y.unwrap()),
+                progress_bar(0.0..=1.0, self.current_scroll_offset.x.unwrap())
                     .style(progress_bar_custom_style)
             ]
             .spacing(10)


### PR DESCRIPTION
Added the ability to not change a specific direction offset when updating the scrollable's offsets. Before this commit, both directions' offsets are updated. This commit resolves an issue with linked scrollables resetting the other scrollable offset to the start position, while zeroing out the one direction of a linked scrollable.