### PR TITLE
adds request_redraw to geometry example

### DIFF
--- a/examples/geometry/src/main.rs
+++ b/examples/geometry/src/main.rs
@@ -37,6 +37,22 @@ mod rainbow {
             layout::Node::new(Size::new(width, width))
         }
 
+        fn update(
+            &mut self,
+            _state: &mut widget::Tree,
+            _event: &iced::Event,
+            _layout: Layout<'_>,
+            cursor: iced::advanced::mouse::Cursor,
+            _renderer: &Renderer,
+            _clipboard: &mut dyn iced::advanced::Clipboard,
+            shell: &mut iced::advanced::Shell<'_, Message>,
+            viewport: &Rectangle,
+        ) {
+            if cursor.is_over(*viewport) {
+                shell.request_redraw();
+            }
+        }
+
         fn draw(
             &self,
             _tree: &widget::Tree,


### PR DESCRIPTION
I noticed that the geometry example doesn't update with the movement of the mouse.