### PR TITLE
Add semantic selectors for iced tests

### DIFF
--- a/core/src/widget.rs
+++ b/core/src/widget.rs
@@ -1,4 +1,5 @@
 //! Create custom widgets and operate on them.
+pub mod metadata;
 pub mod operation;
 pub mod text;
 pub mod tree;
@@ -6,6 +7,7 @@ pub mod tree;
 mod id;
 
 pub use id::Id;
+pub use metadata::Metadata;
 pub use operation::Operation;
 pub use text::Text;
 pub use tree::Tree;

--- a/core/src/widget/metadata.rs
+++ b/core/src/widget/metadata.rs
@@ -1,0 +1,54 @@
+//! Semantic widget metadata.
+
+use crate::SmolStr;
+
+/// Semantic information about a widget.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Metadata {
+    /// The semantic role of the widget.
+    pub role: Role,
+    /// A user-facing label that identifies the widget.
+    pub label: Option<SmolStr>,
+    /// A stable identifier intended for tests.
+    pub test_id: Option<SmolStr>,
+}
+
+impl Metadata {
+    /// Creates new [`Metadata`] with the given [`Role`].
+    pub fn new(role: Role) -> Self {
+        Self {
+            role,
+            label: None,
+            test_id: None,
+        }
+    }
+
+    /// Sets the user-facing label of the [`Metadata`].
+    pub fn label(mut self, label: impl Into<SmolStr>) -> Self {
+        self.label = Some(label.into());
+        self
+    }
+
+    /// Sets the test identifier of the [`Metadata`].
+    pub fn test_id(mut self, test_id: impl Into<SmolStr>) -> Self {
+        self.test_id = Some(test_id.into());
+        self
+    }
+}
+
+/// The semantic role of a widget.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(missing_docs)]
+pub enum Role {
+    Button,
+    Checkbox,
+    TextInput,
+    PickList,
+    Scrollable,
+    Text,
+    Dialog,
+    Tab,
+    List,
+    ListItem,
+    Custom(SmolStr),
+}

--- a/core/src/widget/operation.rs
+++ b/core/src/widget/operation.rs
@@ -7,7 +7,7 @@ pub use focusable::Focusable;
 pub use scrollable::Scrollable;
 pub use text_input::TextInput;
 
-use crate::widget::Id;
+use crate::widget::{Id, Metadata};
 use crate::{Rectangle, Vector};
 
 use std::any::Any;
@@ -28,6 +28,9 @@ pub trait Operation<T = ()>: Send {
 
     /// Operates on a widget that contains other widgets.
     fn container(&mut self, _id: Option<&Id>, _bounds: Rectangle) {}
+
+    /// Operates on a widget that exposes semantic metadata.
+    fn metadata(&mut self, _id: Option<&Id>, _bounds: Rectangle, _metadata: &Metadata) {}
 
     /// Operates on a widget that can be scrolled.
     fn scrollable(
@@ -68,6 +71,10 @@ where
 
     fn container(&mut self, id: Option<&Id>, bounds: Rectangle) {
         self.as_mut().container(id, bounds);
+    }
+
+    fn metadata(&mut self, id: Option<&Id>, bounds: Rectangle, metadata: &Metadata) {
+        self.as_mut().metadata(id, bounds, metadata);
     }
 
     fn focusable(&mut self, id: Option<&Id>, bounds: Rectangle, state: &mut dyn Focusable) {
@@ -151,6 +158,10 @@ where
             self.operation.container(id, bounds);
         }
 
+        fn metadata(&mut self, id: Option<&Id>, bounds: Rectangle, metadata: &Metadata) {
+            self.operation.metadata(id, bounds, metadata);
+        }
+
         fn focusable(&mut self, id: Option<&Id>, bounds: Rectangle, state: &mut dyn Focusable) {
             self.operation.focusable(id, bounds, state);
         }
@@ -225,6 +236,10 @@ where
                     operation.container(id, bounds);
                 }
 
+                fn metadata(&mut self, id: Option<&Id>, bounds: Rectangle, metadata: &Metadata) {
+                    self.operation.metadata(id, bounds, metadata);
+                }
+
                 fn scrollable(
                     &mut self,
                     id: Option<&Id>,
@@ -271,6 +286,10 @@ where
 
         fn container(&mut self, id: Option<&Id>, bounds: Rectangle) {
             self.operation.container(id, bounds);
+        }
+
+        fn metadata(&mut self, id: Option<&Id>, bounds: Rectangle, metadata: &Metadata) {
+            self.operation.metadata(id, bounds, metadata);
         }
 
         fn focusable(&mut self, id: Option<&Id>, bounds: Rectangle, state: &mut dyn Focusable) {
@@ -352,6 +371,10 @@ where
 
         fn container(&mut self, id: Option<&Id>, bounds: Rectangle) {
             self.operation.container(id, bounds);
+        }
+
+        fn metadata(&mut self, id: Option<&Id>, bounds: Rectangle, metadata: &Metadata) {
+            self.operation.metadata(id, bounds, metadata);
         }
 
         fn focusable(&mut self, id: Option<&Id>, bounds: Rectangle, state: &mut dyn Focusable) {

--- a/core/src/widget/text.rs
+++ b/core/src/widget/text.rs
@@ -26,6 +26,7 @@ use crate::mouse;
 use crate::renderer;
 use crate::text;
 use crate::text::paragraph::{self, Paragraph};
+use crate::widget::metadata::{Metadata, Role};
 use crate::widget::tree::{self, Tree};
 use crate::{Color, Element, Layout, Length, Pixels, Rectangle, Size, Theme, Widget};
 
@@ -257,6 +258,11 @@ where
         _renderer: &Renderer,
         operation: &mut dyn super::Operation,
     ) {
+        operation.metadata(
+            None,
+            layout.bounds(),
+            &Metadata::new(Role::Text).label(self.fragment.clone()),
+        );
         operation.text(None, layout.bounds(), &self.fragment);
     }
 }

--- a/selector/src/find.rs
+++ b/selector/src/find.rs
@@ -1,4 +1,5 @@
 use crate::Selector;
+use crate::core::widget::Metadata;
 use crate::core::widget::operation::{Focusable, Outcome, Scrollable, TextInput};
 use crate::core::widget::{Id, Operation};
 use crate::core::{Rectangle, Vector};
@@ -157,6 +158,19 @@ where
             id,
             bounds,
             visible_bounds: self.viewport.intersection(&(bounds + self.translation)),
+        });
+    }
+
+    fn metadata(&mut self, id: Option<&Id>, bounds: Rectangle, metadata: &Metadata) {
+        if self.strategy.is_done() {
+            return;
+        }
+
+        self.strategy.feed(Candidate::Metadata {
+            id,
+            bounds,
+            visible_bounds: self.viewport.intersection(&(bounds + self.translation)),
+            metadata,
         });
     }
 

