### PR TITLE
Add back iter_mut over layers in a `Stack`

### DIFF
--- a/graphics/src/layer.rs
+++ b/graphics/src/layer.rs
@@ -122,6 +122,13 @@ impl<T: Layer> Stack<T> {
         let _ = self.transformations.pop();
     }
 
+    /// Returns an iterator over mutable references to the layers in the [`Stack`].
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut T> {
+        self.flush();
+
+        self.layers[..self.active_count].iter_mut()
+    }
+
     /// Returns an iterator over immutable references to the layers in the [`Stack`].
     pub fn iter(&self) -> impl Iterator<Item = &T> {
         self.layers[..self.active_count].iter()


### PR DESCRIPTION
I'm currently in the process of porting my custom iced renderer to iced-0.14.
I found that [`iced_graphics::layer::Stack`](https://github.com/iced-rs/iced/blob/d062dd7800b852e5bf589911f7861f6607078559/graphics/src/layer.rs#L124) only has `iter` but no `iter_mut` anymore. 

I tracked the change down to [this](https://github.com/SiebenCorgie/iced/commit/fb5ac7dcb0d01893a2ff2a04aab5213b48ac5a87#diff-0412b362b0f0ce5013795072816195d0ccee6ef4ecfe6ad4f3c20968aaa788e7L145) commit. My guess is, that it was not needed by both _native_ renderers anymore. Whenever a (custom) renderer needs to mutate state while preparing or drawing a custom element in a layer, mutable access is needed to the layers in such a `Stack`. 

That's why I propose to add back this function, that was already there in version 0.13. 

Feel free to deny the PR, and if time permits tell me why that isn't a good idea. However, I'd rather merge such a small detail instead of maintaining my own iced fork.

Cheers!