### PR TITLE
Add `Task::discard_{none, err, ok}` helpers

### DIFF
--- a/runtime/src/task.rs
+++ b/runtime/src/task.rs
@@ -266,6 +266,43 @@ impl<T> Task<T> {
     }
 }
 
+impl<T> Task<Option<T>> {
+    /// Creates a new [`Task`] that produces the `Some` value(s) contained in this task's output.
+    ///
+    /// Useful for [`Task`]s that only sometimes produce a value.
+    pub fn discard_none(self) -> Task<T>
+    where
+        T: MaybeSend + 'static,
+    {
+        self.and_then(Task::done)
+    }
+}
+
+impl<T, E> Task<Result<T, E>> {
+    /// Creates a new [`Task`] that produces the `Ok` value(s) contained in this task's output.
+    ///
+    /// Useful for fallible [`Task`]s when you only care about success values.
+    pub fn discard_err(self) -> Task<T>
+    where
+        T: MaybeSend + 'static,
+        E: MaybeSend + 'static,
+    {
+        self.map(Result::ok).discard_none()
+    }
+
+    /// Creates a new [`Task`] that produces the `Err` value(s) contained in this task's output.
+    ///
+    /// Useful for fallible [`Task`]s when you only care about error values, for example when a
+    /// side-effect may fail.
+    pub fn discard_ok(self) -> Task<E>
+    where
+        T: MaybeSend + 'static,
+        E: MaybeSend + 'static,
+    {
+        self.map(Result::err).discard_none()
+    }
+}
+
 impl<T> std::fmt::Debug for Task<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct(&format!("Task<{}>", std::any::type_name::<T>()))


### PR DESCRIPTION
This seems to come up a lot in Discord, which leads me to believe that the current solutions aren't as discoverable as they could be. This could save a good bit on people creating and using `Message::Nothing` variants in place of something like this.

These probably also help code readability, but that wasn't a motivating factor for me opening this.