### PR TITLE
Fixed reference in primitive docs

### DIFF
--- a/wgpu/src/primitive.rs
+++ b/wgpu/src/primitive.rs
@@ -18,7 +18,7 @@ pub trait Primitive: Debug + MaybeSend + MaybeSync + 'static {
     /// a rendering pipeline, buffers, and textures.
     ///
     /// All instances of this [`Primitive`] type will share the same
-    /// [`Renderer`].
+    /// [`Pipeline`].
     type Pipeline: Pipeline + MaybeSend + MaybeSync;
 
     /// Processes the [`Primitive`], allowing for GPU buffer allocation.


### PR DESCRIPTION
After changing from `Primitive::Renderer` to `Primitive::Pipeline`, the reference to `Renderer` in the documentation was not updated. This PR fixes that