### PR TITLE
Reject software wgpu adapters to allow renderer fallback

### DIFF
--- a/renderer/Cargo.toml
+++ b/renderer/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 [features]
 wgpu = ["iced_wgpu/default"]
 wgpu-bare = ["iced_wgpu"]
-tiny-skia = ["iced_tiny_skia"]
+tiny-skia = ["iced_tiny_skia", "iced_wgpu?/software-fallback"]
 image = ["iced_tiny_skia?/image", "iced_wgpu?/image"]
 svg = ["iced_tiny_skia?/svg", "iced_wgpu?/svg"]
 geometry = ["iced_graphics/geometry", "iced_tiny_skia?/geometry", "iced_wgpu?/geometry"]

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -25,6 +25,7 @@ svg = ["iced_graphics/svg", "resvg/text"]
 web-colors = ["iced_graphics/web-colors"]
 webgl = ["wgpu/webgl"]
 strict-assertions = []
+software-fallback = []
 
 [dependencies]
 iced_debug.workspace = true

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -65,6 +65,19 @@ use crate::graphics::mesh;
 use crate::graphics::text::{Editor, Paragraph};
 use crate::graphics::{Shell, Viewport};
 
+fn adapter_is_software(information: &wgpu::AdapterInfo) -> bool {
+    matches!(information.device_type, wgpu::DeviceType::Cpu)
+        || known_software_adapter(&information.name)
+}
+
+fn known_software_adapter(name: &str) -> bool {
+    let name = name.to_ascii_lowercase();
+
+    ["llvmpipe", "lavapipe", "softpipe", "swiftshader"]
+        .iter()
+        .any(|software| name.contains(software))
+}
+
 /// A [`wgpu`] graphics renderer for [`iced`].
 ///
 /// [`wgpu`]: https://github.com/gfx-rs/wgpu-rs
@@ -910,6 +923,10 @@ impl renderer::Headless for Renderer {
             })
             .await
             .ok()?;
