### PR TITLE
Add `unified_titlebar` support for macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,7 +1241,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1308,7 +1308,7 @@ dependencies = [
 [[package]]
 name = "dpi"
 version = "0.1.1"
-source = "git+https://github.com/iced-rs/winit.git?rev=05b8ff17a06562f0a10bb46e6eaacbe2a95cb5ed#05b8ff17a06562f0a10bb46e6eaacbe2a95cb5ed"
+source = "git+https://github.com/airstrike/winit.git?branch=unified-titlebar#a7a0311552ff495ee8f0df60909dd4e5c6d5763b"
 
 [[package]]
 name = "editor"
@@ -1394,7 +1394,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2793,7 +2793,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2851,7 +2851,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3502,7 +3502,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4052,7 +4052,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4967,7 +4967,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5731,7 +5731,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7025,7 +7025,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7442,7 +7442,7 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 [[package]]
 name = "winit"
 version = "0.30.8"
-source = "git+https://github.com/iced-rs/winit.git?rev=05b8ff17a06562f0a10bb46e6eaacbe2a95cb5ed#05b8ff17a06562f0a10bb46e6eaacbe2a95cb5ed"
+source = "git+https://github.com/airstrike/winit.git?branch=unified-titlebar#a7a0311552ff495ee8f0df60909dd4e5c6d5763b"
 dependencies = [
  "ahash",
  "android-activity",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -237,7 +237,7 @@ wasmtimer = "0.4.2"
 web-sys = "=0.3.85"
 web-time = "1.1"
 wgpu = { version = "28.0", default-features = false, features = ["std", "wgsl"] }
-winit = { git = "https://github.com/iced-rs/winit.git", rev = "05b8ff17a06562f0a10bb46e6eaacbe2a95cb5ed", default-features = false, features = ["rwh_06"] }
+winit = { git = "https://github.com/airstrike/winit.git", branch = "unified-titlebar", default-features = false, features = ["rwh_06"] }
 
 [workspace.lints.rust]
 rust_2018_idioms = { level = "deny", priority = -1 }

--- a/core/src/window/settings/macos.rs
+++ b/core/src/window/settings/macos.rs
@@ -9,4 +9,6 @@ pub struct PlatformSpecific {
     pub titlebar_transparent: bool,
     /// Makes the window content appear behind the titlebar.
     pub fullsize_content_view: bool,
+    /// Makes the titlebar unified with the window content.
+    pub unified_titlebar: bool,
 }

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -115,7 +115,8 @@ pub fn window_attributes(
         attributes = attributes
             .with_title_hidden(settings.platform_specific.title_hidden)
             .with_titlebar_transparent(settings.platform_specific.titlebar_transparent)
-            .with_fullsize_content_view(settings.platform_specific.fullsize_content_view);
+            .with_fullsize_content_view(settings.platform_specific.fullsize_content_view)
+            .with_unified_titlebar(settings.platform_specific.unified_titlebar);
     }
 
     #[cfg(target_os = "linux")]


### PR DESCRIPTION
- Adds `unified_titlebar` field to macOS `PlatformSpecific` window settings
- Wires it up in `winit/src/conversion.rs`

Depends on iced-rs/winit#17