### PR TITLE
feat(rich_text): make link never by default

### DIFF
--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -1161,7 +1161,7 @@ where
 /// ```
 pub fn rich_text<'a, Link, Message, Theme, Renderer>(
     spans: impl AsRef<[text::Span<'a, Link, Renderer::Font>]> + 'a,
-) -> text::Rich<'a, Link, Message, Theme, Renderer>
+) -> text::Rich<'a, Message, Link, Theme, Renderer>
 where
     Link: Clone + 'static,
     Theme: text::Catalog + 'a,

--- a/widget/src/text/rich.rs
+++ b/widget/src/text/rich.rs
@@ -135,10 +135,6 @@ where
 
     /// Sets the message that will be produced when a link of the [`Rich`] text
     /// is clicked.
-    ///
-    /// If the spans of the [`Rich`] text contain no links, you may need to call
-    /// this method with `on_link_click(never)` in order for the compiler to infer
-    /// the proper `Link` generic type.
     pub fn on_link_click(mut self, on_link_click: impl Fn(Link) -> Message + 'a) -> Self {
         self.on_link_click = Some(Box::new(on_link_click));
         self

--- a/widget/src/text/rich.rs
+++ b/widget/src/text/rich.rs
@@ -13,8 +13,13 @@ use crate::core::{
 };
 
 /// A bunch of [`Rich`] text.
-pub struct Rich<'a, Link, Message, Theme = crate::Theme, Renderer = crate::Renderer>
-where
+pub struct Rich<
+    'a,
+    Message,
+    Link = crate::core::Never,
+    Theme = crate::Theme,
+    Renderer = crate::Renderer,
+> where
     Link: Clone + 'static,
     Theme: Catalog,
     Renderer: core::text::Renderer,
@@ -34,7 +39,7 @@ where
     on_link_click: Option<Box<dyn Fn(Link) -> Message + 'a>>,
 }
 
-impl<'a, Link, Message, Theme, Renderer> Rich<'a, Link, Message, Theme, Renderer>
+impl<'a, Link, Message, Theme, Renderer> Rich<'a, Message, Link, Theme, Renderer>
 where
     Link: Clone + 'static,
     Theme: Catalog,
@@ -176,7 +181,7 @@ where
     }
 }
 
-impl<'a, Link, Message, Theme, Renderer> Default for Rich<'a, Link, Message, Theme, Renderer>
+impl<'a, Link, Message, Theme, Renderer> Default for Rich<'a, Message, Link, Theme, Renderer>
 where
     Link: Clone + 'a,
     Theme: Catalog,
@@ -195,7 +200,7 @@ struct State<Link, P: Paragraph> {
 }
 
 impl<Link, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
-    for Rich<'_, Link, Message, Theme, Renderer>
+    for Rich<'_, Message, Link, Theme, Renderer>
 where
     Link: Clone + 'static,
     Theme: Catalog,
@@ -507,7 +512,7 @@ where
 }
 
 impl<'a, Link, Message, Theme, Renderer> FromIterator<Span<'a, Link, Renderer::Font>>
-    for Rich<'a, Link, Message, Theme, Renderer>
+    for Rich<'a, Message, Link, Theme, Renderer>
 where
     Link: Clone + 'a,
     Theme: Catalog,
@@ -519,7 +524,7 @@ where
     }
 }
 
-impl<'a, Link, Message, Theme, Renderer> From<Rich<'a, Link, Message, Theme, Renderer>>
+impl<'a, Link, Message, Theme, Renderer> From<Rich<'a, Message, Link, Theme, Renderer>>
     for Element<'a, Message, Theme, Renderer>
 where
     Message: 'a,
@@ -528,7 +533,7 @@ where
     Renderer: core::text::Renderer + 'a,
 {
     fn from(
-        text: Rich<'a, Link, Message, Theme, Renderer>,
+        text: Rich<'a, Message, Link, Theme, Renderer>,
     ) -> Element<'a, Message, Theme, Renderer> {
         Element::new(text)
     }


### PR DESCRIPTION
This is a breaking change as it requires reordering of generics, however storing widgets is definitely an antipattern and hopefully no one does that
