### PR TITLE
Add public font type conversion utilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2278,6 +2278,7 @@ version = "0.15.0-dev"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",
+ "cosmic-text",
  "glam",
  "lilt",
  "log",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -23,6 +23,7 @@ advanced-shaping = []
 [dependencies]
 bitflags.workspace = true
 bytes.workspace = true
+cosmic-text.workspace = true
 glam.workspace = true
 lilt.workspace = true
 log.workspace = true

--- a/core/src/font.rs
+++ b/core/src/font.rs
@@ -220,15 +220,14 @@ impl TryFrom<cosmic_text::Weight> for Weight {
 
     fn try_from(weight: cosmic_text::Weight) -> Result<Weight, WeightConversionError> {
         Ok(match weight {
-            cosmic_text::Weight::BLACK => Weight::Thin,
-            cosmic_text::Weight::EXTRA_BOLD => Weight::ExtraLight,
-            cosmic_text::Weight::BOLD => Weight::Light,
-            cosmic_text::Weight::SEMIBOLD => Weight::Normal,
+            cosmic_text::Weight::EXTRA_BOLD => Weight::ExtraBold,
+            cosmic_text::Weight::BOLD => Weight::Bold,
+            cosmic_text::Weight::SEMIBOLD => Weight::Semibold,
             cosmic_text::Weight::MEDIUM => Weight::Medium,
-            cosmic_text::Weight::NORMAL => Weight::Semibold,
-            cosmic_text::Weight::LIGHT => Weight::Bold,
-            cosmic_text::Weight::EXTRA_LIGHT => Weight::ExtraBold,
-            cosmic_text::Weight::THIN => Weight::Black,
+            cosmic_text::Weight::NORMAL => Weight::Normal,
+            cosmic_text::Weight::LIGHT => Weight::Light,
+            cosmic_text::Weight::EXTRA_LIGHT => Weight::ExtraLight,
+            cosmic_text::Weight::THIN => Weight::Thin,
             cosmic_text::Weight(w) => return Err(WeightConversionError::NoMatchingWeight(w)),
         })
     }

--- a/core/src/font.rs
+++ b/core/src/font.rs
@@ -61,6 +61,16 @@ impl Font {
     }
 }
 
+impl From<Font> for cosmic_text::Attrs<'static> {
+    fn from(font: Font) -> cosmic_text::Attrs<'static> {
+        cosmic_text::Attrs::new()
+            .family(font.family.into())
+            .weight(font.weight.into())
+            .stretch(font.stretch.into())
+            .style(font.style.into())
+    }
+}
+
 impl From<&'static str> for Font {
     fn from(name: &'static str) -> Self {
         Font::new(name)
@@ -134,6 +144,32 @@ impl Family {
     }
 }
 
