### PR TITLE
docs: fix hijacked trunk link in tour example

### DIFF
--- a/examples/tour/README.md
+++ b/examples/tour/README.md
@@ -30,4 +30,4 @@ cd examples/tour
 trunk serve
 ```
 
-[`trunk`]: https://trunkrs.dev/
+[`trunk`]: https://github.com/trunk-rs/trunk


### PR DESCRIPTION
Fixes #3375 by pointing to the official Trunk github repository rather than the hijacked domain.