### PR TITLE
feat(modifiers): add NONE

### DIFF
--- a/core/src/keyboard/modifiers.rs
+++ b/core/src/keyboard/modifiers.rs
@@ -24,6 +24,8 @@ bitflags! {
         const LOGO = 0b100 << 9;
         // const LLOGO = 0b010 << 9;
         // const RLOGO = 0b001 << 9;
+        /// No modifiers
+        const NONE = 0;
     }
 }
 


### PR DESCRIPTION
This pr adds `Modifiers::NONE`. It's equivalent to `Modifiers::empty()` but is allowed to be used in patterns. Currently the user has to check `modifiers.is_empty()` in an if guard which is not as ergonomic as pattern matching. Crossterm already implements this and I think iced should too
