### PR TITLE
Fix IME preedit slicing

### DIFF
--- a/winit/src/window.rs
+++ b/winit/src/window.rs
@@ -346,19 +346,24 @@ where
         };
 
         let spans = match &preedit.selection {
-            Some(selection) => {
-                vec![
-                    text::Span::new(&preedit.content[..selection.start]),
+            Some(selection) => match (
+                preedit.content.get(..selection.start),
+                preedit.content.get(selection.start..selection.end),
+                preedit.content.get(selection.end..),
+            ) {
+                (Some(prefix), Some(selected), Some(suffix)) => vec![
+                    text::Span::new(prefix),
                     text::Span::new(if selection.start == selection.end {
                         "\u{200A}"
                     } else {
-                        &preedit.content[selection.start..selection.end]
+                        selected
                     })
                     .color(background),
-                    text::Span::new(&preedit.content[selection.end..]),
-                ]
-            }
-            _ => vec![text::Span::new(&preedit.content)],
+                    text::Span::new(suffix),
+                ],
+                _ => vec![text::Span::new(&preedit.content)],
+            },
+            None => vec![text::Span::new(&preedit.content)],
         };
 
         if spans != self.spans.as_slice() {


### PR DESCRIPTION
This fixes a crash when typing Chinese in the modal example.

The issue was in the winit preedit rendering path: the composing string was sliced directly with byte ranges, which can panic if the IME returns a range that is not on a valid UTF-8 boundary.

The fix makes preedit rendering UTF-8 safe by:
   *  using checked slicing for the prefix, selection, and suffix
   * falling back to rendering the full preedit when the range is invalid
   * preserving the existing early return for empty preedit content

Validation:
   * cargo check -p modal