### PR TITLE
Add screen absolute mouse position to CursorMoved

### DIFF
--- a/core/src/mouse/event.rs
+++ b/core/src/mouse/event.rs
@@ -18,8 +18,10 @@ pub enum Event {
 
     /// The mouse cursor was moved
     CursorMoved {
-        /// The new position of the mouse cursor
+        /// The new position of the mouse cursor (window-relative)
         position: Point,
+        /// The position of the mouse cursor in screen space (absolute)
+        screen_position: Point,
     },
 
     /// A mouse button was pressed.

--- a/examples/delineate/src/main.rs
+++ b/examples/delineate/src/main.rs
@@ -144,7 +144,7 @@ impl Example {
 
     fn subscription(&self) -> Subscription<Message> {
         event::listen_with(|event, _status, _window| match event {
-            Event::Mouse(mouse::Event::CursorMoved { position }) => {
+            Event::Mouse(mouse::Event::CursorMoved { position, .. }) => {
                 Some(Message::MouseMoved(position))
             }
             Event::Window(window::Event::Resized { .. }) => {

--- a/examples/integration/src/main.rs
+++ b/examples/integration/src/main.rs
@@ -346,6 +346,7 @@ pub fn main() -> Result<(), winit::error::EventLoopError> {
             if let Some(event) = conversion::window_event(
                 event,
                 window.scale_factor() as f32,
+                window.outer_position().ok(),
                 *modifiers,
             ) {
                 events.push(event);

--- a/test/src/emulator.rs
+++ b/test/src/emulator.rs
@@ -313,6 +313,7 @@ impl<P: Program + 'static> Emulator<P> {
                 for event in &events {
                     if let core::Event::Mouse(mouse::Event::CursorMoved {
                         position,
+                        ..
                     }) = event
                     {
                         self.cursor = mouse::Cursor::Available(*position);

--- a/test/src/instruction.rs
+++ b/test/src/instruction.rs
@@ -49,7 +49,7 @@ impl Interaction {
     pub fn from_event(event: &Event) -> Option<Self> {
         Some(match event {
             Event::Mouse(mouse) => Self::Mouse(match mouse {
-                mouse::Event::CursorMoved { position } => {
+                mouse::Event::CursorMoved { position, .. } => {
                     Mouse::Move(Target::Point(*position))
                 }
                 mouse::Event::ButtonPressed(button) => Mouse::Press {
@@ -223,14 +223,14 @@ impl Interaction {
 
     /// Returns a list of runtime events representing the [`Interaction`].
     ///
-    /// The `find_target` closure must convert a [`Target`] into its screen
-    /// coordinates.
+    /// The `find_target` closure must convert a [`Target`] into a position
+    /// in the viewport.
     pub fn events(
         &self,
         find_target: impl FnOnce(&Target) -> Option<Point>,
     ) -> Option<Vec<Event>> {
         let mouse_move_ =
-            |to| Event::Mouse(mouse::Event::CursorMoved { position: to });
+            |to| Event::Mouse(mouse::Event::CursorMoved { position: to, screen_position: to });
 
         let mouse_press =
             |button| Event::Mouse(mouse::Event::ButtonPressed(button));

--- a/tester/src/recorder.rs
+++ b/tester/src/recorder.rs
@@ -402,9 +402,10 @@ fn record<Message>(
     }
 
     let interaction =
-        if let Event::Mouse(mouse::Event::CursorMoved { position }) = event {
+        if let Event::Mouse(mouse::Event::CursorMoved { position, screen_position }) = event {
             Interaction::from_event(&Event::Mouse(mouse::Event::CursorMoved {
                 position: *position - (bounds.position() - Point::ORIGIN),
+                screen_position: *screen_position,
             }))
         } else {
             Interaction::from_event(event)

--- a/widget/src/image/viewer.rs
+++ b/widget/src/image/viewer.rs
@@ -239,7 +239,7 @@ where
                     shell.capture_event();
                 }
             }
-            Event::Mouse(mouse::Event::CursorMoved { position }) => {
+            Event::Mouse(mouse::Event::CursorMoved { position, .. }) => {
                 let state = tree.state.downcast_mut::<State>();
 
                 if let Some(origin) = state.cursor_grabbed_at {

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -822,7 +822,7 @@ where
             | Event::Touch(touch::Event::FingerLost { .. }) => {
                 state::<Renderer>(tree).is_dragging = false;
             }
-            Event::Mouse(mouse::Event::CursorMoved { position })
+            Event::Mouse(mouse::Event::CursorMoved { position, .. })
             | Event::Touch(touch::Event::FingerMoved { position, .. }) => {
                 let state = state::<Renderer>(tree);
 

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -141,6 +141,7 @@ pub fn window_attributes(
 pub fn window_event(
     event: winit::event::WindowEvent,
     scale_factor: f32,
+    window_position: Option<winit::dpi::PhysicalPosition<i32>>,
     modifiers: winit::keyboard::ModifiersState,
 ) -> Option<Event> {
     use winit::event::Ime;
@@ -161,8 +162,18 @@ pub fn window_event(
         WindowEvent::CursorMoved { position, .. } => {
             let position = position.to_logical::<f64>(f64::from(scale_factor));
 
+            let window_position_logical = window_position
+                .unwrap_or_default()
+                .to_logical::<f64>(f64::from(scale_factor));
+
+            let screen_position = Point::new(
+                (window_position_logical.x + position.x) as f32,
+                (window_position_logical.y + position.y) as f32,
+            );
+
             Some(Event::Mouse(mouse::Event::CursorMoved {
                 position: Point::new(position.x as f32, position.y as f32),
+                screen_position,
             }))
         }
         WindowEvent::CursorEntered { .. } => {

--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -972,6 +972,7 @@ async fn run_instance<P>(
                             if let Some(event) = conversion::window_event(
                                 window_event,
                                 window.state.scale_factor(),
+                                window.raw.outer_position().ok(),
                                 window.state.modifiers(),
                             ) {
                                 events.push((id, event));


### PR DESCRIPTION
Add screen-absolute mouse position to CursorMoved event

**Problem:**
When implementing custom window resize handles, window-relative mouse coordinates become unreliable as the window dimensions change. The position jumps around because it's relative to a moving target.

This is particularly problematic for audio plugins (using [nih-plug](https://github.com/robbert-vdh/nih-plug) + [baseview](https://github.com/RustAudio/baseview)) where you can't access native window resize controls and have to implement resize handles yourself.

**Solution:**
Add `screen_position: Point` to `mouse::Event::CursorMoved` alongside the existing window-relative position.

```
  CursorMoved {
      position: Point,           // window-relative
      screen_position: Point,    // screen-absolute
  }
```
The screen position stays constant during resize operations, making drag calculations straightforward.

**Implementation:**
  - Winit backend: calculates as `window.outer_position() + cursor_position`
  - Falls back to window-relative position if window position unavailable (Wayland limitations)
  - Updated `conversion::window_event()` to accept pre-extracted `window_position` parameter (consistent with existing `scale_factor` pattern)

**Breaking Changes:**
  - `CursorMoved` has new field - existing pattern matches need `..`
  - `conversion::window_event()` signature changed

It closes #2773 (only issue I could find related to it)

**Working Result:**
![2025-10-05 00 09 13](https://github.com/user-attachments/assets/da0eb9ee-ea5b-47c9-8de1-d9c64279eb35)
