### PR TITLE
improve simulator's screenshots to compare images

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2427,6 +2427,8 @@ dependencies = [
  "iced_renderer",
  "iced_runtime",
  "iced_selector",
+ "image",
+ "image-compare",
  "nom",
  "png 0.18.1",
  "sha2",
@@ -2645,6 +2647,18 @@ dependencies = [
  "tiff",
  "zune-core 0.5.1",
  "zune-jpeg 0.5.14",
+]
+
+[[package]]
+name = "image-compare"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "176623a137baf75908084aff53578d6336cbd932bffaf12fabe26b343eb13338"
+dependencies = [
+ "image",
+ "itertools 0.14.0",
+ "rayon",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -200,6 +200,7 @@ glam = "0.25"
 guillotiere = "0.6"
 half = "2.2"
 image = { version = "0.25", default-features = false }
+image-compare = { version = "0.5" }
 kamadak-exif = "0.6"
 kurbo = "0.10"
 lilt = "0.8"

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -25,6 +25,8 @@ iced_futures.features = ["thread-pool"]
 iced_renderer.workspace = true
 iced_renderer.features = ["fira-sans"]
 
+image.workspace = true
+image-compare.workspace = true
 nom.workspace = true
 png.workspace = true
 sha2.workspace = true

--- a/test/src/error.rs
+++ b/test/src/error.rs
@@ -25,7 +25,7 @@ pub enum Error {
     IOFailed(Arc<io::Error>),
     /// The decoding of some PNG image failed.
     #[error("the decoding of some PNG image failed: {0}")]
-    PngDecodingFailed(Arc<png::DecodingError>),
+    PngDecodingFailed(Arc<image::ImageError>),
     /// The encoding of some PNG image failed.
     #[error("the encoding of some PNG image failed: {0}")]
     PngEncodingFailed(Arc<png::EncodingError>),
@@ -61,8 +61,8 @@ impl From<io::Error> for Error {
     }
 }
 
-impl From<png::DecodingError> for Error {
-    fn from(error: png::DecodingError) -> Self {
+impl From<image::ImageError> for Error {
+    fn from(error: image::ImageError) -> Self {
         Self::PngDecodingFailed(Arc::new(error))
     }
 }

--- a/test/src/simulator.rs
+++ b/test/src/simulator.rs
@@ -17,7 +17,6 @@ use crate::{Error, Selector};
 use std::borrow::Cow;
 use std::env;
 use std::fs;
-use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -234,20 +233,43 @@ impl Snapshot {
     /// If the PNG image does not exist, it will be created by the [`Snapshot`] for future
     /// testing and `true` will be returned.
     pub fn matches_image(&self, path: impl AsRef<Path>) -> Result<bool, Error> {
+        Ok(self
+            .image_diff_score(path)?
+            .map(|score| score == 1.0)
+            .unwrap_or(true))
+    }
+
+    /// Compares the [`Snapshot`] with the PNG image found in the given path, returning
+    /// their similarity score, which is 1.0 only if they are identical.
+    ///
+    /// If the PNG image does not exist, it will be created by the [`Snapshot`] for future
+    /// testing and `None` will be returned.
+    pub fn image_diff_score(&self, path: impl AsRef<Path>) -> Result<Option<f64>, Error> {
         let path = self.path(path, "png");
 
         if path.exists() {
-            let file = fs::File::open(&path)?;
-            let decoder = png::Decoder::new(io::BufReader::new(file));
+            let mut image1 = vec![];
+            let mut encoder = png::Encoder::new(
+                &mut image1,
+                self.screenshot.size.width,
+                self.screenshot.size.height,
+            );
+            encoder.set_color(png::ColorType::Rgba);
+            let mut writer = encoder.write_header()?;
+            writer.write_image_data(&self.screenshot.rgba)?;
+            writer.finish()?;
 
-            let mut reader = decoder.read_info()?;
-            let n = reader
-                .output_buffer_size()
-                .expect("snapshot should fit in memory");
-            let mut bytes = vec![0; n];
-            let info = reader.next_frame(&mut bytes)?;
+            let image1 = image::load_from_memory_with_format(&image1, image::ImageFormat::Png)?;
+            let image2 = image::open(&path)?;
 
-            Ok(self.screenshot.rgba == bytes[..info.buffer_size()])
+            let Ok(result) =
+                image_compare::rgba_hybrid_compare(&image1.into_rgba8(), &image2.into_rgba8())
+            else {
+                // Images had different dimensions
+                return Ok(Some(0.0));
+            };
+
+            Ok(Some(result.score))
         } else {
             if let Some(directory) = path.parent() {
                 fs::create_dir_all(directory)?;
@@ -266,7 +288,7 @@ impl Snapshot {
             writer.write_image_data(&self.screenshot.rgba)?;
             writer.finish()?;
 
-            Ok(true)
+            Ok(None)
         }
     }
 


### PR DESCRIPTION
Hi,

I'm using the simulator's screenshots for tests and I ran into an issue with mismatches using different renderers even when the actual images are an exact match.

I've changed the comparison to use `image-compare` crate instead of comparing raw bytes, exposing a new `fn image_diff_score` and using it in the original `fn matches_image` to return true only when the score is 1.0, so this should be a non-breaking change.