### PR TITLE
feat: image handle from path with a user provided version

### DIFF
--- a/core/src/image.rs
+++ b/core/src/image.rs
@@ -114,6 +114,19 @@ impl Handle {
         Self::Path(Id::path(&path), path)
     }
 
+    /// Creates an image [`Handle`] pointing to the image of the given path,
+    /// tagged with a caller-supplied version.
+    ///
+    /// The version is folded into the [`Id`], so changing it produces a new
+    /// identity even when the path is the same. This lets callers bust the
+    /// renderer's texture cache when the file at `path` has been rewritten
+    /// in place, for example by passing the file's modification time.
+    pub fn from_path_with_version<T: Into<PathBuf>>(path: T, version: u64) -> Handle {
+        let path = path.into();
+
+        Self::Path(Id::path_with_version(&path, version), path)
+    }
+
     /// Creates an image [`Handle`] containing the encoded image data directly.
     ///
     /// Makes an educated guess about the image format by examining the given data.
@@ -200,6 +213,18 @@ impl Id {
         let hash = {
             let mut hasher = FxHasher::default();
             path.as_ref().hash(&mut hasher);
+
+            hasher.finish()
+        };
+
+        Self(_Id::Hash(hash))
+    }
+
+    fn path_with_version(path: impl AsRef<Path>, version: u64) -> Self {
+        let hash = {
+            let mut hasher = FxHasher::default();
+            path.as_ref().hash(&mut hasher);
+            version.hash(&mut hasher);
 
             hasher.finish()
         };

--- a/core/src/svg.rs
+++ b/core/src/svg.rs
@@ -81,6 +81,17 @@ impl Handle {
         Self::from_data(Data::Path(path.into()))
     }
 
+    /// Creates an SVG [`Handle`] pointing to the vector image of the given
+    /// path, tagged with a caller-supplied version.
+    ///
+    /// The version is folded into the id, so changing it produces a new
+    /// identity even when the path is the same. This lets callers bust the
+    /// renderer's cache when the file at `path` has been rewritten in place,
+    /// for example by passing the file's modification time.
+    pub fn from_path_with_version(path: impl Into<PathBuf>, version: u64) -> Handle {
+        Self::from_data_with_version(Data::Path(path.into()), version)
+    }
+
     /// Creates an SVG [`Handle`] from raw bytes containing either an SVG string
     /// or gzip compressed data.
     ///
@@ -93,6 +104,17 @@ impl Handle {
     fn from_data(data: Data) -> Handle {
         let mut hasher = FxHasher::default();
         data.hash(&mut hasher);
+
+        Handle {
+            id: hasher.finish(),
+            data: Arc::new(data),
+        }
+    }
+
+    fn from_data_with_version(data: Data, version: u64) -> Handle {
+        let mut hasher = FxHasher::default();
+        data.hash(&mut hasher);
+        version.hash(&mut hasher);
 
         Handle {
             id: hasher.finish(),


### PR DESCRIPTION
This allow the user to provide a version alongside the file path. The version could be based on file metadata, size, modification time, inode, file hash... The onus is on the user to provide what makes the image unique. This keeps the construction of the handle cheap, but the handle contains info that the user can use to know if the cached image is outdated.

Alternatively, we can add this to `Handle::from_path` and force everybody to provide something, letting them know that if a file changes in-place the handle won't change and the old cached image will be used.

To fix issues like https://github.com/iced-rs/iced/issues/2941.