--- a/selector/src/lib.rs
+++ b/selector/src/lib.rs
@@ -9,6 +9,7 @@ pub use target::{Bounded, Candidate, Target, Text};
 
 use crate::core::Point;
 use crate::core::widget;
+use crate::core::widget::metadata::Role;
 
 /// A type that traverses the widget tree to "select" data and produce some output.
 pub trait Selector {
@@ -147,6 +148,121 @@ pub fn id(id: impl Into<widget::Id>) -> impl Selector<Output = Target> {
     id.into()
 }
 
+/// Creates a new [`Selector`] that matches widgets with the given semantic [`Role`].
+pub fn by_role(role: Role) -> impl Selector<Output = Target> {
+    struct ByRole {
+        role: Role,
+    }
+
+    impl Selector for ByRole {
+        type Output = Target;
+
+        fn select(&mut self, candidate: Candidate<'_>) -> Option<Self::Output> {
+            candidate
+                .metadata()
+                .is_some_and(|metadata| metadata.role == self.role)
+                .then(|| Target::from(candidate))
+        }
+
+        fn description(&self) -> String {
+            format!("role == {:?}", self.role)
+        }
+    }
+
+    ByRole { role }
+}
+
+/// Creates a new [`Selector`] that matches widgets with the given semantic label.
+pub fn by_label(label: impl Into<core::SmolStr>) -> impl Selector<Output = Target> {
+    struct ByLabel {
+        label: core::SmolStr,
+    }
+
+    impl Selector for ByLabel {
+        type Output = Target;
+
+        fn select(&mut self, candidate: Candidate<'_>) -> Option<Self::Output> {
+            candidate
+                .metadata()
+                .and_then(|metadata| metadata.label.as_ref())
+                .is_some_and(|label| label == &self.label)
+                .then(|| Target::from(candidate))
+        }
+
+        fn description(&self) -> String {
+            format!("label == {:?}", self.label)
+        }
+    }
+
+    ByLabel {
+        label: label.into(),
+    }
+}
+
+/// Creates a new [`Selector`] that matches widgets with the given semantic [`Role`] and label.
+pub fn by_role_and_label(
+    role: Role,
+    label: impl Into<core::SmolStr>,
+) -> impl Selector<Output = Target> {
+    struct ByRoleAndLabel {
+        role: Role,
+        label: core::SmolStr,
+    }
+
+    impl Selector for ByRoleAndLabel {
+        type Output = Target;
+
+        fn select(&mut self, candidate: Candidate<'_>) -> Option<Self::Output> {
+            candidate
+                .metadata()
+                .is_some_and(|metadata| {
+                    metadata.role == self.role
+                        && metadata
+                            .label
+                            .as_ref()
+                            .is_some_and(|label| label == &self.label)
+                })
+                .then(|| Target::from(candidate))
+        }
+
+        fn description(&self) -> String {
+            format!("role == {:?} && label == {:?}", self.role, self.label)
+        }
+    }
+
+    ByRoleAndLabel {
+        role,
+        label: label.into(),
+    }
+}
+
+/// Creates a new [`Selector`] that matches widgets with the given semantic test id.
+pub fn by_test_id(test_id: impl Into<core::SmolStr>) -> impl Selector<Output = Target> {
+    struct ByTestId {
+        test_id: core::SmolStr,
+    }
+
+    impl Selector for ByTestId {
+        type Output = Target;
+
+        fn select(&mut self, candidate: Candidate<'_>) -> Option<Self::Output> {
+            candidate
+                .metadata()
+                .and_then(|metadata| metadata.test_id.as_ref())
+                .is_some_and(|test_id| test_id == &self.test_id)
+                .then(|| Target::from(candidate))
+        }
+
+        fn description(&self) -> String {
+            format!("test_id == {:?}", self.test_id)
+        }
+    }
+
+    ByTestId {
+        test_id: test_id.into(),
+    }
+}
+
 /// Returns a [`Selector`] that matches widgets that are currently focused.
 pub fn is_focused() -> impl Selector<Output = Target> {
     struct IsFocused;
@@ -170,4 +286,102 @@ pub fn is_focused() -> impl Selector<Output = Target> {
     }
 
     IsFocused
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Selector, by_label, by_role, by_role_and_label, by_test_id};
+    use crate::core::Rectangle;
+    use crate::core::widget::Operation;
+    use crate::core::widget::metadata::{Metadata, Role};
+    use crate::core::widget::operation::Outcome;
+    use crate::target::{Candidate, Target};
+
+    #[test]
+    fn selects_by_role() {
+        let metadata = Metadata::new(Role::Button);
+        let candidate = Candidate::Metadata {
+            id: None,
+            bounds: Rectangle::new([1.0, 2.0].into(), [3.0, 4.0].into()),
+            visible_bounds: None,
+            metadata: &metadata,
+        };
+
+        assert!(matches!(
+            by_role(Role::Button).select(candidate),
+            Some(Target::Metadata { metadata, .. })
+                if metadata.role == Role::Button
+        ));
+    }
+
+    #[test]
+    fn selects_by_label() {
+        let metadata = Metadata::new(Role::Button).label("Create");
+        let candidate = Candidate::Metadata {
+            id: None,
+            bounds: Rectangle::default(),
+            visible_bounds: None,
+            metadata: &metadata,
+        };
+
+        assert!(by_label("Create").select(candidate).is_some());
+    }
+
+    #[test]
+    fn selects_by_role_and_label() {
+        let metadata = Metadata::new(Role::Button).label("Create");
+        let candidate = Candidate::Metadata {
+            id: None,
+            bounds: Rectangle::default(),
+            visible_bounds: None,
+            metadata: &metadata,
+        };
+
+        assert!(
+            by_role_and_label(Role::Button, "Create")
+                .select(candidate)
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn selects_by_test_id() {
+        let metadata = Metadata::new(Role::TextInput).test_id("profile-name");
+        let candidate = Candidate::Metadata {
+            id: None,
+            bounds: Rectangle::default(),
+            visible_bounds: None,
+            metadata: &metadata,
+        };
+
+        assert!(by_test_id("profile-name").select(candidate).is_some());
+    }
+
+    #[test]
+    fn label_does_not_match_test_id() {
+        let metadata = Metadata::new(Role::Button).test_id("create");
+        let candidate = Candidate::Metadata {
+            id: None,
+            bounds: Rectangle::default(),
+            visible_bounds: None,
+            metadata: &metadata,
+        };
+
+        assert!(by_label("create").select(candidate).is_none());
+    }
+
+    #[test]
+    fn find_selects_metadata_emitted_by_operation() {
+        let metadata = Metadata::new(Role::Button).test_id("create");
+        let mut operation = by_test_id("create").find();
+        let bounds = Rectangle::new([1.0, 2.0].into(), [3.0, 4.0].into());
+
+        operation.metadata(None, bounds, &metadata);
+
+        assert!(matches!(
+            operation.finish(),
+            Outcome::Some(Some(Target::Metadata { bounds: found, .. }))
+                if found == bounds
+        ));
+    }
 }

--- a/selector/src/target.rs
+++ b/selector/src/target.rs
@@ -1,4 +1,5 @@
 use crate::core::widget::Id;
+use crate::core::widget::metadata::Metadata;
 use crate::core::widget::operation::{Focusable, Scrollable, TextInput};
 use crate::core::{Rectangle, Vector};
 
@@ -42,6 +43,12 @@ pub enum Target {
         bounds: Rectangle,
         visible_bounds: Option<Rectangle>,
     },
+    Metadata {
+        id: Option<Id>,
+        bounds: Rectangle,
+        visible_bounds: Option<Rectangle>,
+        metadata: Metadata,
+    },
 }
 
 impl Target {
@@ -53,7 +60,8 @@ impl Target {
             | Target::Scrollable { bounds, .. }
             | Target::TextInput { bounds, .. }
             | Target::Text { bounds, .. }
-            | Target::Custom { bounds, .. } => *bounds,
+            | Target::Custom { bounds, .. }
+            | Target::Metadata { bounds, .. } => *bounds,
         }
     }
 
@@ -65,7 +73,16 @@ impl Target {
             | Target::Scrollable { visible_bounds, .. }
             | Target::TextInput { visible_bounds, .. }
             | Target::Text { visible_bounds, .. }
-            | Target::Custom { visible_bounds, .. } => *visible_bounds,
+            | Target::Custom { visible_bounds, .. }
+            | Target::Metadata { visible_bounds, .. } => *visible_bounds,
+        }
+    }
+
+    /// Returns the semantic [`Metadata`] of the [`Target`], if any.
+    pub fn metadata(&self) -> Option<&Metadata> {
+        match self {
+            Target::Metadata { metadata, .. } => Some(metadata),
+            _ => None,
         }
     }
 }