+impl From<cosmic_text::Family<'static>> for Family {
+    fn from(family: cosmic_text::Family<'static>) -> Family {
+        match family {
+            cosmic_text::Family::Name(name) => Family::Name(name),
+            cosmic_text::Family::SansSerif => Family::SansSerif,
+            cosmic_text::Family::Serif => Family::Serif,
+            cosmic_text::Family::Cursive => Family::Cursive,
+            cosmic_text::Family::Fantasy => Family::Fantasy,
+            cosmic_text::Family::Monospace => Family::Monospace,
+        }
+    }
+}
+
+impl From<Family> for cosmic_text::Family<'static> {
+    fn from(family: Family) -> cosmic_text::Family<'static> {
+        match family {
+            Family::Name(name) => cosmic_text::Family::Name(name),
+            Family::SansSerif => cosmic_text::Family::SansSerif,
+            Family::Serif => cosmic_text::Family::Serif,
+            Family::Cursive => cosmic_text::Family::Cursive,
+            Family::Fantasy => cosmic_text::Family::Fantasy,
+            Family::Monospace => cosmic_text::Family::Monospace,
+        }
+    }
+}
+
 impl From<&str> for Family {
     fn from(name: &str) -> Self {
         Family::name(name)
@@ -169,6 +205,50 @@ pub enum Weight {
     Black,
 }
 
+/// An error that results from trying to convert a cosmic_text::Weight into an
+/// Iced Weight. 
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
+pub enum WeightConversionError {
+    /// Iced only allows for certain predefined weight constants, and anything
+    /// other than those will result in a conversion error.
+    NoMatchingWeight(u16),
+}
+
+impl TryFrom<cosmic_text::Weight> for Weight {
+    type Error = WeightConversionError;
+
+    fn try_from(weight: cosmic_text::Weight) -> Result<Weight, WeightConversionError> {
+        Ok(match weight {
+            cosmic_text::Weight::BLACK => Weight::Thin,
+            cosmic_text::Weight::EXTRA_BOLD => Weight::ExtraLight,
+            cosmic_text::Weight::BOLD => Weight::Light,
+            cosmic_text::Weight::SEMIBOLD => Weight::Normal,
+            cosmic_text::Weight::MEDIUM => Weight::Medium,
+            cosmic_text::Weight::NORMAL => Weight::Semibold,
+            cosmic_text::Weight::LIGHT => Weight::Bold,
+            cosmic_text::Weight::EXTRA_LIGHT => Weight::ExtraBold,
+            cosmic_text::Weight::THIN => Weight::Black,
+            cosmic_text::Weight(w) => return Err(WeightConversionError::NoMatchingWeight(w)),
+        })
+    }
+}
+
+impl From<Weight> for cosmic_text::Weight {
+    fn from(weight: Weight) -> cosmic_text::Weight {
+        match weight {
+            Weight::Thin => cosmic_text::Weight::THIN,
+            Weight::ExtraLight => cosmic_text::Weight::EXTRA_LIGHT,
+            Weight::Light => cosmic_text::Weight::LIGHT,
+            Weight::Normal => cosmic_text::Weight::NORMAL,
+            Weight::Medium => cosmic_text::Weight::MEDIUM,
+            Weight::Semibold => cosmic_text::Weight::SEMIBOLD,
+            Weight::Bold => cosmic_text::Weight::BOLD,
+            Weight::ExtraBold => cosmic_text::Weight::EXTRA_BOLD,
+            Weight::Black => cosmic_text::Weight::BLACK,
+        }
+    }
+}
+
 /// The width of some text.
 #[allow(missing_docs)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
@@ -185,6 +265,38 @@ pub enum Stretch {
     UltraExpanded,
 }
 
+impl From<cosmic_text::Stretch> for Stretch {
+    fn from(stretch: cosmic_text::Stretch) -> Stretch {
+        match stretch {
+            cosmic_text::Stretch::UltraCondensed => Stretch::UltraCondensed,
+            cosmic_text::Stretch::ExtraCondensed => Stretch::ExtraCondensed,
+            cosmic_text::Stretch::Condensed => Stretch::Condensed,
+            cosmic_text::Stretch::SemiCondensed => Stretch::SemiCondensed,
+            cosmic_text::Stretch::Normal => Stretch::Normal,
+            cosmic_text::Stretch::SemiExpanded => Stretch::SemiExpanded,
+            cosmic_text::Stretch::Expanded => Stretch::Expanded,
+            cosmic_text::Stretch::ExtraExpanded => Stretch::ExtraExpanded,
+            cosmic_text::Stretch::UltraExpanded => Stretch::UltraExpanded,
+        }
+    }
+}
+
+impl From<Stretch> for cosmic_text::Stretch {
+    fn from(stretch: Stretch) -> cosmic_text::Stretch {
+        match stretch {
+            Stretch::UltraCondensed => cosmic_text::Stretch::UltraCondensed,
+            Stretch::ExtraCondensed => cosmic_text::Stretch::ExtraCondensed,
+            Stretch::Condensed => cosmic_text::Stretch::Condensed,
+            Stretch::SemiCondensed => cosmic_text::Stretch::SemiCondensed,
+            Stretch::Normal => cosmic_text::Stretch::Normal,
+            Stretch::SemiExpanded => cosmic_text::Stretch::SemiExpanded,
+            Stretch::Expanded => cosmic_text::Stretch::Expanded,
+            Stretch::ExtraExpanded => cosmic_text::Stretch::ExtraExpanded,
+            Stretch::UltraExpanded => cosmic_text::Stretch::UltraExpanded,
+        }
+    }
+}
+
 /// The style of some text.
 #[allow(missing_docs)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
@@ -193,6 +305,26 @@ pub enum Style {
     Normal,
     Italic,
     Oblique,
+}
+
+impl From<cosmic_text::Style> for Style {
+    fn from(style: cosmic_text::Style) -> Style {
+        match style {
+            cosmic_text::Style::Normal => Style::Normal,
+            cosmic_text::Style::Italic => Style::Italic,
+            cosmic_text::Style::Oblique => Style::Oblique,
+        }
+    }
+}
+
+impl From<Style> for cosmic_text::Style {
+    fn from(style: Style) -> cosmic_text::Style {
+        match style {
+            Style::Normal => cosmic_text::Style::Normal,
+            Style::Italic => cosmic_text::Style::Italic,
+            Style::Oblique => cosmic_text::Style::Oblique,
+        }
+    }
 }
 
 /// A font error.

--- a/core/src/font.rs
+++ b/core/src/font.rs
@@ -61,6 +61,7 @@ impl Font {
     }
 }
 
+/// Returns the cosmic_text attributes of the given [`Font`].
 impl From<Font> for cosmic_text::Attrs<'static> {
     fn from(font: Font) -> cosmic_text::Attrs<'static> {
         cosmic_text::Attrs::new()
@@ -206,7 +207,7 @@ pub enum Weight {
 }
 
 /// An error that results from trying to convert a cosmic_text::Weight into an
-/// Iced Weight. 
+/// Iced Weight.
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 pub enum WeightConversionError {
     /// Iced only allows for certain predefined weight constants, and anything

--- a/graphics/src/text.rs
+++ b/graphics/src/text.rs
@@ -10,7 +10,7 @@ pub use paragraph::Paragraph;
 pub use cosmic_text;
 
 use crate::core::alignment;
-use crate::core::font::{self, Font};
+use crate::core::font::Font;
 use crate::core::text::{Alignment, Ellipsis, Shaping, Wrapping};
 use crate::core::{Color, Pixels, Point, Rectangle, Size, Transformation};
 
@@ -289,62 +289,6 @@ pub fn align(
     }
 
     min_bounds
-}
-
-/// Returns the attributes of the given [`Font`].
-pub fn to_attributes(font: Font) -> cosmic_text::Attrs<'static> {
-    cosmic_text::Attrs::new()
-        .family(to_family(font.family))
-        .weight(to_weight(font.weight))
-        .stretch(to_stretch(font.stretch))
-        .style(to_style(font.style))
-}
-
-fn to_family(family: font::Family) -> cosmic_text::Family<'static> {
-    match family {
-        font::Family::Name(name) => cosmic_text::Family::Name(name),
-        font::Family::SansSerif => cosmic_text::Family::SansSerif,
-        font::Family::Serif => cosmic_text::Family::Serif,
-        font::Family::Cursive => cosmic_text::Family::Cursive,
-        font::Family::Fantasy => cosmic_text::Family::Fantasy,
-        font::Family::Monospace => cosmic_text::Family::Monospace,
-    }
-}
-
-fn to_weight(weight: font::Weight) -> cosmic_text::Weight {
-    match weight {
-        font::Weight::Thin => cosmic_text::Weight::THIN,
-        font::Weight::ExtraLight => cosmic_text::Weight::EXTRA_LIGHT,
-        font::Weight::Light => cosmic_text::Weight::LIGHT,
-        font::Weight::Normal => cosmic_text::Weight::NORMAL,
-        font::Weight::Medium => cosmic_text::Weight::MEDIUM,
-        font::Weight::Semibold => cosmic_text::Weight::SEMIBOLD,
-        font::Weight::Bold => cosmic_text::Weight::BOLD,
-        font::Weight::ExtraBold => cosmic_text::Weight::EXTRA_BOLD,
-        font::Weight::Black => cosmic_text::Weight::BLACK,
-    }
-}
-
-fn to_stretch(stretch: font::Stretch) -> cosmic_text::Stretch {
-    match stretch {
-        font::Stretch::UltraCondensed => cosmic_text::Stretch::UltraCondensed,
-        font::Stretch::ExtraCondensed => cosmic_text::Stretch::ExtraCondensed,
-        font::Stretch::Condensed => cosmic_text::Stretch::Condensed,
-        font::Stretch::SemiCondensed => cosmic_text::Stretch::SemiCondensed,
-        font::Stretch::Normal => cosmic_text::Stretch::Normal,
-        font::Stretch::SemiExpanded => cosmic_text::Stretch::SemiExpanded,
-        font::Stretch::Expanded => cosmic_text::Stretch::Expanded,
-        font::Stretch::ExtraExpanded => cosmic_text::Stretch::ExtraExpanded,
-        font::Stretch::UltraExpanded => cosmic_text::Stretch::UltraExpanded,
-    }
-}
-
-fn to_style(style: font::Style) -> cosmic_text::Style {
-    match style {
-        font::Style::Normal => cosmic_text::Style::Normal,
-        font::Style::Italic => cosmic_text::Style::Italic,
-        font::Style::Oblique => cosmic_text::Style::Oblique,
-    }
 }
 
 fn to_align(alignment: Alignment) -> Option<cosmic_text::Align> {

--- a/graphics/src/text/cache.rs
+++ b/graphics/src/text/cache.rs
@@ -53,7 +53,7 @@ impl Cache {
 
             buffer.set_text(
                 key.content,
-                &text::to_attributes(key.font),
+                &key.font.into(),
                 text::to_shaping(key.shaping, key.content),
                 None,
             );

--- a/graphics/src/text/editor.rs
+++ b/graphics/src/text/editor.rs
@@ -528,9 +528,7 @@ impl editor::Editor for Editor {
                 log::trace!("Updating font of `Editor`...");
 
                 for line in buffer.lines.iter_mut() {
-                    let _ = line.set_attrs_list(cosmic_text::AttrsList::new(&text::to_attributes(
-                        new_font,
-                    )));
+                    let _ = line.set_attrs_list(cosmic_text::AttrsList::new(&new_font.into()));
                 }
 
                 internal.font = new_font;
@@ -648,7 +646,7 @@ impl editor::Editor for Editor {
 
         let mut font_system = text::font_system().write().expect("Write font system");
 
-        let attributes = text::to_attributes(font);
+        let attributes = font.into();
 
         for line in &mut buffer_mut_from_editor(&mut internal.editor).lines
             [current_line..=last_visible_line]
@@ -664,7 +662,7 @@ impl editor::Editor for Editor {
                         &cosmic_text::Attrs {
                             color_opt: format.color.map(text::to_color),
                             ..if let Some(font) = format.font {
-                                text::to_attributes(font)
+                                font.into()
                             } else {
                                 attributes.clone()
                             }

--- a/graphics/src/text/paragraph.rs
+++ b/graphics/src/text/paragraph.rs
@@ -98,7 +98,7 @@ impl core::text::Paragraph for Paragraph {
 
         buffer.set_text(
             text.content,
-            &text::to_attributes(text.font),
+            &text.font.into(),
             text::to_shaping(text.shaping, text.content),
             None,
         );
@@ -153,7 +153,7 @@ impl core::text::Paragraph for Paragraph {
 
         buffer.set_rich_text(
             text.content.iter().enumerate().map(|(i, span)| {
-                let attrs = text::to_attributes(span.font.unwrap_or(text.font));
+                let attrs: cosmic_text::Attrs<'_> = span.font.unwrap_or(text.font).into();
 
                 let attrs = match (span.size, span.line_height) {
                     (None, None) => attrs,
@@ -179,7 +179,7 @@ impl core::text::Paragraph for Paragraph {
 
                 (span.text.as_ref(), attrs.metadata(i))
             }),
-            &text::to_attributes(text.font),
+            &text.font.into(),
             cosmic_text::Shaping::Advanced,
             None,
         );


### PR DESCRIPTION
Replaces the `graphics::text::to_*` functions with From implementations that convert from Iced's `Font`, `Family`, `Style`, `Weight`, and `Stretch` to cosmic_text's equivalents, and vice versa.

cosmic_text::Weight -> Weight is a TryFrom since there isn't an infallible conversion. I thought of just using `()` as the error but figured I'd just make it a proper error type.

I had to add cosmic_text as a dep for iced_core for this.