### PR TITLE
Use custom value in text-input's update

### DIFF
--- a/widget/src/combo_box.rs
+++ b/widget/src/combo_box.rs
@@ -565,7 +565,8 @@ where
         let mut local_shell = Shell::new(&mut local_messages);
 
         // Provide it to the widget
-        self.text_input.update(
+        Widget::update(
+            &mut self.text_input,
             &mut tree.children[0],
             event,
             layout,
@@ -719,7 +720,8 @@ where
                 // Unfocus the input
                 let mut local_messages = Vec::new();
                 let mut local_shell = Shell::new(&mut local_messages);
-                self.text_input.update(
+                Widget::update(
+                    &mut self.text_input,
                     &mut tree.children[0],
                     &Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)),
                     layout,

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -586,6 +586,657 @@ where
             draw(renderer, text_bounds);
         }
     }
+
+    /// Draws the [`TextInput`] with the given [`Renderer`], overriding its
+    /// [`Value`] if provided.
+    ///
+    /// [`Renderer`]: text::Renderer
+    ///
+    /// Update the [`TextInput`]'s value or, if provided, the external `value` [`Value`]
+    pub fn update(
+        &mut self,
+        tree: &mut Tree,
+        event: &Event,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        renderer: &Renderer,
+        shell: &mut Shell<'_, Message>,
+        value: Option<&mut Value>,
+        _viewport: &Rectangle,
+    ) {
+        let update_cache = |state, value| {
+            replace_paragraph(
+                renderer,
+                state,
+                layout,
+                value,
+                self.font,
+                self.size,
+                self.line_height,
+            );
+        };
+
+        match &event {
+            Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
+            | Event::Touch(touch::Event::FingerPressed { .. }) => {
+                let state = state::<Renderer>(tree);
+                let value = value.unwrap_or(&mut self.value);
+
+                let cursor_before = state.cursor;
+
+                let click_position = cursor.position_over(layout.bounds());
+
+                state.is_focused = if click_position.is_some() {
+                    let now = Instant::now();
+
+                    Some(Focus {
+                        updated_at: now,
+                        now,
+                        is_window_focused: true,
+                    })
+                } else {
+                    None
+                };
+
+                if let Some(cursor_position) = click_position {
+                    let text_layout = layout.children().next().unwrap();
+
+                    let target = {
+                        let text_bounds = text_layout.bounds();
+
+                        let alignment_offset = alignment_offset(
+                            text_bounds.width,
+                            state.value.raw().min_width(),
+                            self.alignment,
+                        );
+
+                        cursor_position.x - text_bounds.x - alignment_offset
+                    };
+
+                    let click =
+                        mouse::Click::new(cursor_position, mouse::Button::Left, state.last_click);
+
+                    match click.kind() {
+                        click::Kind::Single => {
+                            let position = if target > 0.0 {
+                                let value = if self.is_secure {
+                                    value.secure()
+                                } else {
+                                    value.clone()
+                                };
+
+                                find_cursor_position(text_layout.bounds(), &value, state, target)
+                            } else {
+                                None
+                            }
+                            .unwrap_or(0);
+
+                            if state.keyboard_modifiers.shift() {
+                                state
+                                    .cursor
+                                    .select_range(state.cursor.start(&value), position);
+                            } else {
+                                state.cursor.move_to(position);
+                            }
+
+                            state.is_dragging = Some(Drag::Select);
+                        }
+                        click::Kind::Double => {
+                            if self.is_secure {
+                                state.cursor.select_all(&value);
+
+                                state.is_dragging = None;
+                            } else {
+                                let position = find_cursor_position(
+                                    text_layout.bounds(),
+                                    &value,
+                                    state,
+                                    target,
+                                )
+                                .unwrap_or(0);
+
+                                state.cursor.select_range(
+                                    value.previous_start_of_word(position),
+                                    value.next_end_of_word(position),
+                                );
+
+                                state.is_dragging = Some(Drag::SelectWords { anchor: position });
+                            }
+                        }
+                        click::Kind::Triple => {
+                            state.cursor.select_all(&value);
+                            state.is_dragging = None;
+                        }
+                    }
+
+                    state.last_click = Some(click);
+
+                    if cursor_before != state.cursor {
+                        shell.request_redraw();
+                    }
+
+                    shell.capture_event();
+                }
+            }
+            Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left))
+            | Event::Touch(touch::Event::FingerLifted { .. })
+            | Event::Touch(touch::Event::FingerLost { .. }) => {
+                state::<Renderer>(tree).is_dragging = None;
+            }
+            Event::Mouse(mouse::Event::CursorMoved { position })
+            | Event::Touch(touch::Event::FingerMoved { position, .. }) => {
+                let state = state::<Renderer>(tree);
+                let value = value.unwrap_or(&mut self.value);
+
+                if let Some(is_dragging) = &state.is_dragging {
+                    let text_layout = layout.children().next().unwrap();
+
+                    let target = {
+                        let text_bounds = text_layout.bounds();
+
+                        let alignment_offset = alignment_offset(
+                            text_bounds.width,
+                            state.value.raw().min_width(),
+                            self.alignment,
+                        );
+
+                        position.x - text_bounds.x - alignment_offset
+                    };
+
+                    let value = if self.is_secure {
+                        value.secure()
+                    } else {
+                        value.clone()
+                    };
+
+                    let position =
+                        find_cursor_position(text_layout.bounds(), &value, state, target)
+                            .unwrap_or(0);
+
+                    let selection_before = state.cursor.selection(&value);
+
+                    match is_dragging {
+                        Drag::Select => {
+                            state
+                                .cursor
+                                .select_range(state.cursor.start(&value), position);
+                        }
+                        Drag::SelectWords { anchor } => {
+                            if position < *anchor {
+                                state.cursor.select_range(
+                                    value.previous_start_of_word(position),
+                                    value.next_end_of_word(*anchor),
+                                );
+                            } else {
+                                state.cursor.select_range(
+                                    value.previous_start_of_word(*anchor),
+                                    value.next_end_of_word(position),
+                                );
+                            }
+                        }
+                    }
+
+                    if let Some(focus) = &mut state.is_focused {
+                        focus.updated_at = Instant::now();
+                    }
+
+                    if selection_before != state.cursor.selection(&value) {
+                        shell.request_redraw();
+                    }
+
+                    shell.capture_event();
+                }
+            }
+            Event::Keyboard(keyboard::Event::KeyPressed {
+                key,
+                text,
+                modified_key,
+                physical_key,
+                ..
+            }) => {
+                let state = state::<Renderer>(tree);
+                let value = value.unwrap_or(&mut self.value);
+
+                if let Some(focus) = &mut state.is_focused {
+                    let modifiers = state.keyboard_modifiers;
+
+                    match key.to_latin(*physical_key) {
+                        Some('c') if state.keyboard_modifiers.command() && !self.is_secure => {
+                            if let Some((start, end)) = state.cursor.selection(&value) {
+                                shell.write_clipboard(clipboard::Content::Text(
+                                    value.select(start, end).to_string(),
+                                ));
+                            }
+
+                            shell.capture_event();
+                            return;
+                        }
+                        Some('x') if state.keyboard_modifiers.command() && !self.is_secure => {
+                            let Some(on_input) = &self.on_input else {
+                                return;
+                            };
+
+                            if let Some((start, end)) = state.cursor.selection(&value) {
+                                shell.write_clipboard(clipboard::Content::Text(
+                                    value.select(start, end).to_string(),
+                                ));
+                            }
+
+                            let mut editor = Editor::new(value, &mut state.cursor);
+                            editor.delete();
+
+                            let message = (on_input)(editor.contents());
+                            shell.publish(message);
+                            shell.capture_event();
+
+                            focus.updated_at = Instant::now();
+                            update_cache(state, &value);
+                            return;
+                        }
+                        Some('v')
+                            if state.keyboard_modifiers.command()
+                                && !state.keyboard_modifiers.alt() =>
+                        {
+                            let Some(on_input) = &self.on_input else {
+                                return;
+                            };
+
+                            let content = match &state.is_pasting {
+                                Some(Paste::Pasting(content)) => content,
+                                Some(Paste::Reading) => return,
+                                None => {
+                                    shell.read_clipboard(clipboard::Kind::Text);
+                                    state.is_pasting = Some(Paste::Reading);
+                                    return;
+                                }
+                            };
+
+                            let mut editor = Editor::new(value, &mut state.cursor);
+                            editor.paste(content.clone());
+
+                            let message = if let Some(paste) = &self.on_paste {
+                                (paste)(editor.contents())
+                            } else {
+                                (on_input)(editor.contents())
+                            };
+                            shell.publish(message);
+                            shell.capture_event();
+
+                            focus.updated_at = Instant::now();
+                            update_cache(state, &value);
+                            return;
+                        }
+                        Some('a') if state.keyboard_modifiers.command() => {
+                            let cursor_before = state.cursor;
+
+                            state.cursor.select_all(&value);
+
+                            if cursor_before != state.cursor {
+                                focus.updated_at = Instant::now();
+
+                                shell.request_redraw();
+                            }
+
+                            shell.capture_event();
+                            return;
+                        }
+                        _ => {}
+                    }
+
+                    if let Some(text) = text {
+                        let Some(on_input) = &self.on_input else {
+                            return;
+                        };
+
+                        state.is_pasting = None;
+
+                        if let Some(c) = text.chars().next().filter(|c| !c.is_control()) {
+                            let mut editor = Editor::new(value, &mut state.cursor);
+
+                            editor.insert(c);
+
+                            let message = (on_input)(editor.contents());
+                            shell.publish(message);
+                            shell.capture_event();
+
+                            focus.updated_at = Instant::now();
+                            update_cache(state, &value);
+                            return;
+                        }
+                    }
+
+                    #[cfg(target_os = "macos")]
+                    let macos_shortcut = crate::text_editor::convert_macos_shortcut(key, modifiers);
+
+                    #[cfg(target_os = "macos")]
+                    let modified_key = macos_shortcut.as_ref().unwrap_or(modified_key);
+
+                    match modified_key.as_ref() {
+                        keyboard::Key::Named(key::Named::Enter) => {
+                            if let Some(on_submit) = self.on_submit.clone() {
+                                shell.publish(on_submit);
+                                shell.capture_event();
+                            }
+                        }
+                        keyboard::Key::Named(key::Named::Backspace) => {
+                            let Some(on_input) = &self.on_input else {
+                                return;
+                            };
+
+                            if state.cursor.selection(&value).is_none() {
+                                if (self.is_secure && modifiers.jump()) || modifiers.macos_command()
+                                {
+                                    state.cursor.select_range(state.cursor.start(&value), 0);
+                                } else if modifiers.jump() {
+                                    state.cursor.select_left_by_words(&value);
+                                }
+                            }
+
+                            let mut editor = Editor::new(value, &mut state.cursor);
+                            editor.backspace();
+
+                            let message = (on_input)(editor.contents());
+                            shell.publish(message);
+                            shell.capture_event();
+
+                            focus.updated_at = Instant::now();
+                            update_cache(state, &value);
+                        }
+                        keyboard::Key::Named(key::Named::Delete) => {
+                            let Some(on_input) = &self.on_input else {
+                                return;
+                            };
+
+                            if state.cursor.selection(&value).is_none() {
+                                if (self.is_secure && modifiers.jump()) || modifiers.macos_command()
+                                {
+                                    state
+                                        .cursor
+                                        .select_range(state.cursor.start(&value), value.len());
+                                } else if modifiers.jump() {
+                                    state.cursor.select_right_by_words(&value);
+                                }
+                            }
+
+                            let mut editor = Editor::new(value, &mut state.cursor);
+                            editor.delete();
+
+                            let message = (on_input)(editor.contents());
+                            shell.publish(message);
+                            shell.capture_event();
+
+                            focus.updated_at = Instant::now();
+                            update_cache(state, &value);
+                        }
+                        keyboard::Key::Named(key::Named::Home) => {
+                            let cursor_before = state.cursor;
+
+                            if modifiers.shift() {
+                                state.cursor.select_range(state.cursor.start(&value), 0);
+                            } else {
+                                state.cursor.move_to(0);
+                            }
+
+                            if cursor_before != state.cursor {
+                                focus.updated_at = Instant::now();
+
+                                shell.request_redraw();
+                            }
+
+                            shell.capture_event();
+                        }
+                        keyboard::Key::Named(key::Named::End) => {
+                            let cursor_before = state.cursor;
+
+                            if modifiers.shift() {
+                                state
+                                    .cursor
+                                    .select_range(state.cursor.start(&value), value.len());
+                            } else {
+                                state.cursor.move_to(value.len());
+                            }
+
+                            if cursor_before != state.cursor {
+                                focus.updated_at = Instant::now();
+
+                                shell.request_redraw();
+                            }
+
+                            shell.capture_event();
+                        }
+                        keyboard::Key::Named(key::Named::ArrowLeft) => {
+                            let cursor_before = state.cursor;
+
+                            if (self.is_secure && modifiers.jump()) || modifiers.macos_command() {
+                                if modifiers.shift() {
+                                    state.cursor.select_range(state.cursor.start(&value), 0);
+                                } else {
+                                    state.cursor.move_to(0);
+                                }
+                            } else if modifiers.jump() {
+                                if modifiers.shift() {
+                                    state.cursor.select_left_by_words(&value);
+                                } else {
+                                    state.cursor.move_left_by_words(&value);
+                                }
+                            } else if modifiers.shift() {
+                                state.cursor.select_left(&value);
+                            } else {
+                                state.cursor.move_left(&value);
+                            }
+
+                            if cursor_before != state.cursor {
+                                focus.updated_at = Instant::now();
+
+                                shell.request_redraw();
+                            }
+
+                            shell.capture_event();
+                        }
+                        keyboard::Key::Named(key::Named::ArrowRight) => {
+                            let cursor_before = state.cursor;
+
+                            if (self.is_secure && modifiers.jump()) || modifiers.macos_command() {
+                                if modifiers.shift() {
+                                    state
+                                        .cursor
+                                        .select_range(state.cursor.start(&value), value.len());
+                                } else {
+                                    state.cursor.move_to(value.len());
+                                }
+                            } else if modifiers.jump() {
+                                if modifiers.shift() {
+                                    state.cursor.select_right_by_words(&value);
+                                } else {
+                                    state.cursor.move_right_by_words(&value);
+                                }
+                            } else if modifiers.shift() {
+                                state.cursor.select_right(&value);
+                            } else {
+                                state.cursor.move_right(&value);
+                            }
+
+                            if cursor_before != state.cursor {
+                                focus.updated_at = Instant::now();
+
+                                shell.request_redraw();
+                            }
+
+                            shell.capture_event();
+                        }
+                        keyboard::Key::Named(key::Named::Escape) => {
+                            state.is_focused = None;
+                            state.is_dragging = None;
+                            state.is_pasting = None;
+
+                            state.keyboard_modifiers = keyboard::Modifiers::default();
+
+                            shell.capture_event();
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            Event::Keyboard(keyboard::Event::KeyReleased { key, .. }) => {
+                let state = state::<Renderer>(tree);
+
+                if state.is_focused.is_some()
+                    && let keyboard::Key::Character("v") = key.as_ref()
+                {
+                    state.is_pasting = None;
+                    shell.capture_event();
+                }
+
+                state.is_pasting = None;
+            }
+            Event::Keyboard(keyboard::Event::ModifiersChanged(modifiers)) => {
+                let state = state::<Renderer>(tree);
+
+                state.keyboard_modifiers = *modifiers;
+            }
+            Event::Clipboard(clipboard::Event::Read(Ok(content))) => {
+                let Some(on_input) = &self.on_input else {
+                    return;
+                };
+
+                let state = state::<Renderer>(tree);
+                let value = value.unwrap_or(&mut self.value);
+
+                let Some(focus) = &mut state.is_focused else {
+                    return;
+                };
+
+                if let clipboard::Content::Text(text) = content.as_ref()
+                    && let Some(Paste::Reading) = state.is_pasting
+                {
+                    state.is_pasting = Some(Paste::Pasting(Value::new(text)));
+
+                    let mut editor = Editor::new(value, &mut state.cursor);
+                    editor.paste(Value::new(text));
+
+                    let message = if let Some(paste) = &self.on_paste {
+                        (paste)(editor.contents())
+                    } else {
+                        (on_input)(editor.contents())
+                    };
+                    shell.publish(message);
+                    shell.capture_event();
+
+                    focus.updated_at = Instant::now();
+                    update_cache(state, &value);
+                    return;
+                }
+            }
+            Event::InputMethod(event) => match event {
+                input_method::Event::Opened | input_method::Event::Closed => {
+                    let state = state::<Renderer>(tree);
+
+                    state.preedit = matches!(event, input_method::Event::Opened)
+                        .then(input_method::Preedit::new);
+
+                    shell.request_redraw();
+                }
+                input_method::Event::Preedit(content, selection) => {
+                    let state = state::<Renderer>(tree);
+
+                    if state.is_focused.is_some() {
+                        state.preedit = Some(input_method::Preedit {
+                            content: content.to_owned(),
+                            selection: selection.clone(),
+                            text_size: self.size,
+                        });
+
+                        shell.request_redraw();
+                    }
+                }
+                input_method::Event::Commit(text) => {
+                    let state = state::<Renderer>(tree);
+                    let value = value.unwrap_or(&mut self.value);
+
+                    if let Some(focus) = &mut state.is_focused {
+                        let Some(on_input) = &self.on_input else {
+                            return;
+                        };
+
+                        let mut editor = Editor::new(value, &mut state.cursor);
+                        editor.paste(Value::new(text));
+
+                        focus.updated_at = Instant::now();
+                        state.is_pasting = None;
+
+                        let message = (on_input)(editor.contents());
+                        shell.publish(message);
+                        shell.capture_event();
+
+                        update_cache(state, &value);
+                    }
+                }
+            },
+            Event::Window(window::Event::Unfocused) => {
+                let state = state::<Renderer>(tree);
+
+                if let Some(focus) = &mut state.is_focused {
+                    focus.is_window_focused = false;
+                }
+            }
+            Event::Window(window::Event::Focused) => {
+                let state = state::<Renderer>(tree);
+
+                if let Some(focus) = &mut state.is_focused {
+                    focus.is_window_focused = true;
+                    focus.updated_at = Instant::now();
+
+                    shell.request_redraw();
+                }
+            }
+            Event::Window(window::Event::RedrawRequested(now)) => {
+                let state = state::<Renderer>(tree);
+
+                if let Some(focus) = &mut state.is_focused
+                    && focus.is_window_focused
+                {
+                    let value = value.map(|v| &*v).unwrap_or(&self.value);
+                    if matches!(state.cursor.state(&value), cursor::State::Index(_)) {
+                        focus.now = *now;
+
+                        let millis_until_redraw = CURSOR_BLINK_INTERVAL_MILLIS
+                            - (*now - focus.updated_at).as_millis() % CURSOR_BLINK_INTERVAL_MILLIS;
+
+                        shell.request_redraw_at(
+                            *now + Duration::from_millis(millis_until_redraw as u64),
+                        );
+                    }
+
+                    shell.request_input_method(&self.input_method(state, layout, &value));
+                }
+            }
+            _ => {}
+        }
+
+        let state = state::<Renderer>(tree);
+        let is_disabled = self.on_input.is_none();
+
+        let status = if is_disabled {
+            Status::Disabled
+        } else if state.is_focused() {
+            Status::Focused {
+                is_hovered: cursor.is_over(layout.bounds()),
+            }
+        } else if cursor.is_over(layout.bounds()) {
+            Status::Hovered
+        } else {
+            Status::Active
+        };
+
+        if let Event::Window(window::Event::RedrawRequested(_now)) = event {
+            self.last_status = Some(status);
+        } else if self
+            .last_status
+            .is_some_and(|last_status| status != last_status)
+        {
+            shell.request_redraw();
+        }
+    }
 }
 
 impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer>
@@ -649,642 +1300,9 @@ where
         cursor: mouse::Cursor,
         renderer: &Renderer,
         shell: &mut Shell<'_, Message>,
-        _viewport: &Rectangle,
+        viewport: &Rectangle,
     ) {
-        let update_cache = |state, value| {
-            replace_paragraph(
-                renderer,
-                state,
-                layout,
-                value,
-                self.font,
-                self.size,
-                self.line_height,
-            );
-        };
-
-        match &event {
-            Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
-            | Event::Touch(touch::Event::FingerPressed { .. }) => {
-                let state = state::<Renderer>(tree);
-                let cursor_before = state.cursor;
-
-                let click_position = cursor.position_over(layout.bounds());
-
-                state.is_focused = if click_position.is_some() {
-                    let now = Instant::now();
-
-                    Some(Focus {
-                        updated_at: now,
-                        now,
-                        is_window_focused: true,
-                    })
-                } else {
-                    None
-                };
-
-                if let Some(cursor_position) = click_position {
-                    let text_layout = layout.children().next().unwrap();
-
-                    let target = {
-                        let text_bounds = text_layout.bounds();
-
-                        let alignment_offset = alignment_offset(
-                            text_bounds.width,
-                            state.value.raw().min_width(),
-                            self.alignment,
-                        );
-
-                        cursor_position.x - text_bounds.x - alignment_offset
-                    };
-
-                    let click =
-                        mouse::Click::new(cursor_position, mouse::Button::Left, state.last_click);
-
-                    match click.kind() {
-                        click::Kind::Single => {
-                            let position = if target > 0.0 {
-                                let value = if self.is_secure {
-                                    self.value.secure()
-                                } else {
-                                    self.value.clone()
-                                };
-
-                                find_cursor_position(text_layout.bounds(), &value, state, target)
-                            } else {
-                                None
-                            }
-                            .unwrap_or(0);
-
-                            if state.keyboard_modifiers.shift() {
-                                state
-                                    .cursor
-                                    .select_range(state.cursor.start(&self.value), position);
-                            } else {
-                                state.cursor.move_to(position);
-                            }
-
-                            state.is_dragging = Some(Drag::Select);
-                        }
-                        click::Kind::Double => {
-                            if self.is_secure {
-                                state.cursor.select_all(&self.value);
-
-                                state.is_dragging = None;
-                            } else {
-                                let position = find_cursor_position(
-                                    text_layout.bounds(),
-                                    &self.value,
-                                    state,
-                                    target,
-                                )
-                                .unwrap_or(0);
-
-                                state.cursor.select_range(
-                                    self.value.previous_start_of_word(position),
-                                    self.value.next_end_of_word(position),
-                                );
-
-                                state.is_dragging = Some(Drag::SelectWords { anchor: position });
-                            }
-                        }
-                        click::Kind::Triple => {
-                            state.cursor.select_all(&self.value);
-                            state.is_dragging = None;
-                        }
-                    }
-
-                    state.last_click = Some(click);
-
-                    if cursor_before != state.cursor {
-                        shell.request_redraw();
-                    }
-
-                    shell.capture_event();
-                }
-            }
-            Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left))
-            | Event::Touch(touch::Event::FingerLifted { .. })
-            | Event::Touch(touch::Event::FingerLost { .. }) => {
-                state::<Renderer>(tree).is_dragging = None;
-            }
-            Event::Mouse(mouse::Event::CursorMoved { position })
-            | Event::Touch(touch::Event::FingerMoved { position, .. }) => {
-                let state = state::<Renderer>(tree);
-
-                if let Some(is_dragging) = &state.is_dragging {
-                    let text_layout = layout.children().next().unwrap();
-
-                    let target = {
-                        let text_bounds = text_layout.bounds();
-
-                        let alignment_offset = alignment_offset(
-                            text_bounds.width,
-                            state.value.raw().min_width(),
-                            self.alignment,
-                        );
-
-                        position.x - text_bounds.x - alignment_offset
-                    };
-
-                    let value = if self.is_secure {
-                        self.value.secure()
-                    } else {
-                        self.value.clone()
-                    };
-
-                    let position =
-                        find_cursor_position(text_layout.bounds(), &value, state, target)
-                            .unwrap_or(0);
-
-                    let selection_before = state.cursor.selection(&value);
-
-                    match is_dragging {
-                        Drag::Select => {
-                            state
-                                .cursor
-                                .select_range(state.cursor.start(&value), position);
-                        }
-                        Drag::SelectWords { anchor } => {
-                            if position < *anchor {
-                                state.cursor.select_range(
-                                    self.value.previous_start_of_word(position),
-                                    self.value.next_end_of_word(*anchor),
-                                );
-                            } else {
-                                state.cursor.select_range(
-                                    self.value.previous_start_of_word(*anchor),
-                                    self.value.next_end_of_word(position),
-                                );
-                            }
-                        }
-                    }
-
-                    if let Some(focus) = &mut state.is_focused {
-                        focus.updated_at = Instant::now();
-                    }
-
-                    if selection_before != state.cursor.selection(&value) {
-                        shell.request_redraw();
-                    }
-
-                    shell.capture_event();
-                }
-            }
-            Event::Keyboard(keyboard::Event::KeyPressed {
-                key,
-                text,
-                modified_key,
-                physical_key,
-                ..
-            }) => {
-                let state = state::<Renderer>(tree);
-
-                if let Some(focus) = &mut state.is_focused {
-                    let modifiers = state.keyboard_modifiers;
-
-                    match key.to_latin(*physical_key) {
-                        Some('c') if state.keyboard_modifiers.command() && !self.is_secure => {
-                            if let Some((start, end)) = state.cursor.selection(&self.value) {
-                                shell.write_clipboard(clipboard::Content::Text(
-                                    self.value.select(start, end).to_string(),
-                                ));
-                            }
-
-                            shell.capture_event();
-                            return;
-                        }
-                        Some('x') if state.keyboard_modifiers.command() && !self.is_secure => {
-                            let Some(on_input) = &self.on_input else {
-                                return;
-                            };
-
-                            if let Some((start, end)) = state.cursor.selection(&self.value) {
-                                shell.write_clipboard(clipboard::Content::Text(
-                                    self.value.select(start, end).to_string(),
-                                ));
-                            }
-
-                            let mut editor = Editor::new(&mut self.value, &mut state.cursor);
-                            editor.delete();
-
-                            let message = (on_input)(editor.contents());
-                            shell.publish(message);
-                            shell.capture_event();
-
-                            focus.updated_at = Instant::now();
-                            update_cache(state, &self.value);
-                            return;
-                        }
-                        Some('v')
-                            if state.keyboard_modifiers.command()
-                                && !state.keyboard_modifiers.alt() =>
-                        {
-                            let Some(on_input) = &self.on_input else {
-                                return;
-                            };
-
-                            let content = match &state.is_pasting {
-                                Some(Paste::Pasting(content)) => content,
-                                Some(Paste::Reading) => return,
-                                None => {
-                                    shell.read_clipboard(clipboard::Kind::Text);
-                                    state.is_pasting = Some(Paste::Reading);
-                                    return;
-                                }
-                            };
-
-                            let mut editor = Editor::new(&mut self.value, &mut state.cursor);
-                            editor.paste(content.clone());
-
-                            let message = if let Some(paste) = &self.on_paste {
-                                (paste)(editor.contents())
-                            } else {
-                                (on_input)(editor.contents())
-                            };
-                            shell.publish(message);
-                            shell.capture_event();
-
-                            focus.updated_at = Instant::now();
-                            update_cache(state, &self.value);
-                            return;
-                        }
-                        Some('a') if state.keyboard_modifiers.command() => {
-                            let cursor_before = state.cursor;
-
-                            state.cursor.select_all(&self.value);
-
-                            if cursor_before != state.cursor {
-                                focus.updated_at = Instant::now();
-
-                                shell.request_redraw();
-                            }
-
-                            shell.capture_event();
-                            return;
-                        }
-                        _ => {}
-                    }
-
-                    if let Some(text) = text {
-                        let Some(on_input) = &self.on_input else {
-                            return;
-                        };
-
-                        state.is_pasting = None;
-
-                        if let Some(c) = text.chars().next().filter(|c| !c.is_control()) {
-                            let mut editor = Editor::new(&mut self.value, &mut state.cursor);
-
-                            editor.insert(c);
-
-                            let message = (on_input)(editor.contents());
-                            shell.publish(message);
-                            shell.capture_event();
-
-                            focus.updated_at = Instant::now();
-                            update_cache(state, &self.value);
-                            return;
-                        }
-                    }
-
-                    #[cfg(target_os = "macos")]
-                    let macos_shortcut = crate::text_editor::convert_macos_shortcut(key, modifiers);
-
-                    #[cfg(target_os = "macos")]
-                    let modified_key = macos_shortcut.as_ref().unwrap_or(modified_key);
-
-                    match modified_key.as_ref() {
-                        keyboard::Key::Named(key::Named::Enter) => {
-                            if let Some(on_submit) = self.on_submit.clone() {
-                                shell.publish(on_submit);
-                                shell.capture_event();
-                            }
-                        }
-                        keyboard::Key::Named(key::Named::Backspace) => {
-                            let Some(on_input) = &self.on_input else {
-                                return;
-                            };
-
-                            if state.cursor.selection(&self.value).is_none() {
-                                if (self.is_secure && modifiers.jump()) || modifiers.macos_command()
-                                {
-                                    state
-                                        .cursor
-                                        .select_range(state.cursor.start(&self.value), 0);
-                                } else if modifiers.jump() {
-                                    state.cursor.select_left_by_words(&self.value);
-                                }
-                            }
-
-                            let mut editor = Editor::new(&mut self.value, &mut state.cursor);
-                            editor.backspace();
-
-                            let message = (on_input)(editor.contents());
-                            shell.publish(message);
-                            shell.capture_event();
-
-                            focus.updated_at = Instant::now();
-                            update_cache(state, &self.value);
-                        }
-                        keyboard::Key::Named(key::Named::Delete) => {
-                            let Some(on_input) = &self.on_input else {
-                                return;
-                            };
-
-                            if state.cursor.selection(&self.value).is_none() {
-                                if (self.is_secure && modifiers.jump()) || modifiers.macos_command()
-                                {
-                                    state.cursor.select_range(
-                                        state.cursor.start(&self.value),
-                                        self.value.len(),
-                                    );
-                                } else if modifiers.jump() {
-                                    state.cursor.select_right_by_words(&self.value);
-                                }
-                            }
-
-                            let mut editor = Editor::new(&mut self.value, &mut state.cursor);
-                            editor.delete();
-
-                            let message = (on_input)(editor.contents());
-                            shell.publish(message);
-                            shell.capture_event();
-
-                            focus.updated_at = Instant::now();
-                            update_cache(state, &self.value);
-                        }
-                        keyboard::Key::Named(key::Named::Home) => {
-                            let cursor_before = state.cursor;
-
-                            if modifiers.shift() {
-                                state
-                                    .cursor
-                                    .select_range(state.cursor.start(&self.value), 0);
-                            } else {
-                                state.cursor.move_to(0);
-                            }
-
-                            if cursor_before != state.cursor {
-                                focus.updated_at = Instant::now();
-
-                                shell.request_redraw();
-                            }
-
-                            shell.capture_event();
-                        }
-                        keyboard::Key::Named(key::Named::End) => {
-                            let cursor_before = state.cursor;
-
-                            if modifiers.shift() {
-                                state.cursor.select_range(
-                                    state.cursor.start(&self.value),
-                                    self.value.len(),
-                                );
-                            } else {
-                                state.cursor.move_to(self.value.len());
-                            }
-
-                            if cursor_before != state.cursor {
-                                focus.updated_at = Instant::now();
-
-                                shell.request_redraw();
-                            }
-
-                            shell.capture_event();
-                        }
-                        keyboard::Key::Named(key::Named::ArrowLeft) => {
-                            let cursor_before = state.cursor;
-
-                            if (self.is_secure && modifiers.jump()) || modifiers.macos_command() {
-                                if modifiers.shift() {
-                                    state
-                                        .cursor
-                                        .select_range(state.cursor.start(&self.value), 0);
-                                } else {
-                                    state.cursor.move_to(0);
-                                }
-                            } else if modifiers.jump() {
-                                if modifiers.shift() {
-                                    state.cursor.select_left_by_words(&self.value);
-                                } else {
-                                    state.cursor.move_left_by_words(&self.value);
-                                }
-                            } else if modifiers.shift() {
-                                state.cursor.select_left(&self.value);
-                            } else {
-                                state.cursor.move_left(&self.value);
-                            }
-
-                            if cursor_before != state.cursor {
-                                focus.updated_at = Instant::now();
-
-                                shell.request_redraw();
-                            }
-
-                            shell.capture_event();
-                        }
-                        keyboard::Key::Named(key::Named::ArrowRight) => {
-                            let cursor_before = state.cursor;
-
-                            if (self.is_secure && modifiers.jump()) || modifiers.macos_command() {
-                                if modifiers.shift() {
-                                    state.cursor.select_range(
-                                        state.cursor.start(&self.value),
-                                        self.value.len(),
-                                    );
-                                } else {
-                                    state.cursor.move_to(self.value.len());
-                                }
-                            } else if modifiers.jump() {
-                                if modifiers.shift() {
-                                    state.cursor.select_right_by_words(&self.value);
-                                } else {
-                                    state.cursor.move_right_by_words(&self.value);
-                                }
-                            } else if modifiers.shift() {
-                                state.cursor.select_right(&self.value);
-                            } else {
-                                state.cursor.move_right(&self.value);
-                            }
-
-                            if cursor_before != state.cursor {
-                                focus.updated_at = Instant::now();
-
-                                shell.request_redraw();
-                            }
-
-                            shell.capture_event();
-                        }
-                        keyboard::Key::Named(key::Named::Escape) => {
-                            state.is_focused = None;
-                            state.is_dragging = None;
-                            state.is_pasting = None;
-
-                            state.keyboard_modifiers = keyboard::Modifiers::default();
-
-                            shell.capture_event();
-                        }
-                        _ => {}
-                    }
-                }
-            }
-            Event::Keyboard(keyboard::Event::KeyReleased { key, .. }) => {
-                let state = state::<Renderer>(tree);
-
-                if state.is_focused.is_some()
-                    && let keyboard::Key::Character("v") = key.as_ref()
-                {
-                    state.is_pasting = None;
-                    shell.capture_event();
-                }
-
-                state.is_pasting = None;
-            }
-            Event::Keyboard(keyboard::Event::ModifiersChanged(modifiers)) => {
-                let state = state::<Renderer>(tree);
-
-                state.keyboard_modifiers = *modifiers;
-            }
-            Event::Clipboard(clipboard::Event::Read(Ok(content))) => {
-                let Some(on_input) = &self.on_input else {
-                    return;
-                };
-
-                let state = state::<Renderer>(tree);
-
-                let Some(focus) = &mut state.is_focused else {
-                    return;
-                };
-
-                if let clipboard::Content::Text(text) = content.as_ref()
-                    && let Some(Paste::Reading) = state.is_pasting
-                {
-                    state.is_pasting = Some(Paste::Pasting(Value::new(text)));
-
-                    let mut editor = Editor::new(&mut self.value, &mut state.cursor);
-                    editor.paste(Value::new(text));
-
-                    let message = if let Some(paste) = &self.on_paste {
-                        (paste)(editor.contents())
-                    } else {
-                        (on_input)(editor.contents())
-                    };
-                    shell.publish(message);
-                    shell.capture_event();
-
-                    focus.updated_at = Instant::now();
-                    update_cache(state, &self.value);
-                    return;
-                }
-            }
-            Event::InputMethod(event) => match event {
-                input_method::Event::Opened | input_method::Event::Closed => {
-                    let state = state::<Renderer>(tree);
-
-                    state.preedit = matches!(event, input_method::Event::Opened)
-                        .then(input_method::Preedit::new);
-
-                    shell.request_redraw();
-                }
-                input_method::Event::Preedit(content, selection) => {
-                    let state = state::<Renderer>(tree);
-
-                    if state.is_focused.is_some() {
-                        state.preedit = Some(input_method::Preedit {
-                            content: content.to_owned(),
-                            selection: selection.clone(),
-                            text_size: self.size,
-                        });
-
-                        shell.request_redraw();
-                    }
-                }
-                input_method::Event::Commit(text) => {
-                    let state = state::<Renderer>(tree);
-
-                    if let Some(focus) = &mut state.is_focused {
-                        let Some(on_input) = &self.on_input else {
-                            return;
-                        };
-
-                        let mut editor = Editor::new(&mut self.value, &mut state.cursor);
-                        editor.paste(Value::new(text));
-
-                        focus.updated_at = Instant::now();
-                        state.is_pasting = None;
-
-                        let message = (on_input)(editor.contents());
-                        shell.publish(message);
-                        shell.capture_event();
-
-                        update_cache(state, &self.value);
-                    }
-                }
-            },
-            Event::Window(window::Event::Unfocused) => {
-                let state = state::<Renderer>(tree);
-
-                if let Some(focus) = &mut state.is_focused {
-                    focus.is_window_focused = false;
-                }
-            }
-            Event::Window(window::Event::Focused) => {
-                let state = state::<Renderer>(tree);
-
-                if let Some(focus) = &mut state.is_focused {
-                    focus.is_window_focused = true;
-                    focus.updated_at = Instant::now();
-
-                    shell.request_redraw();
-                }
-            }
-            Event::Window(window::Event::RedrawRequested(now)) => {
-                let state = state::<Renderer>(tree);
-
-                if let Some(focus) = &mut state.is_focused
-                    && focus.is_window_focused
-                {
-                    if matches!(state.cursor.state(&self.value), cursor::State::Index(_)) {
-                        focus.now = *now;
-
-                        let millis_until_redraw = CURSOR_BLINK_INTERVAL_MILLIS
-                            - (*now - focus.updated_at).as_millis() % CURSOR_BLINK_INTERVAL_MILLIS;
-
-                        shell.request_redraw_at(
-                            *now + Duration::from_millis(millis_until_redraw as u64),
-                        );
-                    }
-
-                    shell.request_input_method(&self.input_method(state, layout, &self.value));
-                }
-            }
-            _ => {}
-        }
-
-        let state = state::<Renderer>(tree);
-        let is_disabled = self.on_input.is_none();
-
-        let status = if is_disabled {
-            Status::Disabled
-        } else if state.is_focused() {
-            Status::Focused {
-                is_hovered: cursor.is_over(layout.bounds()),
-            }
-        } else if cursor.is_over(layout.bounds()) {
-            Status::Hovered
-        } else {
-            Status::Active
-        };
-
-        if let Event::Window(window::Event::RedrawRequested(_now)) = event {
-            self.last_status = Some(status);
-        } else if self
-            .last_status
-            .is_some_and(|last_status| status != last_status)
-        {
-            shell.request_redraw();
-        }
+        self.update(tree, event, layout, cursor, renderer, shell, None, viewport);
     }
 
     fn draw(


### PR DESCRIPTION
Right now, `TextInput`'s [update function](https://github.com/iced-rs/iced/blob/0d12e964da8c3f0f7a02d3d731e3187eecfe5779/widget/src/text_input.rs#L644) does not follow the same pattern as it's `layout` or `draw` function, taking a `value: Option<&Value>` as parameter.

I am trying to implement a thin wrapper over `TextInput` in order to store it's value inside a state, and not exposing it to the user of the widget.

With this PR, I hope to bring the `update` function to same pattern as the `layout` or `draw` function.

I am ready for all the feedback and to make all the changes necessary