### PR TITLE
Fix text alignment for `Text::Cached`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5761,6 +5761,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "text_alignment"
+version = "0.1.0"
+dependencies = [
+ "iced",
+]
+
+[[package]]
 name = "the_matrix"
 version = "0.1.0"
 dependencies = [

--- a/examples/text_alignment/Cargo.toml
+++ b/examples/text_alignment/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "text_alignment"
+version = "0.1.0"
+authors = ["Héctor Ramón Jiménez <hector0193@gmail.com>"]
+edition = "2024"
+publish = false
+
+[dependencies]
+iced = { workspace = true, features = ["advanced"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+iced.workspace = true
+iced.features = ["webgl", "fira-sans", "advanced"]

--- a/examples/text_alignment/src/main.rs
+++ b/examples/text_alignment/src/main.rs
@@ -1,0 +1,139 @@
+use iced::advanced::layout::{self, Layout};
+use iced::advanced::renderer;
+use iced::advanced::text::{self, Text};
+use iced::advanced::widget::{self, Widget};
+use iced::widget::{column, container, text as widget_text};
+use iced::{Color, Element, Font, Length, Pixels, Rectangle, Size, Task, Theme};
+
+pub fn main() -> iced::Result {
+    iced::application(State::new, State::update, State::view)
+        .title(|_: &State| "Text Alignment".to_string())
+        .run()
+}
+
+struct State;
+
+#[derive(Debug, Clone, Copy)]
+enum Message {}
+
+impl State {
+    fn new() -> (Self, Task<Message>) {
+        (State, Task::none())
+    }
+
+    fn update(&mut self, _message: Message) -> Task<Message> {
+        Task::none()
+    }
+
+    fn view(&self) -> Element<'_, Message> {
+        container(
+            column![
+                case("Left Aligned:", text::Alignment::Left),
+                case("Right Aligned:", text::Alignment::Right),
+                case("Center Aligned:", text::Alignment::Center),
+            ]
+            .spacing(10)
+            .padding(20),
+        )
+        .center_x(Length::Fill)
+        .center_y(Length::Fill)
+        .into()
+    }
+}
+
+fn case<'a>(label: &'static str, alignment: text::Alignment) -> Element<'a, Message> {
+    column![
+        widget_text(label),
+        container(CustomText {
+            content: "10".to_string(),
+            alignment,
+        })
+        .width(50)
+        .height(30)
+        .style(|_| container::Style {
+            border: iced::Border {
+                color: Color::BLACK,
+                width: 1.0,
+                radius: 0.0.into()
+            },
+            ..Default::default()
+        })
+    ]
+    .into()
+}
+
+struct CustomText {
+    content: String,
+    alignment: text::Alignment,
+}
+
+impl<Message, Renderer> Widget<Message, Theme, Renderer> for CustomText
+where
+    Renderer: text::Renderer<Font = Font>,
+{
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: Length::Fill,
+            height: Length::Fill,
+        }
+    }
+
+    fn layout(
+        &mut self,
+        _tree: &mut widget::Tree,
+        _renderer: &Renderer,
+        limits: &layout::Limits,
+    ) -> layout::Node {
+        layout::Node::new(limits.max())
+    }
+
+    fn draw(
+        &self,
+        _tree: &widget::Tree,
+        renderer: &mut Renderer,
+        _theme: &Theme,
+        _style: &renderer::Style,
+        layout: Layout<'_>,
+        _cursor: iced::mouse::Cursor,
+        viewport: &Rectangle,
+    ) {
+        let bounds = layout.bounds();
+
+        renderer.fill_quad(
+            renderer::Quad {
+                bounds,
+                border: iced::Border::default(),
+                shadow: iced::Shadow::default(),
+                snap: true,
+            },
+            Color::from_rgb(0.9, 0.9, 0.9),
+        );
+
+        renderer.fill_text(
+            Text {
+                content: self.content.clone(),
+                bounds: bounds.size(),
+                size: Pixels(20.0),
+                line_height: text::LineHeight::default(),
+                font: Font::MONOSPACE,
+                align_x: self.alignment,
+                align_y: iced::alignment::Vertical::Top,
+                shaping: text::Shaping::Basic,
+                wrapping: text::Wrapping::Glyph,
+                hint_factor: None,
+            },
+            bounds.position(),
+            Color::BLACK,
+            *viewport,
+        );
+    }
+}
+
+impl<'a, Message, Renderer> From<CustomText> for Element<'a, Message, Theme, Renderer>
+where
+    Renderer: text::Renderer<Font = Font>,
+{
+    fn from(widget: CustomText) -> Self {
+        Self::new(widget)
+    }
+}

