### PR TITLE
Add From for iced::widget::canvas::Path <-> lyon_path::Path

### DIFF
--- a/graphics/src/geometry/path.rs
+++ b/graphics/src/geometry/path.rs
@@ -77,3 +77,15 @@ impl Path {
         }
     }
 }
+
+impl From<lyon_path::Path> for Path {
+    fn from(raw: lyon_path::Path) -> Self {
+        Self { raw }
+    }
+}
+
+impl From<Path> for lyon_path::Path {
+    fn from(path: Path) -> Self {
+        path.raw
+    }
+}


### PR DESCRIPTION
This is a trivial change that allows for direct conversion of `lyon_path::Path` objects into `iced::widget::canvas::Path` objects (which was not previously possible without iterating though the internals of the `lyon_path::Path` object) and vice versa, something that a use case I have (I am writing a CAM program for PCB manufacturing and am doing a lot of my processing using `lyon_path::Path` objects rather than iced's wrapped objects) requires.

~~Untested, hence the draft PR. Once tested, will undraft.~~ Actually, I genuinely can't see how this could fail. Undrafting anyway.