### PR TITLE
feat(window): expose monitor_position alongside monitor_size

### DIFF
--- a/runtime/src/window.rs
+++ b/runtime/src/window.rs
@@ -177,6 +177,12 @@ pub enum Action {
     /// Get the logical dimensions of the monitor containing the window with the given [`Id`].
     GetMonitorSize(Id, oneshot::Sender<Option<Size>>),
 
+    /// Get the logical top-left position of the monitor containing the
+    /// window with the given [`Id`]. In multi-monitor setups, lets the
+    /// caller align the window to its current monitor's edge instead of
+    /// `(0, 0)`, which lives on the primary monitor.
+    GetMonitorPosition(Id, oneshot::Sender<Option<Point>>),
+
     /// Set whether the system can automatically organize windows into tabs.
     ///
     /// See <https://developer.apple.com/documentation/appkit/nswindow/1646657-allowsautomaticwindowtabbing>
@@ -478,6 +484,14 @@ pub fn disable_mouse_passthrough<Message>(id: Id) -> Task<Message> {
 /// Gets the logical dimensions of the monitor containing the window with the given [`Id`].
 pub fn monitor_size(id: Id) -> Task<Option<Size>> {
     task::oneshot(move |channel| crate::Action::Window(Action::GetMonitorSize(id, channel)))
+}
+
+/// Gets the logical top-left position of the monitor containing the
+/// window with the given [`Id`]. Pair with [`monitor_size`] to align a
+/// window flush with the current monitor's edge in a multi-monitor
+/// setup, where `(0, 0)` is the primary monitor.
+pub fn monitor_position(id: Id) -> Task<Option<Point>> {
+    task::oneshot(move |channel| crate::Action::Window(Action::GetMonitorPosition(id, channel)))
 }
 
 /// Sets whether the system can automatically organize windows into tabs.

--- a/runtime/src/window.rs
+++ b/runtime/src/window.rs
@@ -173,6 +173,12 @@ pub enum Action {
     /// Get the logical dimensions of the monitor containing the window with the given [`Id`].
     GetMonitorSize(Id, oneshot::Sender<Option<Size>>),
 
+    /// Get the logical top-left position of the monitor containing the
+    /// window with the given [`Id`]. In multi-monitor setups, lets the
+    /// caller align the window to its current monitor's edge instead of
+    /// `(0, 0)`, which lives on the primary monitor.
+    GetMonitorPosition(Id, oneshot::Sender<Option<Point>>),
+
     /// Set whether the system can automatically organize windows into tabs.
     ///
     /// See <https://developer.apple.com/documentation/appkit/nswindow/1646657-allowsautomaticwindowtabbing>
@@ -467,6 +473,14 @@ pub fn disable_mouse_passthrough<Message>(id: Id) -> Task<Message> {
 /// Gets the logical dimensions of the monitor containing the window with the given [`Id`].
 pub fn monitor_size(id: Id) -> Task<Option<Size>> {
     task::oneshot(move |channel| crate::Action::Window(Action::GetMonitorSize(id, channel)))
+}
+
+/// Gets the logical top-left position of the monitor containing the
+/// window with the given [`Id`]. Pair with [`monitor_size`] to align a
+/// window flush with the current monitor's edge in a multi-monitor
+/// setup, where `(0, 0)` is the primary monitor.
+pub fn monitor_position(id: Id) -> Task<Option<Point>> {
+    task::oneshot(move |channel| crate::Action::Window(Action::GetMonitorPosition(id, channel)))
 }
 
 /// Sets whether the system can automatically organize windows into tabs.

--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -1571,6 +1571,18 @@ fn run_action<'a, P, C>(
                     let _ = channel.send(size);
                 }
             }
+            window::Action::GetMonitorPosition(id, channel) => {
+                if let Some(window) = window_manager.get(id) {
+                    let position = window.raw.current_monitor().map(|monitor| {
+                        let scale = window.state.scale_factor();
+                        let position = monitor.position().to_logical(f64::from(scale));
+
+                        Point::new(position.x, position.y)
+                    });
+
+                    let _ = channel.send(position);
+                }
+            }
             window::Action::SetAllowAutomaticTabbing(enabled) => {
                 control_sender
                     .start_send(Control::SetAutomaticWindowTabbing(enabled))

--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -1589,6 +1589,18 @@ fn run_action<'a, P, C>(
                     let _ = channel.send(size);
                 }
             }
+            window::Action::GetMonitorPosition(id, channel) => {
+                if let Some(window) = window_manager.get(id) {
+                    let position = window.raw.current_monitor().map(|monitor| {
+                        let scale = window.state.scale_factor();
+                        let position = monitor.position().to_logical(f64::from(scale));
+
+                        Point::new(position.x, position.y)
+                    });
+
+                    let _ = channel.send(position);
+                }
+            }
             window::Action::SetAllowAutomaticTabbing(enabled) => {
                 control_sender
                     .start_send(Control::SetAutomaticWindowTabbing(enabled))


### PR DESCRIPTION
Adds `iced::window::monitor_position(id) -> Task<Option<Point>>` and the matching `Action::GetMonitorPosition` / winit handler. Returns the top-left position of the monitor the window currently lives on, in logical coordinates. 

### Why 

`monitor_size` alone isn't enough to align a window flush with its current monitor's edges in a multi-monitor setup, since `(0, 0)` lives on the primary. Reading `monitor_position` lets the caller compute the correct offset for "snap to monitor top" / "fill monitor height" gestures without jumping windows across monitors.

### Implementation
- New `Action::GetMonitorPosition(Id, oneshot::Sender<Option<Point>>)` in `core::widget::operation` — mirrors `GetMonitorSize`. 
- New `pub fn monitor_position(id) -> Task<Option<Point>>` in `runtime::window`.
- winit handler reads `window.raw.current_monitor().map(|m| m.position().to_logical(scale))` — same pattern as the size handler, just `.position()` instead of `.size()`. 

26 lines net, no behaviour change for existing call sites. 