### PR TITLE
Addes a kinetic scrolling for touchpad scrolling

### DIFF
--- a/core/src/mouse.rs
+++ b/core/src/mouse.rs
@@ -9,5 +9,5 @@ mod interaction;
 pub use button::Button;
 pub use click::Click;
 pub use cursor::Cursor;
-pub use event::{Event, ScrollDelta};
+pub use event::{Event, ScrollDelta, ScrollPhase};
 pub use interaction::Interaction;

--- a/core/src/mouse/event.rs
+++ b/core/src/mouse/event.rs
@@ -28,10 +28,12 @@ pub enum Event {
     /// A mouse button was released.
     ButtonReleased(Button),
 
-    /// The mouse wheel was scrolled.
+    /// The mouse wheel or touchpad was scrolled
     WheelScrolled {
         /// The scroll movement.
         delta: ScrollDelta,
+        /// The scroll phase (for mouse - only Move)
+        phase: ScrollPhase,
     },
 }
 
@@ -53,4 +55,17 @@ pub enum ScrollDelta {
         /// The number of vertical pixels scrolled
         y: f32,
     },
+}
+
+/// A scrolling phase (for mouses it would be only Moved)
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ScrollPhase {
+    /// Start scrolling with touchpad
+    Started,
+    /// Scrolling with mouse or continue scrolling with touchpad
+    Moved,
+    /// End of scrolling with touchpad
+    Ended,
+    /// System cancel process of srcolling (window lost focus, compositor interruption etc)
+    Cancelled,
 }

--- a/core/src/text/editor.rs
+++ b/core/src/text/editor.rs
@@ -423,7 +423,7 @@ impl State {
 
                     Some(Update::Action(Action::Drag(position)))
                 }
