### PR TITLE
Forward trackpad pinch (magnify) gestures as `mouse::Event::PinchGesture`

### DIFF
--- a/core/src/mouse/event.rs
+++ b/core/src/mouse/event.rs
@@ -33,6 +33,16 @@ pub enum Event {
         /// The scroll movement.
         delta: ScrollDelta,
     },
+
+    /// A pinch ("magnify") gesture was performed on a trackpad.
+    ///
+    /// `delta` is the incremental change in magnification since the previous
+    /// event: a positive value means the user is zooming in (fingers moving
+    /// apart), a negative value zooming out. Useful for pinch-to-zoom.
+    PinchGesture {
+        /// The incremental magnification change.
+        delta: f32,
+    },
 }
 
 /// A scroll movement.

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -199,6 +199,11 @@ pub fn window_event(
                 }))
             }
         },
+        WindowEvent::PinchGesture { delta, .. } => {
+            Some(Event::Mouse(mouse::Event::PinchGesture {
+                delta: delta as f32,
+            }))
+        }
         // Ignore keyboard presses/releases during window focus/unfocus
         WindowEvent::KeyboardInput { is_synthetic, .. } if is_synthetic => None,
         WindowEvent::KeyboardInput { event, .. } => Some(Event::Keyboard({


### PR DESCRIPTION
## What

`winit` emits `WindowEvent::PinchGesture` for trackpad magnify (pinch) gestures, but the `iced_winit` event conversion dropped it, so applications had no way to implement pinch-to-zoom.

This adds a `mouse::Event::PinchGesture { delta }` variant and forwards the gesture from the winit backend. `delta` is the incremental magnification change since the previous event (positive = zooming in / fingers moving apart).

The `mouse::Event` doc-comment already invites such additions ("This type is largely incomplete! If you need to track additional events, feel free to open an issue and share your use case!").

## Changes
- `core`: add `mouse::Event::PinchGesture { delta: f32 }`.
- `winit`: convert `WindowEvent::PinchGesture` -> the new event.

The change is additive (one enum variant + one conversion arm); the full workspace (all crates + examples) compiles.
