### PR TITLE
make `Mesh`es cheaply cloneable by using `Arc<[T]>` in `iced_graphics::mesh::Indexed`

### DIFF
--- a/examples/geometry/src/main.rs
+++ b/examples/geometry/src/main.rs
@@ -83,7 +83,7 @@ mod rainbow {
 
             let mesh = Mesh::Solid {
                 buffers: mesh::Indexed {
-                    vertices: vec![
+                    vertices: [
                         SolidVertex2D {
                             position: posn_center,
                             color: color::pack([1.0, 1.0, 1.0, 1.0]),
@@ -120,8 +120,9 @@ mod rainbow {
                             position: posn_l,
                             color: color::pack(color_v),
                         },
-                    ],
-                    indices: vec![
+                    ]
+                    .into(),
+                    indices: [
                         0, 1, 2, // TL
                         0, 2, 3, // T
                         0, 3, 4, // TR
@@ -130,7 +131,8 @@ mod rainbow {
                         0, 6, 7, // B
                         0, 7, 8, // BL
                         0, 8, 1, // L
-                    ],
+                    ]
+                    .into(),
                 },
                 transformation: Transformation::IDENTITY,
                 clip_bounds: Rectangle::INFINITE,

--- a/graphics/src/mesh.rs
+++ b/graphics/src/mesh.rs
@@ -5,6 +5,8 @@ use crate::gradient;
 
 use bytemuck::{Pod, Zeroable};
 
+use std::sync::Arc;
+
 /// A low-level primitive to render a mesh of triangles.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Mesh {
@@ -70,12 +72,12 @@ impl Mesh {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Indexed<T> {
     /// The vertices of the mesh
-    pub vertices: Vec<T>,
+    pub vertices: Arc<[T]>,
 
     /// The list of vertex indices that defines the triangles of the mesh.
     ///
     /// Therefore, this list should always have a length that is a multiple of 3.
-    pub indices: Vec<u32>,
+    pub indices: Arc<[u32]>,
 }
 
 /// A two-dimensional vertex with a color.

--- a/wgpu/src/geometry.rs
+++ b/wgpu/src/geometry.rs
@@ -537,8 +537,8 @@ impl BufferStack {
                 Buffer::Solid(buffer) if !buffer.indices.is_empty() => {
                     Some(Mesh::Solid {
                         buffers: mesh::Indexed {
-                            vertices: buffer.vertices,
-                            indices: buffer.indices,
+                            vertices: buffer.vertices.into(),
+                            indices: buffer.indices.into(),
                         },
                         clip_bounds,
                         transformation: Transformation::IDENTITY,
@@ -547,8 +547,8 @@ impl BufferStack {
                 Buffer::Gradient(buffer) if !buffer.indices.is_empty() => {
                     Some(Mesh::Gradient {
                         buffers: mesh::Indexed {
-                            vertices: buffer.vertices,
-                            indices: buffer.indices,
+                            vertices: buffer.vertices.into(),
+                            indices: buffer.indices.into(),
                         },
                         clip_bounds,
                         transformation: Transformation::IDENTITY,


### PR DESCRIPTION
I have large meshes that I'd like to not have to recreate/clone every time I draw them. When using `wgpu` I can use a `iced_wgpu::geometry::Cache`, however this doesn't work when using `tiny-skia`. Therefore it makes sense to me to make reuse possible with this change.