### PR TITLE
fix: Use adjusted instead of absolute cursor position in `TextInput`

### DIFF
--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -766,11 +766,13 @@ where
             | Event::Touch(touch::Event::FingerLost { .. }) => {
                 state::<Renderer>(tree).is_dragging = None;
             }
-            Event::Mouse(mouse::Event::CursorMoved { position })
-            | Event::Touch(touch::Event::FingerMoved { position, .. }) => {
+            Event::Mouse(mouse::Event::CursorMoved { .. })
+            | Event::Touch(touch::Event::FingerMoved { .. }) => {
                 let state = state::<Renderer>(tree);
 
-                if let Some(is_dragging) = &state.is_dragging {
+                if let Some(is_dragging) = &state.is_dragging
+                    && let Some(position) = cursor.position_over(layout.bounds())
+                {
                     let text_layout = layout.children().next().unwrap();
 
                     let target = {

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -771,7 +771,7 @@ where
                 let state = state::<Renderer>(tree);
 
                 if let Some(is_dragging) = &state.is_dragging
-                    && let Some(position) = cursor.position_over(layout.bounds())
+                    && let Some(position) = cursor.land().position()
                 {
                     let text_layout = layout.children().next().unwrap();
 

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -577,10 +577,14 @@ where
             );
         };
 
+        let Some(intersection) = text_bounds.intersection(viewport) else {
+            return;
+        };
+
         if is_selecting {
-            renderer.with_layer(text_bounds, |renderer| draw(renderer, *viewport));
+            renderer.with_layer(intersection, |renderer| draw(renderer, *viewport));
         } else {
-            draw(renderer, text_bounds);
+            draw(renderer, intersection);
         }
     }
 }


### PR DESCRIPTION
Fixes #3214

I missed it initially, but `TextInput` is using the absolute position of the cursor in the cursor/touch events instead of the adjusted values given by the parent widget.

~~Note: I don't know if it's better to use `cursor.position_over` or `cursor.position_in` here, both seemed to work? Additionally, this might break touch, I can't test that.~~ Neither are proper here.

P.S. It might be worth looking into removing the position values from the Cursor/FingerMoved events to avoid this happening in the future.