### PR TITLE
Add getter for window::Id

### DIFF
--- a/core/src/window/id.rs
+++ b/core/src/window/id.rs
@@ -14,6 +14,11 @@ impl Id {
     pub fn unique() -> Id {
         Id(COUNT.fetch_add(1, atomic::Ordering::Relaxed))
     }
+
+    /// Read-only access to the raw integer id.
+    pub fn get(&self) -> u64 {
+        self.0
+    }
 }
 
 impl fmt::Display for Id {


### PR DESCRIPTION
This commit adds a getter method to window::Id.

The raw integer was already indirectly accessible via the type's Display implementation. This method is more conventient if one wants to work with the integer directly.