### PR TITLE
Add custom cursor support

### DIFF
--- a/core/src/mouse/interaction.rs
+++ b/core/src/mouse/interaction.rs
@@ -1,3 +1,5 @@
+use crate::window;
+
 /// The interaction of a mouse cursor.
 #[derive(Debug, Eq, PartialEq, Clone, Copy, PartialOrd, Ord, Default)]
 #[allow(missing_docs)]
@@ -30,4 +32,5 @@ pub enum Interaction {
     AllScroll,
     ZoomIn,
     ZoomOut,
+    Custom(window::cursor::Id),
 }

--- a/core/src/window.rs
+++ b/core/src/window.rs
@@ -1,4 +1,5 @@
 //! Build window-based GUI applications.
+pub mod cursor;
 pub mod icon;
 pub mod screenshot;
 pub mod settings;

--- a/core/src/window/cursor.rs
+++ b/core/src/window/cursor.rs
@@ -1,0 +1,25 @@
+//! Cursor id
+use std::{
+    fmt,
+    sync::atomic::{self, AtomicU64},
+};
+
+/// The id of a cursor
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Id(u64);
+
+static COUNT: AtomicU64 = AtomicU64::new(1);
+
+impl Id {
+    /// Creates a new unique cursor [`Id`].
+    pub fn unique() -> Id {
+        Id(COUNT.fetch_add(1, atomic::Ordering::Relaxed))
+    }
+}
+
+impl fmt::Display for Id {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -474,6 +474,7 @@ pub fn mouse_interaction(interaction: mouse::Interaction) -> Option<winit::windo
         Interaction::AllScroll => winit::window::CursorIcon::AllScroll,
         Interaction::ZoomIn => winit::window::CursorIcon::ZoomIn,
         Interaction::ZoomOut => winit::window::CursorIcon::ZoomOut,
+        Interaction::Custom(_) => return None,
     };
 
     Some(icon)

--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -60,6 +60,7 @@ use window::WindowManager;
 
 use rustc_hash::FxHashMap;
 use std::borrow::Cow;
+use std::collections::BTreeMap;
 use std::mem::ManuallyDrop;
 use std::slice;
 use std::sync::Arc;
@@ -405,6 +406,21 @@ where
                                     event_loop.set_allows_automatic_window_tabbing(_enabled);
                                 }
                             }
+                            Control::CreateCursor {
+                                id,
+                                source,
+                                on_created,
+                            } => {
+                                let cursor = event_loop.create_custom_cursor(source);
+                                self.process_event(
+                                    event_loop,
+                                    Event::CursorCreated {
+                                        id,
+                                        cursor,
+                                        on_created,
+                                    },
+                                );
+                            }
                         },
                         _ => {
                             break;
@@ -445,6 +461,11 @@ enum Event<Message: 'static> {
         make_visible: bool,
         on_open: oneshot::Sender<window::Id>,
     },
+    CursorCreated {
+        id: window::cursor::Id,
+        cursor: winit::window::CustomCursor,
+        on_created: oneshot::Sender<window::cursor::Id>,
+    },
     EventLoopAwakened(winit::event::Event<Message>),
     Exit,
 }
@@ -462,8 +483,16 @@ enum Control {
         on_open: oneshot::Sender<window::Id>,
         scale_factor: f32,
     },
+    CreateCursor {
+        id: window::cursor::Id,
+        source: winit::window::CustomCursorSource,
+        on_created: oneshot::Sender<window::cursor::Id>,
+    },
     SetAutomaticWindowTabbing(bool),
 }
+
+/// Registry for custom cursors.
+pub type CursorRegistry = BTreeMap<core::window::cursor::Id, winit::window::CustomCursor>;
 
 async fn run_instance<P>(
     mut program: program::Instance<P>,
@@ -484,6 +513,7 @@ async fn run_instance<P>(
     use winit::event_loop::ControlFlow;
 
     let mut window_manager = WindowManager::new();
+    let mut cursor_registry = CursorRegistry::new();
     let mut is_window_opening = !is_daemon;
 
     let mut compositor = None;
@@ -675,6 +705,14 @@ async fn run_instance<P>(
 
                 let _ = on_open.send(id);
                 is_window_opening = false;
+            }
+            Event::CursorCreated {
+                id,
+                cursor,
+                on_created,
+            } => {
+                let _ = cursor_registry.insert(id, cursor);
+                let _ = on_created.send(id);
             }
             Event::EventLoopAwakened(event) => {
                 match event {
@@ -907,7 +945,7 @@ async fn run_instance<P>(
                         {
                             window.request_redraw(redraw_request);
                             window.request_input_method(input_method);
-                            window.update_mouse(mouse_interaction);
+                            window.update_mouse(&cursor_registry, mouse_interaction);
 
                             run_clipboard(&mut proxy, &mut clipboard, clipboard_requests, id);
                         }
@@ -1088,7 +1126,7 @@ async fn run_instance<P>(
                                     clipboard: clipboard_requests,
                                     ..
                                 } => {
-                                    window.update_mouse(mouse_interaction);
+                                    window.update_mouse(&cursor_registry, mouse_interaction);
 
                                     #[cfg(not(feature = "unconditional-rendering"))]
                                     window.request_redraw(_redraw_request);
@@ -1574,6 +1612,29 @@ fn run_action<'a, P, C>(
                     }
 
                     window.raw.request_redraw();
+                }
+            }
+            window::Action::CreateCursor {
+                rgba,
+                size,
+                hotspot,
+                channel,
+            } => {
+                if let Ok(source) = winit::window::CustomCursor::from_rgba(
+                    rgba,
+                    size.width,
+                    size.height,
+                    hotspot.x,
+                    hotspot.y,
+                ) {
+                    let id = core::window::cursor::Id::unique();
+                    control_sender
+                        .start_send(Control::CreateCursor {
+                            id,
+                            source,
+                            on_created: channel,
+                        })
+                        .expect("Send control action");
                 }
             }
         },

--- a/winit/src/window.rs
+++ b/winit/src/window.rs
@@ -2,7 +2,8 @@ mod state;
 
 use state::State;
 
-pub use crate::core::window::{Event, Id, RedrawRequest, Settings};
+use crate::CursorRegistry;
+pub use crate::core::window::{Event, Id, RedrawRequest, Settings, cursor};
 
 use crate::conversion;
 use crate::core::alignment;
@@ -236,9 +237,17 @@ where
         }
     }
 
-    pub fn update_mouse(&mut self, interaction: mouse::Interaction) {
+    pub fn update_mouse(
+        &mut self,
+        cursor_registry: &CursorRegistry,
+        interaction: mouse::Interaction,
+    ) {
         if interaction != self.mouse_interaction {
-            if let Some(icon) = conversion::mouse_interaction(interaction) {
+            if let mouse::Interaction::Custom(id) = interaction {
+                if let Some(cursor) = cursor_registry.get(&id) {
+                    self.raw.set_cursor(cursor.clone());
+                }
+            } else if let Some(icon) = conversion::mouse_interaction(interaction) {
                 self.raw.set_cursor(icon);
 
                 if self.mouse_interaction == mouse::Interaction::Hidden {


### PR DESCRIPTION
Adds `window::create_cursor(...) -> Task<cursor::Id>`.

Adds `mouse::Interaction::Custom(cursor::Id)`.

This allows allocating a custom cursor and using that in widgets.