--- a/examples/text_alignment/src/main.rs
+++ b/examples/text_alignment/src/main.rs
@@ -28,9 +28,50 @@ impl State {
     fn view(&self) -> Element<'_, Message> {
         container(
             column![
-                case("Left Aligned:", text::Alignment::Left),
-                case("Right Aligned:", text::Alignment::Right),
-                case("Center Aligned:", text::Alignment::Center),
+                widget_text("Horizontal Alignment"),
+                case(
+                    "Left Aligned:",
+                    text::Alignment::Left,
+                    iced::alignment::Vertical::Top,
+                    100,
+                    50,
+                ),
+                case(
+                    "Right Aligned:",
+                    text::Alignment::Right,
+                    iced::alignment::Vertical::Top,
+                    100,
+                    50,
+                ),
+                case(
+                    "Center Aligned:",
+                    text::Alignment::Center,
+                    iced::alignment::Vertical::Top,
+                    100,
+                    50,
+                ),
+                widget_text("Vertical Alignment"),
+                case(
+                    "Top Aligned:",
+                    text::Alignment::Center,
+                    iced::alignment::Vertical::Top,
+                    50,
+                    100,
+                ),
+                case(
+                    "Bottom Aligned:",
+                    text::Alignment::Center,
+                    iced::alignment::Vertical::Bottom,
+                    50,
+                    100,
+                ),
+                case(
+                    "Center Aligned:",
+                    text::Alignment::Center,
+                    iced::alignment::Vertical::Center,
+                    50,
+                    100,
+                ),
             ]
             .spacing(10)
             .padding(20),
@@ -41,15 +82,22 @@ impl State {
     }
 }
 
-fn case<'a>(label: &'static str, alignment: text::Alignment) -> Element<'a, Message> {
+fn case<'a>(
+    label: &'static str,
+    align_x: text::Alignment,
+    align_y: iced::alignment::Vertical,
+    width: impl Into<Length>,
+    height: impl Into<Length>,
+) -> Element<'a, Message> {
     column![
         widget_text(label),
         container(CustomText {
             content: "10".to_string(),
-            alignment,
+            align_x,
+            align_y,
         })
-        .width(50)
-        .height(30)
+        .width(width)
+        .height(height)
         .style(|_| container::Style {
             border: iced::Border {
                 color: Color::BLACK,
@@ -64,7 +112,8 @@ fn case<'a>(label: &'static str, alignment: text::Alignment) -> Element<'a, Mess
 
 struct CustomText {
     content: String,
-    alignment: text::Alignment,
+    align_x: text::Alignment,
+    align_y: iced::alignment::Vertical,
 }
 
 impl<Message, Renderer> Widget<Message, Theme, Renderer> for CustomText
@@ -116,8 +165,8 @@ where
                 size: Pixels(20.0),
                 line_height: text::LineHeight::default(),
                 font: Font::MONOSPACE,
-                align_x: self.alignment,
-                align_y: iced::alignment::Vertical::Top,
+                align_x: self.align_x,
+                align_y: self.align_y,
                 shaping: text::Shaping::Basic,
                 wrapping: text::Wrapping::Glyph,
                 hint_factor: None,

--- a/wgpu/src/text.rs
+++ b/wgpu/src/text.rs
@@ -554,16 +554,18 @@ fn prepare(
 
                     let mut position = bounds.position();
 
-                    position.x = match align_x {
-                        Alignment::Default | Alignment::Left | Alignment::Justified => position.x,
-                        Alignment::Center => position.x - entry.min_bounds.width / 2.0,
-                        Alignment::Right => position.x - entry.min_bounds.width,
+                    position.x += match align_x {
+                        Alignment::Left | Alignment::Default | Alignment::Justified => 0.0,
+                        Alignment::Center => (bounds.width - entry.min_bounds.width) / 2.0,
+                        Alignment::Right => bounds.width - entry.min_bounds.width,
                     };
 
-                    position.y = match align_y {
-                        alignment::Vertical::Top => position.y,
-                        alignment::Vertical::Center => position.y - entry.min_bounds.height / 2.0,
-                        alignment::Vertical::Bottom => position.y - entry.min_bounds.height,
+                    position.y += match align_y {
+                        alignment::Vertical::Top => 0.0,
+                        alignment::Vertical::Center => {
+                            (bounds.height - entry.min_bounds.height) / 2.0
+                        }
+                        alignment::Vertical::Bottom => bounds.height - entry.min_bounds.height,
                     };
 
                     (


### PR DESCRIPTION
Currently, the text position is calculated from the `position.x` and `position.y`, this aligns the text outside of the container.
This change adds offsets based on the container bounds `bounds.width - text.width` to support Right, Center, and Bottom alignment.

Add examples/text_alignment to verify the fix across both horizontal and vertical axes.

Before:
<img width="2272" height="1816" alt="image" src="https://github.com/user-attachments/assets/71d1dca3-bad1-42d6-bd3f-a82a1159703f" />

After:
<img width="2272" height="1816" alt="image" src="https://github.com/user-attachments/assets/72721ac2-47b4-4694-aa3c-92868a00d7cf" />
