### PR TITLE
Replace chrono in clock example with jiff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,19 +780,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "chrono"
-version = "0.4.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
-dependencies = [
- "iana-time-zone",
- "js-sys",
- "num-traits",
- "wasm-bindgen",
- "windows-link",
-]
-
-[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -857,8 +844,8 @@ dependencies = [
 name = "clock"
 version = "0.1.0"
 dependencies = [
- "chrono",
  "iced",
+ "jiff",
  "tracing-subscriber",
 ]
 
@@ -2232,30 +2219,6 @@ dependencies = [
  "tower-service",
  "tracing",
  "windows-registry",
-]
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core 0.62.2",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
 ]
 
 [[package]]

--- a/examples/clock/Cargo.toml
+++ b/examples/clock/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 [dependencies]
 iced.workspace = true
 iced.features = ["canvas", "tokio", "debug"]
-chrono = "0.4"
+jiff = "0.2.31"
 tracing-subscriber = "0.3"

--- a/examples/clock/src/main.rs
+++ b/examples/clock/src/main.rs
@@ -18,19 +18,19 @@ pub fn main() -> iced::Result {
 }
 
 struct Clock {
-    now: chrono::DateTime<chrono::Local>,
+    now: jiff::Zoned,
     clock: Cache,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 enum Message {
-    Tick(chrono::DateTime<chrono::Local>),
+    Tick(jiff::Zoned),
 }
 
 impl Clock {
     fn new() -> Self {
         Self {
-            now: chrono::offset::Local::now(),
+            now: jiff::Zoned::now(),
             clock: Cache::default(),
         }
     }
@@ -55,11 +55,11 @@ impl Clock {
     }
 
     fn subscription(&self) -> Subscription<Message> {
-        time::every(milliseconds(500)).map(|_| Message::Tick(chrono::offset::Local::now()))
+        time::every(milliseconds(500)).map(|_| Message::Tick(jiff::Zoned::now()))
     }
 
     fn theme(&self) -> Theme {
-        Theme::ALL[(self.now.timestamp() as usize / 10) % Theme::ALL.len()].clone()
+        Theme::ALL[(self.now.timestamp().as_second() as usize / 10) % Theme::ALL.len()].clone()
     }
 }
 
@@ -74,8 +74,6 @@ impl<Message> canvas::Program<Message> for Clock {
         bounds: Rectangle,
         _cursor: mouse::Cursor,
     ) -> Vec<Geometry> {
-        use chrono::Timelike;
-
         let clock = self.clock.draw(renderer, bounds.size(), |frame| {
             let palette = theme.palette();
             let center = frame.center();
@@ -185,7 +183,7 @@ impl<Message> canvas::Program<Message> for Clock {
     }
 }
 
-fn hand_rotation(n: u32, total: u32) -> Degrees {
+fn hand_rotation(n: i8, total: u32) -> Degrees {
     let turns = n as f32 / total as f32;
 
     Degrees(360.0 * turns)


### PR DESCRIPTION
`chrono` is soft-deprecated (https://github.com/chronotope/chrono/issues/1768) and `jiff` is already used by the changelog example.