### PR TITLE
Switch combo box matchers from ascii-alphanumeric splitting to unicode word splitting

### DIFF
--- a/widget/src/combo_box.rs
+++ b/widget/src/combo_box.rs
@@ -328,6 +328,7 @@ where
 #[derive(Debug, Clone)]
 pub struct State<T> {
     options: Vec<T>,
+    matchers: Vec<String>,
     version: u64,
 }
 
@@ -340,6 +341,7 @@ where
     /// Creates a new [`State`] for a [`ComboBox`] with the given list of options.
     pub fn new(options: Vec<T>) -> Self {
         Self {
+            matchers: options.iter().map(build_matcher).collect(),
             options,
             version: VERSION.fetch_add(1, atomic::Ordering::Relaxed),
         }
@@ -355,6 +357,7 @@ where
 
     /// Pushes a new option to the [`State`].
     pub fn push(&mut self, new_option: T) {
+        self.matchers.push(build_matcher(&new_option));
         self.options.push(new_option);
         self.version = VERSION.fetch_add(1, atomic::Ordering::Relaxed);
     }
@@ -378,7 +381,6 @@ struct Internal<T, R: text::Renderer> {
     editor: Editor<R>,
     menu: menu::State,
     hovered_option: Option<usize>,
-    option_matchers: Vec<String>,
     filtered_options: Vec<T>,
     version: u64,
 }
@@ -390,9 +392,8 @@ impl<T: Display + Clone, R: text::Renderer> Internal<T, R> {
         index.min(self.filtered_options.len().saturating_sub(1))
     }
 
-    fn filter(&mut self, options: &[T], value: &str) {
-        self.option_matchers = build_matchers(options);
-        self.filtered_options = search(options, &self.option_matchers, value)
+    fn filter(&mut self, state: &State<T>, value: &str) {
+        self.filtered_options = search(&state.options, &state.matchers, value)
             .cloned()
             .collect();
     }
@@ -455,7 +456,6 @@ where
             },
             menu: menu::State::new(),
             filtered_options: Vec::new(),
-            option_matchers: Vec::new(),
             hovered_option: Some(0),
             version: 0,
         })
@@ -469,7 +469,7 @@ where
         {
             state.editor.input.overwrite(&self.selection);
             state.editor.selection = Some(self.selection.clone());
-            state.filter(&self.state.options, &self.selection);
+            state.filter(self.state, &self.selection);
 
             state.version = self.state.version;
         }
@@ -504,7 +504,7 @@ where
                 shell.publish(on_input(value.clone()));
             }
 
-            internal.filter(&self.state.options, &value);
+            internal.filter(self.state, &value);
         }
 
         let is_focused = internal.editor.input.is_focused();
@@ -805,11 +805,7 @@ fn search<'a, T, A>(
 where
     A: AsRef<str> + 'a,
 {
-    let query: Vec<String> = query
-        .to_lowercase()
-        .unicode_words()
-        .map(String::from)
-        .collect();
+    let query: Vec<String> = query.unicode_words().map(str::to_lowercase).collect();
 
     options
         .into_iter()
@@ -824,13 +820,6 @@ where
         })
 }
 
-fn build_matchers<'a, T>(options: impl IntoIterator<Item = T> + 'a) -> Vec<String>
-where
-    T: Display + 'a,
-{
-    options.into_iter().map(build_matcher).collect()
-}
-
 fn build_matcher<T>(option: T) -> String
 where
     T: Display,
@@ -838,6 +827,7 @@ where
     option
         .to_string()
         .unicode_words()
+        .flat_map(str::chars)
+        .flat_map(char::to_lowercase)
         .collect::<String>()
-        .to_lowercase()
 }

--- a/widget/src/combo_box.rs
+++ b/widget/src/combo_box.rs
@@ -73,6 +73,7 @@ use crate::text_input;
 
 use std::fmt::Display;
 use std::sync::atomic::{self, AtomicU64};
+use unicode_segmentation::UnicodeSegmentation;
 
 /// A widget for searching and selecting a single value from a list of options.
 ///
@@ -806,7 +807,7 @@ where
 {
     let query: Vec<String> = query
         .to_lowercase()
-        .split(|c: char| !c.is_ascii_alphanumeric())
+        .unicode_words()
         .map(String::from)
         .collect();
 
@@ -834,7 +835,9 @@ fn build_matcher<T>(option: T) -> String
 where
     T: Display,
 {
-    let mut matcher = option.to_string();
-    matcher.retain(|c| c.is_ascii_alphanumeric());
-    matcher.to_lowercase()
+    option
+        .to_string()
+        .unicode_words()
+        .collect::<String>()
+        .to_lowercase()
 }

--- a/widget/src/combo_box.rs
+++ b/widget/src/combo_box.rs
@@ -393,9 +393,9 @@ impl<T: Display + Clone, R: text::Renderer> Internal<T, R> {
     }
 
     fn filter(&mut self, state: &State<T>, value: &str) {
-        self.filtered_options = search(&state.options, &state.matchers, value)
-            .cloned()
-            .collect();
+        self.filtered_options.clear();
+        self.filtered_options
+            .extend(search(&state.options, &state.matchers, value).cloned());
     }
 }
 


### PR DESCRIPTION
Not simply ignoring all non-ascii characters turns out to improve results when non-ascii characters are present :)

I've also included an optimization that changes matchers to be built only once when an option is pushed, instead of on every search.