### PR TITLE
Add configurable max_bind_groups setting

### DIFF
--- a/graphics/src/settings.rs
+++ b/graphics/src/settings.rs
@@ -21,6 +21,20 @@ pub struct Settings {
     ///
     /// By default, it is `true`.
     pub vsync: bool,
+
+    /// The maximum number of bind groups that can be used simultaneously
+    /// in a shader pipeline.
+    ///
+    /// The [WebGPU specification] guarantees a minimum of `4`, which is also
+    /// the default value used by `wgpu`. Applications embedding custom render
+    /// pipelines (e.g. via [`Shader`] primitives) may need more bind groups
+    /// than iced's own pipelines require.
+    ///
+    /// By default, it is set to `4`.
+    ///
+    /// [WebGPU specification]: https://www.w3.org/TR/webgpu/#limits
+    /// [`Shader`]: https://docs.rs/iced/latest/iced/widget/shader/index.html
+    pub max_bind_groups: u32,
 }
 
 impl Default for Settings {
@@ -30,6 +44,7 @@ impl Default for Settings {
             default_text_size: Pixels(16.0),
             antialiasing: None,
             vsync: true,
+            max_bind_groups: 4,
         }
     }
 }
@@ -47,6 +62,7 @@ impl From<core::Settings> for Settings {
             default_text_size: settings.default_text_size,
             antialiasing: settings.antialiasing.then_some(Antialiasing::MSAAx4),
             vsync: settings.vsync,
+            max_bind_groups: 4,
         }
     }
 }

--- a/wgpu/src/settings.rs
+++ b/wgpu/src/settings.rs
@@ -27,6 +27,12 @@ pub struct Settings {
     ///
     /// By default, it is `None`.
     pub antialiasing: Option<Antialiasing>,
+
+    /// The maximum number of bind groups that can be used simultaneously
+    /// in a shader pipeline.
+    ///
+    /// By default, it is set to `4`.
+    pub max_bind_groups: u32,
 }
 
 impl Default for Settings {
@@ -37,6 +43,7 @@ impl Default for Settings {
             default_font: Font::default(),
             default_text_size: Pixels(16.0),
             antialiasing: None,
+            max_bind_groups: 4,
         }
     }
 }
@@ -52,6 +59,7 @@ impl From<graphics::Settings> for Settings {
             default_font: settings.default_font,
             default_text_size: settings.default_text_size,
             antialiasing: settings.antialiasing,
+            max_bind_groups: settings.max_bind_groups,
             ..Settings::default()
         }
     }

--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -149,7 +149,7 @@ impl Compositor {
         let limits = [wgpu::Limits::default(), wgpu::Limits::downlevel_defaults()];
 
         let limits = limits.into_iter().map(|limits| wgpu::Limits {
-            max_bind_groups: 2,
+            max_bind_groups: settings.max_bind_groups,
             max_non_sampler_bindings: 2048,
             ..limits
         });


### PR DESCRIPTION
This pull request introduces a new configurable setting for the maximum number of bind groups in the rendering pipeline, making it possible for applications to adjust this value as needed. This pull request also increases the default max bind group value from 2 to 4, matching the default value used by both wgpu and the [WebGPU spec]( https://www.w3.org/TR/webgpu/#limits).