### PR TITLE
add taskbar_icon to PlatformSpecific struct on Windows

### DIFF
--- a/core/src/window/settings/windows.rs
+++ b/core/src/window/settings/windows.rs
@@ -1,7 +1,7 @@
 //! Platform specific settings for Windows.
 
 /// The platform specific window settings of an application.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct PlatformSpecific {
     /// Drag and drop support
     pub drag_and_drop: bool,
@@ -19,6 +19,10 @@ pub struct PlatformSpecific {
     ///
     /// Supported starting with Windows 11 Build 22000.
     pub corner_preference: CornerPreference,
+
+    /// Set the application's taskbar icon, also known as `ICON_BIG`. A reasonable ceiling
+    /// is a size of 256x256px.
+    pub taskbar_icon: Option<crate::window::Icon>,
 }
 
 impl Default for PlatformSpecific {
@@ -28,6 +32,7 @@ impl Default for PlatformSpecific {
             skip_taskbar: false,
             undecorated_shadow: false,
             corner_preference: Default::default(),
+            taskbar_icon: None,
         }
     }
 }

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -106,6 +106,9 @@ pub fn window_attributes(
                 platform::CornerPreference::Round => CornerPreference::Round,
                 platform::CornerPreference::RoundSmall => CornerPreference::RoundSmall,
             });
+
+        attributes =
+            attributes.with_taskbar_icon(settings.platform_specific.taskbar_icon.and_then(icon));
     }
 
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
See also https://discord.com/channels/628993209984614400/1448647565984923648 for context and screenshots.

I know little about Windows, but from what I've tried so far, there isn't currently a way to get a nice quality window icon and taskbar icon at the same time. 

Currently, if you set window icon with a `.ico` that goes up to 256x256px, which is a generally accepted reasonable value, then it gets really poorly resized down to fit in the top left of the window. The taskbar icon, however, will look good quality.

Alternatively, you can pass in a smaller 16x16px `.ico` and then you'll get a good window icon, but the taskbar icon will suffer by being low res.

This PR basically exposes setting the [taskbar_icon](https://docs.rs/winit/latest/winit/platform/windows/trait.WindowExtWindows.html#tymethod.set_taskbar_icon) in `winit`, allowing users to set `ICON_SMALL` and `ICON_BIG` independently.

I've had to remove a few derives from `windows::PlatformSpecific` so that I can include the `Icon`, but that hasn't seemed to affect anything else.

I generally try to avoid touching anything to do with Windows, so I'm open to the idea that I'm doing something wrong, but the reason I've moved this to a PR is because at least my experience has been validated by someone else in the discord discussion thread.


