### PR TITLE
Expose `bounds` and `min_bounds` publicly through `text_editor::Content`

### DIFF
--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -698,6 +698,16 @@ where
         Some(self.line(0)?.ending)
     }
 
+    /// Returns the current boundaries of the [`Content`].
+    pub fn bounds(&self) -> Size {
+        self.0.borrow().editor.bounds()
+    }
+
+    /// Returns the minimum boundaries to fit the current text in the [`Content`].
+    pub fn min_bounds(&self) -> Size {
+        self.0.borrow().editor.min_bounds()
+    }
+
     /// Returns whether or not the the [`Content`] is empty.
     pub fn is_empty(&self) -> bool {
         self.0.borrow().editor.is_empty()


### PR DESCRIPTION
This PR exposes `bounds` and `min_bounds` publicly through `text_editor::Content`

**potential use case:** a spreadsheet app, for example, extends the text editor by the width of the next cell (please refer to the attached recording). Since the cell size is dynamic, there is no way to implement this precisely using `layout::Limits`. In this situation, exposing the raw bounds would allow the caller to compute the layout bounds on demand

https://github.com/user-attachments/assets/f5160ce2-53db-4391-819b-4f266d71e6c5

