### PR TITLE
Make slider cursor consistent across os and align with web sliders.

### DIFF
--- a/widget/src/slider.rs
+++ b/widget/src/slider.rs
@@ -532,10 +532,8 @@ where
         let bounds = layout.bounds();
         let is_mouse_over = cursor.is_over(bounds);
 
-        if state.is_dragging {
-            mouse::Interaction::Grabbing
-        } else if is_mouse_over {
-            mouse::Interaction::Grab
+        if state.is_dragging || is_mouse_over {
+            mouse::Interaction::Pointer
         } else {
             mouse::Interaction::default()
         }


### PR DESCRIPTION
Basically, this makes the slider use the pointer cursor, which aligns with how it's commonly done on web and other platforms, in addition this fixes the bad choices available on windows, and aligns all OSs to use the same icon.