### PR TITLE
Add underline decoration to `text::editor` via `highlighter::Format`

### DIFF
--- a/core/src/renderer/null.rs
+++ b/core/src/renderer/null.rs
@@ -221,6 +221,10 @@ impl text::Editor for () {
 
     fn overwrite(&mut self, _new_text: &str) {}
 
+    fn decorations(&self) -> Vec<text::editor::Decoration> {
+        Vec::new()
+    }
+
     fn highlight<H: text::Highlighter>(
         &mut self,
         _font: Self::Font,

--- a/core/src/text/editor.rs
+++ b/core/src/text/editor.rs
@@ -81,6 +81,11 @@ pub trait Editor: Sized + Default {
         format_highlight: impl Fn(&H::Highlight) -> highlighter::Format<Self::Font>,
     );
 
+    /// Returns the underline decorations of the [`Editor`].
+    ///
+    /// Coordinates match [`Self::selection`] (scroll + hint factor applied).
+    fn decorations(&self) -> Vec<Decoration>;
+
     /// Returns an iterator of the text of the lines in the [`Editor`].
     fn lines(&self) -> impl Iterator<Item = Line<'_>> {
         (0..)
@@ -250,6 +255,19 @@ pub enum Direction {
     Left,
     /// ->
     Right,
+}
+
+/// An underline decoration of an [`Editor`].
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Decoration {
+    /// The bounds of the decoration.
+    pub bounds: Rectangle,
+    /// The underline [`Color`], if known.
+    ///
+    /// If `None`, the editor text color should be used.
+    pub color: Option<Color>,
+    /// The underline style.
+    pub underline: highlighter::Underline,
 }
 
 /// The cursor of an [`Editor`].
@@ -611,13 +629,37 @@ impl State {
             renderer.fill_editor(editor, position, style.value, clip_bounds);
         }
 
-        if !self.is_focused() {
-            return;
-        }
-
         let translation = position - Point::ORIGIN;
         let text_size = editor.text_size();
         let line_height = editor.line_height();
+        let absolute_line_height = line_height.to_absolute(text_size);
+
+        for decoration in editor.decorations() {
+            if decoration.underline == highlighter::Underline::None {
+                continue;
+            }
+
+            let color = decoration.color.unwrap_or(style.value);
+            let bounds = decoration.bounds + translation;
+            let y = bounds.y + text_size.0 + (absolute_line_height.0 - text_size.0) / 2.0
+                - text_size.0 * 0.08;
+
+            let underline = Rectangle::new(Point::new(bounds.x, y), Size::new(bounds.width, 1.0));
+
+            if let Some(clipped) = clip_bounds.intersection(&underline) {
+                renderer.fill_quad(
+                    renderer::Quad {
+                        bounds: clipped,
+                        ..renderer::Quad::default()
+                    },
+                    color,
+                );
+            }
+        }
+
+        if !self.is_focused() {
+            return;
+        }
 
         match editor.selection() {
             Selection::Caret(position) if self.is_cursor_visible() => {

--- a/core/src/text/highlighter.rs
+++ b/core/src/text/highlighter.rs
@@ -76,6 +76,13 @@ pub struct Format<Font> {
     pub color: Option<Color>,
     /// The `Font` of the text.
     pub font: Option<Font>,
+    /// The underline decoration of the text.
+    pub underline: Underline,
+    /// The [`Color`] of the underline.
+    ///
+    /// If `None`, the underline uses [`Format::color`], or the editor text color
+    /// if that is also `None`.
+    pub underline_color: Option<Color>,
 }
 
 impl<Font> Default for Format<Font> {
@@ -83,6 +90,20 @@ impl<Font> Default for Format<Font> {
         Self {
             color: None,
             font: None,
+            underline: Underline::None,
+            underline_color: None,
         }
     }
+}
+
+/// The underline decoration of some text.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub enum Underline {
+    /// No underline.
+    ///
+    /// This is the default.
+    #[default]
+    None,
+    /// A solid underline.
+    Solid,
 }

--- a/examples/editor/Cargo.toml
+++ b/examples/editor/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 iced.workspace = true
-iced.features = ["highlighter", "tokio", "debug"]
+iced.features = ["highlighter", "tokio", "debug", "advanced"]
 
 tokio.workspace = true
 tokio.features = ["fs"]

--- a/examples/editor/src/main.rs
+++ b/examples/editor/src/main.rs
@@ -1,3 +1,4 @@
+use iced::advanced::text::highlighter::Underline;
 use iced::highlighter;
 use iced::keyboard;
 use iced::widget::{
@@ -5,7 +6,7 @@ use iced::widget::{
     toggler, tooltip,
 };
 use iced::window;
-use iced::{Center, Element, Fill, Font, Task, Theme, Window};
+use iced::{Center, Color, Element, Fill, Font, Task, Theme, Window};
 
 use std::ffi;
 use std::io;
@@ -203,13 +204,23 @@ impl Editor {
                 } else {
                     text::Wrapping::None
                 })
-                .highlight(
-                    self.file
-                        .as_deref()
-                        .and_then(Path::extension)
-                        .and_then(ffi::OsStr::to_str)
-                        .unwrap_or("rs"),
-                    self.theme,
+                .highlight_with::<highlighter::Highlighter>(
+                    highlighter::Settings {
+                        theme: self.theme,
+                        token: self
+                            .file
+                            .as_deref()
+                            .and_then(Path::extension)
+                            .and_then(ffi::OsStr::to_str)
+                            .unwrap_or("rs")
+                            .to_owned(),
+                    },
+                    |highlight, _theme| {
+                        let mut format = highlight.to_format();
+                        format.underline = Underline::Solid;
+                        format.underline_color = Some(Color::from_rgb8(220, 50, 47));
+                        format
+                    },
                 )
                 .key_binding(|key_press| {
                     match key_press.key.as_ref() {

--- a/graphics/src/text/editor.rs
+++ b/graphics/src/text/editor.rs
@@ -2,13 +2,14 @@
 use crate::core::text::editor::{self, Action, Cursor, Direction, Edit, Motion, Selection};
 use crate::core::text::highlighter::{self, Highlighter};
 use crate::core::text::{Alignment, LineHeight, Position, Wrapping};
-use crate::core::{Font, Pixels, Point, Rectangle, Size};
+use crate::core::{Color, Font, Pixels, Point, Rectangle, Size};
 use crate::text;
 
 use cosmic_text::Edit as _;
 
 use std::borrow::Cow;
 use std::fmt;
+use std::ops::Range;
 use std::sync::{self, Arc, RwLock};
 
 /// A multi-line text editor.
@@ -26,6 +27,8 @@ struct Internal {
     hint: bool,
     hint_factor: f32,
     version: text::Version,
+    underline_spans: Vec<(usize, Range<usize>, highlighter::Underline, Option<Color>)>,
+    decorations: Vec<editor::Decoration>,
 }
 
 impl Editor {
@@ -758,6 +761,7 @@ impl editor::Editor for Editor {
             }
 
             internal.editor.shape_as_needed(font_system.raw(), false);
+            relayout_decorations(internal);
         });
     }
 
@@ -794,6 +798,8 @@ impl editor::Editor for Editor {
             internal.editor.set_cursor(new_cursor);
 
             shape_until_cursor(&mut internal.editor, &mut font_system.raw);
+            internal.underline_spans.clear();
+            internal.decorations.clear();
         });
     }
 
@@ -845,9 +851,16 @@ impl editor::Editor for Editor {
 
         let attributes = text::to_attributes(font);
 
-        for line in &mut buffer_mut_from_editor(&mut internal.editor).lines
+        internal
+            .underline_spans
+            .retain(|(line, _, _, _)| *line < current_line || *line > last_visible_line);
+
+        for (i, line) in &mut buffer_mut_from_editor(&mut internal.editor).lines
             [current_line..=last_visible_line]
+            .iter_mut()
+            .enumerate()
         {
+            let line_index = current_line + i;
             let mut list = cosmic_text::AttrsList::new(&attributes);
 
             for (range, highlight) in highlighter.highlight_line(line.text()) {
@@ -855,7 +868,7 @@ impl editor::Editor for Editor {
 
                 if format.color.is_some() || format.font.is_some() {
                     list.add_span(
-                        range,
+                        range.clone(),
                         &cosmic_text::Attrs {
                             color_opt: format.color.map(text::to_color),
                             ..if let Some(font) = format.font {
@@ -866,14 +879,28 @@ impl editor::Editor for Editor {
                         },
                     );
                 }
+
+                if format.underline != highlighter::Underline::None {
+                    internal.underline_spans.push((
+                        line_index,
+                        range,
+                        format.underline,
+                        format.underline_color.or(format.color),
+                    ));
+                }
             }
 
             let _ = line.set_attrs_list(list);
         }
 
         internal.editor.shape_as_needed(font_system.raw(), false);
+        relayout_decorations(&mut internal);
 
         self.0 = Some(Arc::new(internal));
+    }
+
+    fn decorations(&self) -> Vec<editor::Decoration> {
+        self.internal().decorations.clone()
     }
 
     fn text_size(&self) -> Pixels {
@@ -928,6 +955,8 @@ impl Default for Internal {
             hint: false,
             hint_factor: 1.0,
             version: text::Version::default(),
+            underline_spans: Vec::new(),
+            decorations: Vec::new(),
         }
     }
 }
@@ -961,6 +990,40 @@ impl PartialEq for Weak {
         match (self.raw.upgrade(), other.raw.upgrade()) {
             (Some(p1), Some(p2)) => p1 == p2,
             _ => false,
+        }
+    }
+}
+
+fn relayout_decorations(internal: &mut Internal) {
+    let buffer = buffer_from_editor(&internal.editor);
+    let scroll = buffer.scroll();
+    let line_height = buffer.metrics().line_height;
+
+    internal.decorations.clear();
+
+    for (line_index, range, underline, color) in &internal.underline_spans {
+        let Some(line) = buffer.lines.get(*line_index) else {
+            continue;
+        };
+
+        let visual_lines_offset = visual_lines_offset(*line_index, buffer);
+
+        for (visual_line, (x, width)) in highlight_line(line, range.start, range.end).enumerate() {
+            if width <= 0.0 {
+                continue;
+            }
+
+            internal.decorations.push(editor::Decoration {
+                bounds: Rectangle {
+                    x: x - scroll.horizontal,
+                    width,
+                    y: (visual_line as i32 + visual_lines_offset) as f32 * line_height
+                        - scroll.vertical,
+                    height: line_height,
+                } * (1.0 / internal.hint_factor),
+                color: *color,
+                underline: *underline,
+            });
         }
     }
 }

--- a/highlighter/src/lib.rs
+++ b/highlighter/src/lib.rs
@@ -255,6 +255,8 @@ impl Highlight {
         Format {
             color: self.color(),
             font: self.font(),
+            underline: highlighter::Underline::None,
+            underline_color: None,
         }
     }
 }


### PR DESCRIPTION
Extend highlighter::Format with underline and underline_color, and have text::editor lay out and draw solid underlines from highlight spans. Decorations remain visible when the editor is unfocused.

The need comes from implementing a spellchecker in Halloy. I discovered that there is no native underline support in `text::editor` would let Halloy (and other apps) mark spans in a way that respects wrapping, scroll, and layout.
