### PR TITLE
Ensure `menu::Overlay` captures mouse interactions while hovered

### DIFF
--- a/widget/src/overlay/menu.rs
+++ b/widget/src/overlay/menu.rs
@@ -293,8 +293,15 @@ where
         cursor: mouse::Cursor,
         renderer: &Renderer,
     ) -> mouse::Interaction {
-        self.list
-            .mouse_interaction(self.tree, layout, cursor, &self.viewport, renderer)
+        let interaction =
+            self.list
+                .mouse_interaction(self.tree, layout, cursor, &self.viewport, renderer);
+
+        if interaction == mouse::Interaction::None && cursor.is_over(layout.bounds()) {
+            mouse::Interaction::Idle
+        } else {
+            interaction
+        }
     }
 
     fn draw(


### PR DESCRIPTION
Previously, hovering over the scroller in the menu would not block widgets under the menu from having their mouse interaction leak through:

https://github.com/user-attachments/assets/8192ee48-efef-4904-8c5e-946a95e5fb53


