### PR TITLE
Fix handling of modifier keys on wasm

### DIFF
--- a/core/src/keyboard.rs
+++ b/core/src/keyboard.rs
@@ -8,4 +8,4 @@ mod modifiers;
 pub use event::Event;
 pub use key::Key;
 pub use location::Location;
-pub use modifiers::Modifiers;
+pub use modifiers::{Modifiers, set_runtime_macos};

--- a/core/src/keyboard/modifiers.rs
+++ b/core/src/keyboard/modifiers.rs
@@ -1,4 +1,17 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use bitflags::bitflags;
+
+static IS_MACOS: AtomicBool = AtomicBool::new(cfg!(target_os = "macos"));
+
+#[doc(hidden)]
+pub fn set_runtime_macos(value: bool) {
+    IS_MACOS.store(value, Ordering::Relaxed);
+}
+
+fn is_macos() -> bool {
+    IS_MACOS.load(Ordering::Relaxed)
+}
 
 bitflags! {
     /// The current state of the keyboard modifiers.
@@ -36,6 +49,10 @@ impl Modifiers {
     ///
     /// On macOS, this is equivalent to `Self::LOGO`.
     /// Otherwise, this is equivalent to `Self::CTRL`.
+    ///
+    /// This constant is resolved at compile time. On `wasm32` it always
+    /// evaluates to `Self::CTRL` — prefer [`Modifiers::command`] for the
+    /// runtime-aware check.
     pub const COMMAND: Self = if cfg!(target_os = "macos") {
         Self::LOGO
     } else {
@@ -77,14 +94,14 @@ impl Modifiers {
     ///
     /// - It is the `logo` or command key (⌘) on macOS
     /// - It is the `control` key on other platforms
+    ///
+    /// On `wasm32` the host is detected at runtime; see [`set_runtime_macos`].
     pub fn command(self) -> bool {
-        #[cfg(target_os = "macos")]
-        let is_pressed = self.logo();
-
-        #[cfg(not(target_os = "macos"))]
-        let is_pressed = self.control();
-
-        is_pressed
+        if is_macos() {
+            self.logo()
+        } else {
+            self.control()
+        }
     }
 
     /// Returns true if the "jump key" is pressed in the [`Modifiers`].
@@ -92,11 +109,7 @@ impl Modifiers {
     /// The "jump key" is the modifier key used to widen text motions. It is the `Alt`
     /// key in macOS and the `Ctrl` key in other platforms.
     pub fn jump(self) -> bool {
-        if cfg!(target_os = "macos") {
-            self.alt()
-        } else {
-            self.control()
-        }
+        if is_macos() { self.alt() } else { self.control() }
     }
 
     /// Returns true if the "command key" is pressed on a macOS device.
@@ -104,10 +117,6 @@ impl Modifiers {
     /// This is relevant for macOS-specific actions (e.g. `⌘ + ArrowLeft` moves the cursor
     /// to the beginning of the line).
     pub fn macos_command(self) -> bool {
-        if cfg!(target_os = "macos") {
-            self.logo()
-        } else {
-            false
-        }
+        if is_macos() { self.logo() } else { false }
     }
 }

--- a/winit/Cargo.toml
+++ b/winit/Cargo.toml
@@ -42,9 +42,9 @@ sysinfo.optional = true
 arboard.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-web-sys.workspace = true
-web-sys.features = ["Document", "Window", "HtmlCanvasElement"]
 wasm-bindgen-futures.workspace = true
+web-sys.workspace = true
+web-sys.features = ["Document", "HtmlCanvasElement", "Navigator", "Window"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
 mundy.workspace = true

--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -73,6 +73,9 @@ where
 {
     use winit::event_loop::EventLoop;
 
+    #[cfg(target_arch = "wasm32")]
+    detect_host_platform();
+
     let boot_span = debug::boot();
     let settings = program.settings();
     let window_settings = program.window();
@@ -1920,4 +1923,25 @@ fn run_clipboard<Message: Send>(
             });
         });
     }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn detect_host_platform() {
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+
+    let navigator = window.navigator();
+    let platform = navigator.platform().unwrap_or_default();
+
+    let is_macos = if platform.is_empty() {
+        navigator
+            .user_agent()
+            .unwrap_or_default()
+            .contains("Mac OS X")
+    } else {
+        platform.starts_with("Mac")
+    };
+
+    core::keyboard::set_runtime_macos(is_macos);
 }


### PR DESCRIPTION
This PR fixes the implementation of  modifier keys support on the wasm platform. On wasm, the we just assumed "not macos", but in reality, we need to perform a runtime platform check on wasm. This is what this PR implements: platform is detected at window initialization, and store in a static for the rest of the session.
