### PR TITLE
fix: set sensor widget distance to 0 when visible

### DIFF
--- a/widget/src/sensor.rs
+++ b/widget/src/sensor.rs
@@ -186,12 +186,16 @@ where
             }
 
             let bounds = layout.bounds();
-            let top_left_distance = viewport.distance(bounds.position());
+            let distance = if bounds.intersects(viewport) {
+                0.0
+            } else {
+                let top_left_distance = viewport.distance(bounds.position());
 
-            let bottom_right_distance =
-                viewport.distance(bounds.position() + Vector::from(bounds.size()));
+                let bottom_right_distance =
+                    viewport.distance(bounds.position() + Vector::from(bounds.size()));
 
-            let distance = top_left_distance.min(bottom_right_distance);
+                top_left_distance.min(bottom_right_distance)
+            };
 
             if self.on_show.is_none() {
                 if let Some(on_resize) = &self.on_resize {


### PR DESCRIPTION
Currently the `sensor` widget is calculating its distance by measuring the distance between its content's top left and bottom right positions to the viewport's top left and bottom right positions.

The `anticipate` field allows to show/hide a `sensor` when the distance above is lower/higher than the `anticipate` value. This means that if for some reason the `sensor` is bigger than the viewport plus the `anticipate` value it would be hidden while it was still supposed to be visible. This commit makes it consider the distance to be `0.0` if any part of the `sensor` is within the visible bounds of the viewport.

My use case here was me having a listview with thousands of items where I was using the `sensor` widget to keep only the visible items loaded + some other ones set by the `anticipate` distance. The rest of the not visible items are simply set to `space()` with their correct size when they are not visible. The problem is that these items can be expanded to show some inner values, this would sometimes make it so some item would become larger than the viewport, so while scrolling through it, it would disappear (as in it would become a `space()` because the `sensor` emitted the `on_hide` message), and when getting to the bottom of said item it would reappear again.