### PR TITLE
wasm mobile virtual keyboard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2510,6 +2510,7 @@ dependencies = [
  "sysinfo",
  "thiserror 2.0.18",
  "tracing",
+ "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
  "winit",
@@ -6460,6 +6461,14 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtual_keyboard"
+version = "0.1.0"
+dependencies = [
+ "iced",
+ "iced_test",
+]
 
 [[package]]
 name = "virtue"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -232,6 +232,7 @@ tracing = "0.1"
 two-face = { version = "0.4", default-features = false, features = ["syntect-default-fancy"] }
 unicode-segmentation = "1.0"
 url = "2.5"
+wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 wasmtimer = "0.4.2"
 web-sys = "=0.3.85"

--- a/examples/virtual_keyboard/Cargo.toml
+++ b/examples/virtual_keyboard/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "virtual_keyboard"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+# Web builds require trunk (https://trunkrs.dev):
+#   cargo install trunk
+#   cd examples/virtual_keyboard && trunk serve --open
+[package.metadata.webdev]
+trunk = ">=0.21"
+
+[dependencies]
+iced.workspace = true
+iced.features = ["debug"]
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+iced.workspace = true
+iced.features = ["webgl", "debug", "fira-sans"]
+
+[dev-dependencies]
+iced_test.workspace = true

--- a/examples/virtual_keyboard/README.md
+++ b/examples/virtual_keyboard/README.md
@@ -1,0 +1,49 @@
+# Virtual Keyboard
+
+Demonstrates virtual keyboard support for iced applications running in the browser via WebAssembly.
+
+On mobile browsers the OS keyboard only appears when a native `<input>` element is focused. iced renders into a `<canvas>`, so this example relies on the `TextAgent` — a hidden `<input>` managed by `iced_winit` — to bridge keyboard and IME events back into iced's event loop. No changes to your application code are needed; the virtual keyboard appears automatically whenever a [`text_input`] widget is focused.
+
+[`text_input`]: https://docs.rs/iced/latest/iced/widget/fn.text_input.html
+
+## Running
+
+### Native
+
+```sh
+cargo run --package virtual_keyboard
+```
+
+### Web
+
+Install [trunk] once:
+
+```sh
+cargo install trunk
+```
+
+Then serve the example:
+
+```sh
+cd examples/virtual_keyboard
+trunk serve --open
+```
+
+For mobile testing on the same network:
+
+```sh
+trunk serve --address 0.0.0.0
+# Open http://<your-machine-ip>:8080 on the device
+```
+
+[trunk]: https://trunkrs.dev
+
+## Testing
+
+```sh
+cargo test --package virtual_keyboard
+```
+
+## IME support
+
+CJK and other input-method languages work through the standard browser composition event sequence (`compositionstart` → `compositionupdate` → `compositionend`), which is mapped to iced's `InputMethod` events. The preedit overlay is rendered by the `text_input` widget itself, matching the behaviour on native platforms.

--- a/examples/virtual_keyboard/index.html
+++ b/examples/virtual_keyboard/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en" style="height: 100%">
+<head>
+    <meta charset="utf-8" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Virtual Keyboard - Iced</title>
+    <base data-trunk-public-url />
+</head>
+<body style="height: 100%; margin: 0">
+<link data-trunk rel="rust" href="Cargo.toml" data-wasm-opt="z" data-bin="virtual_keyboard" />
+</body>
+</html>

--- a/examples/virtual_keyboard/src/main.rs
+++ b/examples/virtual_keyboard/src/main.rs
@@ -1,0 +1,124 @@
+use iced::widget::{button, column, row, text, text_input};
+use iced::{Center, Element, Fill, Task};
+
+pub fn main() -> iced::Result {
+    iced::run(VirtualKeyboard::update, VirtualKeyboard::view)
+}
+
+#[derive(Default)]
+struct VirtualKeyboard {
+    input_value: String,
+    submitted: String,
+}
+
+#[derive(Debug, Clone)]
+enum Message {
+    InputChanged(String),
+    Submit,
+    Clear,
+}
+
+impl VirtualKeyboard {
+    fn update(&mut self, message: Message) -> Task<Message> {
+        match message {
+            Message::InputChanged(value) => {
+                self.input_value = value;
+            }
+            Message::Submit => {
+                if !self.input_value.is_empty() {
+                    self.submitted = self.input_value.clone();
+                    self.input_value.clear();
+                }
+            }
+            Message::Clear => {
+                self.input_value.clear();
+                self.submitted.clear();
+            }
+        }
+
+        Task::none()
+    }
+
+    fn view(&self) -> Element<'_, Message> {
+        let input = text_input("Type here…", &self.input_value)
+            .on_input(Message::InputChanged)
+            .on_submit(Message::Submit)
+            .padding(12)
+            .size(20);
+
+        let submitted_label = if self.submitted.is_empty() {
+            text("(nothing submitted yet)")
+        } else {
+            text(format!("Submitted: {}", self.submitted))
+        }
+        .size(18);
+
+        let controls = row![
+            button("Submit").on_press(Message::Submit),
+            button("Clear").on_press(Message::Clear),
+        ]
+        .spacing(8);
+
+        column![
+            text("Virtual Keyboard Test").size(28),
+            text("Tap the text box below — the virtual keyboard should appear on mobile.")
+                .size(14),
+            input,
+            controls,
+            submitted_label,
+        ]
+        .spacing(16)
+        .padding(24)
+        .align_x(Center)
+        .width(Fill)
+        .into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use iced_test::{Error, simulator};
+
+    #[test]
+    fn it_submits_input() -> Result<(), Error> {
+        let mut app = VirtualKeyboard::default();
+
+        // Simulate typing into the text input.
+        let _ = app.update(Message::InputChanged("hello".to_owned()));
+        assert_eq!(app.input_value, "hello");
+
+        // Submit should move the value to `submitted` and clear the input.
+        let _ = app.update(Message::Submit);
+        assert_eq!(app.submitted, "hello");
+        assert!(app.input_value.is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn clear_resets_state() -> Result<(), Error> {
+        let mut app = VirtualKeyboard {
+            input_value: "draft".to_owned(),
+            submitted: "old".to_owned(),
+        };
+
+        let _ = app.update(Message::Clear);
+        assert!(app.input_value.is_empty());
+        assert!(app.submitted.is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn view_renders() -> Result<(), Error> {
+        let app = VirtualKeyboard::default();
+        let mut ui = simulator(app.view());
+
+        // The text input and both buttons should be present.
+        assert!(ui.find("Submit").is_ok());
+        assert!(ui.find("Clear").is_ok());
+
+        Ok(())
+    }
+}

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -366,11 +366,16 @@ where
         layout: Layout<'_>,
         value: &Value,
     ) -> InputMethod<&'b str> {
+        #[cfg(not(target_arch = "wasm32"))]
         let Some(Focus {
             is_window_focused: true,
             ..
         }) = &state.is_focused
         else {
+            return InputMethod::Disabled;
+        };
+        #[cfg(target_arch = "wasm32")]
+        if state.is_focused.is_none() {
             return InputMethod::Disabled;
         };
 
@@ -1242,10 +1247,10 @@ where
             Event::Window(window::Event::RedrawRequested(now)) => {
                 let state = state::<Renderer>(tree);
 
-                if let Some(focus) = &mut state.is_focused
-                    && focus.is_window_focused
-                {
-                    if matches!(state.cursor.state(&self.value), cursor::State::Index(_)) {
+                if let Some(focus) = &mut state.is_focused {
+                    if focus.is_window_focused
+                        && matches!(state.cursor.state(&self.value), cursor::State::Index(_))
+                    {
                         focus.now = *now;
 
                         let millis_until_redraw = CURSOR_BLINK_INTERVAL_MILLIS
@@ -1256,6 +1261,11 @@ where
                         );
                     }
 
+                    #[cfg(not(target_arch = "wasm32"))]
+                    if focus.is_window_focused {
+                        shell.request_input_method(&self.input_method(state, layout, &self.value));
+                    }
+                    #[cfg(target_arch = "wasm32")]
                     shell.request_input_method(&self.input_method(state, layout, &self.value));
                 }
             }

--- a/winit/Cargo.toml
+++ b/winit/Cargo.toml
@@ -42,9 +42,25 @@ sysinfo.optional = true
 arboard.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-web-sys.workspace = true
-web-sys.features = ["Document", "Window", "HtmlCanvasElement"]
+wasm-bindgen.workspace = true
 wasm-bindgen-futures.workspace = true
+web-sys.workspace = true
+web-sys.features = [
+    "Document",
+    "Window",
+    "HtmlCanvasElement",
+    # text_agent: virtual keyboard support
+    "CssStyleDeclaration",
+    "CompositionEvent",
+    "Element",
+    "Event",
+    "EventTarget",
+    "HtmlElement",
+    "HtmlInputElement",
+    "InputEvent",
+    "KeyboardEvent",
+    "Node",
+]
 
 [target.'cfg(target_os = "linux")'.dependencies]
 mundy.workspace = true

--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -33,6 +33,12 @@ mod error;
 mod proxy;
 mod window;
 
+#[cfg(target_arch = "wasm32")]
+pub mod text_agent;
+
+#[cfg(target_arch = "wasm32")]
+pub use text_agent::TextAgent;
+
 pub use clipboard::Clipboard;
 pub use error::Error;
 pub use proxy::Proxy;
@@ -42,7 +48,9 @@ use crate::core::renderer;
 use crate::core::theme;
 use crate::core::time::Instant;
 use crate::core::widget::operation;
-use crate::core::{Point, Renderer, Size};
+use crate::core::{Point, Size};
+#[cfg(feature = "hinting")]
+use crate::core::Renderer as _;
 use crate::futures::futures::channel::mpsc;
 use crate::futures::futures::channel::oneshot;
 use crate::futures::futures::task;
@@ -495,6 +503,10 @@ async fn run_instance<P>(
     let mut messages = Vec::new();
     let mut actions = 0;
 
+    #[cfg(target_arch = "wasm32")]
+    let (ime_sender, mut ime_receiver) =
+        mpsc::unbounded::<(window::Id, core::Event)>();
+
     let mut ui_caches = FxHashMap::default();
     let mut user_interfaces = ManuallyDrop::new(FxHashMap::default());
     let mut clipboard = Clipboard::new();
@@ -636,6 +648,21 @@ async fn run_instance<P>(
                     exit_on_close_request,
                     system_theme,
                 );
+
+                #[cfg(target_arch = "wasm32")]
+                {
+                    let raw_window = window.raw.clone();
+                    match TextAgent::new(id, ime_sender.clone(), move || {
+                        raw_window.request_redraw();
+                    }) {
+                        Ok(agent) => {
+                            window.text_agent = Some(agent);
+                        }
+                        Err(e) => {
+                            log::warn!("TextAgent creation failed: {e:?}");
+                        }
+                    }
+                }
 
                 window
                     .raw
@@ -1044,6 +1071,22 @@ async fn run_instance<P>(
                                 window.state.scale_factor(),
                                 window.state.modifiers(),
                             ) {
+                                #[cfg(target_arch = "wasm32")]
+                                if window
+                                    .text_agent
+                                    .as_ref()
+                                    .map_or(false, |a| a.is_active())
+                                    && matches!(
+                                        event,
+                                        core::Event::Window(window::Event::Unfocused)
+                                    )
+                                {
+                                    // Drop the event — the keyboard is still active.
+                                } else {
+                                    events.push((id, event));
+                                }
+
+                                #[cfg(not(target_arch = "wasm32"))]
                                 events.push((id, event));
                             }
                         }
@@ -1052,6 +1095,11 @@ async fn run_instance<P>(
                         if actions > 0 {
                             proxy.free_slots(actions);
                             actions = 0;
+                        }
+
+                        #[cfg(target_arch = "wasm32")]
+                        while let Ok(event) = ime_receiver.try_recv() {
+                            events.push(event);
                         }
 
                         if events.is_empty() && messages.is_empty() && window_manager.is_idle() {

--- a/winit/src/text_agent.rs
+++ b/winit/src/text_agent.rs
@@ -1,0 +1,312 @@
+//! Virtual keyboard support for web (WASM) targets.
+//!
+//! On mobile browsers the virtual keyboard only appears when a native HTML
+//! `<input>` element is focused. [`TextAgent`] manages a hidden `<input>`
+//! and bridges its events into iced's [`input_method::Event`] flow.
+//!
+//! [`text_input`]: iced_widget::text_input
+use crate::core::input_method;
+use crate::core::keyboard::{self, key};
+use crate::core::{self, window};
+use crate::futures::futures::channel::mpsc;
+
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+
+use wasm_bindgen::prelude::*;
+use web_sys::HtmlInputElement;
+
+/// Manages a hidden HTML `<input>` element so that iced [`text_input`]
+/// widgets trigger the native virtual keyboard on mobile browsers.
+///
+/// When a [`text_input`] is focused, [`TextAgent::enable`] is called.
+/// Events from the input (composition, plain text, special keys) are
+/// forwarded as [`input_method::Event`] / [`keyboard::Event`] variants.
+///
+/// ## Mobile focus strategy
+///
+/// Android and desktop browsers allow `focus()` from any JS context, so
+/// [`enable`] calls it directly. iOS Safari requires `focus()` to be called
+/// synchronously inside a user-gesture handler — a `touchstart` listener on
+/// `document` handles this.
+///
+/// [`enable`]: TextAgent::enable
+/// [`text_input`]: iced_widget::text_input
+pub struct TextAgent {
+    input: HtmlInputElement,
+    /// `true` while a [`text_input`] is focused. The event loop suppresses
+    /// [`window::Event::Unfocused`] while this is set.
+    active: Rc<Cell<bool>>,
+}
+
+impl TextAgent {
+    /// Creates a new [`TextAgent`], appending a hidden `<input>` to
+    /// `document.body`. Returns a [`JsValue`] error if the DOM is unavailable.
+    pub fn new(
+        window_id: window::Id,
+        sender: mpsc::UnboundedSender<(window::Id, core::Event)>,
+        request_redraw: impl Fn() + 'static,
+    ) -> Result<Self, JsValue> {
+        let web_window =
+            web_sys::window().ok_or_else(|| JsValue::from_str("no window"))?;
+        let document = web_window
+            .document()
+            .ok_or_else(|| JsValue::from_str("no document"))?;
+        let body = document
+            .body()
+            .ok_or_else(|| JsValue::from_str("no body"))?;
+
+        let input: HtmlInputElement = document
+            .create_element("input")
+            .map_err(|_| JsValue::from_str("create_element failed"))?
+            .dyn_into()
+            .map_err(|_| JsValue::from_str("not an HtmlInputElement"))?;
+
+        let _ = input.set_attribute("type", "text");
+        let _ = input.set_attribute("autocapitalize", "off");
+        let _ = input.set_attribute("autocomplete", "off");
+        let _ = input.set_attribute("autocorrect", "off");
+        let _ = input.set_attribute("spellcheck", "false");
+        // tabindex=-1: reachable via focus() but skipped by Tab navigation.
+        let _ = input.set_attribute("tabindex", "-1");
+
+        // Must NOT be display:none or visibility:hidden — those prevent the
+        // virtual keyboard on iOS/Android. Non-zero size and font-size:16px
+        // prevent iOS from ignoring focus() and auto-zooming.
+        let style = input.style();
+        let _ = style.set_property("position", "fixed");
+        let _ = style.set_property("top", "-100vh");
+        let _ = style.set_property("left", "-100vw");
+        let _ = style.set_property("width", "32px");
+        let _ = style.set_property("height", "32px");
+        let _ = style.set_property("font-size", "16px");
+        let _ = style.set_property("opacity", "0");
+        let _ = style.set_property("color", "transparent");
+        let _ = style.set_property("background", "transparent");
+        let _ = style.set_property("border", "none");
+        let _ = style.set_property("outline", "none");
+        let _ = style.set_property("padding", "0");
+        let _ = style.set_property("caret-color", "transparent");
+        let _ = style.set_property("pointer-events", "none");
+
+        let _ = body
+            .append_child(&input)
+            .map_err(|_| JsValue::from_str("append_child failed"))?;
+
+        let composing: Rc<RefCell<bool>> = Rc::new(RefCell::new(false));
+        let active: Rc<Cell<bool>> = Rc::new(Cell::new(false));
+        let redraw: Rc<dyn Fn()> = Rc::from(request_redraw);
+
+        // iOS Safari requires focus() inside a synchronous user-gesture handler.
+        {
+            let input_ref = input.clone();
+            let closure = Closure::<dyn FnMut(web_sys::Event)>::wrap(Box::new(
+                move |_: web_sys::Event| {
+                    let _ = input_ref.focus();
+                },
+            ));
+            document
+                .add_event_listener_with_callback(
+                    "touchstart",
+                    closure.as_ref().unchecked_ref(),
+                )
+                .expect("touchstart listener");
+            closure.forget();
+        }
+
+        // compositionstart → InputMethod::Opened
+        {
+            let sender = sender.clone();
+            let composing = composing.clone();
+            let redraw = redraw.clone();
+            let closure =
+                Closure::<dyn FnMut(web_sys::CompositionEvent)>::wrap(Box::new(
+                    move |_: web_sys::CompositionEvent| {
+                        *composing.borrow_mut() = true;
+                        let _ = sender.unbounded_send((
+                            window_id,
+                            core::Event::InputMethod(input_method::Event::Opened),
+                        ));
+                        redraw();
+                    },
+                ));
+            input
+                .add_event_listener_with_callback(
+                    "compositionstart",
+                    closure.as_ref().unchecked_ref(),
+                )
+                .expect("compositionstart listener");
+            closure.forget();
+        }
+
+        // compositionupdate → InputMethod::Preedit
+        {
+            let sender = sender.clone();
+            let redraw = redraw.clone();
+            let closure =
+                Closure::<dyn FnMut(web_sys::CompositionEvent)>::wrap(Box::new(
+                    move |e: web_sys::CompositionEvent| {
+                        let data = e.data().unwrap_or_default();
+                        let end = data.len();
+                        let _ = sender.unbounded_send((
+                            window_id,
+                            core::Event::InputMethod(input_method::Event::Preedit(
+                                data,
+                                Some(end..end),
+                            )),
+                        ));
+                        redraw();
+                    },
+                ));
+            input
+                .add_event_listener_with_callback(
+                    "compositionupdate",
+                    closure.as_ref().unchecked_ref(),
+                )
+                .expect("compositionupdate listener");
+            closure.forget();
+        }
+
+        // compositionend → Preedit("") + Commit + Closed
+        {
+            let sender = sender.clone();
+            let input_ref = input.clone();
+            let composing = composing.clone();
+            let redraw = redraw.clone();
+            let closure =
+                Closure::<dyn FnMut(web_sys::CompositionEvent)>::wrap(Box::new(
+                    move |e: web_sys::CompositionEvent| {
+                        *composing.borrow_mut() = false;
+                        let text = e.data().unwrap_or_default();
+                        // Reset value before the trailing `input` event fires.
+                        input_ref.set_value("");
+                        let _ = sender.unbounded_send((
+                            window_id,
+                            core::Event::InputMethod(input_method::Event::Preedit(
+                                String::new(),
+                                None,
+                            )),
+                        ));
+                        let _ = sender.unbounded_send((
+                            window_id,
+                            core::Event::InputMethod(input_method::Event::Commit(text)),
+                        ));
+                        let _ = sender.unbounded_send((
+                            window_id,
+                            core::Event::InputMethod(input_method::Event::Closed),
+                        ));
+                        redraw();
+                    },
+                ));
+            input
+                .add_event_listener_with_callback(
+                    "compositionend",
+                    closure.as_ref().unchecked_ref(),
+                )
+                .expect("compositionend listener");
+            closure.forget();
+        }
+
+        // input → InputMethod::Commit (plain typing / paste; skipped during IME)
+        {
+            let sender = sender.clone();
+            let input_ref = input.clone();
+            let redraw = redraw.clone();
+            let closure = Closure::<dyn FnMut(web_sys::InputEvent)>::wrap(Box::new(
+                move |_: web_sys::InputEvent| {
+                    if *composing.borrow() {
+                        return;
+                    }
+                    let text = input_ref.value();
+                    if text.is_empty() {
+                        return;
+                    }
+                    input_ref.set_value("");
+                    let _ = sender.unbounded_send((
+                        window_id,
+                        core::Event::InputMethod(input_method::Event::Commit(text)),
+                    ));
+                    redraw();
+                },
+            ));
+            input
+                .add_event_listener_with_callback("input", closure.as_ref().unchecked_ref())
+                .expect("input listener");
+            closure.forget();
+        }
+
+        // keydown → KeyPressed for named keys (`input` doesn't fire for these)
+        {
+            let closure =
+                Closure::<dyn FnMut(web_sys::KeyboardEvent)>::wrap(Box::new(
+                    move |e: web_sys::KeyboardEvent| {
+                        let named = match e.key().as_str() {
+                            "Backspace" => key::Named::Backspace,
+                            "Delete" => key::Named::Delete,
+                            "Enter" => key::Named::Enter,
+                            "Escape" => key::Named::Escape,
+                            "ArrowLeft" => key::Named::ArrowLeft,
+                            "ArrowRight" => key::Named::ArrowRight,
+                            "ArrowUp" => key::Named::ArrowUp,
+                            "ArrowDown" => key::Named::ArrowDown,
+                            "Home" => key::Named::Home,
+                            "End" => key::Named::End,
+                            _ => return,
+                        };
+                        let logical_key = keyboard::Key::Named(named);
+                        let _ = sender.unbounded_send((
+                            window_id,
+                            core::Event::Keyboard(keyboard::Event::KeyPressed {
+                                key: logical_key.clone(),
+                                modified_key: logical_key,
+                                physical_key: key::Physical::Unidentified(
+                                    key::NativeCode::Unidentified,
+                                ),
+                                location: keyboard::Location::Standard,
+                                modifiers: keyboard::Modifiers::default(),
+                                text: None,
+                                repeat: false,
+                            }),
+                        ));
+                        redraw();
+                    },
+                ));
+            input
+                .add_event_listener_with_callback("keydown", closure.as_ref().unchecked_ref())
+                .expect("keydown listener");
+            closure.forget();
+        }
+
+        Ok(Self { input, active })
+    }
+
+    /// Marks the agent as active so the virtual keyboard stays visible.
+    ///
+    /// `focus()` is intentionally **not** called here — the `touchstart`
+    /// listener already called it synchronously within the user gesture,
+    /// which is the only path iOS Safari accepts.
+    pub fn enable(&self) {
+        self.active.set(true);
+    }
+
+    /// Blurs the hidden input, hiding the OS virtual keyboard.
+    pub fn disable(&self) {
+        self.active.set(false);
+        let _ = self.input.blur();
+    }
+
+    /// Returns `true` while a [`text_input`] holds focus.
+    ///
+    /// [`text_input`]: iced_widget::text_input
+    pub fn is_active(&self) -> bool {
+        self.active.get()
+    }
+}
+
+impl Drop for TextAgent {
+    fn drop(&mut self) {
+        if let Some(parent) = self.input.parent_node() {
+            let _ = parent.remove_child(&self.input);
+        }
+    }
+}

--- a/winit/src/window.rs
+++ b/winit/src/window.rs
@@ -78,6 +78,8 @@ where
                 redraw_at: None,
                 preedit: None,
                 ime_state: None,
+                #[cfg(target_arch = "wasm32")]
+                text_agent: None,
             },
         );
 
@@ -167,6 +169,9 @@ where
     pub redraw_at: Option<Instant>,
     preedit: Option<Preedit<P::Renderer>>,
     ime_state: Option<(Rectangle, input_method::Purpose)>,
+    /// Manages the hidden `<input>` for virtual keyboard support on web.
+    #[cfg(target_arch = "wasm32")]
+    pub text_agent: Option<crate::TextAgent>,
 }
 
 impl<P, C> Window<P, C>
@@ -261,6 +266,11 @@ where
     }
 
     fn enable_ime(&mut self, cursor: Rectangle, purpose: input_method::Purpose) {
+        #[cfg(target_arch = "wasm32")]
+        if let Some(agent) = &self.text_agent {
+            agent.enable();
+        }
+
         if self.ime_state.is_none() {
             self.raw.set_ime_allowed(true);
         }
@@ -277,6 +287,11 @@ where
     }
 
     fn disable_ime(&mut self) {
+        #[cfg(target_arch = "wasm32")]
+        if let Some(agent) = &self.text_agent {
+            agent.disable();
+        }
+
         if self.ime_state.is_some() {
             self.raw.set_ime_allowed(false);
             self.ime_state = None;


### PR DESCRIPTION
- This brings in a mobile virtual web keyboard with mostly the same logic as: https://github.com/vladbat00/bevy_egui/pull/279
- This was mostly ported with claude code

https://github.com/user-attachments/assets/0ae61e93-0dca-4185-804a-c9673a9bcf1e