@@ -138,6 +155,17 @@ impl From<Candidate<'_>> for Target {
                 bounds,
                 visible_bounds,
             },
+            Candidate::Metadata {
+                id,
+                bounds,
+                visible_bounds,
+                metadata,
+            } => Self::Metadata {
+                id: id.cloned(),
+                bounds,
+                visible_bounds,
+                metadata: metadata.clone(),
+            },
         }
     }
 }
@@ -195,6 +223,12 @@ pub enum Candidate<'a> {
         visible_bounds: Option<Rectangle>,
         state: &'a dyn Any,
     },
+    Metadata {
+        id: Option<&'a Id>,
+        bounds: Rectangle,
+        visible_bounds: Option<Rectangle>,
+        metadata: &'a Metadata,
+    },
 }
 
 impl<'a> Candidate<'a> {
@@ -206,7 +240,8 @@ impl<'a> Candidate<'a> {
             | Candidate::Scrollable { id, .. }
             | Candidate::TextInput { id, .. }
             | Candidate::Text { id, .. }
-            | Candidate::Custom { id, .. } => *id,
+            | Candidate::Custom { id, .. }
+            | Candidate::Metadata { id, .. } => *id,
         }
     }
 
@@ -218,7 +253,8 @@ impl<'a> Candidate<'a> {
             | Candidate::Scrollable { bounds, .. }
             | Candidate::TextInput { bounds, .. }
             | Candidate::Text { bounds, .. }
-            | Candidate::Custom { bounds, .. } => *bounds,
+            | Candidate::Custom { bounds, .. }
+            | Candidate::Metadata { bounds, .. } => *bounds,
         }
     }
 
