### PR TITLE
Basic Layer Merging for `graphics::layer::Stack`

### DIFF
--- a/core/src/renderer.rs
+++ b/core/src/renderer.rs
@@ -60,8 +60,8 @@ pub trait Renderer {
     /// Fills a [`Quad`] with the provided [`Background`].
     fn fill_quad(&mut self, quad: Quad, background: impl Into<Background>);
 
-    /// Clears all of the recorded primitives in the [`Renderer`].
-    fn clear(&mut self);
+    /// Resets the [`Renderer`] to start drawing in the `new_bounds` from scratch.
+    fn reset(&mut self, new_bounds: Rectangle);
 }
 
 /// A polygon with four sides.

--- a/core/src/renderer/null.rs
+++ b/core/src/renderer/null.rs
@@ -16,7 +16,7 @@ impl Renderer for () {
 
     fn end_transformation(&mut self) {}
 
-    fn clear(&mut self) {}
+    fn reset(&mut self, _new_bounds: Rectangle) {}
 
     fn fill_quad(
         &mut self,

--- a/graphics/src/layer.rs
+++ b/graphics/src/layer.rs
@@ -24,17 +24,20 @@ pub trait Layer: Default {
     /// Clears all the layers contents and resets its bounds.
     fn reset(&mut self);
 
-    /// Returns the level of the [`Layer`].
+    /// Returns the start level of the [`Layer`].
     ///
-    /// The level is the lowest "sublayer" index inside of a [`Layer`].
+    /// A level is a "sublayer" index inside of a [`Layer`].
     ///
     /// A [`Layer`] may draw multiple primitive types in a certain order.
     /// The level represents the lowest index of the primitive types it
     /// contains.
     ///
     /// Two layers A and B can therefore be merged if they have the same bounds,
-    /// and the level of A is lower or equal than the level of B.
-    fn level(&self) -> usize;
+    /// and the end level of A is lower or equal than the start level of B.
+    fn start(&self) -> usize;
+
+    /// Returns the end level of the [`Layer`].
+    fn end(&self) -> usize;
 
     /// Merges a [`Layer`] with the current one.
     fn merge(&mut self, _layer: &mut Self);
@@ -106,7 +109,7 @@ impl<T: Layer> Stack<T> {
         let previous_layer = &mut head[previous];
         let current_layer = &mut tail[self.current - previous - 1];
 
-        if previous_layer.level() <= current_layer.level()
+        if previous_layer.end() <= current_layer.start()
             && previous_layer.bounds() == current_layer.bounds()
         {
             previous_layer.merge(current_layer);

--- a/graphics/src/layer.rs
+++ b/graphics/src/layer.rs
@@ -158,12 +158,15 @@ impl<T: Layer> Stack<T> {
 
     /// Clears the layers of the [`Stack`], allowing reuse.
     ///
+    /// It resizes the base layer bounds to the `new_bounds`.
+    ///
     /// This will normally keep layer allocations for future drawing operations.
-    pub fn clear(&mut self) {
+    pub fn reset(&mut self, new_bounds: Rectangle) {
         for layer in self.layers[..self.active_count].iter_mut() {
             layer.reset();
         }
 
+        self.layers[0].resize(new_bounds);
         self.current = 0;
         self.active_count = 1;
         self.previous.clear();

--- a/renderer/src/fallback.rs
+++ b/renderer/src/fallback.rs
@@ -46,8 +46,8 @@ where
         delegate!(self, renderer, renderer.fill_quad(quad, background.into()));
     }
 
-    fn clear(&mut self) {
-        delegate!(self, renderer, renderer.clear());
+    fn reset(&mut self, new_bounds: Rectangle) {
+        delegate!(self, renderer, renderer.reset(new_bounds));
     }
 
     fn start_layer(&mut self, bounds: Rectangle) {

--- a/runtime/src/user_interface.rs
+++ b/runtime/src/user_interface.rs
@@ -482,10 +482,8 @@ where
         style: &renderer::Style,
         cursor: mouse::Cursor,
     ) {
-        // TODO: Move to shell level (?)
-        renderer.clear();
-
         let viewport = Rectangle::with_size(self.bounds);
+        renderer.reset(viewport);
 
         let base_cursor = match &self.overlay {
             None

--- a/tiny_skia/src/layer.rs
+++ b/tiny_skia/src/layer.rs
@@ -17,8 +17,8 @@ pub struct Layer {
     pub bounds: Rectangle,
     pub quads: Vec<(Quad, Background)>,
     pub primitives: Vec<Item<Primitive>>,
-    pub text: Vec<Item<Text>>,
     pub images: Vec<Image>,
+    pub text: Vec<Item<Text>>,
 }
 
 impl Layer {
@@ -284,6 +284,10 @@ impl graphics::Layer for Layer {
         }
     }
 
+    fn bounds(&self) -> Rectangle {
+        self.bounds
+    }
+
     fn flush(&mut self) {}
 
     fn resize(&mut self, bounds: Rectangle) {
@@ -297,6 +301,29 @@ impl graphics::Layer for Layer {
         self.primitives.clear();
         self.text.clear();
         self.images.clear();
+    }
+
+    fn level(&self) -> usize {
+        if !self.text.is_empty() {
+            return 3;
+        }
+
+        if !self.images.is_empty() {
+            return 2;
+        }
+
+        if !self.primitives.is_empty() {
+            return 1;
+        }
+
+        0
+    }
+
+    fn merge(&mut self, layer: &mut Self) {
+        self.quads.append(&mut layer.quads);
+        self.primitives.append(&mut layer.primitives);
+        self.text.append(&mut layer.text);
+        self.images.append(&mut layer.images);
     }
 }
 

--- a/tiny_skia/src/layer.rs
+++ b/tiny_skia/src/layer.rs
@@ -303,7 +303,23 @@ impl graphics::Layer for Layer {
         self.images.clear();
     }
 
-    fn level(&self) -> usize {
+    fn start(&self) -> usize {
+        if !self.quads.is_empty() {
+            return 0;
+        }
+
+        if !self.primitives.is_empty() {
+            return 1;
+        }
+
+        if !self.images.is_empty() {
+            return 2;
+        }
+
+        return 3;
+    }
+
+    fn end(&self) -> usize {
         if !self.text.is_empty() {
             return 3;
         }

--- a/tiny_skia/src/layer.rs
+++ b/tiny_skia/src/layer.rs
@@ -316,7 +316,11 @@ impl graphics::Layer for Layer {
             return 2;
         }
 
-        return 3;
+        if !self.text.is_empty() {
+            return 3;
+        }
+
+        0
     }
 
     fn end(&self) -> usize {

--- a/tiny_skia/src/lib.rs
+++ b/tiny_skia/src/lib.rs
@@ -225,8 +225,8 @@ impl core::Renderer for Renderer {
         layer.draw_quad(quad, background.into(), transformation);
     }
 
-    fn clear(&mut self) {
-        self.layers.clear();
+    fn reset(&mut self, new_bounds: Rectangle) {
+        self.layers.reset(new_bounds);
     }
 }
 

--- a/wgpu/src/image/null.rs
+++ b/wgpu/src/image/null.rs
@@ -11,4 +11,6 @@ impl Batch {
     pub fn is_empty(&self) -> bool {
         true
     }
+
+    pub fn append(&mut self, _batch: &mut Self) {}
 }

--- a/wgpu/src/layer.rs
+++ b/wgpu/src/layer.rs
@@ -310,7 +310,11 @@ impl graphics::Layer for Layer {
             return 3;
         }
 
-        4
+        if !self.text.is_empty() {
+            return 4;
+        }
+
+        0
     }
 
     fn end(&self) -> usize {

--- a/wgpu/src/layer.rs
+++ b/wgpu/src/layer.rs
@@ -293,7 +293,27 @@ impl graphics::Layer for Layer {
         self.pending_text.clear();
     }
 
-    fn level(&self) -> usize {
+    fn start(&self) -> usize {
+        if !self.quads.is_empty() {
+            return 0;
+        }
+
+        if !self.triangles.is_empty() {
+            return 1;
+        }
+
+        if !self.primitives.is_empty() {
+            return 2;
+        }
+
+        if !self.images.is_empty() {
+            return 3;
+        }
+
+        4
+    }
+
+    fn end(&self) -> usize {
         if !self.text.is_empty() {
             return 4;
         }

--- a/wgpu/src/layer.rs
+++ b/wgpu/src/layer.rs
@@ -268,6 +268,10 @@ impl graphics::Layer for Layer {
         }
     }
 
+    fn bounds(&self) -> Rectangle {
+        self.bounds
+    }
+
     fn flush(&mut self) {
         self.flush_meshes();
         self.flush_text();
@@ -287,6 +291,34 @@ impl graphics::Layer for Layer {
         self.images.clear();
         self.pending_meshes.clear();
         self.pending_text.clear();
+    }
+
+    fn level(&self) -> usize {
+        if !self.text.is_empty() {
+            return 4;
+        }
+
+        if !self.images.is_empty() {
+            return 3;
+        }
+
+        if !self.primitives.is_empty() {
+            return 2;
+        }
+
+        if !self.triangles.is_empty() {
+            return 1;
+        }
+
+        0
+    }
+
+    fn merge(&mut self, layer: &mut Self) {
+        self.quads.append(&mut layer.quads);
+        self.triangles.append(&mut layer.triangles);
+        self.primitives.append(&mut layer.primitives);
+        self.images.append(&mut layer.images);
+        self.text.append(&mut layer.text);
     }
 }
 

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -648,8 +648,8 @@ impl core::Renderer for Renderer {
         layer.draw_quad(quad, background.into(), transformation);
     }
 
-    fn clear(&mut self) {
-        self.layers.clear();
+    fn reset(&mut self, new_bounds: Rectangle) {
+        self.layers.reset(new_bounds);
     }
 }
 

--- a/wgpu/src/quad.rs
+++ b/wgpu/src/quad.rs
@@ -304,6 +304,12 @@ impl Batch {
         self.gradients.clear();
         self.order.clear();
     }
+
+    pub fn append(&mut self, batch: &mut Batch) {
+        self.solids.append(&mut batch.solids);
+        self.gradients.append(&mut batch.gradients);
+        self.order.append(&mut batch.order);
+    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]


### PR DESCRIPTION
This PR should reduce the amount of layers produced (and therefore, draw calls) by widgets that leverage `Renderer::with_layer` (like `stack`).

Two layers `A` and `B` will be merged if they have the same bounds and `A` does not contain any primitives that would be rendered above any of the primitives in `B` if merged together.

Effectively, this means that a layer with only text can always be merged down and one with only quads (or empty) can always be merged up.