### PR TITLE
Put wgpu's default features behind a "wgpu_default" feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,11 @@ all-features = true
 maintenance = { status = "actively-developed" }
 
 [features]
-default = ["wgpu", "tiny-skia", "crisp", "web-colors", "thread-pool", "linux-theme-detection"]
+default = ["wgpu_default", "tiny-skia", "crisp", "web-colors", "thread-pool", "linux-theme-detection"]
 # Enables the `wgpu` GPU-accelerated renderer backend
 wgpu = ["iced_renderer/wgpu", "iced_widget/wgpu"]
+# Enables the `wgpu` GPU-accelerated renderer backend with its default features
+wgpu_default = ["wgpu", "iced_renderer/wgpu_default"]
 # Enables the `tiny-skia` software renderer backend
 tiny-skia = ["iced_renderer/tiny-skia"]
 # Enables the `image` widget
@@ -227,7 +229,7 @@ wasm-bindgen-futures = "0.4"
 wasmtimer = "0.4.1"
 web-sys = "0.3.69"
 web-time = "1.1"
-wgpu = "26.0"
+wgpu = { version = "26.0", default-features = false }
 window_clipboard = "0.4.1"
 winit = { git = "https://github.com/iced-rs/winit.git", rev = "05b8ff17a06562f0a10bb46e6eaacbe2a95cb5ed" }
 

--- a/examples/integration/Cargo.toml
+++ b/examples/integration/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 iced_winit.workspace = true
 iced_wgpu.workspace = true
+iced_wgpu.features = ["wgpu_default"]
 
 iced_widget.workspace = true
 iced_widget.features = ["wgpu"]

--- a/renderer/Cargo.toml
+++ b/renderer/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 
 [features]
 wgpu = ["iced_wgpu"]
+wgpu_default = ["wgpu", "iced_wgpu/wgpu_default"]
 tiny-skia = ["iced_tiny_skia"]
 image = ["iced_tiny_skia?/image", "iced_wgpu?/image"]
 svg = ["iced_tiny_skia?/svg", "iced_wgpu?/svg"]

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -18,6 +18,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 all-features = true
 
 [features]
+default = ["wgpu_default"]
+wgpu_default = ["wgpu/default"]
 geometry = ["iced_graphics/geometry", "lyon"]
 image = ["iced_graphics/image"]
 svg = ["iced_graphics/svg", "resvg/text"]


### PR DESCRIPTION
This PR enables users of `iced` to opt out of `wgpu`'s default features.

Since `wgpu` version 25.0.0 the selection of supported backends that `wgpu` compiles with can be fully configured via feature flags. This PR enables users of `iced` to manually select what features they want to enable, not being forced in to the defaults.