-                mouse::Event::WheelScrolled { delta } if cursor.is_over(bounds) => {
+                mouse::Event::WheelScrolled { delta, .. } if cursor.is_over(bounds) => {
                     let bounds = editor.bounds();
 
                     if bounds.height >= i32::MAX as f32 {

--- a/examples/game_of_life/src/main.rs
+++ b/examples/game_of_life/src/main.rs
@@ -450,7 +450,7 @@ mod grid {
                             _ => action.and_capture(),
                         })
                     }
-                    mouse::Event::WheelScrolled { delta } => match *delta {
+                    mouse::Event::WheelScrolled { delta, .. } => match *delta {
                         mouse::ScrollDelta::Lines { y, .. }
                         | mouse::ScrollDelta::Pixels { y, .. } => {
                             if y < 0.0 && self.scaling > Self::MIN_SCALING

--- a/widget/src/image/viewer.rs
+++ b/widget/src/image/viewer.rs
@@ -160,7 +160,7 @@ where
         let bounds = layout.bounds();
 
         match event {
-            Event::Mouse(mouse::Event::WheelScrolled { delta }) => {
+            Event::Mouse(mouse::Event::WheelScrolled { delta, .. }) => {
                 let Some(cursor_position) = cursor.position_over(bounds) else {
                     return;
                 };

--- a/widget/src/mouse_area.rs
+++ b/widget/src/mouse_area.rs
@@ -397,7 +397,7 @@ fn update<Message: Clone, Theme, Renderer>(
                 shell.publish(message.clone());
             }
         }
-        Event::Mouse(mouse::Event::WheelScrolled { delta }) => {
+        Event::Mouse(mouse::Event::WheelScrolled { delta, .. }) => {
             if let Some(on_scroll) = widget.on_scroll.as_ref() {
                 shell.publish(on_scroll(*delta));
                 shell.capture_event();

--- a/widget/src/pick_list.rs
+++ b/widget/src/pick_list.rs
@@ -471,6 +471,7 @@ where
             }
             Event::Mouse(mouse::Event::WheelScrolled {
                 delta: mouse::ScrollDelta::Lines { y, .. },
+                phase: mouse::ScrollPhase::Moved,
             }) => {
                 let Some(on_select) = &self.on_select else {
                     return;

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -105,7 +105,7 @@ where
             content: content.into(),
             on_scroll: None,
             class: Theme::default(),
-            kinetic_retention: 0.9,
+            kinetic_retention: 0.98,
         }
     }
 

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -817,46 +817,50 @@ where
 
                     state.scroll(self.direction.align(delta), bounds, content_bounds);
 
-                    match phase {
-                        mouse::ScrollPhase::Started => {
-                            state.interaction = Interaction::TrackpadScrolling {
-                                timestamp: Instant::now(),
-                                speed: Vector::new(0.0, 0.0),
-                            };
-                        }
-                        mouse::ScrollPhase::Moved
-                            if let Interaction::TrackpadScrolling { timestamp, .. } =
-                                state.interaction =>
-                        {
-                            let cur = Instant::now();
-                            state.interaction = Interaction::TrackpadScrolling {
-                                timestamp: cur,
-                                speed: delta / (cur.duration_since(timestamp).as_secs_f32()),
-                            };
-                        }
-                        mouse::ScrollPhase::Ended
-                            if let Interaction::TrackpadScrolling { speed, .. } =
-                                state.interaction =>
-                        {
-                            if speed.x.abs() + speed.y.abs() > KINETIC_SCROLL_BOUNDARY {
-                                state.interaction = Interaction::KineticScrolling {
+                    // macOS has its own kinetic scrolling
+                    #[cfg(not(target_os = "macos"))]
+                    {
+                        match phase {
+                            mouse::ScrollPhase::Started => {
+                                state.interaction = Interaction::TrackpadScrolling {
                                     timestamp: Instant::now(),
-                                    speed,
+                                    speed: Vector::new(0.0, 0.0),
                                 };
-                                shell.request_redraw();
-                            } else {
+                            }
+                            mouse::ScrollPhase::Moved
+                                if let Interaction::TrackpadScrolling { timestamp, .. } =
+                                    state.interaction =>
+                            {
+                                let cur = Instant::now();
+                                state.interaction = Interaction::TrackpadScrolling {
+                                    timestamp: cur,
+                                    speed: delta / (cur.duration_since(timestamp).as_secs_f32()),
+                                };
+                            }
+                            mouse::ScrollPhase::Ended
+                                if let Interaction::TrackpadScrolling { speed, .. } =
+                                    state.interaction =>
+                            {
+                                if speed.x.abs() + speed.y.abs() > KINETIC_SCROLL_BOUNDARY {
+                                    state.interaction = Interaction::KineticScrolling {
+                                        timestamp: Instant::now(),
+                                        speed,
+                                    };
+                                    shell.request_redraw();
+                                } else {
+                                    state.interaction = Interaction::None;
+                                }
+                            }
+                            mouse::ScrollPhase::Cancelled
+                                if matches!(
+                                    state.interaction,
+                                    Interaction::TrackpadScrolling { .. }
+                                ) =>
+                            {
                                 state.interaction = Interaction::None;
                             }
+                            _ => {}
                         }
-                        mouse::ScrollPhase::Cancelled
-                            if matches!(
-                                state.interaction,
-                                Interaction::TrackpadScrolling { .. }
-                            ) =>
-                        {
-                            state.interaction = Interaction::None;
-                        }
-                        _ => {}
                     }
 
                     let has_scrolled =

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -41,6 +41,7 @@ use crate::core::{
 
 pub use operation::scrollable::{AbsoluteOffset, RelativeOffset};
 
+const KINETIC_SCROLL_BOUNDARY: f32 = 0.5;
 /// A widget that can vertically display an infinite amount of content with a
 /// scrollbar.
 ///
@@ -76,6 +77,8 @@ where
     content: Element<'a, Message, Theme, Renderer>,
     on_scroll: Option<Box<dyn Fn(Viewport) -> Message + 'a>>,
     class: Theme::Class<'a>,
+    /// retention coef for kinetic scroll (active only for touchpads)
+    kinetic_retention: f32,
 }
 
 impl<'a, Message, Theme, Renderer> Scrollable<'a, Message, Theme, Renderer>
@@ -102,7 +105,15 @@ where
             content: content.into(),
             on_scroll: None,
             class: Theme::default(),
+            kinetic_retention: 0.9,
         }
+    }
+
+    /// Set retention coef for kinetic scroll (between 0 and 1, default 0.9. Bigger - longer
+    /// inertia, smaller - shorter inertia)
+    pub fn kinetic_retention(mut self, retention: f32) -> Self {
+        self.kinetic_retention = retention;
+        self
     }
 
     /// Makes the [`Scrollable`] scroll horizontally, with default [`Scrollbar`] settings.
@@ -705,20 +716,22 @@ where
                 }
             }
 
-            if matches!(state.interaction, Interaction::AutoScrolling { .. })
-                && matches!(
-                    event,
-                    Event::Mouse(
-                        mouse::Event::ButtonPressed(_) | mouse::Event::WheelScrolled { .. }
-                    ) | Event::Touch(_)
-                        | Event::Keyboard(_)
-                )
-            {
+            if matches!(
+                state.interaction,
+                Interaction::AutoScrolling { .. } | Interaction::KineticScrolling { .. }
+            ) && matches!(
+                event,
+                Event::Mouse(mouse::Event::ButtonPressed(_) | mouse::Event::WheelScrolled { .. })
+                    | Event::Touch(_)
+                    | Event::Keyboard(_)
+            ) {
                 state.interaction = Interaction::None;
-                shell.capture_event();
-                shell.invalidate_layout();
-                shell.request_redraw();
-                return;
+                if matches!(state.interaction, Interaction::AutoScrolling { .. }) {
+                    shell.capture_event();
+                    shell.invalidate_layout();
+                    shell.request_redraw();
+                    return;
+                }
             }
 
             if state.last_scrolled.is_none()
@@ -774,7 +787,7 @@ where
             }
 
             match event {
-                Event::Mouse(mouse::Event::WheelScrolled { delta }) => {
+                Event::Mouse(mouse::Event::WheelScrolled { delta, phase }) => {
                     if cursor_over_scrollable.is_none() {
                         return;
                     }
@@ -803,6 +816,48 @@ where
                     };
 
                     state.scroll(self.direction.align(delta), bounds, content_bounds);
+
+                    match phase {
+                        mouse::ScrollPhase::Started => {
+                            state.interaction = Interaction::TrackpadScrolling {
+                                timestamp: Instant::now(),
+                                speed: Vector::new(0.0, 0.0),
+                            };
+                        }
+                        mouse::ScrollPhase::Moved
+                            if let Interaction::TrackpadScrolling { timestamp, .. } =
+                                state.interaction =>
+                        {
+                            let cur = Instant::now();
+                            state.interaction = Interaction::TrackpadScrolling {
+                                timestamp: cur,
+                                speed: delta / (cur.duration_since(timestamp).as_secs_f32()),
+                            };
+                        }
+                        mouse::ScrollPhase::Ended
+                            if let Interaction::TrackpadScrolling { speed, .. } =
+                                state.interaction =>
+                        {
+                            if speed.x.abs() + speed.y.abs() > KINETIC_SCROLL_BOUNDARY {
+                                state.interaction = Interaction::KineticScrolling {
+                                    timestamp: Instant::now(),
+                                    speed,
+                                };
+                                shell.request_redraw();
+                            } else {
+                                state.interaction = Interaction::None;
+                            }
+                        }
+                        mouse::ScrollPhase::Cancelled
+                            if matches!(
+                                state.interaction,
+                                Interaction::TrackpadScrolling { .. }
+                            ) =>
+                        {
+                            state.interaction = Interaction::None;
+                        }
+                        _ => {}
+                    }
 
                     let has_scrolled =
                         notify_scroll(state, &self.on_scroll, bounds, content_bounds, shell);
@@ -901,77 +956,112 @@ where
                     state.keyboard_modifiers = *modifiers;
                 }
                 Event::Window(window::Event::RedrawRequested(now)) => {
-                    if let Interaction::AutoScrolling {
-                        origin,
-                        current,
-                        last_frame,
-                    } = state.interaction
-                    {
-                        if last_frame == Some(*now) {
-                            shell.request_redraw();
-                            return;
-                        }
+                    match state.interaction {
+                        Interaction::KineticScrolling { timestamp, speed } => {
+                            if speed.x.abs() + speed.y.abs() > KINETIC_SCROLL_BOUNDARY {
+                                let cur = Instant::now();
+                                let duration = cur.duration_since(timestamp).as_secs_f32();
+                                let new_speed =
+                                    speed * self.kinetic_retention.powf(duration * 60.0);
+                                state.scroll(
+                                    self.direction.align(new_speed * duration),
+                                    bounds,
+                                    content_bounds,
+                                );
+                                let has_scrolled = notify_scroll(
+                                    state,
+                                    &self.on_scroll,
+                                    bounds,
+                                    content_bounds,
+                                    shell,
+                                );
 
-                        state.interaction = Interaction::AutoScrolling {
+                                if !has_scrolled {
+                                    state.interaction = Interaction::None;
+                                } else {
+                                    state.interaction = Interaction::KineticScrolling {
+                                        timestamp: cur,
+                                        speed: new_speed,
+                                    };
+                                    shell.invalidate_layout();
+                                    shell.request_redraw();
+                                    return;
+                                }
+                            } else {
+                                state.interaction = Interaction::None;
+                            }
+                        }
+                        Interaction::AutoScrolling {
                             origin,
                             current,
-                            last_frame: None,
-                        };
-
-                        let mut delta = current - origin;
-
-                        if delta.x.abs() < AUTOSCROLL_DEADZONE {
-                            delta.x = 0.0;
-                        }
-
-                        if delta.y.abs() < AUTOSCROLL_DEADZONE {
-                            delta.y = 0.0;
-                        }
-
-                        if delta.x != 0.0 || delta.y != 0.0 {
-                            let time_delta = if let Some(last_frame) = last_frame {
-                                *now - last_frame
-                            } else {
-                                Duration::ZERO
-                            };
-
-                            let scroll_factor = time_delta.as_secs_f32();
-
-                            state.scroll(
-                                self.direction.align(Vector::new(
-                                    delta.x.signum()
-                                        * delta.x.abs().powf(AUTOSCROLL_SMOOTHNESS)
-                                        * scroll_factor,
-                                    delta.y.signum()
-                                        * delta.y.abs().powf(AUTOSCROLL_SMOOTHNESS)
-                                        * scroll_factor,
-                                )),
-                                bounds,
-                                content_bounds,
-                            );
-
-                            let has_scrolled = notify_scroll(
-                                state,
-                                &self.on_scroll,
-                                bounds,
-                                content_bounds,
-                                shell,
-                            );
-
-                            if has_scrolled || time_delta.is_zero() {
-                                state.interaction = Interaction::AutoScrolling {
-                                    origin,
-                                    current,
-                                    last_frame: Some(*now),
-                                };
-
+                            last_frame,
+                        } => {
+                            if last_frame == Some(*now) {
                                 shell.request_redraw();
+                                return;
                             }
 
-                            return;
-                        }
-                    }
+                            state.interaction = Interaction::AutoScrolling {
+                                origin,
+                                current,
+                                last_frame: None,
+                            };
 
+                            let mut delta = current - origin;
+
+                            if delta.x.abs() < AUTOSCROLL_DEADZONE {
+                                delta.x = 0.0;
+                            }
+
+                            if delta.y.abs() < AUTOSCROLL_DEADZONE {
+                                delta.y = 0.0;
+                            }
+
+                            if delta.x != 0.0 || delta.y != 0.0 {
+                                let time_delta = if let Some(last_frame) = last_frame {
+                                    *now - last_frame
+                                } else {
+                                    Duration::ZERO
+                                };
+
+                                let scroll_factor = time_delta.as_secs_f32();
+
+                                state.scroll(
+                                    self.direction.align(Vector::new(
+                                        delta.x.signum()
+                                            * delta.x.abs().powf(AUTOSCROLL_SMOOTHNESS)
+                                            * scroll_factor,
+                                        delta.y.signum()
+                                            * delta.y.abs().powf(AUTOSCROLL_SMOOTHNESS)
+                                            * scroll_factor,
+                                    )),
+                                    bounds,
+                                    content_bounds,
+                                );
+
+                                let has_scrolled = notify_scroll(
+                                    state,
+                                    &self.on_scroll,
+                                    bounds,
+                                    content_bounds,
+                                    shell,
+                                );
+
+                                if has_scrolled || time_delta.is_zero() {
+                                    state.interaction = Interaction::AutoScrolling {
+                                        origin,
+                                        current,
+                                        last_frame: Some(*now),
+                                    };
+
+                                    shell.request_redraw();
+                                }
+
+                                return;
+                            }
+                        }
+                        _ => {}
+                    }
                     let _ = notify_viewport(state, &self.on_scroll, bounds, content_bounds, shell);
                 }
                 _ => {}
@@ -1504,6 +1594,14 @@ enum Interaction {
     None,
     YScrollerGrabbed(f32),
     XScrollerGrabbed(f32),
+    KineticScrolling {
+        timestamp: Instant,
+        speed: Vector,
+    },
+    TrackpadScrolling {
+        timestamp: Instant,
+        speed: Vector,
+    },
     TouchScrolling(Point),
     AutoScrolling {
         origin: Point,

--- a/widget/src/slider.rs
+++ b/widget/src/slider.rs
@@ -360,7 +360,7 @@ where
 
                     shell.capture_event();
                 }
-                Event::Mouse(mouse::Event::WheelScrolled { delta })
+                Event::Mouse(mouse::Event::WheelScrolled { delta, .. })
                     if state.keyboard_modifiers.control() && cursor.is_over(layout.bounds()) =>
                 {
                     let delta = match delta {

--- a/widget/src/vertical_slider.rs
+++ b/widget/src/vertical_slider.rs
@@ -363,7 +363,7 @@ where
 
                 shell.capture_event();
             }
-            Event::Mouse(mouse::Event::WheelScrolled { delta })
+            Event::Mouse(mouse::Event::WheelScrolled { delta, .. })
                 if state.keyboard_modifiers.control() && cursor.is_over(layout.bounds()) =>
             {
                 let delta = match *delta {

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -10,6 +10,15 @@ use crate::core::touch;
 use crate::core::window;
 use crate::core::{Event, Point, Size};
 
+fn convert_phase(phase: winit::event::TouchPhase) -> mouse::ScrollPhase {
+    match phase {
+        winit::event::TouchPhase::Started => mouse::ScrollPhase::Started,
+        winit::event::TouchPhase::Moved => mouse::ScrollPhase::Moved,
+        winit::event::TouchPhase::Ended => mouse::ScrollPhase::Ended,
+        winit::event::TouchPhase::Cancelled => mouse::ScrollPhase::Cancelled,
+    }
+}
+
 /// Converts some [`window::Settings`] into some `WindowAttributes` from `winit`.
 pub fn window_attributes(
     settings: window::Settings,
@@ -181,13 +190,14 @@ pub fn window_event(
                 winit::event::ElementState::Released => mouse::Event::ButtonReleased(button),
             }))
         }
-        WindowEvent::MouseWheel { delta, .. } => match delta {
+        WindowEvent::MouseWheel { delta, phase, .. } => match delta {
             winit::event::MouseScrollDelta::LineDelta(delta_x, delta_y) => {
                 Some(Event::Mouse(mouse::Event::WheelScrolled {
                     delta: mouse::ScrollDelta::Lines {
                         x: delta_x,
                         y: delta_y,
                     },
+                    phase: convert_phase(phase),
                 }))
             }
             winit::event::MouseScrollDelta::PixelDelta(position) => {
@@ -196,6 +206,7 @@ pub fn window_event(
                         x: position.x as f32,
                         y: position.y as f32,
                     },
+                    phase: convert_phase(phase),
                 }))
             }
         },


### PR DESCRIPTION
This PR addes kinetic scrolling for scrolling via touchpad.
Changes:
* addes phase field to mouse::Event::WheelScrolled. It is enum-sibling to the same enum of winit and this field helps track begin and end phases of touchpad scrolling
* addes TrackpadScrolling and KineticScrolling variant to state.interaction for scrollable widget to correct keep speed of scrolling
* performs logic of kinetic scrolling including stop it on tap on touchpad or any other input (literally like with AutoScrolling)
* addes method kinetic_retention for addes different coef of kinetic retention.
 
This PR does not add kinetic scrolling for touchscreen scrolling. This possibility will be added later.