### PR TITLE
Fix culling of shadowed quads in `tiny_skia` backend

### DIFF
--- a/tiny_skia/src/engine.rs
+++ b/tiny_skia/src/engine.rs
@@ -36,7 +36,18 @@ impl Engine {
     ) {
         let physical_bounds = quad.bounds * transformation;
 
-        if !clip_bounds.intersects(&physical_bounds) {
+        // The shadow paints beyond the quad bounds
+        let visible_bounds = if quad.shadow.color.a > 0.0 {
+            physical_bounds.expand(
+                (quad.shadow.offset.x.abs().max(quad.shadow.offset.y.abs())
+                    + quad.shadow.blur_radius)
+                    * transformation.scale_factor(),
+            )
+        } else {
+            physical_bounds
+        };
+
+        if !clip_bounds.intersects(&visible_bounds) {
             return;
         }
 


### PR DESCRIPTION
Anything that updates near a shadowed quad (here, a dot blinking once a second) eats permanent bites out of the glow:

Before:
<img width="193" height="191" alt="image" src="https://github.com/user-attachments/assets/a2b08bbd-c9ff-41e3-9ba0-6d512e06fdff" />

After:
<img width="227" height="218" alt="image" src="https://github.com/user-attachments/assets/db33c2c4-eff3-496a-b7f8-2b56bba7c255" />

This change to `draw_quad` borrows/steals directly from `Layer::damage` to cull the same way it is