### PR TITLE
Limit the window size on macOS, so the program does not crash.

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -259,6 +259,7 @@ impl<P: Program> Application<P> {
         #[cfg(not(target_os = "macos"))]
         let size = size.into();
 
+        // https://developer.apple.com/documentation/appkit/nswindow/init(contentrect:stylemask:backing:defer:)#parameters
         #[cfg(target_os = "macos")]
         let mut size = size.into();
 

--- a/src/application.rs
+++ b/src/application.rs
@@ -256,9 +256,25 @@ impl<P: Program> Application<P> {
 
     /// Sets the [`window::Settings::size`] of the [`Application`].
     pub fn window_size(self, size: impl Into<Size>) -> Self {
+        #[cfg(not(target_os = "macos"))]
+        let size = size.into();
+
+        #[cfg(target_os = "macos")]
+        let mut size = size.into();
+
+        #[cfg(target_os = "macos")]
+        {
+            if size.height > 10_000. {
+                size.height = 10_000.;
+            }
+            if size.width > 10_000. {
+                size.width = 10_000.;
+            }
+        }
+
         Self {
             window: window::Settings {
-                size: size.into(),
+                size,
                 ..self.window
             },
             ..self


### PR DESCRIPTION
See issue #2802 for discussion.

This is a tiny change to fix a problem on macOS.
