### PR TITLE
Enable drag updates for double/triple clicks in `TextEditor`

### DIFF
--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -1230,7 +1230,11 @@ impl<Message> Update<Message> {
                 }
                 mouse::Event::ButtonReleased(mouse::Button::Left) => Some(Update::Release),
                 mouse::Event::CursorMoved { .. } => match state.drag_click {
-                    Some(mouse::click::Kind::Single) => {
+                    Some(
+                        mouse::click::Kind::Single
+                        | mouse::click::Kind::Double
+                        | mouse::click::Kind::Triple,
+                    ) => {
                         let cursor_position =
                             cursor.position_in(bounds)? - Vector::new(padding.left, padding.top);
 


### PR DESCRIPTION
Makes it so word and line selections can expand on mouse movements.

https://github.com/user-attachments/assets/188b5e17-c11a-4f76-8e97-52df0eaa73f7


