### PR TITLE
Change feature gates from `image` to `image-without-codecs`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -627,7 +627,7 @@ pub mod widget {
     pub use iced_runtime::widget::*;
     pub use iced_widget::*;
 
-    #[cfg(feature = "image")]
+    #[cfg(feature = "image-without-codecs")]
     pub mod image {
         //! Images display raster graphics in different formats (PNG, JPG, etc.).
         pub use iced_runtime::image::{Allocation, Error, allocate};

--- a/src/window/icon.rs
+++ b/src/window/icon.rs
@@ -5,13 +5,13 @@ use crate::core::window::icon;
 
 use std::io;
 
-#[cfg(feature = "image")]
+#[cfg(feature = "image-without-codecs")]
 use std::path::Path;
 
 /// Creates an icon from an image file.
 ///
 /// This will return an error in case the file is missing at run-time. You may prefer [`from_file_data`] instead.
-#[cfg(feature = "image")]
+#[cfg(feature = "image-without-codecs")]
 pub fn from_file<P: AsRef<Path>>(icon_path: P) -> Result<Icon, Error> {
     let icon = image::ImageReader::open(icon_path)?.decode()?.to_rgba8();
 
@@ -22,7 +22,7 @@ pub fn from_file<P: AsRef<Path>>(icon_path: P) -> Result<Icon, Error> {
 ///
 /// This content can be included in your application at compile-time, e.g. using the `include_bytes!` macro.
 /// You can pass an explicit file format. Otherwise, the file format will be guessed at runtime.
-#[cfg(feature = "image")]
+#[cfg(feature = "image-without-codecs")]
 pub fn from_file_data(
     data: &[u8],
     explicit_format: Option<image::ImageFormat>,
@@ -58,7 +58,7 @@ pub enum Error {
     OsError(#[from] io::Error),
 
     /// The `image` crate reported an error.
-    #[cfg(feature = "image")]
+    #[cfg(feature = "image-without-codecs")]
     #[error("Unable to create icon from a file: {0}")]
     ImageError(#[from] image::error::ImageError),
 }


### PR DESCRIPTION
This PR changes all `#[cfg(feature = "image")]`s to `#[cfg(feature = "image-without-codecs")]` in the toplevel iced crate, as noted in https://github.com/iced-rs/iced/issues/3173#issuecomment-3726646869.