### PR TITLE
Update DEPENDENCIES.md

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -27,6 +27,7 @@ pkgs.mkShell rec {
     xorg.libXrandr
     wayland
     libxkbcommon
+    vulkan-loader
   ];
 
   LD_LIBRARY_PATH =
@@ -67,6 +68,7 @@ Alternatively, you can use this `flake.nix` to create a dev shell, activated by 
           xorg.libXrandr
           wayland
           libxkbcommon
+          vulkan-loader
         ];
       in {
         devShells.default = pkgs.mkShell {


### PR DESCRIPTION
I've been having lots of issues trying to run an iced app I wrote on windows while running on NixOS.

```
thread 'main' panicked at /home/rafael/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/wgpu-hal-0.19.5/src/gles/egl.rs:789:88:

called `Option::unwrap()` on a `None` value

note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace 
```

Tinkering a bit and looking at other projects I created, I made it run on a [devenv shell](https://devenv.sh/).

What finally made the error disappear was adding the `vulkan-loader` library into the mix.

Truthfully, I can't 100% explain why it works, I just know it was a linking issue 😭 I just hope this helps anyone who catches the same issue as me