+
+        if adapter_is_software(&adapter.get_info()) {
+            return None;
+        }
 
         let (device, queue) = adapter
             .request_device(&wgpu::DeviceDescriptor {

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -924,7 +924,7 @@ impl renderer::Headless for Renderer {
             .await
             .ok()?;
 
-        if adapter_is_software(&adapter.get_info()) {
+        if cfg!(feature = "software-fallback") && adapter_is_software(&adapter.get_info()) {
             return None;
         }
 

--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -47,7 +47,7 @@ impl From<Error> for backend::Error {
 }
 
 fn reject_software_adapter(information: &wgpu::AdapterInfo) -> Result<(), Error> {
-    if crate::adapter_is_software(information) {
+    if cfg!(feature = "software-fallback") && crate::adapter_is_software(information) {
         Err(Error::SoftwareAdapter(information.clone()))
     } else {
         Ok(())
@@ -460,7 +460,10 @@ pub fn present_mode_from_env() -> Option<wgpu::PresentMode> {
 
 #[cfg(test)]
 mod tests {
-    use super::{Error, reject_software_adapter};
+    use super::reject_software_adapter;
+
+    #[cfg(feature = "software-fallback")]
+    use super::Error;
 
     fn adapter_info(name: &str, device_type: wgpu::DeviceType) -> wgpu::AdapterInfo {
         wgpu::AdapterInfo {
@@ -478,6 +481,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "software-fallback")]
     #[test]
     fn llvmpipe_adapter_is_rejected_before_requesting_device() {
         let information = adapter_info("llvmpipe (LLVM 17.0.2, 256 bits)", wgpu::DeviceType::Cpu);
@@ -488,6 +492,7 @@ mod tests {
         ));
     }
 
+    #[cfg(feature = "software-fallback")]
     #[test]
     fn llvmpipe_name_is_rejected_even_if_device_type_is_unknown() {
         let information = adapter_info("llvmpipe (LLVM 17.0.2, 256 bits)", wgpu::DeviceType::Other);
@@ -498,9 +503,17 @@ mod tests {
         ));
     }
 
+    #[cfg(not(feature = "software-fallback"))]
+    #[test]
+    fn llvmpipe_adapter_is_accepted_without_software_fallback() {
+        let information = adapter_info("llvmpipe (LLVM 17.0.2, 256 bits)", wgpu::DeviceType::Cpu);
+
+        assert!(reject_software_adapter(&information).is_ok());
+    }
+
     #[test]
     fn hardware_adapter_is_accepted() {
-        let information = adapter_info("NVIDIA GeForce RTX 4090", wgpu::DeviceType::IntegratedGpu);
+        let information = adapter_info("NVIDIA GeForce RTX 4090", wgpu::DeviceType::DiscreteGpu);
 
         assert!(reject_software_adapter(&information).is_ok());
     }

--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -29,6 +29,9 @@ pub enum Error {
     /// No adapter was found for the options requested.
     #[error("no adapter was found for the options requested: {0:?}")]
     NoAdapterFound(String),
+    /// The selected adapter renders in software.
+    #[error("the selected adapter renders in software: {0:#?}")]
+    SoftwareAdapter(wgpu::AdapterInfo),
     /// No device request succeeded.
     #[error("no device request succeeded: {0:?}")]
     RequestDeviceFailed(Vec<(wgpu::Limits, wgpu::RequestDeviceError)>),
@@ -40,6 +43,14 @@ impl From<Error> for backend::Error {
             backend: "wgpu",
             reason: backend::Reason::RequestFailed(error.to_string()),
         }
+    }
+}
+
+fn reject_software_adapter(information: &wgpu::AdapterInfo) -> Result<(), Error> {
+    if crate::adapter_is_software(information) {
+        Err(Error::SoftwareAdapter(information.clone()))
+    } else {
+        Ok(())
     }
 }
 
@@ -94,7 +105,11 @@ impl Compositor {
             .await
             .map_err(|_error| Error::NoAdapterFound(format!("{adapter_options:?}")))?;
 
-        log::info!("Selected: {:#?}", adapter.get_info());
+        let adapter_info = adapter.get_info();
+
+        log::info!("Selected: {adapter_info:#?}");
+
+        reject_software_adapter(&adapter_info)?;
 
         let (format, alpha_mode) = compatible_surface
             .as_ref()
@@ -440,5 +455,53 @@ pub fn present_mode_from_env() -> Option<wgpu::PresentMode> {
         "fifo_relaxed" => Some(wgpu::PresentMode::FifoRelaxed),
         "mailbox" => Some(wgpu::PresentMode::Mailbox),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Error, reject_software_adapter};
+
+    fn adapter_info(name: &str, device_type: wgpu::DeviceType) -> wgpu::AdapterInfo {
+        wgpu::AdapterInfo {
+            name: name.to_owned(),
+            vendor: 0,
+            device: 0,
+            device_type,
+            device_pci_bus_id: String::new(),
+            driver: String::new(),
+            driver_info: String::new(),
+            backend: wgpu::Backend::Gl,
+            subgroup_min_size: 4,
+            subgroup_max_size: 128,
+            transient_saves_memory: false,
+        }
+    }
+
+    #[test]
+    fn llvmpipe_adapter_is_rejected_before_requesting_device() {
+        let information = adapter_info("llvmpipe (LLVM 17.0.2, 256 bits)", wgpu::DeviceType::Cpu);
+
+        assert!(matches!(
+            reject_software_adapter(&information),
+            Err(Error::SoftwareAdapter(adapter)) if adapter.name == information.name
+        ));
+    }
+
+    #[test]
+    fn llvmpipe_name_is_rejected_even_if_device_type_is_unknown() {
+        let information = adapter_info("llvmpipe (LLVM 17.0.2, 256 bits)", wgpu::DeviceType::Other);
+
+        assert!(matches!(
+            reject_software_adapter(&information),
+            Err(Error::SoftwareAdapter(adapter)) if adapter.name == information.name
+        ));
+    }
+
+    #[test]
+    fn hardware_adapter_is_accepted() {
+        let information = adapter_info("NVIDIA GeForce RTX 4090", wgpu::DeviceType::IntegratedGpu);
+
+        assert!(reject_software_adapter(&information).is_ok());
     }
 }


### PR DESCRIPTION
This PR prevents `iced_wgpu` from selecting software-rendered wgpu adapters, such as `llvmpipe (LLVM 17.0.2, 256 bits)` on `Red Hat 8.10`, as the primary renderer.

Previously, when `Backend::Best` was used, the fallback compositor tried `wgpu` first. If wgpu successfully created an adapter backed by `llvmpipe`, iced treated it as a valid wgpu renderer and never fell back to `tiny-skia`.

The change now:

- Detects software adapters using `wgpu::DeviceType::Cpu`
- Also checks known software adapter names like `llvmpipe`, `lavapipe`, `softpipe`, and `swiftshader`
- Rejects these adapters before requesting a device in the window compositor
- Applies the same detection to the headless wgpu renderer
- Adds tests covering `llvmpipe` rejection and normal hardware adapter acceptance