### PR TITLE
add Default derives to text editor Position and Cursor

### DIFF
--- a/core/src/text/editor.rs
+++ b/core/src/text/editor.rs
@@ -201,7 +201,7 @@ pub enum Selection {
 }
 
 /// The range of an [`Editor`].
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct Cursor {
     /// The cursor position.
     pub position: Position,
@@ -211,7 +211,7 @@ pub struct Cursor {
 }
 
 /// A cursor position in an [`Editor`].
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct Position {
     /// The line of text.
     pub line: usize,


### PR DESCRIPTION
This PR adds the Default derive macro to the text editor's `Position` and `Cursor` structs for easier creation of `Cursor`s