### PR TITLE
Clip text groups in `tiny_skia` backend

### DIFF
--- a/tiny_skia/src/layer.rs
+++ b/tiny_skia/src/layer.rs
@@ -109,8 +109,11 @@ impl Layer {
         clip_bounds: Rectangle,
         transformation: Transformation,
     ) {
-        self.text
-            .push(Item::Group(text, clip_bounds, transformation));
+        self.text.push(Item::Group(
+            text,
+            clip_bounds * transformation,
+            transformation,
+        ));
     }
 
     pub fn draw_text_cache(
@@ -119,8 +122,11 @@ impl Layer {
         clip_bounds: Rectangle,
         transformation: Transformation,
     ) {
-        self.text
-            .push(Item::Cached(text, clip_bounds, transformation));
+        self.text.push(Item::Cached(
+            text,
+            clip_bounds * transformation,
+            transformation,
+        ));
     }
 
     pub fn draw_image(&mut self, image: Image, transformation: Transformation) {

--- a/tiny_skia/src/lib.rs
+++ b/tiny_skia/src/lib.rs
@@ -166,15 +166,25 @@ impl Renderer {
                     let render_span = debug::render(debug::Primitive::Image);
 
                     for group in &layer.text {
+                        let Some(group_bounds) =
+                            (group.clip_bounds() * scale_factor).intersection(&layer_bounds)
+                        else {
+                            continue;
+                        };
+
+                        engine::adjust_clip_mask(clip_mask, group_bounds);
+
                         for text in group.as_slice() {
                             self.engine.draw_text(
                                 text,
                                 Transformation::scale(scale_factor) * group.transformation(),
                                 pixels,
                                 clip_mask,
-                                layer_bounds,
+                                group_bounds,
                             );
                         }
+
+                        engine::adjust_clip_mask(clip_mask, layer_bounds);
                     }
 
                     render_span.finish();


### PR DESCRIPTION
Before:

<img width="636" height="96" alt="image" src="https://github.com/user-attachments/assets/fee246d6-9f36-4e93-b5ce-1e400a717b4b" />

After:

<img width="682" height="104" alt="image" src="https://github.com/user-attachments/assets/b586ae33-c356-4b3f-808a-c1cabccd9020" />

This clips text in canvases similar to how 76b32d49 settled clipping for primitive groups

Repro:

```rust
use iced::mouse;
use iced::widget::canvas::{self, Geometry};
use iced::widget::{canvas as canvas_widget, container, row, space, text};
use iced::{alignment, Color, Element, Length, Point, Rectangle, Renderer, Theme};

fn main() -> iced::Result {
    std::env::set_var("ICED_BACKEND", "tiny-skia");
    iced::application(State::default, State::update, State::view).run()
}

#[derive(Default)]
struct State;

#[derive(Debug, Clone, Copy)]
enum Message {}

impl State {
    fn update(&mut self, _message: Message) {}

    fn view(&self) -> Element<Message> {
        row![
            text("this text gets painted over"),
            space::horizontal(),
            container(
                canvas_widget(self as &Self)
                    .width(Length::Fixed(160.0))
                    .height(Length::Fixed(90.0)),
            ),
        ]
        .padding(40)
        .into()
    }
}

impl canvas::Program<Message> for State {
    type State = ();

    fn draw(
        &self,
        _state: &Self::State,
        renderer: &Renderer,
        _theme: &Theme,
        bounds: Rectangle,
        _cursor: mouse::Cursor,
    ) -> Vec<Geometry> {
        let mut frame = canvas::Frame::new(renderer, bounds.size());

        frame.fill_text(canvas::Text {
            content: "OVERFLOWING CANVAS TEXT".to_string(),
            position: Point::new(-200.0, 30.0),
            color: Color::from_rgb(0.2, 0.6, 1.0),
            size: 36.0.into(),
            align_y: alignment::Vertical::Top,
            ..canvas::Text::default()
        });

        vec![frame.into_geometry()]
    }
}
```