### PR TITLE
fix(image): prevent panic on 0x0 images by asserting size early

### DIFF
--- a/core/src/image.rs
+++ b/core/src/image.rs
@@ -132,6 +132,11 @@ impl Handle {
     ///
     /// This is useful if you have already decoded your image.
     pub fn from_rgba(width: u32, height: u32, pixels: impl Into<Bytes>) -> Handle {
+        assert!(
+            width > 0 && height > 0,
+            "Image width and height must be greater than 0"
+        );
+
         Self::Rgba {
             id: Id::unique(),
             width,

--- a/examples/tour/README.md
+++ b/examples/tour/README.md
@@ -30,4 +30,4 @@ cd examples/tour
 trunk serve
 ```
 
-[`trunk`]: https://trunkrs.dev/
+[`trunk`]: https://github.com/trunk-rs/trunk


### PR DESCRIPTION
Fixes #3342. This adds an assertion to \Handle::from_rgba\ so that it panics immediately with a clear message instead of crashing later in the WGPU pipeline.