### PR TITLE
add `combo_box::State::insert`

### DIFF
--- a/widget/src/combo_box.rs
+++ b/widget/src/combo_box.rs
@@ -354,7 +354,12 @@ where
 
     /// Pushes a new option to the [`State`].
     pub fn push(&mut self, new_option: T) {
-        self.options.push(new_option);
+        self.insert(self.options.len(), new_option);
+    }
+
+    /// Inserts a new option to the [`State`].
+    pub fn insert(&mut self, index: usize, new_option: T) {
+        self.options.insert(index, new_option);
         self.version = VERSION.fetch_add(1, atomic::Ordering::Relaxed);
     }
 


### PR DESCRIPTION
I have a bunch of entries for a combo box streaming into my app from the background. I'd like these options to be in sorted order in the combo box, however `combo_box::State::into_options` -> `slice::partition_point` -> `Vec::insert` -> `combo_box::State::new` loses the current search state, which can be disorienting when a new option arrives while searching. With this method present, I can use `combo_box::State::options` -> `slice::partition_point` -> `combo_box::State::insert` to maintain both sorted order and search state.