### PR TITLE
Remove erroneous `Status` args from some `StyleFn` docs

### DIFF
--- a/core/src/widget/text.rs
+++ b/core/src/widget/text.rs
@@ -411,7 +411,7 @@ pub trait Catalog: Sized {
 
 /// A styling function for a [`Text`].
 ///
-/// This is just a boxed closure: `Fn(&Theme, Status) -> Style`.
+/// This is just a boxed closure: `Fn(&Theme) -> Style`.
 pub type StyleFn<'a, Theme> = Box<dyn Fn(&Theme) -> Style + 'a>;
 
 impl Catalog for Theme {

--- a/widget/src/pane_grid.rs
+++ b/widget/src/pane_grid.rs
@@ -1220,7 +1220,7 @@ pub trait Catalog: container::Catalog {
 
 /// A styling function for a [`PaneGrid`].
 ///
-/// This is just a boxed closure: `Fn(&Theme, Status) -> Style`.
+/// This is just a boxed closure: `Fn(&Theme) -> Style`.
 pub type StyleFn<'a, Theme> = Box<dyn Fn(&Theme) -> Style + 'a>;
 
 impl Catalog for Theme {

--- a/widget/src/progress_bar.rs
+++ b/widget/src/progress_bar.rs
@@ -264,7 +264,7 @@ pub trait Catalog: Sized {
 
 /// A styling function for a [`ProgressBar`].
 ///
-/// This is just a boxed closure: `Fn(&Theme, Status) -> Style`.
+/// This is just a boxed closure: `Fn(&Theme) -> Style`.
 pub type StyleFn<'a, Theme> = Box<dyn Fn(&Theme) -> Style + 'a>;
 
 impl Catalog for Theme {

--- a/widget/src/rule.rs
+++ b/widget/src/rule.rs
@@ -288,7 +288,7 @@ pub trait Catalog: Sized {
 
 /// A styling function for a [`Rule`].
 ///
-/// This is just a boxed closure: `Fn(&Theme, Status) -> Style`.
+/// This is just a boxed closure: `Fn(&Theme) -> Style`.
 pub type StyleFn<'a, Theme> = Box<dyn Fn(&Theme) -> Style + 'a>;
 
 impl Catalog for Theme {


### PR DESCRIPTION
Looks like they were all copy and pasted originally, but four of the `StyleFn`s don't take a `Status` arg.
