### PR TITLE
Mark `Space` widget as `Copy` and `Clone`

### DIFF
--- a/widget/src/space.rs
+++ b/widget/src/space.rs
@@ -25,7 +25,7 @@ pub fn vertical() -> Space {
 /// An amount of empty space.
 ///
 /// It can be useful if you want to fill some space with nothing.
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct Space {
     width: Length,
     height: Length,


### PR DESCRIPTION
This makes usage more ergonomic when multiple `Space` identical objects are used.

For example, this situation:
```rust
let search_header = row![
    Space::new().width(Length::FillPortion(1)),
    searchbar.width(Length::FillPortion(4)),
    Space::new().width(Length::FillPortion(1)),
];
```

Becomes:
```rust
let space = Space::new().width(Length::FillPortion(1));
let search_header = row![
    space,
    searchbar.width(Length::FillPortion(4)),
    space,
];
```