### PR TITLE
Add window blur support for Windows 11

### DIFF
--- a/core/src/window/settings.rs
+++ b/core/src/window/settings.rs
@@ -74,10 +74,15 @@ pub struct Settings {
     /// [`Settings::transparent`] and set a proper opacity value to the background color with
     /// `Application::style`.
     ///
-    /// This option is only supported on macOS and Linux. Please read the [winit document][winit]
-    /// for more details.
+    /// This option is supported on macOS, Windows 11 and Linux (please read the [winit
+    /// document][winit_set_blur] for more details).
     ///
-    /// [winit]: https://docs.rs/winit/0.30/winit/window/struct.Window.html#method.set_blur
+    /// On Windows, it sets the [backdrop][winit_backdrop] to `TransientWindow`, making the
+    /// window [acrylic][acrylic].
+    ///
+    /// [winit_set_blur]: https://docs.rs/winit/0.30/winit/window/struct.Window.html#method.set_blur
+    /// [winit_backdrop]: https://docs.rs/winit/0.30/winit/platform/windows/enum.BackdropType.html
+    /// [acrylic]: https://learn.microsoft.com/en-us/windows/apps/design/style/acrylic
     pub blur: bool,
 
     /// The window [`Level`].

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -90,7 +90,9 @@ pub fn window_attributes(
     #[cfg(target_os = "windows")]
     {
         use window::settings::platform;
-        use winit::platform::windows::{CornerPreference, WindowAttributesExtWindows};
+        use winit::platform::windows::{
+            BackdropType, CornerPreference, WindowAttributesExtWindows,
+        };
 
         attributes = attributes.with_drag_and_drop(settings.platform_specific.drag_and_drop);
 
@@ -106,6 +108,10 @@ pub fn window_attributes(
                 platform::CornerPreference::Round => CornerPreference::Round,
                 platform::CornerPreference::RoundSmall => CornerPreference::RoundSmall,
             });
+
+        if settings.blur {
+            attributes = attributes.with_system_backdrop(BackdropType::TransientWindow);
+        }
     }
 
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
This sets the backdrop to [Acrylic](https://learn.microsoft.com/en-us/windows/apps/design/style/acrylic), similarly to my earlier PR, #2900.