### PR TITLE
Switch operations order in text_input

### DIFF
--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -634,8 +634,8 @@ where
     ) {
         let state = tree.state.downcast_mut::<State<Renderer::Paragraph>>();
 
-        operation.text_input(self.id.as_ref(), layout.bounds(), state);
         operation.focusable(self.id.as_ref(), layout.bounds(), state);
+        operation.text_input(self.id.as_ref(), layout.bounds(), state);
     }
 
     fn update(


### PR DESCRIPTION
Switches the order `focusable` and `text_input` are called in `TextInput`. This would allow me to have a single operation that can focus an input and then set the selection (since `focus()` resets the selection) instead of running two operations.
