### PR TITLE
Fix missing redraw request in `PaneGrid`

### DIFF
--- a/widget/src/pane_grid/content.rs
+++ b/widget/src/pane_grid/content.rs
@@ -101,6 +101,7 @@ where
         layout: Layout<'_>,
         cursor: mouse::Cursor,
         viewport: &Rectangle,
+        show_controls: bool,
     ) {
         let bounds = layout.bounds();
 
@@ -114,8 +115,6 @@ where
             let mut children = layout.children();
             let title_bar_layout = children.next().unwrap();
             let body_layout = children.next().unwrap();
-
-            let show_controls = cursor.is_over(bounds);
 
             self.body.as_widget().draw(
                 &tree.children[0],


### PR DESCRIPTION
This fixes a missing redraw request in the `PaneGrid` widget when determining whether a `TitleBar`'s controls should be shown.