@@ -230,7 +266,16 @@ impl<'a> Candidate<'a> {
             | Candidate::Scrollable { visible_bounds, .. }
             | Candidate::TextInput { visible_bounds, .. }
             | Candidate::Text { visible_bounds, .. }
-            | Candidate::Custom { visible_bounds, .. } => *visible_bounds,
+            | Candidate::Custom { visible_bounds, .. }
+            | Candidate::Metadata { visible_bounds, .. } => *visible_bounds,
+        }
+    }
+
+    /// Returns the semantic [`Metadata`] of the [`Candidate`], if any.
+    pub fn metadata(&self) -> Option<&'a Metadata> {
+        match self {
+            Candidate::Metadata { metadata, .. } => Some(metadata),
+            _ => None,
         }
     }
 }

--- a/test/src/emulator.rs
+++ b/test/src/emulator.rs
@@ -313,6 +313,79 @@ impl<P: Program + 'static> Emulator<P> {
                             _ => None,
                         }
                     }
+                    instruction::Target::Role(role) => {
+                        use widget::Operation;
+
+                        let mut operation = Selector::find(crate::selector::by_role(role.clone()));
+
+                        user_interface.operate(
+                            &self.renderer,
+                            &mut widget::operation::black_box(&mut operation),
+                        );
+
+                        match operation.finish() {
+                            widget::operation::Outcome::Some(target) => {
+                                Some(target?.visible_bounds()?.center())
+                            }
+                            _ => None,
+                        }
+                    }
+                    instruction::Target::Label(label) => {
+                        use widget::Operation;
+
+                        let mut operation =
+                            Selector::find(crate::selector::by_label(label.clone()));
+
+                        user_interface.operate(
+                            &self.renderer,
+                            &mut widget::operation::black_box(&mut operation),
+                        );
+
+                        match operation.finish() {
+                            widget::operation::Outcome::Some(target) => {
+                                Some(target?.visible_bounds()?.center())
+                            }
+                            _ => None,
+                        }
+                    }
+                    instruction::Target::TestId(test_id) => {
+                        use widget::Operation;
+
+                        let mut operation =
+                            Selector::find(crate::selector::by_test_id(test_id.clone()));
+
+                        user_interface.operate(
+                            &self.renderer,
+                            &mut widget::operation::black_box(&mut operation),
+                        );
+
+                        match operation.finish() {
+                            widget::operation::Outcome::Some(target) => {
+                                Some(target?.visible_bounds()?.center())
+                            }
+                            _ => None,
+                        }
+                    }
+                    instruction::Target::RoleLabel { role, label } => {
+                        use widget::Operation;
+
+                        let mut operation = Selector::find(crate::selector::by_role_and_label(
+                            role.clone(),
+                            label.clone(),
+                        ));
+
+                        user_interface.operate(
+                            &self.renderer,
+                            &mut widget::operation::black_box(&mut operation),
+                        );
+
+                        match operation.finish() {
+                            widget::operation::Outcome::Some(target) => {
+                                Some(target?.visible_bounds()?.center())
+                            }
+                            _ => None,
+                        }
+                    }
                     instruction::Target::Point(position) => Some(*position),
                 }) else {
                     self.runtime.send(Event::Failed(instruction.clone()));
@@ -360,6 +433,115 @@ impl<P: Program + 'static> Emulator<P> {
                         _ => {
                             self.runtime.send(Event::Failed(instruction.clone()));
                         }
+                    }
+
+                    self.cache = Some(user_interface.into_cache());
+                }
+                instruction::Expectation::Target(target) => {
+                    let found = match target {
+                        instruction::Target::Id(id) => {
+                            use widget::Operation;
+
+                            let mut operation = Selector::find(widget::Id::from(id.to_owned()));
+
+                            user_interface.operate(
+                                &self.renderer,
+                                &mut widget::operation::black_box(&mut operation),
+                            );
+
+                            matches!(
+                                operation.finish(),
+                                widget::operation::Outcome::Some(Some(_))
+                            )
+                        }
+                        instruction::Target::Text(text) => {
+                            use widget::Operation;
+
+                            let mut operation = Selector::find(text.as_str());
+
+                            user_interface.operate(
+                                &self.renderer,
+                                &mut widget::operation::black_box(&mut operation),
+                            );
+
+                            matches!(
+                                operation.finish(),
+                                widget::operation::Outcome::Some(Some(_))
+                            )
+                        }
+                        instruction::Target::Role(role) => {
+                            use widget::Operation;
+
+                            let mut operation =
+                                Selector::find(crate::selector::by_role(role.clone()));
+
+                            user_interface.operate(
+                                &self.renderer,
+                                &mut widget::operation::black_box(&mut operation),
+                            );
+
+                            matches!(
+                                operation.finish(),
+                                widget::operation::Outcome::Some(Some(_))
+                            )
+                        }
+                        instruction::Target::Label(label) => {
+                            use widget::Operation;
+
+                            let mut operation =
+                                Selector::find(crate::selector::by_label(label.clone()));
+
+                            user_interface.operate(
+                                &self.renderer,
+                                &mut widget::operation::black_box(&mut operation),
+                            );
+
+                            matches!(
+                                operation.finish(),
+                                widget::operation::Outcome::Some(Some(_))
+                            )
+                        }
+                        instruction::Target::TestId(test_id) => {
+                            use widget::Operation;
+
+                            let mut operation =
+                                Selector::find(crate::selector::by_test_id(test_id.clone()));
+
+                            user_interface.operate(
+                                &self.renderer,
+                                &mut widget::operation::black_box(&mut operation),
+                            );
+
+                            matches!(
+                                operation.finish(),
+                                widget::operation::Outcome::Some(Some(_))
+                            )
+                        }
+                        instruction::Target::RoleLabel { role, label } => {
+                            use widget::Operation;
+
+                            let mut operation = Selector::find(crate::selector::by_role_and_label(
+                                role.clone(),
+                                label.clone(),
+                            ));
+
+                            user_interface.operate(
+                                &self.renderer,
+                                &mut widget::operation::black_box(&mut operation),
+                            );
+
+                            matches!(
+                                operation.finish(),
+                                widget::operation::Outcome::Some(Some(_))
+                            )
+                        }
+                        instruction::Target::Point(_) => true,
+                    };
+
+                    if found {
+                        self.runtime.send(Event::Ready);
+                    } else {
+                        self.runtime.send(Event::Failed(instruction.clone()));
                     }
 
                     self.cache = Some(user_interface.into_cache());

--- a/test/src/ice.rs
+++ b/test/src/ice.rs
@@ -40,6 +40,8 @@ impl Ice {
     /// click "What needs to be done?"
     /// type "Create the universe"
     /// type enter
+    /// click role=button label="Create"
+    /// expect test_id="task-list"
     /// type "Make an apple pie"
     /// type enter
     /// expect "2 tasks left"

--- a/test/src/instruction.rs
+++ b/test/src/instruction.rs
@@ -1,6 +1,7 @@
 //! A step in an end-to-end test.
 use crate::core::keyboard;
 use crate::core::mouse;
+use crate::core::widget::metadata::Role;
 use crate::core::{Event, Point};
 use crate::simulator;
 
@@ -328,6 +329,19 @@ pub enum Target {
     Id(String),
     /// A UI element containing the given text.
     Text(String),
+    /// A widget with the given semantic role.
+    Role(Role),
+    /// A widget with the given semantic label.
+    Label(String),
+    /// A widget with the given semantic test identifier.
+    TestId(String),
+    /// A widget with the given semantic role and label.
+    RoleLabel {
+        /// The semantic role of the target.
+        role: Role,
+        /// The semantic label of the target.
+        label: String,
+    },
     /// A specific point of the viewport.
     Point(Point),
 }
@@ -338,6 +352,17 @@ impl fmt::Display for Target {
             Self::Id(id) => f.write_str(&format::id(id)),
             Self::Point(point) => f.write_str(&format::point(*point)),
             Self::Text(text) => f.write_str(&format::string(text)),
+            Self::Role(role) => write!(f, "role={}", format::role(role)),
+            Self::Label(label) => write!(f, "label={}", format::string(label)),
+            Self::TestId(test_id) => write!(f, "test_id={}", format::string(test_id)),
+            Self::RoleLabel { role, label } => {
+                write!(
+                    f,
+                    "role={} label={}",
+                    format::role(role),
+                    format::string(label)
+                )
+            }
         }
     }
 }
