### PR TITLE
Disable `png-format` feature from `tiny-skia`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,7 +202,7 @@ softbuffer = "0.4"
 syntect = "5.1"
 sysinfo = "0.33"
 thiserror = "1.0"
-tiny-skia = "0.11"
+tiny-skia = { version = "0.11", default-features = false, features = ["std", "simd"] }
 tokio = "1.0"
 tracing = "0.1"
 unicode-segmentation = "1.0"


### PR DESCRIPTION
I was looking through the dependencies of my iced application, and noticed `png` and transitive deps.

<img width="733" height="386" alt="image" src="https://github.com/user-attachments/assets/88baba0e-d367-45b1-9d92-27a9f8b7a73e" />

I don't need it, and I don't have `tiny_skia/image` enabled. The dependency came from `tiny_skia/png_format` which allows loading/encoding the pixmap to png, which as far as I can tell isn't used by `iced`.

Fixing this cuts 10 dependencies from my `cargo build`.
