### PR TITLE
modify `Shell::merge` to take `FnMut(B) -> Option<Message>`

### DIFF
--- a/core/src/element.rs
+++ b/core/src/element.rs
@@ -334,7 +334,7 @@ where
             viewport,
         );
 
-        shell.merge(local_shell, &self.mapper);
+        shell.merge(local_shell, |m| Some((self.mapper)(m)));
     }
 
     fn draw(

--- a/core/src/overlay/element.rs
+++ b/core/src/overlay/element.rs
@@ -90,7 +90,7 @@ where
         self.content
             .update(event, layout, cursor, renderer, &mut local_shell);
 
-        shell.merge(local_shell, self.mapper);
+        shell.merge(local_shell, |m| Some((self.mapper)(m)));
     }
 
     fn mouse_interaction(

--- a/core/src/shell.rs
+++ b/core/src/shell.rs
@@ -211,13 +211,13 @@ impl<'a, Message> Shell<'a, Message> {
     /// function to the messages of the latter.
     ///
     /// This method is useful for composition.
-    pub fn merge<B>(&mut self, mut other: Shell<'_, B>, f: impl Fn(B) -> Message) {
+    pub fn merge<B>(&mut self, mut other: Shell<'_, B>, f: impl Fn(B) -> Option<Message>) {
         self.bus.messages.extend(
             other
                 .bus
                 .messages
                 .drain(..)
-                .map(|(message, receipt)| (f(message), receipt)),
+                .filter_map(|(message, receipt)| Some((f(message)?, receipt))),
         );
 
         self.is_layout_invalid = match (self.is_layout_invalid, other.is_layout_invalid) {

--- a/examples/toast/src/main.rs
+++ b/examples/toast/src/main.rs
@@ -524,7 +524,7 @@ mod toast {
                     instant.take();
                 }
 
-                shell.merge(local_shell, std::convert::identity);
+                shell.merge(local_shell, Some);
             }
         }
 


### PR DESCRIPTION
I just encountered a use-case where not every message in the local shell should result in a message in the global shell, but rather should result in some action taken by the widget that owns the local shell. This makes that use-case possible without needing to manually update all of `Shell`'s fields like the new `Component` does.