### PR TITLE
Markdown text color

### DIFF
--- a/widget/src/markdown.rs
+++ b/widget/src/markdown.rs
@@ -317,7 +317,7 @@ impl Span {
                         .border(style.inline_code_highlight.border)
                         .padding(style.inline_code_padding)
                 } else if *strong || *emphasis {
-                    span.font(Font {
+                    span.color_maybe(style.strong_color).font(Font {
                         weight: if *strong {
                             font::Weight::Bold
                         } else {
@@ -331,7 +331,7 @@ impl Span {
                         ..style.font
                     })
                 } else {
-                    span.font(style.font)
+                    span.color_maybe(style.text_color).font(style.font)
                 };
 
                 if let Some(link) = link.as_ref() {
@@ -1059,6 +1059,10 @@ impl From<Theme> for Settings {
 /// The text styling of some Markdown rendering in [`view`].
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Style {
+    /// The [`Color`] to be applied to basic text.
+    pub text_color: Option<Color>,
+    /// The [`Color`] to be applied to strong/emphasized text.
+    pub strong_color: Option<Color>,
     /// The [`Font`] to be applied to basic text.
     pub font: Font,
     /// The [`Highlight`] to be applied to the background of inline code.
@@ -1079,6 +1083,8 @@ impl Style {
     /// Creates a new [`Style`] from the given [`theme::Palette`].
     pub fn from_palette(palette: theme::Palette) -> Self {
         Self {
+            text_color: Some(palette.text),
+            strong_color: Some(palette.text),
             font: Font::default(),
             inline_code_padding: padding::left(1).right(1),
             inline_code_highlight: Highlight {


### PR DESCRIPTION
This PR adds an option for setting the text color of rendered markdown. `markdown::Style` has been updated to include two new fields, `text_color` to set the color for basic text and `strong_color` for strong and emphasized text color