### PR TITLE
Add opacity implementation, basic widget, and example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3883,6 +3883,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "opacity"
+version = "0.1.0"
+dependencies = [
+ "iced",
+]
+
+[[package]]
 name = "open"
 version = "5.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/core/src/renderer.rs
+++ b/core/src/renderer.rs
@@ -50,6 +50,30 @@ pub trait Renderer {
         self.with_transformation(Transformation::translate(translation.x, translation.y), f);
     }
 
+    /// Starts recording a new opacity group.
+    ///
+    /// All primitives drawn until [`end_opacity`](Self::end_opacity) is called
+    /// will be rendered to an offscreen texture and then composited with the
+    /// given opacity value.
+    ///
+    /// Opacity values should be in the range `0.0` (fully transparent) to `1.0` (fully opaque).
+    fn start_opacity(&mut self, _bounds: Rectangle, _opacity: f32) {}
+
+    /// Ends recording the current opacity group.
+    ///
+    /// The contents will be composited with the opacity specified in [`start_opacity`](Self::start_opacity).
+    fn end_opacity(&mut self) {}
+
+    /// Draws the primitives recorded in the given closure with the specified opacity.
+    ///
+    /// The primitives will be rendered to an offscreen texture and then composited
+    /// with the given opacity value.
+    fn with_opacity(&mut self, bounds: Rectangle, opacity: f32, f: impl FnOnce(&mut Self)) {
+        self.start_opacity(bounds, opacity);
+        f(self);
+        self.end_opacity();
+    }
+
     /// Fills a [`Quad`] with the provided [`Background`].
     fn fill_quad(&mut self, quad: Quad, background: impl Into<Background>);
 

--- a/core/src/renderer.rs
+++ b/core/src/renderer.rs
@@ -50,11 +50,13 @@ pub trait Renderer {
         self.with_transformation(Transformation::translate(translation.x, translation.y), f);
     }
 
-    /// Starts recording a new opacity group.
+    /// Starts recording a new opacity group inside the given `bounds`.
     ///
     /// All primitives drawn until [`end_opacity`](Self::end_opacity) is called
-    /// will be rendered to an offscreen texture and then composited with the
-    /// given opacity value.
+    /// are rendered to an isolated, offscreen buffer and then composited as a
+    /// whole with the given opacity value. Because the group is flattened before
+    /// the opacity is applied, overlapping primitives fade together instead of
+    /// blending through each other, and nested groups multiply.
     ///
     /// Opacity values should be in the range `0.0` (fully transparent) to `1.0` (fully opaque).
     fn start_opacity(&mut self, _bounds: Rectangle, _opacity: f32) {}
@@ -64,10 +66,11 @@ pub trait Renderer {
     /// The contents will be composited with the opacity specified in [`start_opacity`](Self::start_opacity).
     fn end_opacity(&mut self) {}
 
-    /// Draws the primitives recorded in the given closure with the specified opacity.
+    /// Draws the primitives recorded in the given closure as a single group with
+    /// the specified opacity.
     ///
-    /// The primitives will be rendered to an offscreen texture and then composited
-    /// with the given opacity value.
+    /// The primitives are rendered to an isolated, offscreen buffer and then
+    /// composited as a whole with the given opacity value.
     fn with_opacity(&mut self, bounds: Rectangle, opacity: f32, f: impl FnOnce(&mut Self)) {
         self.start_opacity(bounds, opacity);
         f(self);

--- a/core/src/renderer.rs
+++ b/core/src/renderer.rs
@@ -50,31 +50,37 @@ pub trait Renderer {
         self.with_transformation(Transformation::translate(translation.x, translation.y), f);
     }
 
-    /// Starts recording a new opacity group inside the given `bounds`.
+    /// Starts recording a new group of layers inside the given `bounds`.
     ///
-    /// All primitives drawn until [`end_opacity`](Self::end_opacity) is called
-    /// are rendered to an isolated, offscreen buffer and then composited as a
-    /// whole with the given opacity value. Because the group is flattened before
-    /// the opacity is applied, overlapping primitives fade together instead of
-    /// blending through each other, and nested groups multiply.
-    ///
-    /// Opacity values should be in the range `0.0` (fully transparent) to `1.0` (fully opaque).
-    fn start_opacity(&mut self, _bounds: Rectangle, _opacity: f32) {}
+    /// All primitives drawn until [`end_group`](Self::end_group) is called are
+    /// rendered to an isolated, offscreen buffer and then composited back as a
+    /// whole with the given [`GroupEffect`]. Because the group is flattened
+    /// before the effect is applied, overlapping primitives are affected together
+    /// instead of independently, and nested groups compose.
+    fn start_group(&mut self, _bounds: Rectangle, _effect: GroupEffect) {}
 
-    /// Ends recording the current opacity group.
+    /// Ends recording the current group.
     ///
-    /// The contents will be composited with the opacity specified in [`start_opacity`](Self::start_opacity).
-    fn end_opacity(&mut self) {}
+    /// The contents will be composited with the [`GroupEffect`] specified in
+    /// [`start_group`](Self::start_group).
+    fn end_group(&mut self) {}
+
+    /// Draws the primitives recorded in the given closure as a single group,
+    /// compositing them back with the given [`GroupEffect`].
+    fn with_group(&mut self, bounds: Rectangle, effect: GroupEffect, f: impl FnOnce(&mut Self)) {
+        self.start_group(bounds, effect);
+        f(self);
+        self.end_group();
+    }
 
     /// Draws the primitives recorded in the given closure as a single group with
     /// the specified opacity.
     ///
-    /// The primitives are rendered to an isolated, offscreen buffer and then
-    /// composited as a whole with the given opacity value.
+    /// This is a convenience for [`with_group`](Self::with_group) with a
+    /// [`GroupEffect::Opacity`]. The primitives are rendered to an isolated,
+    /// offscreen buffer and then composited as a whole with the given opacity.
     fn with_opacity(&mut self, bounds: Rectangle, opacity: f32, f: impl FnOnce(&mut Self)) {
-        self.start_opacity(bounds, opacity);
-        f(self);
-        self.end_opacity();
+        self.with_group(bounds, GroupEffect::Opacity(opacity), f);
     }
 
     /// Fills a [`Quad`] with the provided [`Background`].
@@ -120,6 +126,41 @@ pub trait Renderer {
     ///
     /// By default, it does nothing.
     fn tick(&mut self) {}
+}
+
+/// The effect applied when compositing a group of layers back onto its target.
+///
+/// A group (see [`Renderer::start_group`]) isolates its layers into an offscreen
+/// buffer; the effect describes how that buffer is blended back. This makes
+/// effects composable and lets new ones — like blur or color filters — reuse the
+/// same isolation machinery.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum GroupEffect {
+    /// Blends the group with the given opacity, from `0.0` (fully transparent)
+    /// to `1.0` (fully opaque).
+    Opacity(f32),
+}
+
+impl GroupEffect {
+    /// Returns whether the effect has no visible impact, so the group can be
+    /// drawn inline without an isolated target.
+    pub fn is_noop(self) -> bool {
+        match self {
+            GroupEffect::Opacity(opacity) => opacity >= 1.0,
+        }
+    }
+
+    /// Returns whether adjacent, non-overlapping groups with an equal effect can
+    /// be merged and composited together.
+    ///
+    /// Effects whose result depends only on each pixel independently (like
+    /// opacity) can batch; effects that read neighbouring pixels (like blur)
+    /// cannot.
+    pub fn is_batchable(self) -> bool {
+        match self {
+            GroupEffect::Opacity(_) => true,
+        }
+    }
 }
 
 /// A polygon with four sides.

--- a/core/src/window/settings/windows.rs
+++ b/core/src/window/settings/windows.rs
@@ -27,7 +27,7 @@ impl Default for PlatformSpecific {
             drag_and_drop: true,
             skip_taskbar: false,
             undecorated_shadow: false,
-            corner_preference: Default::default(),
+            corner_preference: CornerPreference::default(),
         }
     }
 }

--- a/examples/opacity/Cargo.toml
+++ b/examples/opacity/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "opacity"
+version = "0.1.0"
+authors = ["Iced contributors"]
+edition = "2024"
+publish = false
+
+[dependencies]
+iced.workspace = true
+iced.features = ["svg", "advanced", "tokio", "image"]

--- a/examples/opacity/README.md
+++ b/examples/opacity/README.md
@@ -1,0 +1,22 @@
+# Opacity
+
+An example demonstrating the opacity rendering feature.
+
+This example shows:
+- Static opacity applied to widgets
+- Fade-in animation
+- Fade-out animation
+- Nested opacity (opacity stacking)
+
+The opacity feature allows you to render any widget with transparency,
+and properly composes with nested opacity calls.
+
+<div align="center">
+  <img src="https://iced.rs/examples/opacity.gif">
+</div>
+
+You can run it with `cargo run`:
+
+```bash
+cargo run --package opacity
+```

