### PR TITLE
Prioritize `Shrink` over `Fill`

### DIFF
--- a/examples/layout/src/main.rs
+++ b/examples/layout/src/main.rs
@@ -94,14 +94,14 @@ impl Layout {
 
         let controls = row([
             (!self.example.is_first()).then_some(
-                button("← Previous")
+                button(text("← Previous").shaping(text::Shaping::Advanced))
                     .padding([5, 10])
                     .on_press(Message::Previous)
                     .into(),
             ),
             Some(horizontal_space().into()),
             (!self.example.is_last()).then_some(
-                button("Next →")
+                button(text("Next →").shaping(text::Shaping::Advanced))
                     .padding([5, 10])
                     .on_press(Message::Next)
                     .into(),
@@ -294,7 +294,7 @@ fn quotes<'a>() -> Element<'a, Message> {
     fn quote<'a>(
         content: impl Into<Element<'a, Message>>,
     ) -> Element<'a, Message> {
-        row![vertical_rule(2), content.into()]
+        row![vertical_rule(1), content.into()]
             .spacing(10)
             .height(Shrink)
             .into()
@@ -313,7 +313,7 @@ fn quotes<'a>() -> Element<'a, Message> {
             "This is another reply",
         ),
         horizontal_rule(1),
-        "A separator ↑",
+        text("A separator ↑").shaping(text::Shaping::Advanced),
     ]
     .width(Shrink)
     .spacing(10)

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -111,21 +111,11 @@ where
             class: Theme::default(),
             last_status: None,
         }
-        .validate()
+        .enclose()
     }
 
-    fn validate(mut self) -> Self {
+    fn enclose(mut self) -> Self {
         let size_hint = self.content.as_widget().size_hint();
-
-        debug_assert!(
-            self.direction.vertical().is_none() || !size_hint.height.is_fill(),
-            "scrollable content must not fill its vertical scrolling axis"
-        );
-
-        debug_assert!(
-            self.direction.horizontal().is_none() || !size_hint.width.is_fill(),
-            "scrollable content must not fill its horizontal scrolling axis"
-        );
 
         if self.direction.horizontal().is_none() {
             self.width = self.width.enclose(size_hint.width);
@@ -146,7 +136,7 @@ where
     /// Sets the [`Direction`] of the [`Scrollable`].
     pub fn direction(mut self, direction: impl Into<Direction>) -> Self {
         self.direction = direction.into();
-        self.validate()
+        self.enclose()
     }
 
     /// Sets the [`Id`] of the [`Scrollable`].
@@ -437,20 +427,24 @@ where
                     ..Padding::ZERO
                 },
                 |limits| {
-                    let child_limits = layout::Limits::new(
+                    let is_horizontal = self.direction.horizontal().is_some();
+                    let is_vertical = self.direction.vertical().is_some();
+
+                    let child_limits = layout::Limits::with_compression(
                         limits.min(),
                         Size::new(
-                            if self.direction.horizontal().is_some() {
+                            if is_horizontal {
                                 f32::INFINITY
                             } else {
                                 limits.max().width
                             },
-                            if self.direction.vertical().is_some() {
+                            if is_vertical {
                                 f32::INFINITY
                             } else {
                                 limits.max().height
                             },
                         ),
+                        Size::new(is_horizontal, is_vertical),
                     );
 
                     self.content.as_widget_mut().layout(


### PR DESCRIPTION
This PR makes a `Fill` inside a `Shrink` behave as if it was `Shrink`.

Effectively, this allows controlling and overriding `Fill` behavior from a higher level container widget.

As a consequence, `scrollable` can now handle `Fill` content by simply forcing it to behave as `Shrink`; so it will no longer panic in `debug` mode.