### PR TITLE
pane_grid: setting to show controls on title hover

### DIFF
--- a/widget/src/pane_grid.rs
+++ b/widget/src/pane_grid.rs
@@ -76,7 +76,7 @@ pub use node::Node;
 pub use pane::Pane;
 pub use split::Split;
 pub use state::State;
-pub use title_bar::TitleBar;
+pub use title_bar::{ShowControls, TitleBar};
 
 use crate::container;
 use crate::core::layout;


### PR DESCRIPTION
Soo, i wanted to be able to show pane controls only when the title bar is hovered.

Demo When adding `.show_controls(pane_grid::ShowControls::TitleBar)` to `examples/pane_grid/src/main.rs`

https://github.com/user-attachments/assets/16bd42e7-e531-4895-8bc9-1d69fc68428a

Screenshot when Always is set:
![always](https://github.com/user-attachments/assets/3fddf609-8be7-4dea-8332-6f8dc1c0ca2c)
