### PR TITLE
Don't allocate for zero- or one-stream batches in `Task::batch`

### DIFF
--- a/runtime/src/task.rs
+++ b/runtime/src/task.rs
@@ -96,11 +96,14 @@ impl<T> Task<T> {
     where
         T: 'static,
     {
+        let mut last_stream = None;
         let mut select_all = stream::SelectAll::new();
         let mut units = 0;
 
         for task in tasks.into_iter() {
-            if let Some(stream) = task.stream {
+            if let Some(stream) = task.stream
+                && let Some(stream) = last_stream.replace(stream)
+            {
                 select_all.push(stream);
             }
 
@@ -108,7 +111,12 @@ impl<T> Task<T> {
         }
 
         Self {
-            stream: Some(boxed_stream(select_all)),
+            stream: if select_all.is_empty() {
+                last_stream
+            } else {
+                select_all.extend(last_stream);
+                Some(boxed_stream(select_all))
+            },
             units,
         }
     }


### PR DESCRIPTION
A rather trivial optimization that saves on allocating when batching an iterator of zero or one non-none tasks.

I heavily abuse `Task::batch` to compose messages, and it not adding unnecessary heap allocations and `dyn`-indirection would make me feel a lot less bad about it 😆