@@ -445,6 +470,22 @@ mod format {
     pub fn id(id: &str) -> String {
         format!("#{id}")
     }
+
+    pub fn role(role: &Role) -> &str {
+        match role {
+            Role::Button => "button",
+            Role::Checkbox => "checkbox",
+            Role::TextInput => "text_input",
+            Role::PickList => "pick_list",
+            Role::Scrollable => "scrollable",
+            Role::Text => "text",
+            Role::Dialog => "dialog",
+            Role::Tab => "tab",
+            Role::List => "list",
+            Role::ListItem => "list_item",
+            Role::Custom(_) => "custom",
+        }
+    }
 }
 
 /// A testing assertion.
@@ -455,6 +496,8 @@ mod format {
 pub enum Expectation {
     /// Expect some element to contain some text.
     Text(String),
+    /// Expect a target to exist.
+    Target(Target),
 }
 
 impl fmt::Display for Expectation {
@@ -462,6 +505,9 @@ impl fmt::Display for Expectation {
         match self {
             Expectation::Text(text) => {
                 write!(f, "expect {}", format::string(text))
+            }
+            Expectation::Target(target) => {
+                write!(f, "expect {target}")
             }
         }
     }
@@ -547,10 +593,26 @@ mod parser {
 
     fn target(input: &str) -> IResult<&str, Target> {
         alt((
+            semantic_role_label,
+            preceded(tag("role="), role).map(Target::Role),
+            preceded(tag("label="), string).map(Target::Label),
+            preceded(tag("test_id="), string).map(Target::TestId),
             id.map(String::from).map(Target::Id),
             string.map(Target::Text),
             point.map(Target::Point),
         ))
+        .parse(input)
+    }
+
+    fn semantic_role_label(input: &str) -> IResult<&str, Target> {
+        map(
+            separated_pair(
+                preceded(tag("role="), role),
+                multispace1,
+                preceded(tag("label="), string),
+            ),
+            |(role, label)| Target::RoleLabel { role, label },
+        )
         .parse(input)
     }
 
@@ -571,9 +633,13 @@ mod parser {
     }
 
     fn expectation(input: &str) -> IResult<&str, Expectation> {
-        map(preceded(tag("expect "), string), |text| {
-            Expectation::Text(text)
-        })
+        preceded(
+            tag("expect "),
+            alt((
+                map(string, Expectation::Text),
+                map(target, Expectation::Target),
+            )),
+        )
         .parse(input)
     }
 
@@ -592,6 +658,22 @@ mod parser {
             char('#'),
             recognize(many1_count(alt((alphanumeric1, tag("_"), tag("-"))))),
         )
+        .parse(input)
+    }
+
+    fn role(input: &str) -> IResult<&str, Role> {
+        alt((
+            value(Role::Button, tag("button")),
+            value(Role::Checkbox, tag("checkbox")),
+            value(Role::TextInput, tag("text_input")),
+            value(Role::PickList, tag("pick_list")),
+            value(Role::Scrollable, tag("scrollable")),
+            value(Role::Text, tag("text")),
+            value(Role::Dialog, tag("dialog")),
+            value(Role::Tab, tag("tab")),
+            value(Role::ListItem, tag("list_item")),
+            value(Role::List, tag("list")),
+        ))
         .parse(input)
     }
 
@@ -708,5 +790,47 @@ mod parser {
         });
 
         delimited(char('"'), build_string, char('"')).parse(input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Expectation, Instruction, Interaction, Mouse, Target};
+    use crate::core::mouse;
+    use crate::core::widget::metadata::Role;
+
+    #[test]
+    fn parses_click_by_test_id() {
+        assert_eq!(
+            Instruction::parse(r#"click test_id="profile-name""#).unwrap(),
+            Instruction::Interact(Interaction::Mouse(Mouse::Click {
+                button: mouse::Button::Left,
+                target: Some(Target::TestId("profile-name".to_owned())),
+            }))
+        );
+    }
+
+    #[test]
+    fn parses_click_by_role_and_label() {
+        assert_eq!(
+            Instruction::parse(r#"click role=button label="Create""#).unwrap(),
+            Instruction::Interact(Interaction::Mouse(Mouse::Click {
+                button: mouse::Button::Left,
+                target: Some(Target::RoleLabel {
+                    role: Role::Button,
+                    label: "Create".to_owned(),
+                }),
+            }))
+        );
+    }
+
+    #[test]
+    fn parses_expect_by_semantic_target() {
+        assert_eq!(
+            Instruction::parse(r#"expect test_id="profile-name""#).unwrap(),
+            Instruction::Expect(Expectation::Target(Target::TestId(
+                "profile-name".to_owned()
+            )))
+        );
     }
 }

--- a/widget/src/button.rs
+++ b/widget/src/button.rs
@@ -24,6 +24,7 @@ use crate::core::renderer;
 use crate::core::theme::palette;
 use crate::core::touch;
 use crate::core::widget::Operation;
+use crate::core::widget::metadata::{Metadata, Role};
 use crate::core::widget::tree::{self, Tree};
 use crate::core::window;
 use crate::core::{
@@ -248,6 +249,7 @@ where
         renderer: &Renderer,
         operation: &mut dyn Operation,
     ) {
+        operation.metadata(None, layout.bounds(), &Metadata::new(Role::Button));
         operation.container(None, layout.bounds());
         operation.traverse(&mut |operation| {
             self.content.as_widget_mut().operate(

--- a/widget/src/checkbox.rs
+++ b/widget/src/checkbox.rs
@@ -39,6 +39,7 @@ use crate::core::text;
 use crate::core::theme::palette;
 use crate::core::touch;
 use crate::core::widget;
+use crate::core::widget::metadata::{Metadata, Role};
 use crate::core::widget::tree::{self, Tree};
 use crate::core::window;
 use crate::core::{
@@ -462,6 +463,13 @@ where
         _renderer: &Renderer,
         operation: &mut dyn widget::Operation,
     ) {
+        let metadata = self.label.as_ref().map_or_else(
+            || Metadata::new(Role::Checkbox),
+            |label| Metadata::new(Role::Checkbox).label(label.clone()),
+        );
+
+        operation.metadata(None, layout.bounds(), &metadata);
+
         if let Some(label) = self.label.as_deref() {
             operation.text(None, layout.bounds(), label);
         }

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -16,6 +16,7 @@ use crate::pick_list::{self, PickList};
 use crate::progress_bar::{self, ProgressBar};
 use crate::radio::{self, Radio};
 use crate::scrollable::{self, Scrollable};
+use crate::semantics::Semantics;
 use crate::slider::{self, Slider};
 use crate::text::{self, Text};
 use crate::text_editor::{self, TextEditor};
@@ -990,6 +991,17 @@ where
     Renderer: core::Renderer,
 {
     Sensor::new(content)
+}
+
+/// Creates a new [`Semantics`] widget with the given role and content.
+pub fn semantics<'a, Message, Theme, Renderer>(
+    role: core::widget::metadata::Role,
+    content: impl Into<Element<'a, Message, Theme, Renderer>>,
+) -> Semantics<'a, Message, Theme, Renderer>
+where
+    Renderer: core::Renderer,
+{
+    Semantics::new(role, content)
 }
 
 /// Creates a new [`Scrollable`] with the provided content.

--- a/widget/src/lib.rs
+++ b/widget/src/lib.rs
@@ -32,6 +32,7 @@ pub mod radio;
 pub mod row;
 pub mod rule;
 pub mod scrollable;
+pub mod semantics;
 pub mod sensor;
 pub mod slider;
 pub mod space;
@@ -87,6 +88,7 @@ pub use row::Row;
 pub use rule::Rule;
 #[doc(no_inline)]
 pub use scrollable::Scrollable;
+pub use semantics::Semantics;
 #[doc(no_inline)]
 pub use sensor::Sensor;
 #[doc(no_inline)]

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -31,6 +31,7 @@ use crate::core::text;
 use crate::core::time::{Duration, Instant};
 use crate::core::touch;
 use crate::core::widget;
+use crate::core::widget::metadata::{Metadata, Role};
 use crate::core::widget::operation::{self, Operation};
 use crate::core::widget::tree::{self, Tree};
 use crate::core::window;
@@ -535,6 +536,7 @@ where
         let content_bounds = content_layout.bounds();
         let translation = state.translation(self.direction, bounds, content_bounds);
 
+        operation.metadata(self.id.as_ref(), bounds, &Metadata::new(Role::Scrollable));
         operation.scrollable(self.id.as_ref(), bounds, content_bounds, translation, state);
 
         operation.traverse(&mut |operation| {

--- a/widget/src/semantics.rs
+++ b/widget/src/semantics.rs
@@ -1,0 +1,164 @@
+//! Add semantic metadata to widgets.
+
+use crate::core::layout;
+use crate::core::mouse;
+use crate::core::overlay;
+use crate::core::renderer;
+use crate::core::widget::metadata::{Metadata, Role};
+use crate::core::widget::tree::Tree;
+use crate::core::{Element, Event, Layout, Length, Rectangle, Shell, Size, Vector, Widget};
+
+/// A widget that adds semantic metadata to its contents.
+pub struct Semantics<'a, Message, Theme, Renderer = crate::Renderer>
+where
+    Renderer: crate::core::Renderer,
+{
+    content: Element<'a, Message, Theme, Renderer>,
+    metadata: Metadata,
+}
+
+impl<'a, Message, Theme, Renderer> Semantics<'a, Message, Theme, Renderer>
+where
+    Renderer: crate::core::Renderer,
+{
+    /// Creates new [`Semantics`] with the given [`Role`] and `content`.
+    pub fn new(role: Role, content: impl Into<Element<'a, Message, Theme, Renderer>>) -> Self {
+        Self {
+            content: content.into(),
+            metadata: Metadata::new(role),
+        }
+    }
+
+    /// Sets the user-facing label.
+    pub fn label(mut self, label: impl Into<crate::core::SmolStr>) -> Self {
+        self.metadata.label = Some(label.into());
+        self
+    }
+
+    /// Sets the test identifier.
+    pub fn test_id(mut self, test_id: impl Into<crate::core::SmolStr>) -> Self {
+        self.metadata.test_id = Some(test_id.into());
+        self
+    }
+}
+
+impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer>
+    for Semantics<'_, Message, Theme, Renderer>
+where
+    Renderer: crate::core::Renderer,
+{
+    fn tag(&self) -> crate::core::widget::tree::Tag {
+        self.content.as_widget().tag()
+    }
+
+    fn state(&self) -> crate::core::widget::tree::State {
+        self.content.as_widget().state()
+    }
+
+    fn children(&self) -> Vec<Tree> {
+        self.content.as_widget().children()
+    }
+
+    fn diff(&self, tree: &mut Tree) {
+        self.content.as_widget().diff(tree);
+    }
+
+    fn size(&self) -> Size<Length> {
+        self.content.as_widget().size()
+    }
+
+    fn size_hint(&self) -> Size<Length> {
+        self.content.as_widget().size_hint()
+    }
+
+    fn layout(
+        &mut self,
+        tree: &mut Tree,
+        renderer: &Renderer,
+        limits: &layout::Limits,
+    ) -> layout::Node {
+        self.content.as_widget_mut().layout(tree, renderer, limits)
+    }
+
+    fn operate(
+        &mut self,
+        tree: &mut Tree,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+        operation: &mut dyn crate::core::widget::Operation,
+    ) {
+        operation.metadata(None, layout.bounds(), &self.metadata);
+
+        self.content
+            .as_widget_mut()
+            .operate(tree, layout, renderer, operation);
+    }
+
+    fn update(
+        &mut self,
+        tree: &mut Tree,
+        event: &Event,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        renderer: &Renderer,
+        shell: &mut Shell<'_, Message>,
+        viewport: &Rectangle,
+    ) {
+        self.content
+            .as_widget_mut()
+            .update(tree, event, layout, cursor, renderer, shell, viewport);
+    }
+
+    fn mouse_interaction(
+        &self,
+        tree: &Tree,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+        renderer: &Renderer,
+    ) -> mouse::Interaction {
+        self.content
+            .as_widget()
+            .mouse_interaction(tree, layout, cursor, viewport, renderer)
+    }
+
+    fn draw(
+        &self,
+        tree: &Tree,
+        renderer: &mut Renderer,
+        theme: &Theme,
+        style: &renderer::Style,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+    ) {
+        self.content
+            .as_widget()
+            .draw(tree, renderer, theme, style, layout, cursor, viewport);
+    }
+
+    fn overlay<'b>(
+        &'b mut self,
+        tree: &'b mut Tree,
+        layout: Layout<'b>,
+        renderer: &Renderer,
+        viewport: &Rectangle,
+        translation: Vector,
+    ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
+        self.content
+            .as_widget_mut()
+            .overlay(tree, layout, renderer, viewport, translation)
+    }
+}
+
+impl<'a, Message, Theme, Renderer> From<Semantics<'a, Message, Theme, Renderer>>
+    for Element<'a, Message, Theme, Renderer>
+where
+    Message: 'a,
+    Theme: 'a,
+    Renderer: 'a + crate::core::Renderer,
+{
+    fn from(semantics: Semantics<'a, Message, Theme, Renderer>) -> Self {
+        Element::new(semantics)
+    }
+}

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -53,6 +53,7 @@ use crate::core::text::{self, Text};
 use crate::core::time::{Duration, Instant};
 use crate::core::touch;
 use crate::core::widget;
+use crate::core::widget::metadata::{Metadata, Role};
 use crate::core::widget::operation::{self, Operation};
 use crate::core::widget::tree::{self, Tree};
 use crate::core::window;
@@ -637,6 +638,11 @@ where
     ) {
         let state = tree.state.downcast_mut::<State<Renderer::Paragraph>>();
 
+        operation.metadata(
+            self.id.as_ref(),
+            layout.bounds(),
+            &Metadata::new(Role::TextInput),
+        );
         operation.text_input(self.id.as_ref(), layout.bounds(), state);
         operation.focusable(self.id.as_ref(), layout.bounds(), state);
     }


### PR DESCRIPTION
## Summary

Adds semantic metadata to widget operations so `iced_selector` and `iced_test` can target widgets by role, label, and stable test id. This is intended to make headless E2E tests less dependent on visible text or implementation-only widget ids.

## Changes

- Add `iced_core::widget::metadata::{Metadata, Role}`.
- Add a non-breaking `Operation::metadata` hook.
- Extend `iced_selector` candidates and targets with metadata.
- Add semantic selectors: `by_role`, `by_label`, `by_role_and_label`, and `by_test_id`.
- Add `widget::Semantics` / `widget::semantics(...)` for explicit metadata.
- Emit metadata from `button`, `checkbox`, `text_input`, `scrollable`, and `text`.
- Extend `.ice` instructions to accept semantic targets like `test_id="profile-name"` and `role=button label="Create"`.

## Validation

```bash
nix shell nixpkgs#cargo nixpkgs#rustfmt -c cargo fmt --check
nix shell nixpkgs#cargo nixpkgs#rustc nixpkgs#rustfmt nixpkgs#stdenv.cc -c cargo test -p iced_selector
nix shell nixpkgs#cargo nixpkgs#rustc nixpkgs#rustfmt nixpkgs#stdenv.cc -c cargo test -p iced_widget
nix shell nixpkgs#cargo nixpkgs#rustc nixpkgs#rustfmt nixpkgs#stdenv.cc -c cargo test -p iced_test
nix shell nixpkgs#cargo nixpkgs#rustc nixpkgs#rustfmt nixpkgs#clippy nixpkgs#stdenv.cc nixpkgs#pkg-config nixpkgs#openssl.dev -c bash -lc 'export PKG_CONFIG_PATH=$(nix eval --raw nixpkgs#openssl.dev.outPath)/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}; cargo lint'
```
