### PR TITLE
Fix `hover` ignoring events in certain conditions

### DIFF
--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -907,11 +907,11 @@ where
                 if !is_visible {
                     Shell::replace_redraw_request(shell, redraw_request);
                 }
-            };
 
-            if shell.is_event_captured() {
-                return;
-            }
+                if shell.is_event_captured() {
+                    return;
+                }
+            };
 
             self.base.as_widget_mut().update(
                 base_tree,


### PR DESCRIPTION
This PR fixes the `hover` widget ignoring events for the base element caused by checking for captured events. Including elements (even stateless elements like `horizontal_space`) over a `text_input` would cause the focus state to appear visually glitchy. This was caused by an `if shell.is_event_captured()` check that was being performed after an earlier `self.top.as_widget_mut().update` call, but the capture check was happening regardless of whether the `self.top` element was getting updated. Moving the capture check into the same scope as the `update` call fixes the issue.

Here's a before and after example of the issue, and a minimal reproduction. Interestingly, the issue only appears if you click on text inputs going _up_, but not down.

**Before change**
<video src="https://github.com/user-attachments/assets/c7fb2b97-0f38-4d2a-9ecc-118bd55281c4" />

**After change**
<video src="https://github.com/user-attachments/assets/a1d931e8-f9c4-41d5-ae51-8a8e2a898780" />

**Minimal reproduction**
```rs
#[derive(Default)]
struct App {
    values: [String; 5],
}

#[derive(Debug, Clone)]
enum Message {
    ChangeValue(usize, String),
}

impl App {
    fn update(&mut self, message: Message) {
        match message {
            Message::ChangeValue(index, value) => {
                self.values[index] = value;
            }
        }
    }

    fn view(&self) -> iced::Element<Message> {
        use iced::widget::{column, horizontal_space, hover, text_input};

        let inputs = self
            .values
            .iter()
            .enumerate()
            .map(|(i, value)| {
                hover(
                    text_input("Value", value)
                        .on_input(move |v| Message::ChangeValue(i, v))
                        .padding(10),
                    horizontal_space(),
                )
            })
            .fold(column![].spacing(4), |col, input| col.push(input))
            .padding(8);

        inputs.into()
    }
}

fn main() -> iced::Result {
    iced::application(App::default, App::update, App::view)
        .title("Hover focus")
        .run()
}

```