### PR TITLE
feat(line_height): accept into pixels

### DIFF
--- a/core/src/text.rs
+++ b/core/src/text.rs
@@ -233,9 +233,9 @@ pub enum LineHeight {
 
 impl LineHeight {
     /// Returns the [`LineHeight`] in absolute logical pixels.
-    pub fn to_absolute(self, text_size: Pixels) -> Pixels {
+    pub fn to_absolute(self, text_size: impl Into<Pixels>) -> Pixels {
         match self {
-            Self::Relative(factor) => Pixels(factor * text_size.0),
+            Self::Relative(factor) => Pixels(factor * text_size.into().0),
             Self::Absolute(pixels) => pixels,
         }
     }


### PR DESCRIPTION
Modifies `LineHeight::to_absolute` so it accepts `impl Into<Pixels>`
