### PR TITLE
Ensure widget layout is recomputed on resize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4852,6 +4852,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "resizing"
+version = "0.1.0"
+dependencies = [
+ "iced",
+ "tokio",
+]
+
+[[package]]
 name = "resvg"
 version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/examples/resizing/Cargo.toml
+++ b/examples/resizing/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "resizing"
+version = "0.1.0"
+authors = ["Matthew Pomes <matthew.pomes@pm.me>"]
+edition = "2024"
+publish = false
+
+[dependencies]
+iced = { workspace = true, features = ["tokio"] }
+tokio = { workspace = true, features = ["rt", "time"] }

--- a/examples/resizing/README.md
+++ b/examples/resizing/README.md
@@ -1,0 +1,12 @@
+## Checkbox
+
+A box that can be checked.
+
+The __[`main`]__ file contains all the code of the example.
+
+You can run it with `cargo run`:
+```
+cargo run --package checkbox
+```
+
+[`main`]: src/main.rs

--- a/examples/resizing/README.md
+++ b/examples/resizing/README.md
@@ -1,12 +1,13 @@
-## Checkbox
+## Resizing
 
-A box that can be checked.
+A window with buttons to programatically resize the window. This may not work on
+all platforms, since not all platforms allow user code to resize the window.
 
 The __[`main`]__ file contains all the code of the example.
 
 You can run it with `cargo run`:
 ```
-cargo run --package checkbox
+cargo run --package resizing
 ```
 
 [`main`]: src/main.rs

--- a/examples/resizing/src/main.rs
+++ b/examples/resizing/src/main.rs
@@ -1,0 +1,52 @@
+use std::time::Duration;
+
+use iced::widget::{button, center, column};
+use iced::window::{Event, Id};
+use iced::{Element, Size, Task, window};
+
+pub fn main() -> iced::Result {
+    iced::application(Example::default, Example::update, Example::view)
+        .subscription(|_| window::events().map(Message::WinEvent))
+        .executor::<tokio::runtime::Runtime>()
+        .run()
+}
+
+#[derive(Default)]
+struct Example { }
+
+#[derive(Debug, Clone)]
+enum Message {
+    ResizeWindow(Size),
+    DelayedResize(Size),
+    WinEvent((Id, Event)),
+}
+
+impl Example {
+    fn update(&mut self, message: Message) -> Task<Message> {
+        match message {
+            Message::ResizeWindow(size) => {
+                        return window::latest().and_then(move |id| window::resize(id, size));
+                    }
+            Message::DelayedResize(size) => {
+                        return Task::future(async {
+                            tokio::time::sleep(Duration::from_secs(1)).await;
+                        })
+                        .then(move |_| window::latest().and_then(move |id| window::resize(id, size)));
+                    }
+            // Message::WinEvent((id, ev)) => println!("Event for {id:?}: {ev:?}"),
+            Message::WinEvent((id, ev)) => (),
+        }
+        Task::none()
+    }
+
+    fn view(&self) -> Element<'_, Message> {
+        let content = column![
+            button("Resize to 100x100").on_press(Message::ResizeWindow(Size::new(100., 100.))),
+            button("Resize to 200x200").on_press(Message::ResizeWindow(Size::new(200., 200.))),
+            button("Resize to 100x100 after 1 second").on_press(Message::DelayedResize(Size::new(100., 100.))),
+        ]
+        .spacing(20);
+
+        center(content).into()
+    }
+}

--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -755,7 +755,7 @@ async fn run_instance<P>(
                         }
 
                         // Window was resized between redraws
-                        if window.surface_version != window.state.surface_version() {
+                        if window.surface_version != window.state.surface_version() || window.needs_layout {
                             #[cfg(feature = "hinting")]
                             window.renderer.hint(window.state.scale_factor());
 
@@ -773,6 +773,7 @@ async fn run_instance<P>(
                             );
 
                             window.surface_version = window.state.surface_version();
+                            window.needs_layout = false;
                         }
 
                         let redraw_event =
@@ -1349,6 +1350,8 @@ fn run_action<'a, P, C>(
                         }
                         .to_physical::<f32>(f64::from(window.state.scale_factor())),
                     );
+                    window.needs_layout = true;
+                    window.state.update(program, &window.raw, &winit::event::WindowEvent::Resized(window.raw.inner_size()));
                 }
             }
             window::Action::SetMinSize(id, size) => {

--- a/winit/src/window.rs
+++ b/winit/src/window.rs
@@ -77,7 +77,6 @@ where
                 redraw_at: None,
                 preedit: None,
                 ime_state: None,
-                needs_layout: true,
             },
         );
 
@@ -165,7 +164,6 @@ where
     pub surface_version: u64,
     pub renderer: P::Renderer,
     pub redraw_at: Option<Instant>,
-    pub(crate) needs_layout: bool,
     preedit: Option<Preedit<P::Renderer>>,
     ime_state: Option<(Rectangle, input_method::Purpose)>,
 }

--- a/winit/src/window.rs
+++ b/winit/src/window.rs
@@ -77,6 +77,7 @@ where
                 redraw_at: None,
                 preedit: None,
                 ime_state: None,
+                needs_layout: true,
             },
         );
 
@@ -164,6 +165,7 @@ where
     pub surface_version: u64,
     pub renderer: P::Renderer,
     pub redraw_at: Option<Instant>,
+    pub(crate) needs_layout: bool,
     preedit: Option<Preedit<P::Renderer>>,
     ime_state: Option<(Rectangle, input_method::Purpose)>,
 }


### PR DESCRIPTION
closes: #3156

See the linked issue for a full description of the issue. I've included a very similar example in this PR, which demonstrates the corrected behavior.

As noted in the issue, I have an Arch Linux+KDE+Wayland system. I don't have easy access to a Windows or Mac system to test, but I suspect my changes shouldn't cause any issues on those systems.

My first attempt to fix this only triggered a re-layout at the next window redraw event. I've since explored both the Winit and Iced code quite a bit more, and have a simpler and likely more consistent solution. From the [winit docs for `request_inner_size`](https://docs.rs/winit/latest/winit/window/struct.Window.html#method.request_inner_size), a `Resized` event is only emitted if the underlying window system doesn't immediately know what the window's new size will be, otherwise the function just immediately returns the new size. This PR takes that new size, and injects a `Resized` event to ensure the layout is recomputed, an event is emitted to the application (if subscribed), and any other side effects happen as expected.

## Old (left here for reference)

I'm not sure if it's desirable to actually emit a `Window::Resized` event for window event subscriptions or not. For my use-case, it doesn't matter (because I'm not subscribed for `Window::Resized` events).