### PR TITLE
Add envvar to define beacon server listen address

### DIFF
--- a/beacon/src/client.rs
+++ b/beacon/src/client.rs
@@ -15,8 +15,6 @@ use std::sync::Arc;
 use std::sync::atomic::{self, AtomicBool};
 use std::thread;
 
-pub const SERVER_ADDRESS: &str = "127.0.0.1:9167";
-
 #[derive(Debug, Clone)]
 pub struct Client {
     sender: mpsc::Sender<Action>,
@@ -224,7 +222,8 @@ async fn run(
 
 async fn _connect() -> Result<net::TcpStream, io::Error> {
     log::debug!("Attempting to connect to server...");
-    let stream = net::TcpStream::connect(SERVER_ADDRESS).await?;
+    let addr = crate::server_address_from_env();
+    let stream = net::TcpStream::connect(&addr).await?;
 
     stream.set_nodelay(true)?;
     stream.writable().await?;


### PR DESCRIPTION
This commit replaces the default hardcoded value for the beacon server address with an envvar. This allows one to run comet on one machine while running the UI on another one (e.g. embedded system).

The core team is busy and does not have time to mentor nor babysit new contributors. If a member of the core team thinks that reviewing and understanding your work will take more time and effort than writing it from scratch by themselves, your contribution will be dismissed. It is your responsibility to communicate and figure out how to reduce the likelihood of this!

Read the contributing guidelines for more details: https://github.com/iced-rs/iced/blob/master/CONTRIBUTING.md
