### PR TITLE
Fix: sensor should emit `on_show` every time it pops into view

### DIFF
--- a/widget/src/sensor.rs
+++ b/widget/src/sensor.rs
@@ -212,9 +212,11 @@ where
                             shell.publish(on_resize(size));
                         }
                     }
-                } else if self.on_hide.is_some() {
+                } else {
                     state.has_popped_in = false;
-                    state.should_notify_at = Some((false, *now + self.delay));
+                    if self.on_hide.is_some() {
+                        state.should_notify_at = Some((false, *now + self.delay));
+                    }
                 }
             } else if distance <= self.anticipate.0 {
                 let size = bounds.size();


### PR DESCRIPTION
If no `on_hide` is set, then the sensor was only emitting `on_show` once, the first time it popped into view. After that, if it popped out of view the `has_popped_in` variable wasn't being set to `false` so it thought the sensor was always in view and never emitted the `on_show` again.

If the user wants to have the behavior as it is currently (only emitting once), then it should be on them to implement that logic. The sensor should always emit what it "senses", that is it should always generate messages when it pops in and out of view.
