### PR TITLE
Added text_input Arrow Up/Down actions

### DIFF
--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -1019,7 +1019,8 @@ where
                             focus.updated_at = Instant::now();
                             update_cache(state, &self.value);
                         }
-                        keyboard::Key::Named(key::Named::Home) => {
+                        keyboard::Key::Named(key::Named::Home)
+                        | keyboard::Key::Named(key::Named::ArrowUp) => {
                             let cursor_before = state.cursor;
 
                             if modifiers.shift() {
@@ -1038,7 +1039,8 @@ where
 
                             shell.capture_event();
                         }
-                        keyboard::Key::Named(key::Named::End) => {
+                        keyboard::Key::Named(key::Named::End)
+                        | keyboard::Key::Named(key::Named::ArrowDown) => {
                             let cursor_before = state.cursor;
 
                             if modifiers.shift() {


### PR DESCRIPTION
This PR adds support for the `ArrowUp` and `ArrowDown` keys to the `text_input` widget by reusing  the existing implementations for the `Home` and `End` keys respectively.