### PR TITLE
Fix geometry clip bounds for infinite rectangles

### DIFF
--- a/core/src/transformation.rs
+++ b/core/src/transformation.rs
@@ -101,6 +101,10 @@ impl Mul<Transformation> for Rectangle {
     type Output = Self;
 
     fn mul(self, transformation: Transformation) -> Self {
+        if self == Rectangle::INFINITE {
+            return self;
+        }
+
         let position = self.position();
         let size = self.size();
 

--- a/wgpu/src/triangle.rs
+++ b/wgpu/src/triangle.rs
@@ -395,13 +395,21 @@ impl Layer {
 
         for mesh in meshes {
             let clip_bounds = mesh.clip_bounds() * transformation;
-            let snap_distance = clip_bounds
-                .snap()
-                .map(|snapped_bounds| {
-                    Point::new(snapped_bounds.x as f32, snapped_bounds.y as f32)
-                        - clip_bounds.position()
-                })
-                .unwrap_or(Vector::ZERO);
+            let snap_distance = if clip_bounds.x.is_finite()
+                && clip_bounds.y.is_finite()
+                && clip_bounds.width.is_finite()
+                && clip_bounds.height.is_finite()
+            {
+                clip_bounds
+                    .snap()
+                    .map(|snapped_bounds| {
+                        Point::new(snapped_bounds.x as f32, snapped_bounds.y as f32)
+                            - clip_bounds.position()
+                    })
+                    .unwrap_or(Vector::ZERO)
+            } else {
+                Vector::ZERO
+            };
 
             let uniforms = Uniforms::new(
                 transformation


### PR DESCRIPTION
This fixes the geometry example rendering issue on native Linux by preserving infinite clip bounds through the transformation and mesh preparation pipeline.

What changed:
* Keep Rectangle::INFINITE unchanged when applying a transformation.
* Skip snap/translation logic for infinite mesh clip bounds in iced_wgpu.

Why:
* The geometry example uses an infinite clip region for its custom mesh.
* Previously, the clip bounds could become NaN during transformation/snap calculation, which caused the mesh to be clipped away and the window to appear blank.

Validation:
* cargo check -p geometry passes
* cargo r -p geometry now produces finite clip bounds and renders through wgpu