--- a/examples/opacity/src/main.rs
+++ b/examples/opacity/src/main.rs
@@ -1,0 +1,301 @@
+//! An example demonstrating opacity and fade animations.
+//!
+//! This example shows how to use the built-in `opacity` widget
+//! to apply transparency to widgets, including animated fade effects.
+
+use iced::time::{self, milliseconds};
+use iced::widget::{button, center, column, container, image, opacity, row, slider, text};
+use iced::{Border, Center, Color, Element, Subscription, Theme};
+
+use std::time::Instant;
+
+pub fn main() -> iced::Result {
+    iced::application(App::new, App::update, App::view)
+        .subscription(App::subscription)
+        .theme(App::theme)
+        .run()
+}
+
+struct App {
+    /// Static opacity value (0.0 to 1.0)
+    static_opacity: f32,
+    /// Whether fade animation is running
+    animation_state: AnimationState,
+    /// Current animated opacity
+    animated_opacity: f32,
+    /// Animation duration in milliseconds
+    animation_duration_ms: u64,
+}
+
+#[derive(Default, Clone, Copy, PartialEq)]
+enum AnimationState {
+    #[default]
+    Idle,
+    FadingIn {
+        start: Instant,
+    },
+    FadingOut {
+        start: Instant,
+    },
+}
+
+#[derive(Debug, Clone)]
+enum Message {
+    StaticOpacityChanged(f32),
+    FadeIn,
+    FadeOut,
+    AnimationTick,
+    DurationChanged(f32),
+    Reset,
+}
+
+impl App {
+    fn new() -> Self {
+        Self {
+            static_opacity: 1.0,
+            animation_state: AnimationState::Idle,
+            animated_opacity: 1.0,
+            animation_duration_ms: 500,
+        }
+    }
+
+    fn update(&mut self, message: Message) {
+        match message {
+            Message::StaticOpacityChanged(value) => {
+                self.static_opacity = value;
+            }
+            Message::FadeIn => {
+                self.animation_state = AnimationState::FadingIn {
+                    start: Instant::now(),
+                };
+                self.animated_opacity = 0.0;
+            }
+            Message::FadeOut => {
+                self.animation_state = AnimationState::FadingOut {
+                    start: Instant::now(),
+                };
+                self.animated_opacity = 1.0;
+            }
+            Message::AnimationTick => {
+                let duration_secs = self.animation_duration_ms as f32 / 1000.0;
+
+                match self.animation_state {
+                    AnimationState::FadingIn { start } => {
+                        let elapsed = start.elapsed().as_secs_f32();
+                        let progress = (elapsed / duration_secs).min(1.0);
+                        // Ease-out cubic
+                        self.animated_opacity = 1.0 - (1.0 - progress).powi(3);
+
+                        if progress >= 1.0 {
+                            self.animation_state = AnimationState::Idle;
+                            self.animated_opacity = 1.0;
+                        }
+                    }
+                    AnimationState::FadingOut { start } => {
+                        let elapsed = start.elapsed().as_secs_f32();
+                        let progress = (elapsed / duration_secs).min(1.0);
+                        // Ease-in cubic
+                        self.animated_opacity = 1.0 - progress.powi(3);
+
+                        if progress >= 1.0 {
+                            self.animation_state = AnimationState::Idle;
+                            self.animated_opacity = 0.0;
+                        }
+                    }
+                    AnimationState::Idle => {}
+                }
+            }
+            Message::DurationChanged(ms) => {
+                self.animation_duration_ms = ms as u64;
+            }
+            Message::Reset => {
+                self.animated_opacity = 1.0;
+                self.animation_state = AnimationState::Idle;
+            }
+        }
+    }
+
+    fn subscription(&self) -> Subscription<Message> {
+        match self.animation_state {
+            AnimationState::Idle => Subscription::none(),
+            _ => time::every(milliseconds(16)).map(|_| Message::AnimationTick),
+        }
+    }
+
+    fn view(&self) -> Element<'_, Message> {
+        let title = text("Opacity Demo").size(32);
+
+        // Static opacity section
+        let static_section = {
+            let label = text(format!(
+                "Static Opacity: {:>3.0}%",
+                self.static_opacity * 100.0
+            ))
+            .width(180);
+            let opacity_slider = slider(
+                0.0..=1.0,
+                self.static_opacity,
+                Message::StaticOpacityChanged,
+            )
+            .step(0.01)
+            .width(200);
+
+            let demo_box = opacity(
+                self.static_opacity,
+                demo_card("Static Opacity", Color::from_rgb(0.2, 0.6, 0.9)),
+            );
+
+            column![
+                text("Static Opacity").size(24),
+                row![label, opacity_slider].spacing(20).align_y(Center),
+                demo_box,
+            ]
+            .spacing(15)
+        };
+
+        // Animation section
+        let animation_section = {
+            let duration_label =
+                text(format!("Duration: {:>4}ms", self.animation_duration_ms)).width(150);
+            let duration_slider = slider(100.0..=2000.0, self.animation_duration_ms as f32, |v| {
+                Message::DurationChanged(v)
+            })
+            .step(50.0)
+            .width(200);
+
+            let fade_in_btn = button(text("Fade In"))
+                .on_press(Message::FadeIn)
+                .padding([8, 16]);
+
+            let fade_out_btn = button(text("Fade Out"))
+                .on_press(Message::FadeOut)
+                .padding([8, 16]);
+
+            let reset_btn = button(text("Reset"))
+                .on_press(Message::Reset)
+                .style(button::secondary)
+                .padding([8, 16]);
+
+            let status = text(format!(
+                "Opacity: {:.0}% | {}",
+                self.animated_opacity * 100.0,
+                match self.animation_state {
+                    AnimationState::Idle => "Idle",
+                    AnimationState::FadingIn { .. } => "Fading In...",
+                    AnimationState::FadingOut { .. } => "Fading Out...",
+                }
+            ));
+
+            let animated_box = opacity(
+                self.animated_opacity,
+                demo_card("Animated!", Color::from_rgb(0.9, 0.4, 0.3)),
+            );
+
+            column![
+                text("Fade Animation").size(24),
+                row![duration_label, duration_slider]
+                    .spacing(20)
+                    .align_y(Center),
+                row![fade_in_btn, fade_out_btn, reset_btn].spacing(10),
+                status,
+                animated_box,
+            ]
+            .spacing(15)
+        };
+
+        // Nested opacity section
+        let nested_section = {
+            // Demonstrate nested opacity: outer 50% * inner 50% = 25% final
+            let inner = opacity(
+                0.5,
+                demo_card("Inner (50%)", Color::from_rgb(0.3, 0.8, 0.4)),
+            );
+            let outer = opacity(
+                0.5,
+                container(
+                    column![
+                        text("Outer Container (50%)").size(16),
+                        inner,
+                        text("Combined: 25%").size(12),
+                    ]
+                    .spacing(10)
+                    .align_x(Center),
+                )
+                .padding(20)
+                .style(|_| container::Style {
+                    background: Some(Color::from_rgb(0.15, 0.15, 0.2).into()),
+                    border: Border {
+                        color: Color::from_rgb(0.4, 0.4, 0.5),
+                        width: 2.0,
+                        radius: 12.0.into(),
+                    },
+                    ..Default::default()
+                }),
+            );
+
+            column![
+                text("Nested Opacity").size(24),
+                text("Nested opacity multiplies: 50% × 50% = 25%").size(14),
+                outer
+            ]
+            .spacing(15)
+        };
+
+        // Image opacity section
+        let image_section = {
+            let ferris = image(format!(
+                "{}/examples/tour/images/ferris.png",
+                env!("CARGO_MANIFEST_DIR").replace("/examples/opacity", "")
+            ))
+            .width(150);
+
+            let image_with_opacity = opacity(self.static_opacity, ferris);
+
+            column![
+                text("Image Opacity").size(24),
+                text("Images also fade with the static opacity slider above").size(14),
+                image_with_opacity,
+            ]
+            .spacing(15)
+            .align_x(Center)
+        };
+
+        let content = column![
+            title,
+            row![static_section, animation_section,].spacing(60),
+            row![nested_section, image_section].spacing(60),
+        ]
+        .padding(30)
+        .spacing(30);
+
+        center(content).into()
+    }
+
+    fn theme(&self) -> Theme {
+        Theme::Dark
+    }
+}
+
+/// A demo card widget for showing opacity effects
+fn demo_card<'a, Message: 'a>(label: &'a str, color: Color) -> Element<'a, Message> {
+    container(
+        column![
+            text(label).size(18),
+            text("This content has opacity applied").size(12),
+        ]
+        .spacing(8)
+        .align_x(Center),
+    )
+    .width(200)
+    .padding(20)
+    .style(move |_| container::Style {
+        background: Some(color.into()),
+        border: Border {
+            color: Color::WHITE,
+            width: 2.0,
+            radius: 10.0.into(),
+        },
+        ..Default::default()
+    })
+    .into()
+}

--- a/examples/opacity/src/main.rs
+++ b/examples/opacity/src/main.rs
@@ -4,8 +4,8 @@
 //! to apply transparency to widgets, including animated fade effects.
 
 use iced::time::{self, milliseconds};
-use iced::widget::{button, center, column, container, image, opacity, row, slider, text};
-use iced::{Border, Center, Color, Element, Subscription, Theme};
+use iced::widget::{button, center, column, container, image, opacity, row, slider, stack, text};
+use iced::{Border, Center, Color, Element, Length, Subscription, Theme};
 
 use std::time::Instant;
 
@@ -260,10 +260,72 @@ impl App {
             .align_x(Center)
         };
 
+        // Overlapping items section - demonstrates how items composite within an opacity layer
+        let overlapping_section = {
+            // Blue rectangle (larger, behind)
+            let blue_rect = container(text(""))
+                .width(120)
+                .height(80)
+                .style(|_| container::Style {
+                    background: Some(Color::from_rgb(0.2, 0.4, 0.9).into()),
+                    border: Border {
+                        color: Color::WHITE,
+                        width: 2.0,
+                        radius: 8.0.into(),
+                    },
+                    ..Default::default()
+                });
+
+            // Red rectangle (smaller, in front, offset via alignment)
+            let red_rect = container(text(""))
+                .width(120)
+                .height(80)
+                .style(|_| container::Style {
+                    background: Some(Color::from_rgb(0.9, 0.2, 0.2).into()),
+                    border: Border {
+                        color: Color::WHITE,
+                        width: 2.0,
+                        radius: 8.0.into(),
+                    },
+                    ..Default::default()
+                });
+
+            // Stack both - blue aligned top-left, red aligned bottom-right
+            // This creates overlap in the center
+            let overlapping = container(
+                stack![
+                    container(blue_rect)
+                        .width(Length::Fill)
+                        .height(Length::Fill)
+                        .align_x(iced::alignment::Horizontal::Left)
+                        .align_y(iced::alignment::Vertical::Top),
+                    container(red_rect)
+                        .width(Length::Fill)
+                        .height(Length::Fill)
+                        .align_x(iced::alignment::Horizontal::Right)
+                        .align_y(iced::alignment::Vertical::Bottom),
+                ]
+                .width(Length::Fill)
+                .height(Length::Fill),
+            )
+            .width(180)
+            .height(120);
+
+            let with_opacity = opacity(self.static_opacity, overlapping);
+
+            column![
+                text("Overlapping Items").size(24),
+                text("Items composite first, then opacity applies to the whole group.").size(14),
+                with_opacity,
+            ]
+            .spacing(15)
+            .align_x(Center)
+        };
+
         let content = column![
             title,
             row![static_section, animation_section,].spacing(60),
-            row![nested_section, image_section].spacing(60),
+            row![nested_section, image_section, overlapping_section].spacing(60),
         ]
         .padding(30)
         .spacing(30);

--- a/examples/opacity/src/main.rs
+++ b/examples/opacity/src/main.rs
@@ -243,9 +243,9 @@ impl App {
 
         // Image opacity section
         let image_section = {
-            let ferris = image(format!(
-                "{}/examples/tour/images/ferris.png",
-                env!("CARGO_MANIFEST_DIR").replace("/examples/opacity", "")
+            let ferris = image(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/../tour/images/ferris.png",
             ))
             .width(150);
 

--- a/graphics/src/layer.rs
+++ b/graphics/src/layer.rs
@@ -41,6 +41,50 @@ pub trait Layer: Default {
 
     /// Merges a [`Layer`] with the current one.
     fn merge(&mut self, _layer: &mut Self);
+
+    /// Sets the effective opacity of the [`Layer`] (the product of the opacity
+    /// groups it belongs to).
+    ///
+    /// Renderers that composite opacity groups can use this to include opacity
+    /// in their damage tracking, so a changing opacity triggers a redraw even
+    /// when the underlying primitives are unchanged. The default is a no-op.
+    fn set_opacity(&mut self, _opacity: f32) {}
+}
+
+/// An opacity group recorded in a [`Stack`].
+#[derive(Debug, Clone, Copy)]
+pub struct OpacityGroup {
+    /// The opacity of the group, in the range `0.0..=1.0`.
+    pub opacity: f32,
+    /// The bounds of the group, already transformed by the current
+    /// [`Transformation`] at the time the group was created.
+    pub bounds: Rectangle,
+    /// The parent group this group is nested in, if any.
+    pub parent: Option<usize>,
+}
+
+/// A plan describing when opacity groups open and close while iterating the
+/// layers of a [`Stack`] in order.
+///
+/// A renderer walks its layers together with [`OpacityPlan::steps`]; when a
+/// group opens it must redirect drawing to an isolated target, and when it
+/// closes it must composite that target at the group's opacity.
+#[derive(Debug, Default)]
+pub struct OpacityPlan {
+    /// One entry per active layer, in layer order.
+    pub steps: Vec<OpacityStep>,
+    /// Groups still open after the last layer, to be closed in this order
+    /// (innermost first).
+    pub trailing: Vec<usize>,
+}
+
+/// The opacity groups that open and close right before a given layer is drawn.
+#[derive(Debug, Default, Clone)]
+pub struct OpacityStep {
+    /// Groups to close before this layer, innermost first.
+    pub closes: Vec<usize>,
+    /// Groups to open before this layer, outermost first.
+    pub opens: Vec<usize>,
 }
 
 /// A stack of layers used for drawing.
@@ -51,6 +95,17 @@ pub struct Stack<T: Layer> {
     previous: Vec<usize>,
     current: usize,
     active_count: usize,
+    /// All opacity groups recorded this frame, indexed by group id.
+    opacity_groups: Vec<OpacityGroup>,
+    /// The innermost opacity group each layer slot belongs to, parallel to
+    /// `layers` by slot index.
+    layer_groups: Vec<Option<usize>>,
+    /// The opacity groups currently open while recording, as a stack of ids.
+    active_groups: Vec<usize>,
+    /// For each open opacity scope, whether it actually created an isolated
+    /// group (fully-opaque scopes are elided). Keeps `push_opacity` and
+    /// `pop_opacity` balanced.
+    opacity_isolated: Vec<bool>,
 }
 
 impl<T: Layer> Stack<T> {
@@ -62,6 +117,10 @@ impl<T: Layer> Stack<T> {
             previous: vec![],
             current: 0,
             active_count: 1,
+            opacity_groups: Vec::new(),
+            layer_groups: vec![None],
+            active_groups: Vec::new(),
+            opacity_isolated: Vec::new(),
         }
     }
 
@@ -88,12 +147,69 @@ impl<T: Layer> Stack<T> {
         self.current = self.active_count;
         self.active_count += 1;
 
+        let group = self.active_groups.last().copied();
+        let opacity = self.current_opacity();
         let bounds = bounds * self.transformation();
 
         if self.current == self.layers.len() {
             self.layers.push(T::with_bounds(bounds));
+            self.layer_groups.push(group);
         } else {
             self.layers[self.current].resize(bounds);
+            self.layer_groups[self.current] = group;
+        }
+
+        self.layers[self.current].set_opacity(opacity);
+    }
+
+    /// Returns the effective opacity at the current point in recording: the
+    /// product of every open opacity group's opacity.
+    fn current_opacity(&self) -> f32 {
+        self.active_groups
+            .iter()
+            .map(|id| self.opacity_groups[*id].opacity)
+            .product()
+    }
+
+    /// Pushes a new opacity group in the [`Stack`].
+    ///
+    /// A new layer is created for the group (like [`push_clip`]) and every layer
+    /// drawn until the matching [`pop_opacity`] belongs to it. The renderer is
+    /// expected to composite all of those layers into an isolated target and
+    /// blend the result with `opacity`, so that overlapping primitives fade as a
+    /// single group instead of independently.
+    ///
+    /// [`push_clip`]: Self::push_clip
+    /// [`pop_opacity`]: Self::pop_opacity
+    pub fn push_opacity(&mut self, opacity: f32, bounds: Rectangle) {
+        // A fully-opaque group has no visible effect, so we skip isolating it
+        // entirely and avoid the cost of an offscreen target.
+        if opacity >= 1.0 {
+            self.opacity_isolated.push(false);
+            return;
+        }
+
+        let parent = self.active_groups.last().copied();
+        let id = self.opacity_groups.len();
+
+        self.opacity_groups.push(OpacityGroup {
+            opacity: opacity.clamp(0.0, 1.0),
+            bounds: bounds * self.transformation(),
+            parent,
+        });
+
+        // The group must be active before `push_clip` so the freshly created
+        // layer is tagged as belonging to it.
+        self.active_groups.push(id);
+        self.push_clip(bounds);
+        self.opacity_isolated.push(true);
+    }
+
+    /// Pops the current opacity group from the [`Stack`].
+    pub fn pop_opacity(&mut self) {
+        if self.opacity_isolated.pop() == Some(true) {
+            self.pop_clip();
+            let _ = self.active_groups.pop();
         }
     }
 
@@ -168,8 +284,13 @@ impl<T: Layer> Stack<T> {
                 }
 
                 // Candidate can be merged if primitive sublayers do not overlap with
-                // previous targets and the clipping bounds match
-                if end > target_start || candidate.bounds() != target.bounds() {
+                // previous targets, the clipping bounds match, and both layers
+                // belong to the same opacity group (so isolated groups never leak
+                // primitives in or out).
+                if end > target_start
+                    || candidate.bounds() != target.bounds()
+                    || self.layer_groups[current] != self.layer_groups[target_index]
+                {
                     break;
                 }
 
@@ -211,6 +332,77 @@ impl<T: Layer> Stack<T> {
         self.current = 0;
         self.active_count = 1;
         self.previous.clear();
+
+        self.opacity_groups.clear();
+        self.active_groups.clear();
+        self.opacity_isolated.clear();
+        if let Some(first) = self.layer_groups.first_mut() {
+            *first = None;
+        }
+    }
+
+    /// Returns the opacity groups recorded in the [`Stack`], indexed by group id.
+    pub fn opacity_groups(&self) -> &[OpacityGroup] {
+        &self.opacity_groups
+    }
+
+    /// Returns whether any opacity group was recorded in the [`Stack`].
+    pub fn has_opacity(&self) -> bool {
+        !self.opacity_groups.is_empty()
+    }
+
+    /// Returns the chain of opacity groups a group belongs to, outermost first.
+    fn opacity_chain(&self, group: usize) -> Vec<usize> {
+        let mut chain = Vec::new();
+        let mut current = Some(group);
+
+        while let Some(id) = current {
+            chain.push(id);
+            current = self.opacity_groups[id].parent;
+        }
+
+        chain.reverse();
+        chain
+    }
+
+    /// Builds the [`OpacityPlan`] describing when opacity groups open and close
+    /// as the active layers are iterated in order.
+    ///
+    /// Groups occupy contiguous layer ranges, so a group opens right before its
+    /// first layer and closes once the walk leaves it.
+    pub fn opacity_plan(&self) -> OpacityPlan {
+        let mut plan = OpacityPlan::default();
+
+        if self.opacity_groups.is_empty() {
+            plan.steps
+                .resize_with(self.active_count, OpacityStep::default);
+            return plan;
+        }
+
+        let mut previous: Vec<usize> = Vec::new();
+
+        for index in 0..self.active_count {
+            let chain = match self.layer_groups[index] {
+                Some(group) => self.opacity_chain(group),
+                None => Vec::new(),
+            };
+
+            let common = previous
+                .iter()
+                .zip(chain.iter())
+                .take_while(|(a, b)| a == b)
+                .count();
+
+            plan.steps.push(OpacityStep {
+                closes: previous[common..].iter().rev().copied().collect(),
+                opens: chain[common..].to_vec(),
+            });
+
+            previous = chain;
+        }
+
+        plan.trailing = previous.iter().rev().copied().collect();
+        plan
     }
 }
 

--- a/graphics/src/layer.rs
+++ b/graphics/src/layer.rs
@@ -1,4 +1,5 @@
 //! Draw and stack layers of graphical primitives.
+use crate::core::renderer::GroupEffect;
 use crate::core::{Rectangle, Transformation};
 
 /// A layer of graphical primitives.
@@ -51,11 +52,15 @@ pub trait Layer: Default {
     fn set_opacity(&mut self, _opacity: f32) {}
 }
 
-/// An opacity group recorded in a [`Stack`].
+/// A composable group of layers recorded in a [`Stack`].
+///
+/// Its layers are isolated into an offscreen target and composited back with
+/// [`effect`](Self::effect), enabling composable effects (opacity today; blur,
+/// color filters, etc. in the future) on top of the same machinery.
 #[derive(Debug, Clone, Copy)]
-pub struct OpacityGroup {
-    /// The opacity of the group, in the range `0.0..=1.0`.
-    pub opacity: f32,
+pub struct LayerGroup {
+    /// The effect applied when compositing the group back onto its target.
+    pub effect: GroupEffect,
     /// The bounds of the group, already transformed by the current
     /// [`Transformation`] at the time the group was created.
     pub bounds: Rectangle,
@@ -63,24 +68,24 @@ pub struct OpacityGroup {
     pub parent: Option<usize>,
 }
 
-/// A plan describing when opacity groups open and close while iterating the
+/// A plan describing when layer groups open and close while iterating the
 /// layers of a [`Stack`] in order.
 ///
-/// A renderer walks its layers together with [`OpacityPlan::steps`]; when a
-/// group opens it must redirect drawing to an isolated target, and when it
-/// closes it must composite that target at the group's opacity.
+/// A renderer walks its layers together with [`GroupPlan::steps`]; when a group
+/// opens it must redirect drawing to an isolated target, and when it closes it
+/// must composite that target with the group's effect.
 #[derive(Debug, Default)]
-pub struct OpacityPlan {
+pub struct GroupPlan {
     /// One entry per active layer, in layer order.
-    pub steps: Vec<OpacityStep>,
+    pub steps: Vec<GroupStep>,
     /// Groups still open after the last layer, to be closed in this order
     /// (innermost first).
     pub trailing: Vec<usize>,
 }
 
-/// The opacity groups that open and close right before a given layer is drawn.
+/// The layer groups that open and close right before a given layer is drawn.
 #[derive(Debug, Default, Clone)]
-pub struct OpacityStep {
+pub struct GroupStep {
     /// Groups to close before this layer, innermost first.
     pub closes: Vec<usize>,
     /// Groups to open before this layer, outermost first.
@@ -95,17 +100,16 @@ pub struct Stack<T: Layer> {
     previous: Vec<usize>,
     current: usize,
     active_count: usize,
-    /// All opacity groups recorded this frame, indexed by group id.
-    opacity_groups: Vec<OpacityGroup>,
-    /// The innermost opacity group each layer slot belongs to, parallel to
-    /// `layers` by slot index.
+    /// All layer groups recorded this frame, indexed by group id.
+    groups: Vec<LayerGroup>,
+    /// The innermost group each layer slot belongs to, parallel to `layers` by
+    /// slot index.
     layer_groups: Vec<Option<usize>>,
-    /// The opacity groups currently open while recording, as a stack of ids.
+    /// The groups currently open while recording, as a stack of ids.
     active_groups: Vec<usize>,
-    /// For each open opacity scope, whether it actually created an isolated
-    /// group (fully-opaque scopes are elided). Keeps `push_opacity` and
-    /// `pop_opacity` balanced.
-    opacity_isolated: Vec<bool>,
+    /// For each open group scope, whether it actually created an isolated group
+    /// (no-op effects are elided). Keeps `push_group` and `pop_group` balanced.
+    group_isolated: Vec<bool>,
 }
 
 impl<T: Layer> Stack<T> {
@@ -117,10 +121,10 @@ impl<T: Layer> Stack<T> {
             previous: vec![],
             current: 0,
             active_count: 1,
-            opacity_groups: Vec::new(),
+            groups: Vec::new(),
             layer_groups: vec![None],
             active_groups: Vec::new(),
-            opacity_isolated: Vec::new(),
+            group_isolated: Vec::new(),
         }
     }
 
@@ -164,36 +168,41 @@ impl<T: Layer> Stack<T> {
 
     /// Returns the effective opacity at the current point in recording: the
     /// product of every open opacity group's opacity.
+    ///
+    /// Only [`GroupEffect::Opacity`] groups contribute; other effects are
+    /// transparent to opacity. Used to track opacity in a [`Layer`]'s damage.
     fn current_opacity(&self) -> f32 {
         self.active_groups
             .iter()
-            .map(|id| self.opacity_groups[*id].opacity)
+            .map(|id| match self.groups[*id].effect {
+                GroupEffect::Opacity(opacity) => opacity,
+            })
             .product()
     }
 
-    /// Pushes a new opacity group in the [`Stack`].
+    /// Pushes a new layer group in the [`Stack`].
     ///
     /// A new layer is created for the group (like [`push_clip`]) and every layer
-    /// drawn until the matching [`pop_opacity`] belongs to it. The renderer is
+    /// drawn until the matching [`pop_group`] belongs to it. The renderer is
     /// expected to composite all of those layers into an isolated target and
-    /// blend the result with `opacity`, so that overlapping primitives fade as a
-    /// single group instead of independently.
+    /// blend the result with `effect`, so that overlapping primitives are
+    /// affected as a single group instead of independently.
     ///
     /// [`push_clip`]: Self::push_clip
-    /// [`pop_opacity`]: Self::pop_opacity
-    pub fn push_opacity(&mut self, opacity: f32, bounds: Rectangle) {
-        // A fully-opaque group has no visible effect, so we skip isolating it
-        // entirely and avoid the cost of an offscreen target.
-        if opacity >= 1.0 {
-            self.opacity_isolated.push(false);
+    /// [`pop_group`]: Self::pop_group
+    pub fn push_group(&mut self, effect: GroupEffect, bounds: Rectangle) {
+        // An effect with no visible impact is skipped entirely, avoiding the cost
+        // of an offscreen target.
+        if effect.is_noop() {
+            self.group_isolated.push(false);
             return;
         }
 
         let parent = self.active_groups.last().copied();
-        let id = self.opacity_groups.len();
+        let id = self.groups.len();
 
-        self.opacity_groups.push(OpacityGroup {
-            opacity: opacity.clamp(0.0, 1.0),
+        self.groups.push(LayerGroup {
+            effect,
             bounds: bounds * self.transformation(),
             parent,
         });
@@ -202,12 +211,12 @@ impl<T: Layer> Stack<T> {
         // layer is tagged as belonging to it.
         self.active_groups.push(id);
         self.push_clip(bounds);
-        self.opacity_isolated.push(true);
+        self.group_isolated.push(true);
     }
 
-    /// Pops the current opacity group from the [`Stack`].
-    pub fn pop_opacity(&mut self) {
-        if self.opacity_isolated.pop() == Some(true) {
+    /// Pops the current layer group from the [`Stack`].
+    pub fn pop_group(&mut self) {
+        if self.group_isolated.pop() == Some(true) {
             self.pop_clip();
             let _ = self.active_groups.pop();
         }
@@ -333,28 +342,32 @@ impl<T: Layer> Stack<T> {
         self.active_count = 1;
         self.previous.clear();
 
-        self.opacity_groups.clear();
+        self.groups.clear();
         self.active_groups.clear();
-        self.opacity_isolated.clear();
+        self.group_isolated.clear();
         if let Some(first) = self.layer_groups.first_mut() {
             *first = None;
         }
     }
 
-    /// Returns the opacity groups recorded in the [`Stack`], indexed by group id.
-    pub fn opacity_groups(&self) -> &[OpacityGroup] {
-        &self.opacity_groups
+    /// Returns the layer groups recorded in the [`Stack`], indexed by group id.
+    pub fn groups(&self) -> &[LayerGroup] {
+        &self.groups
     }
 
-    /// Returns whether any opacity group was recorded in the [`Stack`].
-    pub fn has_opacity(&self) -> bool {
-        !self.opacity_groups.is_empty()
+    /// Returns whether any layer group was recorded in the [`Stack`].
+    pub fn has_groups(&self) -> bool {
+        !self.groups.is_empty()
     }
 
-    /// Fuses adjacent sibling opacity groups that can share a single isolated
-    /// target and composite.
-    pub fn batch_opacity(&mut self) {
-        let count = self.opacity_groups.len();
+    /// Fuses adjacent sibling groups that can share a single isolated target and
+    /// composite: same parent, equal and [batchable](GroupEffect::is_batchable)
+    /// effect, adjacent layer ranges, and non-overlapping bounds.
+    ///
+    /// The later groups' layers are reassigned to the first, whose bounds grow to
+    /// the union, so the renderer isolates and composites the whole run once.
+    pub fn batch_groups(&mut self) {
+        let count = self.groups.len();
 
         if count < 2 {
             return;
@@ -362,7 +375,7 @@ impl<T: Layer> Stack<T> {
 
         // A group that is some other group's parent is not a leaf.
         let mut is_parent = vec![false; count];
-        for group in &self.opacity_groups {
+        for group in &self.groups {
             if let Some(parent) = group.parent {
                 is_parent[parent] = true;
             }
@@ -394,11 +407,12 @@ impl<T: Layer> Stack<T> {
 
         for group in leaves {
             let can_extend = representative.is_some_and(|rep| {
-                let a = &self.opacity_groups[group];
-                let b = &self.opacity_groups[rep];
+                let a = &self.groups[group];
+                let b = &self.groups[rep];
 
                 a.parent == b.parent
-                    && a.opacity == b.opacity
+                    && a.effect == b.effect
+                    && a.effect.is_batchable()
                     && first[group] == run_last + 1
                     && members
                         .iter()
@@ -407,7 +421,7 @@ impl<T: Layer> Stack<T> {
 
             if can_extend {
                 let rep = representative.expect("Run has a representative");
-                let bounds = self.opacity_groups[group].bounds;
+                let bounds = self.groups[group].bounds;
 
                 for index in first[group]..=last[group] {
                     if self.layer_groups[index] == Some(group) {
@@ -415,43 +429,43 @@ impl<T: Layer> Stack<T> {
                     }
                 }
 
-                self.opacity_groups[rep].bounds = self.opacity_groups[rep].bounds.union(&bounds);
+                self.groups[rep].bounds = self.groups[rep].bounds.union(&bounds);
                 members.push(bounds);
                 run_last = last[group];
             } else {
                 representative = Some(group);
                 members.clear();
-                members.push(self.opacity_groups[group].bounds);
+                members.push(self.groups[group].bounds);
                 run_last = last[group];
             }
         }
     }
 
-    /// Returns the chain of opacity groups a group belongs to, outermost first.
-    fn opacity_chain(&self, group: usize) -> Vec<usize> {
+    /// Returns the chain of groups a group belongs to, outermost first.
+    fn group_chain(&self, group: usize) -> Vec<usize> {
         let mut chain = Vec::new();
         let mut current = Some(group);
 
         while let Some(id) = current {
             chain.push(id);
-            current = self.opacity_groups[id].parent;
+            current = self.groups[id].parent;
         }
 
         chain.reverse();
         chain
     }
 
-    /// Builds the [`OpacityPlan`] describing when opacity groups open and close
-    /// as the active layers are iterated in order.
+    /// Builds the [`GroupPlan`] describing when layer groups open and close as
+    /// the active layers are iterated in order.
     ///
     /// Groups occupy contiguous layer ranges, so a group opens right before its
     /// first layer and closes once the walk leaves it.
-    pub fn opacity_plan(&self) -> OpacityPlan {
-        let mut plan = OpacityPlan::default();
+    pub fn group_plan(&self) -> GroupPlan {
+        let mut plan = GroupPlan::default();
 
-        if self.opacity_groups.is_empty() {
+        if self.groups.is_empty() {
             plan.steps
-                .resize_with(self.active_count, OpacityStep::default);
+                .resize_with(self.active_count, GroupStep::default);
             return plan;
         }
 
@@ -459,7 +473,7 @@ impl<T: Layer> Stack<T> {
 
         for index in 0..self.active_count {
             let chain = match self.layer_groups[index] {
-                Some(group) => self.opacity_chain(group),
+                Some(group) => self.group_chain(group),
                 None => Vec::new(),
             };
 
@@ -469,7 +483,7 @@ impl<T: Layer> Stack<T> {
                 .take_while(|(a, b)| a == b)
                 .count();
 
-            plan.steps.push(OpacityStep {
+            plan.steps.push(GroupStep {
                 closes: previous[common..].iter().rev().copied().collect(),
                 opens: chain[common..].to_vec(),
             });

--- a/graphics/src/layer.rs
+++ b/graphics/src/layer.rs
@@ -351,6 +351,82 @@ impl<T: Layer> Stack<T> {
         !self.opacity_groups.is_empty()
     }
 
+    /// Fuses adjacent sibling opacity groups that can share a single isolated
+    /// target and composite.
+    pub fn batch_opacity(&mut self) {
+        let count = self.opacity_groups.len();
+
+        if count < 2 {
+            return;
+        }
+
+        // A group that is some other group's parent is not a leaf.
+        let mut is_parent = vec![false; count];
+        for group in &self.opacity_groups {
+            if let Some(parent) = group.parent {
+                is_parent[parent] = true;
+            }
+        }
+
+        // The (contiguous) layer range occupied by each group.
+        let mut first = vec![usize::MAX; count];
+        let mut last = vec![0usize; count];
+        for index in 0..self.active_count {
+            if let Some(group) = self.layer_groups[index] {
+                if first[group] == usize::MAX {
+                    first[group] = index;
+                }
+                last[group] = index;
+            }
+        }
+
+        // Visit leaf groups in layer order so adjacency can be checked.
+        let mut leaves: Vec<usize> = (0..count)
+            .filter(|&group| !is_parent[group] && first[group] != usize::MAX)
+            .collect();
+        leaves.sort_by_key(|&group| first[group]);
+
+        // The current run being accumulated: its representative group, the
+        // bounds of its members (to test overlap), and the last layer consumed.
+        let mut representative: Option<usize> = None;
+        let mut members: Vec<Rectangle> = Vec::new();
+        let mut run_last = 0;
+
+        for group in leaves {
+            let can_extend = representative.is_some_and(|rep| {
+                let a = &self.opacity_groups[group];
+                let b = &self.opacity_groups[rep];
+
+                a.parent == b.parent
+                    && a.opacity == b.opacity
+                    && first[group] == run_last + 1
+                    && members
+                        .iter()
+                        .all(|bounds| bounds.intersection(&a.bounds).is_none())
+            });
+
+            if can_extend {
+                let rep = representative.expect("Run has a representative");
+                let bounds = self.opacity_groups[group].bounds;
+
+                for index in first[group]..=last[group] {
+                    if self.layer_groups[index] == Some(group) {
+                        self.layer_groups[index] = Some(rep);
+                    }
+                }
+
+                self.opacity_groups[rep].bounds = self.opacity_groups[rep].bounds.union(&bounds);
+                members.push(bounds);
+                run_last = last[group];
+            } else {
+                representative = Some(group);
+                members.clear();
+                members.push(self.opacity_groups[group].bounds);
+                run_last = last[group];
+            }
+        }
+    }
+
     /// Returns the chain of opacity groups a group belongs to, outermost first.
     fn opacity_chain(&self, group: usize) -> Vec<usize> {
         let mut chain = Vec::new();

--- a/renderer/src/fallback.rs
+++ b/renderer/src/fallback.rs
@@ -62,6 +62,14 @@ where
         delegate!(self, renderer, renderer.end_transformation());
     }
 
+    fn start_opacity(&mut self, bounds: Rectangle, opacity: f32) {
+        delegate!(self, renderer, renderer.start_opacity(bounds, opacity));
+    }
+
+    fn end_opacity(&mut self) {
+        delegate!(self, renderer, renderer.end_opacity());
+    }
+
     fn allocate_image(
         &mut self,
         handle: &image::Handle,

--- a/renderer/src/fallback.rs
+++ b/renderer/src/fallback.rs
@@ -62,12 +62,12 @@ where
         delegate!(self, renderer, renderer.end_transformation());
     }
 
-    fn start_opacity(&mut self, bounds: Rectangle, opacity: f32) {
-        delegate!(self, renderer, renderer.start_opacity(bounds, opacity));
+    fn start_group(&mut self, bounds: Rectangle, effect: renderer::GroupEffect) {
+        delegate!(self, renderer, renderer.start_group(bounds, effect));
     }
 
-    fn end_opacity(&mut self) {
-        delegate!(self, renderer, renderer.end_opacity());
+    fn end_group(&mut self) {
+        delegate!(self, renderer, renderer.end_group());
     }
 
     fn allocate_image(

--- a/tiny_skia/Cargo.toml
+++ b/tiny_skia/Cargo.toml
@@ -37,3 +37,6 @@ tiny-skia.workspace = true
 
 resvg.workspace = true
 resvg.optional = true
+
+[dev-dependencies]
+tiny-skia.workspace = true

--- a/tiny_skia/src/layer.rs
+++ b/tiny_skia/src/layer.rs
@@ -17,6 +17,10 @@ pub struct Layer {
     pub primitives: Vec<Item<Primitive>>,
     pub images: Vec<Image>,
     pub text: Vec<Item<Text>>,
+    /// Effective opacity of the group this layer belongs to. Opacity is applied
+    /// at composite time rather than baked into the primitives, so it is tracked
+    /// here to be part of damage detection.
+    pub opacity: f32,
 }
 
 impl Layer {
@@ -208,6 +212,10 @@ impl Layer {
             return vec![previous.bounds, current.bounds];
         }
 
+        if previous.opacity != current.opacity {
+            return vec![current.bounds];
+        }
+
         let layer_bounds = current.bounds.expand(1.0);
 
         let mut damage = damage::list(
@@ -308,6 +316,7 @@ impl Default for Layer {
             primitives: Vec::new(),
             text: Vec::new(),
             images: Vec::new(),
+            opacity: 1.0,
         }
     }
 }
@@ -332,11 +341,16 @@ impl graphics::Layer for Layer {
 
     fn reset(&mut self) {
         self.bounds = Rectangle::INFINITE;
+        self.opacity = 1.0;
 
         self.quads.clear();
         self.primitives.clear();
         self.text.clear();
         self.images.clear();
+    }
+
+    fn set_opacity(&mut self, opacity: f32) {
+        self.opacity = opacity;
     }
 
     fn start(&self) -> usize {

--- a/tiny_skia/src/lib.rs
+++ b/tiny_skia/src/lib.rs
@@ -42,8 +42,6 @@ pub struct Renderer {
     settings: renderer::Settings,
     layers: layer::Stack,
     engine: Engine, // TODO: Shared engine
-    /// Stack of opacity values for nested opacity groups
-    opacity_stack: Vec<f32>,
 }
 
 impl Renderer {
@@ -52,13 +50,7 @@ impl Renderer {
             settings,
             layers: layer::Stack::new(),
             engine: Engine::new(),
-            opacity_stack: vec![1.0],
         }
-    }
-
-    /// Returns the current opacity value (product of all nested opacity values)
-    fn current_opacity(&self) -> f32 {
-        *self.opacity_stack.last().unwrap_or(&1.0)
     }
 
     pub fn layers(&mut self) -> &[Layer] {
@@ -76,6 +68,9 @@ impl Renderer {
     ) {
         let scale_factor = viewport.scale_factor();
         self.layers.flush();
+
+        let plan = self.layers.opacity_plan();
+        let opacity_groups = self.layers.opacity_groups().to_vec();
 
         for &damage_bounds in damage {
             let damage_bounds = damage_bounds * scale_factor;
@@ -103,130 +98,268 @@ impl Renderer {
                 None,
             );
 
-            for layer in self.layers.iter() {
+            // Isolated targets for the currently open opacity groups. Each group
+            // is composited into its own transparent pixmap and then blended as a
+            // whole, so overlapping primitives fade together instead of each on
+            // its own. The pixmap is sized to the group's bounds within this
+            // damage region (not the whole window), which keeps compositing cheap.
+            let mut targets: Vec<GroupTarget> = Vec::new();
+
+            for (index, layer) in self.layers.iter().enumerate() {
+                let step = &plan.steps[index];
+
+                for _ in &step.closes {
+                    composite_opacity_group(&mut targets, pixels);
+                }
+
+                for &group in &step.opens {
+                    let opacity_group = opacity_groups[group];
+                    let rect = (opacity_group.bounds * scale_factor)
+                        .intersection(&damage_bounds)
+                        .and_then(Rectangle::snap);
+
+                    targets.push(match rect {
+                        Some(rect) if rect.width > 0 && rect.height > 0 => GroupTarget {
+                            pixmap: tiny_skia::Pixmap::new(rect.width, rect.height)
+                                .expect("Create opacity group pixmap"),
+                            mask: tiny_skia::Mask::new(rect.width, rect.height)
+                                .expect("Create opacity group mask"),
+                            origin: (rect.x as f32, rect.y as f32),
+                            opacity: opacity_group.opacity,
+                            active: true,
+                        },
+                        _ => GroupTarget::inactive(opacity_group.opacity),
+                    });
+                }
+
                 let Some(layer_bounds) = damage_bounds.intersection(&(layer.bounds * scale_factor))
                 else {
                     continue;
                 };
 
-                engine::adjust_clip_mask(clip_mask, layer_bounds);
+                match targets.last_mut() {
+                    Some(target) if target.active => {
+                        let origin = target.origin;
+                        let group_rect = Rectangle {
+                            x: origin.0,
+                            y: origin.1,
+                            width: target.pixmap.width() as f32,
+                            height: target.pixmap.height() as f32,
+                        };
 
-                if !layer.quads.is_empty() {
-                    let render_span = debug::render(debug::Primitive::Quad);
-                    for (quad, background) in &layer.quads {
-                        self.engine.draw_quad(
-                            quad,
-                            background,
-                            Transformation::scale(scale_factor),
-                            pixels,
-                            clip_mask,
-                            layer_bounds,
-                        );
-                    }
-                    render_span.finish();
-                }
-
-                if !layer.primitives.is_empty() {
-                    let render_span = debug::render(debug::Primitive::Triangle);
-
-                    for group in &layer.primitives {
-                        let Some(group_bounds) =
-                            (group.clip_bounds() * scale_factor).intersection(&layer_bounds)
-                        else {
+                        let Some(source_bounds) = layer_bounds.intersection(&group_rect) else {
                             continue;
                         };
 
-                        engine::adjust_clip_mask(clip_mask, group_bounds);
-
-                        for primitive in group.as_slice() {
-                            self.engine.draw_primitive(
-                                primitive,
-                                Transformation::scale(scale_factor) * group.transformation(),
-                                pixels,
-                                clip_mask,
-                                group_bounds,
-                            );
-                        }
-
-                        engine::adjust_clip_mask(clip_mask, layer_bounds);
-                    }
-
-                    render_span.finish();
-                }
-
-                if !layer.images.is_empty() {
-                    let render_span = debug::render(debug::Primitive::Image);
-
-                    for image in &layer.images {
-                        self.engine.draw_image(
-                            image,
-                            Transformation::scale(scale_factor),
-                            pixels,
-                            clip_mask,
-                            layer_bounds,
+                        let mut pixmap = target.pixmap.as_mut();
+                        Self::render_layer(
+                            &mut self.engine,
+                            layer,
+                            &mut pixmap,
+                            &mut target.mask,
+                            origin,
+                            source_bounds,
+                            scale_factor,
                         );
                     }
-
-                    render_span.finish();
-                }
-
-                if !layer.text.is_empty() {
-                    let render_span = debug::render(debug::Primitive::Image);
-
-                    for group in &layer.text {
-                        for text in group.as_slice() {
-                            self.engine.draw_text(
-                                text,
-                                Transformation::scale(scale_factor) * group.transformation(),
-                                pixels,
-                                clip_mask,
-                                layer_bounds,
-                            );
-                        }
+                    Some(_) => {}
+                    None => {
+                        Self::render_layer(
+                            &mut self.engine,
+                            layer,
+                            pixels,
+                            clip_mask,
+                            (0.0, 0.0),
+                            layer_bounds,
+                            scale_factor,
+                        );
                     }
-
-                    render_span.finish();
                 }
+            }
+
+            for _ in &plan.trailing {
+                composite_opacity_group(&mut targets, pixels);
             }
         }
 
         self.engine.trim();
     }
-}
 
-/// Applies opacity to a background and quad border, returning the modified values.
-#[inline]
-fn apply_opacity(
-    opacity: f32,
-    background: impl Into<Background>,
-    quad: renderer::Quad,
-) -> (Background, renderer::Quad) {
-    if opacity >= 1.0 {
-        return (background.into(), quad);
-    }
+    /// Draws a single layer into the given target pixmap (either the frame or an
+    /// isolated opacity-group pixmap).
+    ///
+    /// `offset` is the physical top-left of the target within the frame; it is
+    /// `(0, 0)` for the frame and the group's origin for an opacity group, so
+    /// that a group can render into a small, bounds-sized pixmap. `layer_bounds`
+    /// is in physical (frame) coordinates.
+    fn render_layer(
+        engine: &mut Engine,
+        layer: &Layer,
+        pixels: &mut tiny_skia::PixmapMut<'_>,
+        clip_mask: &mut tiny_skia::Mask,
+        offset: (f32, f32),
+        layer_bounds: Rectangle,
+        scale_factor: f32,
+    ) {
+        let (offset_x, offset_y) = offset;
+        let to_local = |bounds: Rectangle| Rectangle {
+            x: bounds.x - offset_x,
+            y: bounds.y - offset_y,
+            ..bounds
+        };
+        // Logical -> frame-physical (scale), then frame-physical -> target-local
+        // (translate by the target's origin).
+        let transformation =
+            Transformation::translate(-offset_x, -offset_y) * Transformation::scale(scale_factor);
+        let layer_bounds = to_local(layer_bounds);
 
-    let background = match background.into() {
-        Background::Color(mut color) => {
-            color.a *= opacity;
-            Background::Color(color)
+        engine::adjust_clip_mask(clip_mask, layer_bounds);
+
+        if !layer.quads.is_empty() {
+            let render_span = debug::render(debug::Primitive::Quad);
+            for (quad, background) in &layer.quads {
+                engine.draw_quad(
+                    quad,
+                    background,
+                    transformation,
+                    pixels,
+                    clip_mask,
+                    layer_bounds,
+                );
+            }
+            render_span.finish();
         }
-        Background::Gradient(mut gradient) => {
-            match &mut gradient {
-                core::Gradient::Linear(linear) => {
-                    for color_stop in linear.stops.iter_mut().flatten() {
-                        color_stop.color.a *= opacity;
-                    }
+
+        if !layer.primitives.is_empty() {
+            let render_span = debug::render(debug::Primitive::Triangle);
+
+            for group in &layer.primitives {
+                let Some(group_bounds) =
+                    to_local(group.clip_bounds() * scale_factor).intersection(&layer_bounds)
+                else {
+                    continue;
+                };
+
+                engine::adjust_clip_mask(clip_mask, group_bounds);
+
+                for primitive in group.as_slice() {
+                    engine.draw_primitive(
+                        primitive,
+                        transformation * group.transformation(),
+                        pixels,
+                        clip_mask,
+                        group_bounds,
+                    );
+                }
+
+                engine::adjust_clip_mask(clip_mask, layer_bounds);
+            }
+
+            render_span.finish();
+        }
+
+        if !layer.images.is_empty() {
+            let render_span = debug::render(debug::Primitive::Image);
+
+            for image in &layer.images {
+                engine.draw_image(image, transformation, pixels, clip_mask, layer_bounds);
+            }
+
+            render_span.finish();
+        }
+
+        if !layer.text.is_empty() {
+            let render_span = debug::render(debug::Primitive::Image);
+
+            for group in &layer.text {
+                for text in group.as_slice() {
+                    engine.draw_text(
+                        text,
+                        transformation * group.transformation(),
+                        pixels,
+                        clip_mask,
+                        layer_bounds,
+                    );
                 }
             }
-            Background::Gradient(gradient)
+
+            render_span.finish();
         }
+    }
+}
+
+/// An isolated target for an opacity group, sized to the group's bounds within
+/// the current damage region.
+struct GroupTarget {
+    pixmap: tiny_skia::Pixmap,
+    mask: tiny_skia::Mask,
+    /// Physical top-left of the group within the frame.
+    origin: (f32, f32),
+    opacity: f32,
+    /// `false` when the group does not intersect the damage region, in which
+    /// case it has nothing to render or composite (kept to balance open/close).
+    active: bool,
+}
+
+impl GroupTarget {
+    fn inactive(opacity: f32) -> Self {
+        Self {
+            pixmap: tiny_skia::Pixmap::new(1, 1).expect("Create pixmap"),
+            mask: tiny_skia::Mask::new(1, 1).expect("Create mask"),
+            origin: (0.0, 0.0),
+            opacity,
+            active: false,
+        }
+    }
+}
+
+/// Composites the top-most opacity-group target into its parent (an enclosing
+/// group target, or the base frame) at the group's opacity.
+///
+/// This is what turns opacity into a single flattened layer: the group has
+/// already been drawn into its own transparent pixmap, so blending it as a whole
+/// yields correct results even when its primitives overlap.
+fn composite_opacity_group(targets: &mut Vec<GroupTarget>, base: &mut tiny_skia::PixmapMut<'_>) {
+    let Some(group) = targets.pop() else {
+        return;
     };
 
-    let mut border = quad.border;
-    border.color.a *= opacity;
-    let quad = renderer::Quad { border, ..quad };
+    if !group.active {
+        return;
+    }
 
-    (background, quad)
+    let paint = tiny_skia::PixmapPaint {
+        opacity: group.opacity,
+        blend_mode: tiny_skia::BlendMode::SourceOver,
+        quality: tiny_skia::FilterQuality::Nearest,
+    };
+
+    let (x, y) = group.origin;
+
+    // Composite into the nearest enclosing active group, or the frame. The child
+    // is positioned relative to whichever target it lands in.
+    match targets.last_mut() {
+        Some(parent) if parent.active => {
+            parent.pixmap.as_mut().draw_pixmap(
+                (x - parent.origin.0) as i32,
+                (y - parent.origin.1) as i32,
+                group.pixmap.as_ref(),
+                &paint,
+                tiny_skia::Transform::identity(),
+                None,
+            );
+        }
+        _ => {
+            base.draw_pixmap(
+                x as i32,
+                y as i32,
+                group.pixmap.as_ref(),
+                &paint,
+                tiny_skia::Transform::identity(),
+                None,
+            );
+        }
+    }
 }
 
 impl core::Renderer for Renderer {
@@ -246,21 +379,17 @@ impl core::Renderer for Renderer {
         self.layers.pop_transformation();
     }
 
-    fn start_opacity(&mut self, _bounds: Rectangle, opacity: f32) {
-        let current = self.current_opacity();
-        self.opacity_stack.push(current * opacity.clamp(0.0, 1.0));
+    fn start_opacity(&mut self, bounds: Rectangle, opacity: f32) {
+        self.layers.push_opacity(opacity, bounds);
     }
 
     fn end_opacity(&mut self) {
-        if self.opacity_stack.len() > 1 {
-            let _ = self.opacity_stack.pop();
-        }
+        self.layers.pop_opacity();
     }
 
     fn fill_quad(&mut self, quad: renderer::Quad, background: impl Into<Background>) {
-        let (background, quad) = apply_opacity(self.current_opacity(), background, quad);
         let (layer, transformation) = self.layers.current_mut();
-        layer.draw_quad(quad, background, transformation);
+        layer.draw_quad(quad, background.into(), transformation);
     }
 
     fn allocate_image(
@@ -288,8 +417,6 @@ impl core::Renderer for Renderer {
 
     fn reset(&mut self, new_bounds: Rectangle) {
         self.layers.reset(new_bounds);
-        self.opacity_stack.clear();
-        self.opacity_stack.push(1.0);
     }
 
     fn settings(&self) -> renderer::Settings {
@@ -326,11 +453,6 @@ impl core::text::Renderer for Renderer {
         color: Color,
         clip_bounds: Rectangle,
     ) {
-        let opacity = self.current_opacity();
-        let color = Color {
-            a: color.a * opacity,
-            ..color
-        };
         let (layer, transformation) = self.layers.current_mut();
 
         layer.draw_paragraph(text, position, color, clip_bounds, transformation);
@@ -343,11 +465,6 @@ impl core::text::Renderer for Renderer {
         color: Color,
         clip_bounds: Rectangle,
     ) {
-        let opacity = self.current_opacity();
-        let color = Color {
-            a: color.a * opacity,
-            ..color
-        };
         let (layer, transformation) = self.layers.current_mut();
         layer.draw_editor(editor, position, color, clip_bounds, transformation);
     }
@@ -359,11 +476,6 @@ impl core::text::Renderer for Renderer {
         color: Color,
         clip_bounds: Rectangle,
     ) {
-        let opacity = self.current_opacity();
-        let color = Color {
-            a: color.a * opacity,
-            ..color
-        };
         let (layer, transformation) = self.layers.current_mut();
         layer.draw_text(text, position, color, clip_bounds, transformation);
     }
@@ -442,11 +554,6 @@ impl core::image::Renderer for Renderer {
     }
 
     fn draw_image(&mut self, image: core::Image, bounds: Rectangle, clip_bounds: Rectangle) {
-        let opacity = self.current_opacity();
-        let image = core::Image {
-            opacity: image.opacity * opacity,
-            ..image
-        };
         let (layer, transformation) = self.layers.current_mut();
         layer.draw_raster(image, bounds, clip_bounds, transformation);
     }
@@ -459,11 +566,6 @@ impl core::svg::Renderer for Renderer {
     }
 
     fn draw_svg(&mut self, svg: core::Svg, bounds: Rectangle, clip_bounds: Rectangle) {
-        let opacity = self.current_opacity();
-        let svg = core::Svg {
-            opacity: svg.opacity * opacity,
-            ..svg
-        };
         let (layer, transformation) = self.layers.current_mut();
         layer.draw_svg(svg, bounds, clip_bounds, transformation);
     }

--- a/tiny_skia/src/lib.rs
+++ b/tiny_skia/src/lib.rs
@@ -42,6 +42,8 @@ pub struct Renderer {
     settings: renderer::Settings,
     layers: layer::Stack,
     engine: Engine, // TODO: Shared engine
+    /// Stack of opacity values for nested opacity groups
+    opacity_stack: Vec<f32>,
 }
 
 impl Renderer {
@@ -50,7 +52,13 @@ impl Renderer {
             settings,
             layers: layer::Stack::new(),
             engine: Engine::new(),
+            opacity_stack: vec![1.0],
         }
+    }
+
+    /// Returns the current opacity value (product of all nested opacity values)
+    fn current_opacity(&self) -> f32 {
+        *self.opacity_stack.last().unwrap_or(&1.0)
     }
 
     pub fn layers(&mut self) -> &[Layer] {
@@ -186,6 +194,43 @@ impl Renderer {
     }
 }
 
+/// Applies opacity to a background and quad border, returning the modified values.
+#[inline]
+fn apply_opacity(
+    opacity: f32,
+    background: impl Into<Background>,
+    quad: renderer::Quad,
+) -> (Background, renderer::Quad) {
+    if opacity >= 1.0 {
+        return (background.into(), quad);
+    }
+
+    let background = match background.into() {
+        Background::Color(mut color) => {
+            color.a *= opacity;
+            Background::Color(color)
+        }
+        Background::Gradient(mut gradient) => {
+            match &mut gradient {
+                core::Gradient::Linear(linear) => {
+                    for stop in &mut linear.stops {
+                        if let Some(color_stop) = stop {
+                            color_stop.color.a *= opacity;
+                        }
+                    }
+                }
+            }
+            Background::Gradient(gradient)
+        }
+    };
+
+    let mut border = quad.border;
+    border.color.a *= opacity;
+    let quad = renderer::Quad { border, ..quad };
+
+    (background, quad)
+}
+
 impl core::Renderer for Renderer {
     fn start_layer(&mut self, bounds: Rectangle) {
         self.layers.push_clip(bounds);
@@ -203,9 +248,21 @@ impl core::Renderer for Renderer {
         self.layers.pop_transformation();
     }
 
+    fn start_opacity(&mut self, _bounds: Rectangle, opacity: f32) {
+        let current = self.current_opacity();
+        self.opacity_stack.push(current * opacity.clamp(0.0, 1.0));
+    }
+
+    fn end_opacity(&mut self) {
+        if self.opacity_stack.len() > 1 {
+            let _ = self.opacity_stack.pop();
+        }
+    }
+
     fn fill_quad(&mut self, quad: renderer::Quad, background: impl Into<Background>) {
+        let (background, quad) = apply_opacity(self.current_opacity(), background, quad);
         let (layer, transformation) = self.layers.current_mut();
-        layer.draw_quad(quad, background.into(), transformation);
+        layer.draw_quad(quad, background, transformation);
     }
 
     fn allocate_image(
@@ -233,6 +290,8 @@ impl core::Renderer for Renderer {
 
     fn reset(&mut self, new_bounds: Rectangle) {
         self.layers.reset(new_bounds);
+        self.opacity_stack.clear();
+        self.opacity_stack.push(1.0);
     }
 
     fn settings(&self) -> renderer::Settings {
@@ -269,6 +328,11 @@ impl core::text::Renderer for Renderer {
         color: Color,
         clip_bounds: Rectangle,
     ) {
+        let opacity = self.current_opacity();
+        let color = Color {
+            a: color.a * opacity,
+            ..color
+        };
         let (layer, transformation) = self.layers.current_mut();
 
         layer.draw_paragraph(text, position, color, clip_bounds, transformation);
@@ -281,6 +345,11 @@ impl core::text::Renderer for Renderer {
         color: Color,
         clip_bounds: Rectangle,
     ) {
+        let opacity = self.current_opacity();
+        let color = Color {
+            a: color.a * opacity,
+            ..color
+        };
         let (layer, transformation) = self.layers.current_mut();
         layer.draw_editor(editor, position, color, clip_bounds, transformation);
     }
@@ -292,6 +361,11 @@ impl core::text::Renderer for Renderer {
         color: Color,
         clip_bounds: Rectangle,
     ) {
+        let opacity = self.current_opacity();
+        let color = Color {
+            a: color.a * opacity,
+            ..color
+        };
         let (layer, transformation) = self.layers.current_mut();
         layer.draw_text(text, position, color, clip_bounds, transformation);
     }
@@ -370,6 +444,11 @@ impl core::image::Renderer for Renderer {
     }
 
     fn draw_image(&mut self, image: core::Image, bounds: Rectangle, clip_bounds: Rectangle) {
+        let opacity = self.current_opacity();
+        let image = core::Image {
+            opacity: image.opacity * opacity,
+            ..image
+        };
         let (layer, transformation) = self.layers.current_mut();
         layer.draw_raster(image, bounds, clip_bounds, transformation);
     }
@@ -382,6 +461,11 @@ impl core::svg::Renderer for Renderer {
     }
 
     fn draw_svg(&mut self, svg: core::Svg, bounds: Rectangle, clip_bounds: Rectangle) {
+        let opacity = self.current_opacity();
+        let svg = core::Svg {
+            opacity: svg.opacity * opacity,
+            ..svg
+        };
         let (layer, transformation) = self.layers.current_mut();
         layer.draw_svg(svg, bounds, clip_bounds, transformation);
     }

--- a/tiny_skia/src/lib.rs
+++ b/tiny_skia/src/lib.rs
@@ -213,10 +213,8 @@ fn apply_opacity(
         Background::Gradient(mut gradient) => {
             match &mut gradient {
                 core::Gradient::Linear(linear) => {
-                    for stop in &mut linear.stops {
-                        if let Some(color_stop) = stop {
-                            color_stop.color.a *= opacity;
-                        }
+                    for color_stop in linear.stops.iter_mut().flatten() {
+                        color_stop.color.a *= opacity;
                     }
                 }
             }

--- a/tiny_skia/src/lib.rs
+++ b/tiny_skia/src/lib.rs
@@ -69,8 +69,8 @@ impl Renderer {
         let scale_factor = viewport.scale_factor();
         self.layers.flush();
 
-        let plan = self.layers.opacity_plan();
-        let opacity_groups = self.layers.opacity_groups().to_vec();
+        let plan = self.layers.group_plan();
+        let groups = self.layers.groups().to_vec();
 
         for &damage_bounds in damage {
             let damage_bounds = damage_bounds * scale_factor;
@@ -109,12 +109,12 @@ impl Renderer {
                 let step = &plan.steps[index];
 
                 for _ in &step.closes {
-                    composite_opacity_group(&mut targets, pixels);
+                    composite_group(&mut targets, pixels);
                 }
 
                 for &group in &step.opens {
-                    let opacity_group = opacity_groups[group];
-                    let rect = (opacity_group.bounds * scale_factor)
+                    let layer_group = groups[group];
+                    let rect = (layer_group.bounds * scale_factor)
                         .intersection(&damage_bounds)
                         .and_then(Rectangle::snap);
 
@@ -125,10 +125,10 @@ impl Renderer {
                             mask: tiny_skia::Mask::new(rect.width, rect.height)
                                 .expect("Create opacity group mask"),
                             origin: (rect.x as f32, rect.y as f32),
-                            opacity: opacity_group.opacity,
+                            effect: layer_group.effect,
                             active: true,
                         },
-                        _ => GroupTarget::inactive(opacity_group.opacity),
+                        _ => GroupTarget::inactive(layer_group.effect),
                     });
                 }
 
@@ -178,7 +178,7 @@ impl Renderer {
             }
 
             for _ in &plan.trailing {
-                composite_opacity_group(&mut targets, pixels);
+                composite_group(&mut targets, pixels);
             }
         }
 
@@ -288,38 +288,41 @@ impl Renderer {
     }
 }
 
-/// An isolated target for an opacity group, sized to the group's bounds within
-/// the current damage region.
+/// An isolated target for a layer group, sized to the group's bounds within the
+/// current damage region.
 struct GroupTarget {
     pixmap: tiny_skia::Pixmap,
     mask: tiny_skia::Mask,
     /// Physical top-left of the group within the frame.
     origin: (f32, f32),
-    opacity: f32,
+    effect: core::renderer::GroupEffect,
     /// `false` when the group does not intersect the damage region, in which
     /// case it has nothing to render or composite (kept to balance open/close).
     active: bool,
 }
 
 impl GroupTarget {
-    fn inactive(opacity: f32) -> Self {
+    fn inactive(effect: core::renderer::GroupEffect) -> Self {
         Self {
             pixmap: tiny_skia::Pixmap::new(1, 1).expect("Create pixmap"),
             mask: tiny_skia::Mask::new(1, 1).expect("Create mask"),
             origin: (0.0, 0.0),
-            opacity,
+            effect,
             active: false,
         }
     }
 }
 
-/// Composites the top-most opacity-group target into its parent (an enclosing
-/// group target, or the base frame) at the group's opacity.
+/// Composites the top-most group target into its parent (an enclosing group
+/// target, or the base frame), dispatching on the group's [`GroupEffect`].
 ///
-/// This is what turns opacity into a single flattened layer: the group has
-/// already been drawn into its own transparent pixmap, so blending it as a whole
-/// yields correct results even when its primitives overlap.
-fn composite_opacity_group(targets: &mut Vec<GroupTarget>, base: &mut tiny_skia::PixmapMut<'_>) {
+/// This is what turns a group into a single flattened layer: the group has
+/// already been drawn into its own transparent pixmap, so applying the effect to
+/// it as a whole yields correct results even when its primitives overlap. New
+/// effects add a match arm here.
+///
+/// [`GroupEffect`]: core::renderer::GroupEffect
+fn composite_group(targets: &mut Vec<GroupTarget>, base: &mut tiny_skia::PixmapMut<'_>) {
     let Some(group) = targets.pop() else {
         return;
     };
@@ -328,8 +331,11 @@ fn composite_opacity_group(targets: &mut Vec<GroupTarget>, base: &mut tiny_skia:
         return;
     }
 
+    // Dispatch on the effect.
+    let core::renderer::GroupEffect::Opacity(opacity) = group.effect;
+
     let paint = tiny_skia::PixmapPaint {
-        opacity: group.opacity,
+        opacity,
         blend_mode: tiny_skia::BlendMode::SourceOver,
         quality: tiny_skia::FilterQuality::Nearest,
     };
@@ -379,12 +385,12 @@ impl core::Renderer for Renderer {
         self.layers.pop_transformation();
     }
 
-    fn start_opacity(&mut self, bounds: Rectangle, opacity: f32) {
-        self.layers.push_opacity(opacity, bounds);
+    fn start_group(&mut self, bounds: Rectangle, effect: core::renderer::GroupEffect) {
+        self.layers.push_group(effect, bounds);
     }
 
-    fn end_opacity(&mut self) {
-        self.layers.pop_opacity();
+    fn end_group(&mut self) {
+        self.layers.pop_group();
     }
 
     fn fill_quad(&mut self, quad: renderer::Quad, background: impl Into<Background>) {

--- a/tiny_skia/tests/opacity.rs
+++ b/tiny_skia/tests/opacity.rs
@@ -1,0 +1,288 @@
+//! Verifies that the `opacity` group is composited as a single flattened layer
+//! rather than fading each primitive independently.
+use iced_tiny_skia::Layer;
+use iced_tiny_skia::Renderer;
+use iced_tiny_skia::core::renderer::{Quad, Renderer as _, Scale, Settings};
+use iced_tiny_skia::core::{Background, Border, Color, Rectangle, Shadow, Size};
+use iced_tiny_skia::graphics::Viewport;
+
+const RED: Color = Color::from_rgb(1.0, 0.0, 0.0);
+const GREEN: Color = Color::from_rgb(0.0, 1.0, 0.0);
+
+fn quad(x: f32, y: f32, width: f32, height: f32) -> Quad {
+    Quad {
+        bounds: Rectangle {
+            x,
+            y,
+            width,
+            height,
+        },
+        border: Border::default(),
+        shadow: Shadow::default(),
+        snap: true,
+    }
+}
+
+/// Renders `f` on a black background over the given damage regions and returns
+/// the resulting pixmap.
+fn render_with_damage(damage: &[Rectangle], f: impl FnOnce(&mut Renderer)) -> tiny_skia::Pixmap {
+    let mut renderer = Renderer::new(Settings::default());
+    let viewport = Viewport::with_physical_size(Size::new(100, 100), Scale::default());
+
+    renderer.reset(Rectangle::with_size(Size::new(100.0, 100.0)));
+    f(&mut renderer);
+
+    let mut pixmap = tiny_skia::Pixmap::new(100, 100).expect("Create pixmap");
+    let mut mask = tiny_skia::Mask::new(100, 100).expect("Create mask");
+
+    {
+        let mut view = pixmap.as_mut();
+        renderer.draw(&mut view, &mut mask, &viewport, damage, Color::BLACK);
+    }
+
+    pixmap
+}
+
+/// Renders `f` on a black background (full-window damage) and returns the pixmap.
+fn render(f: impl FnOnce(&mut Renderer)) -> tiny_skia::Pixmap {
+    render_with_damage(&[Rectangle::with_size(Size::new(100.0, 100.0))], f)
+}
+
+/// Returns the straight (demultiplied) RGB of a pixel, in iced color space.
+///
+/// `iced_tiny_skia` stores colors as BGRA (see `engine::into_color`), so the
+/// pixmap's red/blue channels are swapped relative to iced's `Color`.
+fn rgb(pixmap: &tiny_skia::Pixmap, x: u32, y: u32) -> (u8, u8, u8) {
+    let c = pixmap.pixel(x, y).expect("Pixel in bounds").demultiply();
+    (c.blue(), c.green(), c.red())
+}
+
+#[test]
+fn overlapping_group_does_not_bleed_through() {
+    // A red quad (back) and a green quad (front) overlapping in the center, all
+    // inside a single 50% opacity group.
+    let pixmap = render(|renderer| {
+        renderer.with_opacity(
+            Rectangle {
+                x: 10.0,
+                y: 10.0,
+                width: 80.0,
+                height: 80.0,
+            },
+            0.5,
+            |renderer| {
+                renderer.fill_quad(quad(10.0, 10.0, 60.0, 60.0), Background::Color(RED));
+                renderer.fill_quad(quad(30.0, 30.0, 60.0, 60.0), Background::Color(GREEN));
+            },
+        );
+    });
+
+    // In the overlap, only the front (green) quad must show at ~50% over black.
+    // If opacity were applied per-primitive, the back red quad would bleed
+    // through here (red ~63).
+    let (r, g, b) = rgb(&pixmap, 50, 50);
+    assert!(
+        r < 12,
+        "red bled through the overlap: got r={r} (expected ~0)"
+    );
+    assert!(
+        (110..=145).contains(&g),
+        "front green should be ~half: g={g}"
+    );
+    assert!(b < 12, "unexpected blue in overlap: b={b}");
+
+    // Back-only region: red at ~50% over black.
+    let (r, g, _b) = rgb(&pixmap, 18, 50);
+    assert!((110..=145).contains(&r), "back red should be ~half: r={r}");
+    assert!(g < 12, "unexpected green in back-only region: g={g}");
+
+    // Front-only region: green at ~50% over black.
+    let (r, g, _b) = rgb(&pixmap, 82, 50);
+    assert!(r < 12, "unexpected red in front-only region: r={r}");
+    assert!(
+        (110..=145).contains(&g),
+        "front green should be ~half: g={g}"
+    );
+
+    // Outside the group: untouched black background.
+    assert_eq!(rgb(&pixmap, 2, 2), (0, 0, 0));
+}
+
+#[test]
+fn full_opacity_is_opaque() {
+    // A single opaque quad at opacity 1.0 must remain fully opaque.
+    let pixmap = render(|renderer| {
+        renderer.with_opacity(
+            Rectangle {
+                x: 10.0,
+                y: 10.0,
+                width: 60.0,
+                height: 60.0,
+            },
+            1.0,
+            |renderer| {
+                renderer.fill_quad(quad(10.0, 10.0, 60.0, 60.0), Background::Color(RED));
+            },
+        );
+    });
+
+    assert_eq!(rgb(&pixmap, 40, 40), (255, 0, 0));
+}
+
+#[test]
+fn split_damage_regions_do_not_double_composite() {
+    // A single 50% red quad spanning two disjoint damage regions. Each region
+    // must composite only its own slice of the group, so every pixel is blended
+    // exactly once (~50% red over black), never twice.
+    let pixmap = render_with_damage(
+        &[
+            Rectangle {
+                x: 0.0,
+                y: 0.0,
+                width: 50.0,
+                height: 100.0,
+            },
+            Rectangle {
+                x: 50.0,
+                y: 0.0,
+                width: 50.0,
+                height: 100.0,
+            },
+        ],
+        |renderer| {
+            renderer.with_opacity(
+                Rectangle {
+                    x: 10.0,
+                    y: 10.0,
+                    width: 80.0,
+                    height: 60.0,
+                },
+                0.5,
+                |renderer| {
+                    renderer.fill_quad(quad(10.0, 10.0, 80.0, 60.0), Background::Color(RED));
+                },
+            );
+        },
+    );
+
+    // Sample either side of the region boundary (x=50); both are single-composited.
+    for x in [30, 70] {
+        let (r, g, b) = rgb(&pixmap, x, 40);
+        assert!(
+            (110..=145).contains(&r),
+            "x={x}: expected single ~50% composite, got r={r} (double would be ~190)"
+        );
+        assert!(g < 12 && b < 12, "x={x}: unexpected color g={g} b={b}");
+    }
+}
+
+#[test]
+fn opacity_change_is_damaged() {
+    // A changing opacity leaves the primitives identical, so it must be caught by
+    // the layer's opacity field; otherwise the software compositor would reuse
+    // the stale (previous-opacity) pixels and the UI would not update.
+    let previous = Layer {
+        bounds: Rectangle {
+            x: 10.0,
+            y: 10.0,
+            width: 50.0,
+            height: 50.0,
+        },
+        opacity: 1.0,
+        ..Layer::default()
+    };
+
+    let current = Layer {
+        opacity: 0.5,
+        ..previous.clone()
+    };
+
+    assert!(
+        !Layer::damage(&previous, &current).is_empty(),
+        "an opacity change must produce damage"
+    );
+
+    // Identical layers (same opacity, same content) produce no damage.
+    assert!(
+        Layer::damage(&previous, &previous.clone()).is_empty(),
+        "identical layers should not be damaged"
+    );
+}
+
+#[test]
+fn opacity_change_is_damaged_end_to_end() {
+    // Mimics the software compositor: diff the layers of two real draws that
+    // differ only in opacity, through iced's own `damage::diff`. This is what
+    // decides whether the window repaints when the opacity slider moves.
+    use iced_tiny_skia::graphics::damage;
+
+    let layers_at = |opacity: f32| -> Vec<Layer> {
+        let mut renderer = Renderer::new(Settings::default());
+        renderer.reset(Rectangle::with_size(Size::new(100.0, 100.0)));
+        renderer.with_opacity(
+            Rectangle {
+                x: 10.0,
+                y: 10.0,
+                width: 60.0,
+                height: 60.0,
+            },
+            opacity,
+            |renderer| {
+                renderer.fill_quad(quad(10.0, 10.0, 60.0, 60.0), Background::Color(RED));
+            },
+        );
+        renderer.layers().to_vec()
+    };
+
+    let previous = layers_at(0.8);
+    let current = layers_at(0.4);
+
+    let damage = damage::diff(
+        &previous,
+        &current,
+        |layer| vec![layer.bounds],
+        Layer::damage,
+    );
+
+    assert!(
+        !damage.is_empty(),
+        "changing group opacity (0.8 -> 0.4) must be detected as damage"
+    );
+}
+
+#[test]
+fn nested_opacity_multiplies() {
+    // 50% inside 50% -> the inner content ends up at ~25%.
+    let pixmap = render(|renderer| {
+        renderer.with_opacity(
+            Rectangle {
+                x: 10.0,
+                y: 10.0,
+                width: 60.0,
+                height: 60.0,
+            },
+            0.5,
+            |renderer| {
+                renderer.with_opacity(
+                    Rectangle {
+                        x: 10.0,
+                        y: 10.0,
+                        width: 60.0,
+                        height: 60.0,
+                    },
+                    0.5,
+                    |renderer| {
+                        renderer.fill_quad(quad(10.0, 10.0, 60.0, 60.0), Background::Color(RED));
+                    },
+                );
+            },
+        );
+    });
+
+    // 255 * 0.25 ~= 64 over black.
+    let (r, _g, _b) = rgb(&pixmap, 40, 40);
+    assert!(
+        (52..=76).contains(&r),
+        "nested opacity should be ~25%: r={r}"
+    );
+}

--- a/tiny_skia/tests/opacity.rs
+++ b/tiny_skia/tests/opacity.rs
@@ -209,11 +209,17 @@ fn non_overlapping_siblings_batch_correctly() {
     });
 
     let (r, g, _b) = rgb(&pixmap, 25, 50);
-    assert!((110..=145).contains(&r), "left group should be ~50% red: r={r}");
+    assert!(
+        (110..=145).contains(&r),
+        "left group should be ~50% red: r={r}"
+    );
     assert!(g < 12, "left group should be pure red: g={g}");
 
     let (r, g, _b) = rgb(&pixmap, 75, 50);
-    assert!((110..=145).contains(&g), "right group should be ~50% green: g={g}");
+    assert!(
+        (110..=145).contains(&g),
+        "right group should be ~50% green: g={g}"
+    );
     assert!(r < 12, "right group should be pure green: r={r}");
 
     assert_eq!(rgb(&pixmap, 50, 50), (0, 0, 0), "gap between groups");
@@ -254,7 +260,10 @@ fn overlapping_siblings_are_not_batched() {
 
     // Overlap: the back (red) group shows through the front (green) one.
     let (r, g, _b) = rgb(&pixmap, 50, 50);
-    assert!(r > 40, "back red must show through (not batched away): r={r}");
+    assert!(
+        r > 40,
+        "back red must show through (not batched away): r={r}"
+    );
     assert!(g > 80, "front green must be present: g={g}");
 }
 

--- a/tiny_skia/tests/opacity.rs
+++ b/tiny_skia/tests/opacity.rs
@@ -177,6 +177,88 @@ fn split_damage_regions_do_not_double_composite() {
 }
 
 #[test]
+fn non_overlapping_siblings_batch_correctly() {
+    // Two independent 50% groups side by side. These are batched into one
+    // isolated target; the result must be unchanged: each quad at ~50% over
+    // black, with an untouched gap between them.
+    let pixmap = render(|renderer| {
+        renderer.with_opacity(
+            Rectangle {
+                x: 10.0,
+                y: 10.0,
+                width: 30.0,
+                height: 80.0,
+            },
+            0.5,
+            |renderer| {
+                renderer.fill_quad(quad(10.0, 10.0, 30.0, 80.0), Background::Color(RED));
+            },
+        );
+        renderer.with_opacity(
+            Rectangle {
+                x: 60.0,
+                y: 10.0,
+                width: 30.0,
+                height: 80.0,
+            },
+            0.5,
+            |renderer| {
+                renderer.fill_quad(quad(60.0, 10.0, 30.0, 80.0), Background::Color(GREEN));
+            },
+        );
+    });
+
+    let (r, g, _b) = rgb(&pixmap, 25, 50);
+    assert!((110..=145).contains(&r), "left group should be ~50% red: r={r}");
+    assert!(g < 12, "left group should be pure red: g={g}");
+
+    let (r, g, _b) = rgb(&pixmap, 75, 50);
+    assert!((110..=145).contains(&g), "right group should be ~50% green: g={g}");
+    assert!(r < 12, "right group should be pure green: r={r}");
+
+    assert_eq!(rgb(&pixmap, 50, 50), (0, 0, 0), "gap between groups");
+}
+
+#[test]
+fn overlapping_siblings_are_not_batched() {
+    // Two 50% groups that overlap must NOT be batched: each composites over the
+    // other, so both colors show through the overlap. If they were wrongly
+    // merged into one group, the front quad would fully hide the back one and no
+    // red would remain.
+    let pixmap = render(|renderer| {
+        renderer.with_opacity(
+            Rectangle {
+                x: 10.0,
+                y: 10.0,
+                width: 50.0,
+                height: 50.0,
+            },
+            0.5,
+            |renderer| {
+                renderer.fill_quad(quad(10.0, 10.0, 50.0, 50.0), Background::Color(RED));
+            },
+        );
+        renderer.with_opacity(
+            Rectangle {
+                x: 40.0,
+                y: 40.0,
+                width: 50.0,
+                height: 50.0,
+            },
+            0.5,
+            |renderer| {
+                renderer.fill_quad(quad(40.0, 40.0, 50.0, 50.0), Background::Color(GREEN));
+            },
+        );
+    });
+
+    // Overlap: the back (red) group shows through the front (green) one.
+    let (r, g, _b) = rgb(&pixmap, 50, 50);
+    assert!(r > 40, "back red must show through (not batched away): r={r}");
+    assert!(g > 80, "front green must be present: g={g}");
+}
+
+#[test]
 fn opacity_change_is_damaged() {
     // A changing opacity leaves the primitives identical, so it must be caught by
     // the layer's opacity field; otherwise the software compositor would reuse

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -49,3 +49,6 @@ guillotiere.optional = true
 
 resvg.workspace = true
 resvg.optional = true
+
+[dev-dependencies]
+futures = { workspace = true, features = ["executor"] }

--- a/wgpu/src/engine.rs
+++ b/wgpu/src/engine.rs
@@ -15,6 +15,7 @@ pub struct Engine {
     pub(crate) quad_pipeline: quad::Pipeline,
     pub(crate) text_pipeline: text::Pipeline,
     pub(crate) triangle_pipeline: triangle::Pipeline,
+    pub(crate) opacity_pipeline: crate::opacity::Pipeline,
     #[cfg(any(feature = "image", feature = "svg"))]
     pub(crate) image_pipeline: crate::image::Pipeline,
     pub(crate) primitive_storage: Arc<RwLock<primitive::Storage>>,
@@ -36,6 +37,7 @@ impl Engine {
             quad_pipeline: quad::Pipeline::new(&device, format),
             text_pipeline: text::Pipeline::new(&device, &queue, format),
             triangle_pipeline: triangle::Pipeline::new(&device, format, antialiasing),
+            opacity_pipeline: crate::opacity::Pipeline::new(&device, format),
 
             #[cfg(any(feature = "image", feature = "svg"))]
             image_pipeline: {

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -690,10 +690,8 @@ fn apply_opacity(
         Background::Gradient(mut gradient) => {
             match &mut gradient {
                 core::Gradient::Linear(linear) => {
-                    for stop in &mut linear.stops {
-                        if let Some(color_stop) = stop {
-                            color_stop.color.a *= opacity;
-                        }
+                    for color_stop in linear.stops.iter_mut().flatten() {
+                        color_stop.color.a *= opacity;
                     }
                 }
             }

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -75,6 +75,8 @@ pub struct Renderer {
 
     layers: layer::Stack,
     scale: Option<renderer::Scale>,
+    /// Stack of opacity values (multiplied together for nested opacity)
+    opacity_stack: Vec<f32>,
 
     quad: quad::State,
     triangle: triangle::State,
@@ -97,6 +99,7 @@ impl Renderer {
             settings,
             layers: layer::Stack::new(),
             scale: None,
+            opacity_stack: vec![1.0],
 
             quad: quad::State::new(),
             triangle: triangle::State::new(&engine.device, &engine.triangle_pipeline),
@@ -119,6 +122,12 @@ impl Renderer {
 
             engine,
         }
+    }
+
+    /// Returns the current combined opacity value from the opacity stack.
+    #[inline]
+    fn current_opacity(&self) -> f32 {
+        *self.opacity_stack.last().unwrap_or(&1.0)
     }
 
     /// Record commands that draw the current primitives to the target texture view.
@@ -662,6 +671,43 @@ impl Renderer {
     }
 }
 
+/// Applies opacity to a background and quad border, returning the modified values.
+#[inline]
+fn apply_opacity(
+    opacity: f32,
+    background: impl Into<Background>,
+    quad: core::renderer::Quad,
+) -> (Background, core::renderer::Quad) {
+    if opacity >= 1.0 {
+        return (background.into(), quad);
+    }
+
+    let background = match background.into() {
+        Background::Color(mut color) => {
+            color.a *= opacity;
+            Background::Color(color)
+        }
+        Background::Gradient(mut gradient) => {
+            match &mut gradient {
+                core::Gradient::Linear(linear) => {
+                    for stop in &mut linear.stops {
+                        if let Some(color_stop) = stop {
+                            color_stop.color.a *= opacity;
+                        }
+                    }
+                }
+            }
+            Background::Gradient(gradient)
+        }
+    };
+
+    let mut border = quad.border;
+    border.color.a *= opacity;
+    let quad = core::renderer::Quad { border, ..quad };
+
+    (background, quad)
+}
+
 impl core::Renderer for Renderer {
     fn start_layer(&mut self, bounds: Rectangle) {
         self.layers.push_clip(bounds);
@@ -680,8 +726,9 @@ impl core::Renderer for Renderer {
     }
 
     fn fill_quad(&mut self, quad: core::renderer::Quad, background: impl Into<Background>) {
+        let (background, quad) = apply_opacity(self.current_opacity(), background, quad);
         let (layer, transformation) = self.layers.current_mut();
-        layer.draw_quad(quad, background.into(), transformation);
+        layer.draw_quad(quad, background, transformation);
     }
 
     fn allocate_image(
@@ -715,6 +762,19 @@ impl core::Renderer for Renderer {
 
     fn reset(&mut self, new_bounds: Rectangle) {
         self.layers.reset(new_bounds);
+        self.opacity_stack.clear();
+        self.opacity_stack.push(1.0);
+    }
+
+    fn start_opacity(&mut self, _bounds: Rectangle, opacity: f32) {
+        let current = *self.opacity_stack.last().unwrap_or(&1.0);
+        self.opacity_stack.push(current * opacity.clamp(0.0, 1.0));
+    }
+
+    fn end_opacity(&mut self) {
+        if self.opacity_stack.len() > 1 {
+            let _ = self.opacity_stack.pop();
+        }
     }
 
     fn settings(&self) -> renderer::Settings {
@@ -751,6 +811,11 @@ impl core::text::Renderer for Renderer {
         color: Color,
         clip_bounds: Rectangle,
     ) {
+        let opacity = self.current_opacity();
+        let color = Color {
+            a: color.a * opacity,
+            ..color
+        };
         let (layer, transformation) = self.layers.current_mut();
 
         layer.draw_paragraph(text, position, color, clip_bounds, transformation);
@@ -763,6 +828,11 @@ impl core::text::Renderer for Renderer {
         color: Color,
         clip_bounds: Rectangle,
     ) {
+        let opacity = self.current_opacity();
+        let color = Color {
+            a: color.a * opacity,
+            ..color
+        };
         let (layer, transformation) = self.layers.current_mut();
         layer.draw_editor(editor, position, color, clip_bounds, transformation);
     }
@@ -774,6 +844,11 @@ impl core::text::Renderer for Renderer {
         color: Color,
         clip_bounds: Rectangle,
     ) {
+        let opacity = self.current_opacity();
+        let color = Color {
+            a: color.a * opacity,
+            ..color
+        };
         let (layer, transformation) = self.layers.current_mut();
         layer.draw_text(text, position, color, clip_bounds, transformation);
     }
@@ -804,6 +879,11 @@ impl core::image::Renderer for Renderer {
     }
 
     fn draw_image(&mut self, image: core::Image, bounds: Rectangle, clip_bounds: Rectangle) {
+        let opacity = self.current_opacity();
+        let image = core::Image {
+            opacity: image.opacity * opacity,
+            ..image
+        };
         let (layer, transformation) = self.layers.current_mut();
         layer.draw_raster(image, bounds, clip_bounds, transformation);
     }
@@ -816,6 +896,11 @@ impl core::svg::Renderer for Renderer {
     }
 
     fn draw_svg(&mut self, svg: core::Svg, bounds: Rectangle, clip_bounds: Rectangle) {
+        let opacity = self.current_opacity();
+        let svg = core::Svg {
+            opacity: svg.opacity * opacity,
+            ..svg
+        };
         let (layer, transformation) = self.layers.current_mut();
         layer.draw_svg(svg, bounds, clip_bounds, transformation);
     }

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -32,6 +32,7 @@ pub mod geometry;
 mod buffer;
 mod color;
 mod engine;
+mod opacity;
 mod quad;
 mod text;
 mod triangle;
@@ -75,8 +76,6 @@ pub struct Renderer {
 
     layers: layer::Stack,
     scale: Option<renderer::Scale>,
-    /// Stack of opacity values (multiplied together for nested opacity)
-    opacity_stack: Vec<f32>,
 
     quad: quad::State,
     triangle: triangle::State,
@@ -99,7 +98,6 @@ impl Renderer {
             settings,
             layers: layer::Stack::new(),
             scale: None,
-            opacity_stack: vec![1.0],
 
             quad: quad::State::new(),
             triangle: triangle::State::new(&engine.device, &engine.triangle_pipeline),
@@ -122,12 +120,6 @@ impl Renderer {
 
             engine,
         }
-    }
-
-    /// Returns the current combined opacity value from the opacity stack.
-    #[inline]
-    fn current_opacity(&self) -> f32 {
-        *self.opacity_stack.last().unwrap_or(&1.0)
     }
 
     /// Record commands that draw the current primitives to the target texture view.
@@ -411,6 +403,11 @@ impl Renderer {
     ) {
         use std::mem::ManuallyDrop;
 
+        if self.layers.has_opacity() {
+            self.render_with_opacity(encoder, frame, clear_color, viewport);
+            return;
+        }
+
         let mut render_pass =
             ManuallyDrop::new(encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                 label: Some("iced_wgpu render pass"),
@@ -648,6 +645,372 @@ impl Renderer {
         });
     }
 
+    /// Renders the layers while compositing opacity groups into isolated,
+    /// full-viewport offscreen textures.
+    fn render_with_opacity(
+        &mut self,
+        encoder: &mut wgpu::CommandEncoder,
+        frame: &wgpu::TextureView,
+        clear_color: Option<Color>,
+        viewport: &Viewport,
+    ) {
+        use std::mem::ManuallyDrop;
+
+        struct GroupTarget {
+            // Owns the texture the `view` points into for the whole frame.
+            _texture: wgpu::Texture,
+            view: wgpu::TextureView,
+            opacity: f32,
+            scissor: Option<(u32, u32, u32, u32)>,
+        }
+
+        let scale_factor = viewport.scale_factor();
+        let physical_bounds =
+            Rectangle::<f32>::from(Rectangle::with_size(viewport.physical_size()));
+        let scale = Transformation::scale(scale_factor);
+
+        // Since targets are switched per layer, the frame is cleared up front and
+        // every layer pass loads afterwards.
+        {
+            let _clear = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("iced_wgpu.opacity.clear"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: frame,
+                    depth_slice: None,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: match clear_color {
+                            Some(background_color) => wgpu::LoadOp::Clear({
+                                let [r, g, b, a] =
+                                    graphics::color::pack(background_color).components();
+
+                                wgpu::Color {
+                                    r: f64::from(r * a),
+                                    g: f64::from(g * a),
+                                    b: f64::from(b * a),
+                                    a: f64::from(a),
+                                }
+                            }),
+                            None => wgpu::LoadOp::Load,
+                        },
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+                multiview_mask: None,
+            });
+        }
+
+        let plan = self.layers.opacity_plan();
+        let groups = self.layers.opacity_groups().to_vec();
+
+        let mut quad_layer = 0;
+        let mut mesh_layer = 0;
+        let mut text_layer = 0;
+
+        #[cfg(any(feature = "svg", feature = "image"))]
+        let mut image_layer = 0;
+
+        let mut targets: Vec<GroupTarget> = Vec::new();
+
+        for (index, layer) in self.layers.iter().enumerate() {
+            let step = &plan.steps[index];
+
+            for _ in &step.closes {
+                let group = targets.pop().expect("Opacity groups are balanced");
+                let target = targets.last().map(|t| &t.view).unwrap_or(frame);
+
+                self.engine.opacity_pipeline.composite(
+                    &self.engine.device,
+                    encoder,
+                    target,
+                    &group.view,
+                    group.opacity,
+                    group.scissor,
+                );
+            }
+
+            for &group in &step.opens {
+                let (texture, view) = self.create_group_target(viewport);
+
+                // Clear the group target to transparent so untouched pixels do
+                // not leak into the composite.
+                {
+                    let _clear = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                        label: Some("iced_wgpu.opacity.group_clear"),
+                        color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                            view: &view,
+                            depth_slice: None,
+                            resolve_target: None,
+                            ops: wgpu::Operations {
+                                load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                                store: wgpu::StoreOp::Store,
+                            },
+                        })],
+                        depth_stencil_attachment: None,
+                        timestamp_writes: None,
+                        occlusion_query_set: None,
+                        multiview_mask: None,
+                    });
+                }
+
+                let scissor = (groups[group].bounds * scale_factor)
+                    .intersection(&physical_bounds)
+                    .and_then(Rectangle::snap)
+                    .map(|r| (r.x, r.y, r.width, r.height));
+
+                targets.push(GroupTarget {
+                    _texture: texture,
+                    view,
+                    opacity: groups[group].opacity,
+                    scissor,
+                });
+            }
+
+            let Some(layer_bounds) = physical_bounds.intersection(&(layer.bounds * scale_factor))
+            else {
+                continue;
+            };
+
+            let Some(scissor_rect) = layer_bounds.snap() else {
+                continue;
+            };
+
+            let target_view = targets.last().map(|t| &t.view).unwrap_or(frame);
+
+            let mut render_pass =
+                ManuallyDrop::new(encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                    label: Some("iced_wgpu.opacity.layer"),
+                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                        view: target_view,
+                        depth_slice: None,
+                        resolve_target: None,
+                        ops: wgpu::Operations {
+                            load: wgpu::LoadOp::Load,
+                            store: wgpu::StoreOp::Store,
+                        },
+                    })],
+                    depth_stencil_attachment: None,
+                    timestamp_writes: None,
+                    occlusion_query_set: None,
+                    multiview_mask: None,
+                }));
+
+            if !layer.quads.is_empty() {
+                let render_span = debug::render(debug::Primitive::Quad);
+                self.quad.render(
+                    &self.engine.quad_pipeline,
+                    quad_layer,
+                    scissor_rect,
+                    &layer.quads,
+                    &mut render_pass,
+                );
+                render_span.finish();
+
+                quad_layer += 1;
+            }
+
+            if !layer.triangles.is_empty() {
+                let _ = ManuallyDrop::into_inner(render_pass);
+
+                let render_span = debug::render(debug::Primitive::Triangle);
+                mesh_layer += self.triangle.render(
+                    &self.engine.triangle_pipeline,
+                    encoder,
+                    target_view,
+                    mesh_layer,
+                    &layer.triangles,
+                    layer_bounds,
+                    scale,
+                );
+                render_span.finish();
+
+                render_pass =
+                    ManuallyDrop::new(encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                        label: Some("iced_wgpu.opacity.layer"),
+                        color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                            view: target_view,
+                            depth_slice: None,
+                            resolve_target: None,
+                            ops: wgpu::Operations {
+                                load: wgpu::LoadOp::Load,
+                                store: wgpu::StoreOp::Store,
+                            },
+                        })],
+                        depth_stencil_attachment: None,
+                        timestamp_writes: None,
+                        occlusion_query_set: None,
+                        multiview_mask: None,
+                    }));
+            }
+
+            if !layer.primitives.is_empty() {
+                let render_span = debug::render(debug::Primitive::Shader);
+
+                let primitive_storage = self
+                    .engine
+                    .primitive_storage
+                    .read()
+                    .expect("Read primitive storage");
+
+                let mut need_render = Vec::new();
+
+                for instance in &layer.primitives {
+                    let bounds = instance.bounds * scale;
+
+                    if let Some(clip_bounds) = (instance.bounds * scale)
+                        .intersection(&layer_bounds)
+                        .and_then(Rectangle::snap)
+                    {
+                        render_pass.set_viewport(
+                            bounds.x,
+                            bounds.y,
+                            bounds.width,
+                            bounds.height,
+                            0.0,
+                            1.0,
+                        );
+
+                        render_pass.set_scissor_rect(
+                            clip_bounds.x,
+                            clip_bounds.y,
+                            clip_bounds.width,
+                            clip_bounds.height,
+                        );
+
+                        let drawn = instance
+                            .primitive
+                            .draw(&primitive_storage, &mut render_pass);
+
+                        if !drawn {
+                            need_render.push((instance, clip_bounds));
+                        }
+                    }
+                }
+
+                render_pass.set_viewport(
+                    0.0,
+                    0.0,
+                    viewport.physical_width() as f32,
+                    viewport.physical_height() as f32,
+                    0.0,
+                    1.0,
+                );
+
+                render_pass.set_scissor_rect(
+                    0,
+                    0,
+                    viewport.physical_width(),
+                    viewport.physical_height(),
+                );
+
+                if !need_render.is_empty() {
+                    let _ = ManuallyDrop::into_inner(render_pass);
+
+                    for (instance, clip_bounds) in need_render {
+                        instance.primitive.render(
+                            &primitive_storage,
+                            encoder,
+                            target_view,
+                            &clip_bounds,
+                        );
+                    }
+
+                    render_pass =
+                        ManuallyDrop::new(encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                            label: Some("iced_wgpu.opacity.layer"),
+                            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                                view: target_view,
+                                depth_slice: None,
+                                resolve_target: None,
+                                ops: wgpu::Operations {
+                                    load: wgpu::LoadOp::Load,
+                                    store: wgpu::StoreOp::Store,
+                                },
+                            })],
+                            depth_stencil_attachment: None,
+                            timestamp_writes: None,
+                            occlusion_query_set: None,
+                            multiview_mask: None,
+                        }));
+                }
+
+                render_span.finish();
+            }
+
+            #[cfg(any(feature = "svg", feature = "image"))]
+            if !layer.images.is_empty() {
+                let render_span = debug::render(debug::Primitive::Image);
+                self.image.render(
+                    &self.engine.image_pipeline,
+                    image_layer,
+                    scissor_rect,
+                    &mut render_pass,
+                );
+                render_span.finish();
+
+                image_layer += 1;
+            }
+
+            if !layer.text.is_empty() {
+                let render_span = debug::render(debug::Primitive::Text);
+                text_layer += self.text.render(
+                    &self.engine.text_pipeline,
+                    &self.text_viewport,
+                    text_layer,
+                    &layer.text,
+                    scissor_rect,
+                    &mut render_pass,
+                );
+                render_span.finish();
+            }
+
+            let _ = ManuallyDrop::into_inner(render_pass);
+        }
+
+        // Close any groups still open after the last layer.
+        for _ in &plan.trailing {
+            let group = targets.pop().expect("Opacity groups are balanced");
+            let target = targets.last().map(|t| &t.view).unwrap_or(frame);
+
+            self.engine.opacity_pipeline.composite(
+                &self.engine.device,
+                encoder,
+                target,
+                &group.view,
+                group.opacity,
+                group.scissor,
+            );
+        }
+    }
+
+    /// Creates a transparent, full-viewport offscreen texture used to isolate an
+    /// opacity group before compositing it.
+    fn create_group_target(&self, viewport: &Viewport) -> (wgpu::Texture, wgpu::TextureView) {
+        let size = viewport.physical_size();
+
+        let texture = self.engine.device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("iced_wgpu.opacity.group_texture"),
+            size: wgpu::Extent3d {
+                width: size.width.max(1),
+                height: size.height.max(1),
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: self.engine.format,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING,
+            view_formats: &[],
+        });
+
+        let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+        (texture, view)
+    }
+
     /// Prepares currently mapped buffers for use in a submission.
     ///
     /// Usually, this method is only needed if you are calling [`Renderer::draw`] directly,
@@ -671,41 +1034,6 @@ impl Renderer {
     }
 }
 
-/// Applies opacity to a background and quad border, returning the modified values.
-#[inline]
-fn apply_opacity(
-    opacity: f32,
-    background: impl Into<Background>,
-    quad: core::renderer::Quad,
-) -> (Background, core::renderer::Quad) {
-    if opacity >= 1.0 {
-        return (background.into(), quad);
-    }
-
-    let background = match background.into() {
-        Background::Color(mut color) => {
-            color.a *= opacity;
-            Background::Color(color)
-        }
-        Background::Gradient(mut gradient) => {
-            match &mut gradient {
-                core::Gradient::Linear(linear) => {
-                    for color_stop in linear.stops.iter_mut().flatten() {
-                        color_stop.color.a *= opacity;
-                    }
-                }
-            }
-            Background::Gradient(gradient)
-        }
-    };
-
-    let mut border = quad.border;
-    border.color.a *= opacity;
-    let quad = core::renderer::Quad { border, ..quad };
-
-    (background, quad)
-}
-
 impl core::Renderer for Renderer {
     fn start_layer(&mut self, bounds: Rectangle) {
         self.layers.push_clip(bounds);
@@ -724,9 +1052,8 @@ impl core::Renderer for Renderer {
     }
 
     fn fill_quad(&mut self, quad: core::renderer::Quad, background: impl Into<Background>) {
-        let (background, quad) = apply_opacity(self.current_opacity(), background, quad);
         let (layer, transformation) = self.layers.current_mut();
-        layer.draw_quad(quad, background, transformation);
+        layer.draw_quad(quad, background.into(), transformation);
     }
 
     fn allocate_image(
@@ -760,19 +1087,14 @@ impl core::Renderer for Renderer {
 
     fn reset(&mut self, new_bounds: Rectangle) {
         self.layers.reset(new_bounds);
-        self.opacity_stack.clear();
-        self.opacity_stack.push(1.0);
     }
 
-    fn start_opacity(&mut self, _bounds: Rectangle, opacity: f32) {
-        let current = *self.opacity_stack.last().unwrap_or(&1.0);
-        self.opacity_stack.push(current * opacity.clamp(0.0, 1.0));
+    fn start_opacity(&mut self, bounds: Rectangle, opacity: f32) {
+        self.layers.push_opacity(opacity, bounds);
     }
 
     fn end_opacity(&mut self) {
-        if self.opacity_stack.len() > 1 {
-            let _ = self.opacity_stack.pop();
-        }
+        self.layers.pop_opacity();
     }
 
     fn settings(&self) -> renderer::Settings {
@@ -809,11 +1131,6 @@ impl core::text::Renderer for Renderer {
         color: Color,
         clip_bounds: Rectangle,
     ) {
-        let opacity = self.current_opacity();
-        let color = Color {
-            a: color.a * opacity,
-            ..color
-        };
         let (layer, transformation) = self.layers.current_mut();
 
         layer.draw_paragraph(text, position, color, clip_bounds, transformation);
@@ -826,11 +1143,6 @@ impl core::text::Renderer for Renderer {
         color: Color,
         clip_bounds: Rectangle,
     ) {
-        let opacity = self.current_opacity();
-        let color = Color {
-            a: color.a * opacity,
-            ..color
-        };
         let (layer, transformation) = self.layers.current_mut();
         layer.draw_editor(editor, position, color, clip_bounds, transformation);
     }
@@ -842,11 +1154,6 @@ impl core::text::Renderer for Renderer {
         color: Color,
         clip_bounds: Rectangle,
     ) {
-        let opacity = self.current_opacity();
-        let color = Color {
-            a: color.a * opacity,
-            ..color
-        };
         let (layer, transformation) = self.layers.current_mut();
         layer.draw_text(text, position, color, clip_bounds, transformation);
     }
@@ -877,11 +1184,6 @@ impl core::image::Renderer for Renderer {
     }
 
     fn draw_image(&mut self, image: core::Image, bounds: Rectangle, clip_bounds: Rectangle) {
-        let opacity = self.current_opacity();
-        let image = core::Image {
-            opacity: image.opacity * opacity,
-            ..image
-        };
         let (layer, transformation) = self.layers.current_mut();
         layer.draw_raster(image, bounds, clip_bounds, transformation);
     }
@@ -894,11 +1196,6 @@ impl core::svg::Renderer for Renderer {
     }
 
     fn draw_svg(&mut self, svg: core::Svg, bounds: Rectangle, clip_bounds: Rectangle) {
-        let opacity = self.current_opacity();
-        let svg = core::Svg {
-            opacity: svg.opacity * opacity,
-            ..svg
-        };
         let (layer, transformation) = self.layers.current_mut();
         layer.draw_svg(svg, bounds, clip_bounds, transformation);
     }

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -403,8 +403,8 @@ impl Renderer {
     ) {
         use std::mem::ManuallyDrop;
 
-        if self.layers.has_opacity() {
-            self.render_with_opacity(encoder, frame, clear_color, viewport);
+        if self.layers.has_groups() {
+            self.render_with_groups(encoder, frame, clear_color, viewport);
             return;
         }
 
@@ -647,7 +647,7 @@ impl Renderer {
 
     /// Renders the layers while compositing opacity groups into isolated,
     /// full-viewport offscreen textures.
-    fn render_with_opacity(
+    fn render_with_groups(
         &mut self,
         encoder: &mut wgpu::CommandEncoder,
         frame: &wgpu::TextureView,
@@ -661,7 +661,7 @@ impl Renderer {
             // nesting depth reuse a texture because they are rendered and
             // composited sequentially, so only one is live at a time.
             depth: usize,
-            opacity: f32,
+            effect: core::renderer::GroupEffect,
             // Physical rectangle of the group; `None` when it does not intersect
             // the frame (nothing to clear, render or composite).
             scissor: Option<Rectangle<u32>>,
@@ -701,10 +701,10 @@ impl Renderer {
             Rectangle::<f32>::from(Rectangle::with_size(viewport.physical_size()));
         let scale = Transformation::scale(scale_factor);
 
-        self.layers.batch_opacity();
+        self.layers.batch_groups();
 
-        let plan = self.layers.opacity_plan();
-        let groups = self.layers.opacity_groups().to_vec();
+        let plan = self.layers.group_plan();
+        let groups = self.layers.groups().to_vec();
 
         // Pre-allocate the offscreen texture pool up front (one per nesting
         // depth) so a render pass can be kept open across layers while the pool
@@ -719,8 +719,9 @@ impl Renderer {
             max
         };
 
-        let pool: Vec<(wgpu::Texture, wgpu::TextureView)> =
-            (0..max_nesting).map(|_| self.create_group_target(viewport)).collect();
+        let pool: Vec<(wgpu::Texture, wgpu::TextureView)> = (0..max_nesting)
+            .map(|_| self.create_group_target(viewport))
+            .collect();
 
         let mut quad_layer = 0;
         let mut mesh_layer = 0;
@@ -769,13 +770,12 @@ impl Renderer {
                             None => frame,
                         };
 
-                        self.engine.opacity_pipeline.composite(
-                            &self.engine.device,
+                        self.composite_group(
                             encoder,
                             target,
                             &pool[group.depth].1,
-                            group.opacity,
-                            Some((scissor.x, scissor.y, scissor.width, scissor.height)),
+                            group.effect,
+                            scissor,
                         );
                     }
                 }
@@ -812,7 +812,7 @@ impl Renderer {
 
                 targets.push(GroupTarget {
                     depth,
-                    opacity: groups[group].opacity,
+                    effect: groups[group].effect,
                     scissor,
                     cleared: false,
                 });
@@ -1010,12 +1010,30 @@ impl Renderer {
                     None => frame,
                 };
 
+                self.composite_group(encoder, target, &pool[group.depth].1, group.effect, scissor);
+            }
+        }
+    }
+
+    /// Composites an isolated group `source` back onto `target`, dispatching on
+    /// the group's [`GroupEffect`]. New effects (blur, color filters, …) add a
+    /// match arm and their own pipeline here.
+    fn composite_group(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        target: &wgpu::TextureView,
+        source: &wgpu::TextureView,
+        effect: core::renderer::GroupEffect,
+        scissor: Rectangle<u32>,
+    ) {
+        match effect {
+            core::renderer::GroupEffect::Opacity(opacity) => {
                 self.engine.opacity_pipeline.composite(
                     &self.engine.device,
                     encoder,
                     target,
-                    &pool[group.depth].1,
-                    group.opacity,
+                    source,
+                    opacity,
                     Some((scissor.x, scissor.y, scissor.width, scissor.height)),
                 );
             }
@@ -1125,12 +1143,12 @@ impl core::Renderer for Renderer {
         self.layers.reset(new_bounds);
     }
 
-    fn start_opacity(&mut self, bounds: Rectangle, opacity: f32) {
-        self.layers.push_opacity(opacity, bounds);
+    fn start_group(&mut self, bounds: Rectangle, effect: core::renderer::GroupEffect) {
+        self.layers.push_group(effect, bounds);
     }
 
-    fn end_opacity(&mut self) {
-        self.layers.pop_opacity();
+    fn end_group(&mut self) {
+        self.layers.pop_group();
     }
 
     fn settings(&self) -> renderer::Settings {

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -657,42 +657,35 @@ impl Renderer {
         use std::mem::ManuallyDrop;
 
         struct GroupTarget {
-            // Owns the texture the `view` points into for the whole frame.
-            _texture: wgpu::Texture,
-            view: wgpu::TextureView,
+            // Index into the full-viewport texture pool. Groups at the same
+            // nesting depth reuse a texture because they are rendered and
+            // composited sequentially, so only one is live at a time.
+            depth: usize,
             opacity: f32,
-            scissor: Option<(u32, u32, u32, u32)>,
+            // Physical rectangle of the group; `None` when it does not intersect
+            // the frame (nothing to clear, render or composite).
+            scissor: Option<Rectangle<u32>>,
+            // Whether the (reused) texture has been cleared for this group yet.
+            // The clear is folded into the group's first layer render.
+            cleared: bool,
         }
 
-        let scale_factor = viewport.scale_factor();
-        let physical_bounds =
-            Rectangle::<f32>::from(Rectangle::with_size(viewport.physical_size()));
-        let scale = Transformation::scale(scale_factor);
-
-        // Since targets are switched per layer, the frame is cleared up front and
-        // every layer pass loads afterwards.
-        {
-            let _clear = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                label: Some("iced_wgpu.opacity.clear"),
+        // Begins a render pass on `view`. Consecutive layers that target the same
+        // texture reuse a single pass (batched groups collapse into one), so this
+        // is only called on target changes and after triangle/primitive breaks.
+        fn begin<'a>(
+            encoder: &'a mut wgpu::CommandEncoder,
+            view: &'a wgpu::TextureView,
+            load: wgpu::LoadOp<wgpu::Color>,
+        ) -> wgpu::RenderPass<'a> {
+            encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("iced_wgpu.opacity.layer"),
                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                    view: frame,
+                    view,
                     depth_slice: None,
                     resolve_target: None,
                     ops: wgpu::Operations {
-                        load: match clear_color {
-                            Some(background_color) => wgpu::LoadOp::Clear({
-                                let [r, g, b, a] =
-                                    graphics::color::pack(background_color).components();
-
-                                wgpu::Color {
-                                    r: f64::from(r * a),
-                                    g: f64::from(g * a),
-                                    b: f64::from(b * a),
-                                    a: f64::from(a),
-                                }
-                            }),
-                            None => wgpu::LoadOp::Load,
-                        },
+                        load,
                         store: wgpu::StoreOp::Store,
                     },
                 })],
@@ -700,11 +693,34 @@ impl Renderer {
                 timestamp_writes: None,
                 occlusion_query_set: None,
                 multiview_mask: None,
-            });
+            })
         }
+
+        let scale_factor = viewport.scale_factor();
+        let physical_bounds =
+            Rectangle::<f32>::from(Rectangle::with_size(viewport.physical_size()));
+        let scale = Transformation::scale(scale_factor);
+
+        self.layers.batch_opacity();
 
         let plan = self.layers.opacity_plan();
         let groups = self.layers.opacity_groups().to_vec();
+
+        // Pre-allocate the offscreen texture pool up front (one per nesting
+        // depth) so a render pass can be kept open across layers while the pool
+        // is not being reallocated mid-frame.
+        let max_nesting = {
+            let mut depth = vec![0usize; groups.len()];
+            let mut max = 0;
+            for id in 0..groups.len() {
+                depth[id] = groups[id].parent.map_or(0, |parent| depth[parent] + 1);
+                max = max.max(depth[id] + 1);
+            }
+            max
+        };
+
+        let pool: Vec<(wgpu::Texture, wgpu::TextureView)> =
+            (0..max_nesting).map(|_| self.create_group_target(viewport)).collect();
 
         let mut quad_layer = 0;
         let mut mesh_layer = 0;
@@ -715,57 +731,90 @@ impl Renderer {
 
         let mut targets: Vec<GroupTarget> = Vec::new();
 
+        // A single render pass is kept open across consecutive layers that draw
+        // to the same target (batched groups collapse into one pass). It is moved
+        // out and rebuilt around anything that needs the encoder — a composite or
+        // a triangle/primitive sub-pass. `pass_target` is the target it draws to
+        // (`None` = frame, `Some(depth)` = `pool[depth]`). The frame clear is
+        // folded into this first pass.
+        let frame_load = match clear_color {
+            Some(background_color) => wgpu::LoadOp::Clear({
+                let [r, g, b, a] = graphics::color::pack(background_color).components();
+
+                wgpu::Color {
+                    r: f64::from(r * a),
+                    g: f64::from(g * a),
+                    b: f64::from(b * a),
+                    a: f64::from(a),
+                }
+            }),
+            None => wgpu::LoadOp::Load,
+        };
+
+        let mut render_pass = ManuallyDrop::new(begin(encoder, frame, frame_load));
+        let mut pass_target: Option<usize> = None;
+
         for (index, layer) in self.layers.iter().enumerate() {
             let step = &plan.steps[index];
 
-            for _ in &step.closes {
-                let group = targets.pop().expect("Opacity groups are balanced");
-                let target = targets.last().map(|t| &t.view).unwrap_or(frame);
+            if !step.closes.is_empty() {
+                let _ = ManuallyDrop::into_inner(render_pass);
 
-                self.engine.opacity_pipeline.composite(
-                    &self.engine.device,
-                    encoder,
-                    target,
-                    &group.view,
-                    group.opacity,
-                    group.scissor,
-                );
+                for _ in &step.closes {
+                    let group = targets.pop().expect("Opacity groups are balanced");
+
+                    if let Some(scissor) = group.scissor {
+                        let target = match targets.last() {
+                            Some(parent) => &pool[parent.depth].1,
+                            None => frame,
+                        };
+
+                        self.engine.opacity_pipeline.composite(
+                            &self.engine.device,
+                            encoder,
+                            target,
+                            &pool[group.depth].1,
+                            group.opacity,
+                            Some((scissor.x, scissor.y, scissor.width, scissor.height)),
+                        );
+                    }
+                }
+
+                // Reopen on whatever target is now current (clearing it if this is
+                // its first use).
+                let (target_depth, load) = match targets.last_mut() {
+                    Some(target) => {
+                        let load = if target.cleared {
+                            wgpu::LoadOp::Load
+                        } else {
+                            target.cleared = true;
+                            wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT)
+                        };
+                        (Some(target.depth), load)
+                    }
+                    None => (None, wgpu::LoadOp::Load),
+                };
+                let view = match target_depth {
+                    Some(depth) => &pool[depth].1,
+                    None => frame,
+                };
+                render_pass = ManuallyDrop::new(begin(encoder, view, load));
+                pass_target = target_depth;
             }
 
             for &group in &step.opens {
-                let (texture, view) = self.create_group_target(viewport);
-
-                // Clear the group target to transparent so untouched pixels do
-                // not leak into the composite.
-                {
-                    let _clear = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                        label: Some("iced_wgpu.opacity.group_clear"),
-                        color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                            view: &view,
-                            depth_slice: None,
-                            resolve_target: None,
-                            ops: wgpu::Operations {
-                                load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
-                                store: wgpu::StoreOp::Store,
-                            },
-                        })],
-                        depth_stencil_attachment: None,
-                        timestamp_writes: None,
-                        occlusion_query_set: None,
-                        multiview_mask: None,
-                    });
-                }
+                let depth = targets.len();
 
                 let scissor = (groups[group].bounds * scale_factor)
                     .intersection(&physical_bounds)
                     .and_then(Rectangle::snap)
-                    .map(|r| (r.x, r.y, r.width, r.height));
+                    .filter(|rect| rect.width > 0 && rect.height > 0);
 
                 targets.push(GroupTarget {
-                    _texture: texture,
-                    view,
+                    depth,
                     opacity: groups[group].opacity,
                     scissor,
+                    cleared: false,
                 });
             }
 
@@ -778,25 +827,37 @@ impl Renderer {
                 continue;
             };
 
-            let target_view = targets.last().map(|t| &t.view).unwrap_or(frame);
+            let target_depth = match targets.last() {
+                Some(target) => {
+                    // Skip layers inside a group that is off-screen.
+                    if target.scissor.is_none() {
+                        continue;
+                    }
+                    Some(target.depth)
+                }
+                None => None,
+            };
 
-            let mut render_pass =
-                ManuallyDrop::new(encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                    label: Some("iced_wgpu.opacity.layer"),
-                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                        view: target_view,
-                        depth_slice: None,
-                        resolve_target: None,
-                        ops: wgpu::Operations {
-                            load: wgpu::LoadOp::Load,
-                            store: wgpu::StoreOp::Store,
-                        },
-                    })],
-                    depth_stencil_attachment: None,
-                    timestamp_writes: None,
-                    occlusion_query_set: None,
-                    multiview_mask: None,
-                }));
+            let target_view = match target_depth {
+                Some(depth) => &pool[depth].1,
+                None => frame,
+            };
+
+            // Switch the open pass to the layer's target if needed, clearing a
+            // group's texture on its first layer.
+            if pass_target != target_depth {
+                let _ = ManuallyDrop::into_inner(render_pass);
+
+                let load = match targets.last_mut() {
+                    Some(target) if !target.cleared => {
+                        target.cleared = true;
+                        wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT)
+                    }
+                    _ => wgpu::LoadOp::Load,
+                };
+                render_pass = ManuallyDrop::new(begin(encoder, target_view, load));
+                pass_target = target_depth;
+            }
 
             if !layer.quads.is_empty() {
                 let render_span = debug::render(debug::Primitive::Quad);
@@ -827,23 +888,7 @@ impl Renderer {
                 );
                 render_span.finish();
 
-                render_pass =
-                    ManuallyDrop::new(encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                        label: Some("iced_wgpu.opacity.layer"),
-                        color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                            view: target_view,
-                            depth_slice: None,
-                            resolve_target: None,
-                            ops: wgpu::Operations {
-                                load: wgpu::LoadOp::Load,
-                                store: wgpu::StoreOp::Store,
-                            },
-                        })],
-                        depth_stencil_attachment: None,
-                        timestamp_writes: None,
-                        occlusion_query_set: None,
-                        multiview_mask: None,
-                    }));
+                render_pass = ManuallyDrop::new(begin(encoder, target_view, wgpu::LoadOp::Load));
             }
 
             if !layer.primitives.is_empty() {
@@ -890,6 +935,7 @@ impl Renderer {
                     }
                 }
 
+                // Restore full viewport/scissor for later layers sharing the pass.
                 render_pass.set_viewport(
                     0.0,
                     0.0,
@@ -898,7 +944,6 @@ impl Renderer {
                     0.0,
                     1.0,
                 );
-
                 render_pass.set_scissor_rect(
                     0,
                     0,
@@ -919,22 +964,7 @@ impl Renderer {
                     }
 
                     render_pass =
-                        ManuallyDrop::new(encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                            label: Some("iced_wgpu.opacity.layer"),
-                            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                                view: target_view,
-                                depth_slice: None,
-                                resolve_target: None,
-                                ops: wgpu::Operations {
-                                    load: wgpu::LoadOp::Load,
-                                    store: wgpu::StoreOp::Store,
-                                },
-                            })],
-                            depth_stencil_attachment: None,
-                            timestamp_writes: None,
-                            occlusion_query_set: None,
-                            multiview_mask: None,
-                        }));
+                        ManuallyDrop::new(begin(encoder, target_view, wgpu::LoadOp::Load));
                 }
 
                 render_span.finish();
@@ -966,23 +996,29 @@ impl Renderer {
                 );
                 render_span.finish();
             }
-
-            let _ = ManuallyDrop::into_inner(render_pass);
         }
+
+        let _ = ManuallyDrop::into_inner(render_pass);
 
         // Close any groups still open after the last layer.
         for _ in &plan.trailing {
             let group = targets.pop().expect("Opacity groups are balanced");
-            let target = targets.last().map(|t| &t.view).unwrap_or(frame);
 
-            self.engine.opacity_pipeline.composite(
-                &self.engine.device,
-                encoder,
-                target,
-                &group.view,
-                group.opacity,
-                group.scissor,
-            );
+            if let Some(scissor) = group.scissor {
+                let target = match targets.last() {
+                    Some(parent) => &pool[parent.depth].1,
+                    None => frame,
+                };
+
+                self.engine.opacity_pipeline.composite(
+                    &self.engine.device,
+                    encoder,
+                    target,
+                    &pool[group.depth].1,
+                    group.opacity,
+                    Some((scissor.x, scissor.y, scissor.width, scissor.height)),
+                );
+            }
         }
     }
 

--- a/wgpu/src/opacity.rs
+++ b/wgpu/src/opacity.rs
@@ -1,0 +1,188 @@
+//! Composite an isolated opacity group into a target at a given opacity.
+//!
+//! An opacity group is first rendered to its own offscreen texture and then
+//! blended as a whole with this pipeline, so overlapping primitives fade
+//! together instead of each one independently.
+use std::borrow::Cow;
+
+use wgpu::util::DeviceExt;
+
+#[derive(Debug, Clone)]
+pub struct Pipeline {
+    pipeline: wgpu::RenderPipeline,
+    sampler: wgpu::Sampler,
+    constants_layout: wgpu::BindGroupLayout,
+    texture_layout: wgpu::BindGroupLayout,
+}
+
+impl Pipeline {
+    pub fn new(device: &wgpu::Device, format: wgpu::TextureFormat) -> Self {
+        let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            label: Some("iced_wgpu.opacity.sampler"),
+            ..wgpu::SamplerDescriptor::default()
+        });
+
+        let constants_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("iced_wgpu.opacity.constants_layout"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::NonFiltering),
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+            ],
+        });
+
+        let texture_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("iced_wgpu.opacity.texture_layout"),
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Texture {
+                    sample_type: wgpu::TextureSampleType::Float { filterable: false },
+                    view_dimension: wgpu::TextureViewDimension::D2,
+                    multisampled: false,
+                },
+                count: None,
+            }],
+        });
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("iced_wgpu.opacity.pipeline_layout"),
+            bind_group_layouts: &[Some(&constants_layout), Some(&texture_layout)],
+            immediate_size: 0,
+        });
+
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("iced_wgpu.opacity.shader"),
+            source: wgpu::ShaderSource::Wgsl(Cow::Borrowed(include_str!("shader/opacity.wgsl"))),
+        });
+
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("iced_wgpu.opacity.pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                buffers: &[],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format,
+                    blend: Some(wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            }),
+            primitive: wgpu::PrimitiveState::default(),
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            multiview_mask: None,
+            cache: None,
+        });
+
+        Self {
+            pipeline,
+            sampler,
+            constants_layout,
+            texture_layout,
+        }
+    }
+
+    /// Composites `source` into `target` at the given `opacity`, optionally
+    /// scissored to `scissor` (physical pixels: `x, y, width, height`).
+    ///
+    /// `source` must be a premultiplied-alpha texture that matches the target's
+    /// dimensions and projection (the group is rendered full-viewport).
+    #[allow(clippy::too_many_arguments)]
+    pub fn composite(
+        &self,
+        device: &wgpu::Device,
+        encoder: &mut wgpu::CommandEncoder,
+        target: &wgpu::TextureView,
+        source: &wgpu::TextureView,
+        opacity: f32,
+        scissor: Option<(u32, u32, u32, u32)>,
+    ) {
+        #[derive(Clone, Copy, bytemuck::Zeroable, bytemuck::Pod)]
+        #[repr(C)]
+        struct Opacity {
+            opacity: f32,
+            _padding: [f32; 3],
+        }
+
+        let uniform = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("iced_wgpu.opacity.uniform"),
+            contents: bytemuck::bytes_of(&Opacity {
+                opacity,
+                _padding: [0.0; 3],
+            }),
+            usage: wgpu::BufferUsages::UNIFORM,
+        });
+
+        let constants = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("iced_wgpu.opacity.constants"),
+            layout: &self.constants_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::Sampler(&self.sampler),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: uniform.as_entire_binding(),
+                },
+            ],
+        });
+
+        let texture = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("iced_wgpu.opacity.texture"),
+            layout: &self.texture_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: wgpu::BindingResource::TextureView(source),
+            }],
+        });
+
+        let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("iced_wgpu.opacity.composite"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: target,
+                depth_slice: None,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Load,
+                    store: wgpu::StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        });
+
+        pass.set_pipeline(&self.pipeline);
+        pass.set_bind_group(0, &constants, &[]);
+        pass.set_bind_group(1, &texture, &[]);
+
+        if let Some((x, y, width, height)) = scissor {
+            pass.set_scissor_rect(x, y, width, height);
+        }
+
+        pass.draw(0..6, 0..1);
+    }
+}

--- a/wgpu/src/opacity.rs
+++ b/wgpu/src/opacity.rs
@@ -103,11 +103,12 @@ impl Pipeline {
         }
     }
 
-    /// Composites `source` into `target` at the given `opacity`, optionally
-    /// scissored to `scissor` (physical pixels: `x, y, width, height`).
+    /// Composites `source` into `target` at the given `opacity`, scissored to
+    /// `scissor` (physical pixels: `x, y, width, height`).
     ///
-    /// `source` must be a premultiplied-alpha texture that matches the target's
-    /// dimensions and projection (the group is rendered full-viewport).
+    /// `source` shares the target's dimensions and projection (groups render
+    /// full-viewport), so the composite is a 1:1 blit limited to the group's
+    /// rectangle, multiplied by `opacity`.
     #[allow(clippy::too_many_arguments)]
     pub fn composite(
         &self,

--- a/wgpu/src/shader/opacity.wgsl
+++ b/wgpu/src/shader/opacity.wgsl
@@ -1,0 +1,38 @@
+var<private> positions: array<vec2<f32>, 6> = array<vec2<f32>, 6>(
+    vec2<f32>(0.0, 0.0),
+    vec2<f32>(1.0, 0.0),
+    vec2<f32>(1.0, 1.0),
+    vec2<f32>(0.0, 0.0),
+    vec2<f32>(0.0, 1.0),
+    vec2<f32>(1.0, 1.0)
+);
+
+@group(0) @binding(0) var u_sampler: sampler;
+// x = opacity, yzw = padding for 16-byte alignment.
+@group(0) @binding(1) var<uniform> u_opacity: vec4<f32>;
+@group(1) @binding(0) var u_texture: texture_2d<f32>;
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+}
+
+@vertex
+fn vs_main(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
+    let p = positions[vertex_index];
+
+    var out: VertexOutput;
+    out.uv = p;
+    out.position = vec4<f32>(p * vec2<f32>(2.0, -2.0) + vec2<f32>(-1.0, 1.0), 0.0, 1.0);
+
+    return out;
+}
+
+@fragment
+fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
+    // The group texture stores premultiplied-alpha color. Scaling every channel
+    // by the opacity keeps it premultiplied, so blending the result with a
+    // premultiplied "over" produces correct group opacity: the group is
+    // flattened first and faded as a whole.
+    return textureSample(u_texture, u_sampler, input.uv) * u_opacity.x;
+}

--- a/wgpu/tests/opacity.rs
+++ b/wgpu/tests/opacity.rs
@@ -1,0 +1,124 @@
+//! Verifies that `iced_wgpu` composites an `opacity` group as a single
+//! flattened layer (offscreen texture) rather than fading each primitive
+//! independently.
+//!
+//! Requires a working `wgpu` adapter; the test skips itself if none is
+//! available (e.g. on a headless CI without a GPU).
+use iced_wgpu::Renderer;
+use iced_wgpu::core::renderer::{Headless, Quad, Renderer as _, Scale, Settings};
+use iced_wgpu::core::{Background, Border, Color, Rectangle, Shadow, Size};
+use iced_wgpu::graphics::Viewport;
+
+const RED: Color = Color::from_rgb(1.0, 0.0, 0.0);
+const GREEN: Color = Color::from_rgb(0.0, 1.0, 0.0);
+
+fn quad(x: f32, y: f32, width: f32, height: f32) -> Quad {
+    Quad {
+        bounds: Rectangle {
+            x,
+            y,
+            width,
+            height,
+        },
+        border: Border::default(),
+        shadow: Shadow::default(),
+        snap: true,
+    }
+}
+
+/// Renders `f` on a black background and returns the RGBA screenshot bytes,
+/// or `None` if no GPU adapter is available.
+fn render(f: impl FnOnce(&mut Renderer)) -> Option<Vec<u8>> {
+    let mut renderer =
+        futures::executor::block_on(<Renderer as Headless>::new(Settings::default(), None))?;
+
+    let viewport = Viewport::with_physical_size(Size::new(100, 100), Scale::default());
+
+    renderer.reset(Rectangle::with_size(Size::new(100.0, 100.0)));
+    f(&mut renderer);
+
+    Some(Headless::screenshot(
+        &mut renderer,
+        viewport.physical_size(),
+        1.0,
+        Color::BLACK,
+    ))
+}
+
+fn rgb(bytes: &[u8], x: u32, y: u32) -> (u8, u8, u8) {
+    let i = ((y * 100 + x) * 4) as usize;
+    (bytes[i], bytes[i + 1], bytes[i + 2])
+}
+
+#[test]
+fn overlapping_group_does_not_bleed_through() {
+    let Some(bytes) = render(|renderer| {
+        renderer.with_opacity(
+            Rectangle {
+                x: 10.0,
+                y: 10.0,
+                width: 80.0,
+                height: 80.0,
+            },
+            0.5,
+            |renderer| {
+                renderer.fill_quad(quad(10.0, 10.0, 60.0, 60.0), Background::Color(RED));
+                renderer.fill_quad(quad(30.0, 30.0, 60.0, 60.0), Background::Color(GREEN));
+            },
+        );
+    }) else {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    };
+
+    // In the overlap, only the front (green) quad may show. If opacity were
+    // applied per-primitive, the back red quad would bleed through here.
+    // (Exact channel magnitudes depend on gamma, so bounds are loose; the key
+    // assertion is the near-absence of red.)
+    let (r, g, b) = rgb(&bytes, 50, 50);
+    assert!(r < 24, "red bled through the overlap: r={r}");
+    assert!(g > 90, "front green missing in overlap: g={g}");
+    assert!(b < 24, "unexpected blue in overlap: b={b}");
+    assert!(
+        r + 24 < g,
+        "red should be far below green in overlap: r={r} g={g}"
+    );
+
+    // Back-only region shows red; front-only region shows green.
+    let (r, g, _b) = rgb(&bytes, 18, 50);
+    assert!(r > 90, "back red missing: r={r}");
+    assert!(g < 24, "unexpected green in back-only region: g={g}");
+
+    let (r, g, _b) = rgb(&bytes, 82, 50);
+    assert!(r < 24, "unexpected red in front-only region: r={r}");
+    assert!(g > 90, "front green missing: g={g}");
+
+    // Outside the group: untouched black background.
+    let (r, g, b) = rgb(&bytes, 2, 2);
+    assert!(r < 8 && g < 8 && b < 8, "background not black: {r},{g},{b}");
+}
+
+#[test]
+fn full_opacity_is_opaque() {
+    let Some(bytes) = render(|renderer| {
+        renderer.with_opacity(
+            Rectangle {
+                x: 10.0,
+                y: 10.0,
+                width: 60.0,
+                height: 60.0,
+            },
+            1.0,
+            |renderer| {
+                renderer.fill_quad(quad(10.0, 10.0, 60.0, 60.0), Background::Color(RED));
+            },
+        );
+    }) else {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    };
+
+    let (r, g, b) = rgb(&bytes, 40, 40);
+    assert!(r > 240, "opaque red should be full: r={r}");
+    assert!(g < 12 && b < 12, "opaque red should be pure: g={g} b={b}");
+}

--- a/wgpu/tests/opacity.rs
+++ b/wgpu/tests/opacity.rs
@@ -204,7 +204,10 @@ fn non_overlapping_siblings_batch_correctly() {
     assert!(r < 24, "right group should be pure green: r={r}");
 
     let (r, g, b) = rgb(&bytes, 50, 50);
-    assert!(r < 8 && g < 8 && b < 8, "gap between groups must stay black");
+    assert!(
+        r < 8 && g < 8 && b < 8,
+        "gap between groups must stay black"
+    );
 }
 
 #[test]

--- a/wgpu/tests/opacity.rs
+++ b/wgpu/tests/opacity.rs
@@ -98,6 +98,115 @@ fn overlapping_group_does_not_bleed_through() {
     assert!(r < 8 && g < 8 && b < 8, "background not black: {r},{g},{b}");
 }
 
+fn red_quad_at(renderer_opacity: &dyn Fn(&mut Renderer)) -> Option<(u8, u8, u8)> {
+    render(renderer_opacity).map(|bytes| rgb(&bytes, 40, 40))
+}
+
+#[test]
+fn nested_opacity_multiplies() {
+    // Exercises the texture pool at two nesting depths (outer uses pool[0], inner
+    // pool[1], inner composites into pool[0], then pool[0] into the frame).
+    //
+    // Nesting must multiply: 50% inside 50% has to match a single 25% group.
+    // Comparing renders avoids depending on the exact gamma/sRGB value.
+    let single = |alpha: f32| {
+        move |renderer: &mut Renderer| {
+            renderer.with_opacity(
+                Rectangle {
+                    x: 10.0,
+                    y: 10.0,
+                    width: 60.0,
+                    height: 60.0,
+                },
+                alpha,
+                |renderer| {
+                    renderer.fill_quad(quad(10.0, 10.0, 60.0, 60.0), Background::Color(RED));
+                },
+            );
+        }
+    };
+
+    let nested = |renderer: &mut Renderer| {
+        renderer.with_opacity(
+            Rectangle {
+                x: 10.0,
+                y: 10.0,
+                width: 60.0,
+                height: 60.0,
+            },
+            0.5,
+            |renderer| {
+                (single(0.5))(renderer);
+            },
+        );
+    };
+
+    let Some((nested_r, _, _)) = red_quad_at(&nested) else {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    };
+    let (quarter_r, _, _) = red_quad_at(&single(0.25)).unwrap();
+    let (half_r, _, _) = red_quad_at(&single(0.5)).unwrap();
+
+    // Nested 0.5*0.5 should match a single 0.25 group, and be clearly darker
+    // than a single 0.5 group (i.e. the inner opacity is not lost).
+    assert!(
+        nested_r.abs_diff(quarter_r) <= 6,
+        "nested 0.5*0.5 (r={nested_r}) should match single 0.25 (r={quarter_r})"
+    );
+    assert!(
+        nested_r + 10 < half_r,
+        "nested 0.5*0.5 (r={nested_r}) should be darker than single 0.5 (r={half_r})"
+    );
+}
+
+#[test]
+fn non_overlapping_siblings_batch_correctly() {
+    // Two independent 50% groups side by side are batched into one isolated
+    // target and rendered in a single shared pass. The result must be unchanged:
+    // each quad at ~50% over black, with an untouched gap between them.
+    let Some(bytes) = render(|renderer| {
+        renderer.with_opacity(
+            Rectangle {
+                x: 10.0,
+                y: 10.0,
+                width: 30.0,
+                height: 80.0,
+            },
+            0.5,
+            |renderer| {
+                renderer.fill_quad(quad(10.0, 10.0, 30.0, 80.0), Background::Color(RED));
+            },
+        );
+        renderer.with_opacity(
+            Rectangle {
+                x: 60.0,
+                y: 10.0,
+                width: 30.0,
+                height: 80.0,
+            },
+            0.5,
+            |renderer| {
+                renderer.fill_quad(quad(60.0, 10.0, 30.0, 80.0), Background::Color(GREEN));
+            },
+        );
+    }) else {
+        eprintln!("skipping: no wgpu adapter available");
+        return;
+    };
+
+    let (r, g, _b) = rgb(&bytes, 25, 50);
+    assert!(r > 90, "left group should show ~50% red: r={r}");
+    assert!(g < 24, "left group should be pure red: g={g}");
+
+    let (r, g, _b) = rgb(&bytes, 75, 50);
+    assert!(g > 90, "right group should show ~50% green: g={g}");
+    assert!(r < 24, "right group should be pure green: r={r}");
+
+    let (r, g, b) = rgb(&bytes, 50, 50);
+    assert!(r < 8 && g < 8 && b < 8, "gap between groups must stay black");
+}
+
 #[test]
 fn full_opacity_is_opaque() {
     let Some(bytes) = render(|renderer| {

--- a/widget/src/lib.rs
+++ b/widget/src/lib.rs
@@ -12,6 +12,7 @@ pub use core::widget::{Id, Void};
 mod action;
 mod column;
 mod mouse_area;
+mod opacity;
 mod pin;
 mod responsive;
 mod stack;
@@ -70,6 +71,8 @@ pub use float::Float;
 pub use grid::Grid;
 #[doc(no_inline)]
 pub use mouse_area::MouseArea;
+#[doc(no_inline)]
+pub use opacity::{Opacity, opacity};
 #[doc(no_inline)]
 pub use pane_grid::PaneGrid;
 #[doc(no_inline)]

--- a/widget/src/opacity.rs
+++ b/widget/src/opacity.rs
@@ -17,8 +17,9 @@ use crate::core::{Element, Event, Length, Rectangle, Shell, Size, Vector, Widget
 ///
 /// # Example
 /// ```no_run
+/// # mod iced { pub mod widget { pub use iced_widget::*; } }
+/// # pub type Element<'a, Message> = iced_widget::core::Element<'a, Message, iced_widget::Theme, iced_widget::Renderer>;
 /// use iced::widget::{opacity, container, text};
-/// use iced::Element;
 ///
 /// fn view<'a>() -> Element<'a, ()> {
 ///     opacity(0.5, container(text("50% transparent"))).into()
@@ -169,8 +170,9 @@ where
 ///
 /// # Example
 /// ```no_run
+/// # mod iced { pub mod widget { pub use iced_widget::*; } }
+/// # pub type Element<'a, Message> = iced_widget::core::Element<'a, Message, iced_widget::Theme, iced_widget::Renderer>;
 /// use iced::widget::{opacity, text};
-/// use iced::Element;
 ///
 /// fn view<'a>() -> Element<'a, ()> {
 ///     opacity(0.5, text("50% transparent")).into()

--- a/widget/src/opacity.rs
+++ b/widget/src/opacity.rs
@@ -1,0 +1,187 @@
+//! Apply opacity to any widget.
+//!
+//! The [`Opacity`] widget wraps content and applies transparency to it.
+//! Nested opacity widgets multiply their values (e.g., 50% × 50% = 25%).
+use crate::core::layout::{self, Layout};
+use crate::core::mouse;
+use crate::core::overlay;
+use crate::core::renderer;
+use crate::core::widget::Operation;
+use crate::core::widget::tree::{self, Tree};
+use crate::core::{Element, Event, Length, Rectangle, Shell, Size, Vector, Widget};
+
+/// A widget that applies opacity to its content.
+///
+/// Opacity values range from `0.0` (fully transparent) to `1.0` (fully opaque).
+/// Nested [`Opacity`] widgets multiply their values together.
+///
+/// # Example
+/// ```no_run
+/// use iced::widget::{opacity, container, text};
+/// use iced::Element;
+///
+/// fn view<'a>() -> Element<'a, ()> {
+///     opacity(0.5, container(text("50% transparent"))).into()
+/// }
+/// ```
+#[allow(missing_debug_implementations)]
+pub struct Opacity<'a, Message, Theme = crate::Theme, Renderer = crate::Renderer> {
+    opacity: f32,
+    content: Element<'a, Message, Theme, Renderer>,
+}
+
+impl<'a, Message, Theme, Renderer> Opacity<'a, Message, Theme, Renderer> {
+    /// Creates a new [`Opacity`] widget with the given opacity value and content.
+    ///
+    /// The opacity is clamped to the range `[0.0, 1.0]`.
+    pub fn new(opacity: f32, content: impl Into<Element<'a, Message, Theme, Renderer>>) -> Self {
+        Self {
+            opacity: opacity.clamp(0.0, 1.0),
+            content: content.into(),
+        }
+    }
+
+    /// Sets the opacity value.
+    ///
+    /// The opacity is clamped to the range `[0.0, 1.0]`.
+    pub fn opacity(mut self, opacity: f32) -> Self {
+        self.opacity = opacity.clamp(0.0, 1.0);
+        self
+    }
+}
+
+impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer>
+    for Opacity<'_, Message, Theme, Renderer>
+where
+    Renderer: renderer::Renderer,
+{
+    fn tag(&self) -> tree::Tag {
+        self.content.as_widget().tag()
+    }
+
+    fn state(&self) -> tree::State {
+        self.content.as_widget().state()
+    }
+
+    fn diff(&mut self, tree: &mut Tree) {
+        self.content.as_widget_mut().diff(tree);
+    }
+
+    fn size(&self) -> Size<Length> {
+        self.content.as_widget().size()
+    }
+
+    fn layout(
+        &mut self,
+        tree: &mut Tree,
+        renderer: &Renderer,
+        limits: &layout::Limits,
+    ) -> layout::Node {
+        self.content.as_widget_mut().layout(tree, renderer, limits)
+    }
+
+    fn operate(
+        &mut self,
+        tree: &mut Tree,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+        operation: &mut dyn Operation,
+    ) {
+        self.content
+            .as_widget_mut()
+            .operate(tree, layout, renderer, operation);
+    }
+
+    fn update(
+        &mut self,
+        tree: &mut Tree,
+        event: &Event,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        renderer: &Renderer,
+        shell: &mut Shell<'_, Message>,
+        viewport: &Rectangle,
+    ) {
+        self.content
+            .as_widget_mut()
+            .update(tree, event, layout, cursor, renderer, shell, viewport);
+    }
+
+    fn mouse_interaction(
+        &self,
+        tree: &Tree,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+        renderer: &Renderer,
+    ) -> mouse::Interaction {
+        self.content
+            .as_widget()
+            .mouse_interaction(tree, layout, cursor, viewport, renderer)
+    }
+
+    fn draw(
+        &self,
+        tree: &Tree,
+        renderer: &mut Renderer,
+        theme: &Theme,
+        style: &renderer::Style,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+    ) {
+        renderer.with_opacity(layout.bounds(), self.opacity, |renderer| {
+            self.content
+                .as_widget()
+                .draw(tree, renderer, theme, style, layout, cursor, viewport);
+        });
+    }
+
+    fn overlay<'b>(
+        &'b mut self,
+        tree: &'b mut Tree,
+        layout: Layout<'b>,
+        renderer: &Renderer,
+        viewport: &Rectangle,
+        translation: Vector,
+    ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
+        self.content
+            .as_widget_mut()
+            .overlay(tree, layout, renderer, viewport, translation)
+    }
+}
+
+impl<'a, Message, Theme, Renderer> From<Opacity<'a, Message, Theme, Renderer>>
+    for Element<'a, Message, Theme, Renderer>
+where
+    Message: 'a,
+    Theme: 'a,
+    Renderer: renderer::Renderer + 'a,
+{
+    fn from(opacity: Opacity<'a, Message, Theme, Renderer>) -> Self {
+        Self::new(opacity)
+    }
+}
+
+/// Creates a new [`Opacity`] widget with the given opacity value and content.
+///
+/// Opacity values range from `0.0` (fully transparent) to `1.0` (fully opaque).
+///
+/// # Example
+/// ```no_run
+/// use iced::widget::{opacity, text};
+/// use iced::Element;
+///
+/// fn view<'a>() -> Element<'a, ()> {
+///     opacity(0.5, text("50% transparent")).into()
+/// }
+/// ```
+pub fn opacity<'a, Message, Theme, Renderer>(
+    opacity: f32,
+    content: impl Into<Element<'a, Message, Theme, Renderer>>,
+) -> Opacity<'a, Message, Theme, Renderer>
+where
+    Renderer: renderer::Renderer,
+{
+    Opacity::new(opacity, content)
+}


### PR DESCRIPTION
Re-opening this PR with correct source branch: https://github.com/iced-rs/iced/pull/3182
And fully rebased on latest master.

Features:

New Opacity widget - Wraps any content and applies transparency
Nested opacity support - Opacity values multiply when nested (e.g., 50% × 50% = 25%)
GPU-accelerated - Implemented in both wgpu and tiny-skia renderers
Affects everything - Backgrounds, borders, images, SVGs, and text all respect opacity
Example added demonstrating how simple it is to integrate and how to do fade-in/out animations.

Related issue: https://github.com/iced-rs/iced/issues/912

<img width="1783" height="1324" alt="image" src="https://github.com/user-attachments/assets/eaebf256-9366-4a01-b267-cab41e34a5d2" />
