### PR TITLE
Sort using more deterministic algorithm

### DIFF
--- a/core/src/point.rs
+++ b/core/src/point.rs
@@ -34,6 +34,18 @@ impl<T: Num> Point<T> {
 
         a.hypot(b)
     }
+
+    /// Computes squared distance to another [`Point`], using a deterministic algorithm.
+    /// Suitable for sorting algorithms.
+    pub fn distance_squared(&self, to: Self) -> T
+    where
+        T: Float,
+    {
+        let a = self.x - to.x;
+        let b = self.y - to.y;
+
+        a * a + b * b
+    }
 }
 
 impl<T> From<[T; 2]> for Point<T>

--- a/graphics/src/damage.rs
+++ b/graphics/src/damage.rs
@@ -49,8 +49,8 @@ pub fn group(mut damage: Vec<Rectangle>, bounds: Rectangle) -> Vec<Rectangle> {
 
     damage.sort_by(|a, b| {
         a.center()
-            .distance(Point::ORIGIN)
-            .total_cmp(&b.center().distance(Point::ORIGIN))
+            .distance_squared(Point::ORIGIN)
+            .total_cmp(&b.center().distance_squared(Point::ORIGIN))
     });
 
     let mut output = Vec::new();


### PR DESCRIPTION
Replaces https://github.com/iced-rs/iced/pull/3194 which turned out to be insufficient.

`distance` method uses `hypot` which while useful for most of the cases, may break sorting assumptions like deterministic comparison.
As seen in: https://github.com/pop-os/cosmic-launcher/issues/352