### PR TITLE
Support SVG `currentColor` being set to renderer text color

### DIFF
--- a/core/src/svg.rs
+++ b/core/src/svg.rs
@@ -22,6 +22,11 @@ pub struct Svg<H = Handle> {
     /// (e.g. with a theme).
     pub color: Option<Color>,
 
+    /// The default color used when the [`Svg`] references `currentColor`.
+    ///
+    /// Overrides the `color` field of the SVG.
+    pub current_color: Option<Color>,
+
     /// The rotation to be applied to the image; on its center.
     pub rotation: Radians,
 
@@ -37,6 +42,7 @@ impl Svg<Handle> {
         Self {
             handle: handle.into(),
             color: None,
+            current_color: None,
             rotation: Radians(0.0),
             opacity: 1.0,
         }
@@ -45,6 +51,12 @@ impl Svg<Handle> {
     /// Sets the [`Color`] filter of the [`Svg`].
     pub fn color(mut self, color: impl Into<Color>) -> Self {
         self.color = Some(color.into());
+        self
+    }
+
+    /// Sets the current renderer color of the [`Svg`].
+    pub fn current_color(mut self, current_color: impl Into<Color>) -> Self {
+        self.current_color = Some(current_color.into());
         self
     }
 
@@ -156,4 +168,13 @@ pub trait Renderer: crate::Renderer {
 
     /// Draws an SVG with the given [`Handle`], an optional [`Color`] filter, and inside the provided `bounds`.
     fn draw_svg(&mut self, svg: Svg, bounds: Rectangle, clip_bounds: Rectangle);
+}
+
+/// Gets the style sheet to apply to an SVG to override the `color` attribute.
+pub fn color_style_sheet(color: Color) -> String {
+    let color = color.into_rgba8();
+    format!(
+        "svg {{ color: rgba({}, {}, {}, {}); }}",
+        color[0], color[1], color[2], color[3]
+    )
 }

--- a/examples/svg/src/main.rs
+++ b/examples/svg/src/main.rs
@@ -34,6 +34,7 @@ impl Tiger {
                 } else {
                     None
                 },
+                ..Default::default()
             });
 
         let apply_color_filter = checkbox(self.apply_color_filter)

--- a/tiny_skia/src/engine.rs
+++ b/tiny_skia/src/engine.rs
@@ -574,6 +574,7 @@ impl Engine {
                 self.vector_pipeline.draw(
                     &svg.handle,
                     svg.color,
+                    svg.current_color,
                     *bounds,
                     svg.opacity,
                     _pixels,

--- a/tiny_skia/src/vector.rs
+++ b/tiny_skia/src/vector.rs
@@ -1,4 +1,4 @@
-use crate::core::svg::{Data, Handle};
+use crate::core::svg::{self, Data, Handle};
 use crate::core::{Color, Rectangle, Size};
 
 use resvg::usvg;
@@ -35,6 +35,7 @@ impl Pipeline {
         &mut self,
         handle: &Handle,
         color: Option<Color>,
+        current_color: Option<Color>,
         bounds: Rectangle,
         opacity: f32,
         pixels: &mut tiny_skia::PixmapMut<'_>,
@@ -44,6 +45,7 @@ impl Pipeline {
         if let Some(image) = self.cache.borrow_mut().draw(
             handle,
             color,
+            current_color,
             Size::new(
                 (bounds.width * transform.sx) as u32,
                 (bounds.height * transform.sy) as u32,
@@ -70,23 +72,42 @@ impl Pipeline {
 
 #[derive(Default)]
 struct Cache {
-    trees: FxHashMap<u64, Option<resvg::usvg::Tree>>,
-    tree_hits: FxHashSet<u64>,
+    trees: FxHashMap<Key, Option<resvg::usvg::Tree>>,
+    tree_hits: FxHashSet<Key>,
     rasters: FxHashMap<RasterKey, tiny_skia::Pixmap>,
     raster_hits: FxHashSet<RasterKey>,
     #[cfg(feature = "svg-text")]
     fontdb: Option<Arc<usvg::fontdb::Database>>,
 }
 
+/// Key for identifying SVGs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct Key {
+    id: u64,
+    current_color: ColorKey,
+}
+
+impl Key {
+    pub fn new(id: u64, color: Option<Color>) -> Self {
+        Self {
+            id,
+            current_color: color.map(Color::into_rgba8),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 struct RasterKey {
     id: u64,
-    color: Option<[u8; 4]>,
+    color: ColorKey,
+    current_color: ColorKey,
     size: Size<u32>,
 }
 
+type ColorKey = Option<[u8; 4]>;
+
 impl Cache {
-    fn load(&mut self, handle: &Handle) -> Option<&usvg::Tree> {
+    fn load(&mut self, handle: &Handle, current_color: Option<Color>) -> Option<&usvg::Tree> {
         let id = handle.id();
 
         // TODO: Reuse `cosmic-text` font database
@@ -105,10 +126,12 @@ impl Cache {
                 .as_ref()
                 .expect("fontdb must be initialized")
                 .clone(),
+            style_sheet: current_color.map(svg::color_style_sheet),
             ..usvg::Options::default()
         };
 
-        if let hash_map::Entry::Vacant(entry) = self.trees.entry(id) {
+        let key = Key::new(id, current_color);
+        if let hash_map::Entry::Vacant(entry) = self.trees.entry(key) {
             let svg = match handle.data() {
                 Data::Path(path) => fs::read_to_string(path)
                     .ok()
@@ -119,12 +142,12 @@ impl Cache {
             let _ = entry.insert(svg);
         }
 
-        let _ = self.tree_hits.insert(id);
-        self.trees.get(&id).unwrap().as_ref()
+        let _ = self.tree_hits.insert(key);
+        self.trees.get(&key).unwrap().as_ref()
     }
 
     fn viewport_dimensions(&mut self, handle: &Handle) -> Option<Size<u32>> {
-        let tree = self.load(handle)?;
+        let tree = self.load(handle, None)?;
         let size = tree.size();
 
         Some(Size::new(size.width() as u32, size.height() as u32))
@@ -134,6 +157,7 @@ impl Cache {
         &mut self,
         handle: &Handle,
         color: Option<Color>,
+        current_color: Option<Color>,
         size: Size<u32>,
     ) -> Option<tiny_skia::PixmapRef<'_>> {
         if size.width == 0 || size.height == 0 {
@@ -143,12 +167,13 @@ impl Cache {
         let key = RasterKey {
             id: handle.id(),
             color: color.map(Color::into_rgba8),
+            current_color: current_color.map(Color::into_rgba8),
             size,
         };
 
         #[allow(clippy::map_entry)]
         if !self.rasters.contains_key(&key) {
-            let tree = self.load(handle)?;
+            let tree = self.load(handle, current_color)?;
 
             let mut image = tiny_skia::Pixmap::new(size.width, size.height)?;
 

--- a/wgpu/src/image/cache.rs
+++ b/wgpu/src/image/cache.rs
@@ -184,7 +184,7 @@ impl Cache {
     #[cfg(feature = "svg")]
     pub fn measure_svg(&mut self, handle: &core::svg::Handle) -> Size<u32> {
         // TODO: Concurrency
-        self.vector.load(handle).viewport_dimensions()
+        self.vector.load(handle, None).viewport_dimensions()
     }
 
     #[cfg(feature = "image")]
@@ -257,11 +257,21 @@ impl Cache {
         belt: &mut wgpu::util::StagingBelt,
         handle: &core::svg::Handle,
         color: Option<core::Color>,
+        current_color: Option<core::Color>,
         size: Size<u32>,
     ) -> Option<(&atlas::Entry, &Arc<wgpu::BindGroup>)> {
         // TODO: Concurrency
         self.vector
-            .upload(device, encoder, belt, handle, color, size, &mut self.atlas)
+            .upload(
+                device,
+                encoder,
+                belt,
+                handle,
+                color,
+                current_color,
+                size,
+                &mut self.atlas,
+            )
             .map(|entry| (entry, self.atlas.bind_group()))
     }
 

--- a/wgpu/src/image/mod.rs
+++ b/wgpu/src/image/mod.rs
@@ -293,6 +293,7 @@ impl State {
                         belt,
                         &svg.handle,
                         svg.color,
+                        svg.current_color,
                         Size::new(bounds.width as u32, bounds.height as u32),
                     ) {
                         match atlas.as_mut() {

--- a/wgpu/src/image/vector.rs
+++ b/wgpu/src/image/vector.rs
@@ -35,22 +35,48 @@ impl Svg {
 /// Caches svg vector and raster data
 #[derive(Debug, Default)]
 pub struct Cache {
-    svgs: FxHashMap<u64, Svg>,
-    rasterized: FxHashMap<(u64, u32, u32, ColorFilter), atlas::Entry>,
-    svg_hits: FxHashSet<u64>,
-    rasterized_hits: FxHashSet<(u64, u32, u32, ColorFilter)>,
+    svgs: FxHashMap<Key, Svg>,
+    rasterized: FxHashMap<RasterKey, atlas::Entry>,
+    svg_hits: FxHashSet<Key>,
+    rasterized_hits: FxHashSet<RasterKey>,
     should_trim: bool,
     #[cfg(feature = "svg-text")]
     fontdb: Option<Arc<usvg::fontdb::Database>>,
 }
 
-type ColorFilter = Option<[u8; 4]>;
+/// Key for identifying SVGs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct Key {
+    id: u64,
+    current_color: ColorKey,
+}
+
+impl Key {
+    pub fn new(id: u64, color: Option<Color>) -> Self {
+        Self {
+            id,
+            current_color: color.map(Color::into_rgba8),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct RasterKey {
+    pub id: u64,
+    pub width: u32,
+    pub height: u32,
+    pub color: ColorKey,
+    pub current_color: ColorKey,
+}
+
+type ColorKey = Option<[u8; 4]>;
 
 impl Cache {
     /// Load svg
-    pub fn load(&mut self, handle: &svg::Handle) -> &Svg {
-        if self.svgs.contains_key(&handle.id()) {
-            return self.svgs.get(&handle.id()).unwrap();
+    pub fn load(&mut self, handle: &svg::Handle, current_color: Option<Color>) -> &Svg {
+        let key = Key::new(handle.id(), current_color);
+        if self.svgs.contains_key(&key) {
+            return self.svgs.get(&key).unwrap();
         }
 
         // TODO: Reuse `cosmic-text` font database
@@ -69,6 +95,7 @@ impl Cache {
                 .as_ref()
                 .expect("fontdb must be initialized")
                 .clone(),
+            style_sheet: current_color.map(svg::color_style_sheet),
             ..usvg::Options::default()
         };
 
@@ -86,8 +113,9 @@ impl Cache {
 
         self.should_trim = true;
 
-        let _ = self.svgs.insert(handle.id(), svg);
-        self.svgs.get(&handle.id()).unwrap()
+        let key = Key::new(handle.id(), current_color);
+        let _ = self.svgs.insert(key, svg);
+        self.svgs.get(&key).unwrap()
     }
 
     /// Load svg and upload raster data
@@ -98,26 +126,33 @@ impl Cache {
         belt: &mut wgpu::util::StagingBelt,
         handle: &svg::Handle,
         color: Option<Color>,
+        current_color: Option<Color>,
         size: Size<u32>,
         atlas: &mut Atlas,
     ) -> Option<&atlas::Entry> {
         let id = handle.id();
 
         let color = color.map(Color::into_rgba8);
-        let key = (id, size.width, size.height, color);
+        let key = RasterKey {
+            id,
+            width: size.width,
+            height: size.height,
+            color,
+            current_color: current_color.map(Color::into_rgba8),
+        };
 
         // TODO: Optimize!
         // We currently rerasterize the SVG when its size changes. This is slow
         // as heck. A GPU rasterizer like `pathfinder` may perform better.
         // It would be cool to be able to smooth resize the `svg` example.
         if self.rasterized.contains_key(&key) {
-            let _ = self.svg_hits.insert(id);
+            let _ = self.svg_hits.insert(Key::new(handle.id(), current_color));
             let _ = self.rasterized_hits.insert(key);
 
             return self.rasterized.get(&key);
         }
 
-        match self.load(handle) {
+        match self.load(handle, current_color) {
             Svg::Loaded(tree) => {
                 // TODO: Optimize!
                 // We currently rerasterize the SVG when its size changes. This is slow
@@ -174,7 +209,7 @@ impl Cache {
 
                 log::debug!("allocating {id} {}x{}", size.width, size.height);
 
-                let _ = self.svg_hits.insert(id);
+                let _ = self.svg_hits.insert(Key::new(handle.id(), current_color));
                 let _ = self.rasterized_hits.insert(key);
                 let _ = self.rasterized.insert(key, allocation);
                 self.should_trim = true;

--- a/widget/src/svg.rs
+++ b/widget/src/svg.rs
@@ -224,7 +224,7 @@ where
         _state: &Tree,
         renderer: &mut Renderer,
         theme: &Theme,
-        _style: &renderer::Style,
+        defaults: &renderer::Style,
         layout: Layout<'_>,
         _cursor: mouse::Cursor,
         _viewport: &Rectangle,
@@ -261,6 +261,7 @@ where
             svg::Svg {
                 handle: self.handle.clone(),
                 color: style.color,
+                current_color: style.inherit_current_color.then_some(defaults.text_color),
                 rotation: self.rotation.radians(),
                 opacity: self.opacity,
             },
@@ -298,6 +299,12 @@ pub struct Style {
     ///
     /// `None` keeps the original color.
     pub color: Option<Color>,
+
+    /// Whether the [`Svg`] should inherit the current rendering color.
+    ///
+    /// This will override the SVG's original `color` field so that
+    /// `currentColor` is the same as the current renderer style's color.
+    pub inherit_current_color: bool,
 }
 
 /// The theme catalog of an [`Svg`].
@@ -332,5 +339,13 @@ pub type StyleFn<'a, Theme> = Box<dyn Fn(&Theme, Status) -> Style + 'a>;
 impl<Theme> From<Style> for StyleFn<'_, Theme> {
     fn from(style: Style) -> Self {
         Box::new(move |_theme, _status| style)
+    }
+}
+
+/// Returns a [`Style`] that inherits the current rendering color.
+pub fn current_color(_theme: &Theme, _status: Status) -> Style {
+    Style {
+        color: None,
+        inherit_current_color: true,
     }
 }


### PR DESCRIPTION
## Overview

This PR allows SVGs to conditionally inherit the renderer style's color so that SVGs using `currentColor` can use the same color as text would. An example of this is a button that contains a leading icon and some text: it would be great if the SVG could inherit the same renderer text color so the SVG and text match.

Currently, using an SVG with `currentColor` set up would result in the default black color being used and possibly not matching the SVG:

<img width="149" height="167" alt="counter-before" src="https://github.com/user-attachments/assets/163b9cb5-77c3-4cd3-af4e-988780a89d7e" />

After these changes, the SVG can correctly inherit the renderer color:

<img width="149" height="161" alt="counter-after" src="https://github.com/user-attachments/assets/6ba06ee7-5bac-4203-ab1c-86c810b6ff1b" />

I've added `inherit_current_color: bool` to `svg::Style` so that users can control it, and it defaults to off to avoid changing existing behavior. I've also added a helper `fn current_color` that can be used on an SVG to enable this behavior. An example of SVGs with and without this style:

<img width="316" height="164" alt="counter-mixed" src="https://github.com/user-attachments/assets/c704718c-6f35-4bab-a717-a377c5224a79" />

Under the hood, I pass in a custom style sheet to `usvg` that overrides the SVG's `color` attribute, as recommended in [this resvg issue](https://github.com/linebender/resvg/issues/768). The one caveat with this approach is that we end up parsing the SVG twice when a current color is provided: once in `layout` to measure the SVG (which doesn't yet have the current color), and then once more in `draw` when we call `draw_svg` and the provided `current_color` causes a cache miss since the current color is part of the cache key now. This is necessary if we want to avoid changing the SVG renderer's `measure_svg` function, since it would be silly to require a color param to measure an SVG. 

I don't see a way around this without changing that trait for now unless `usvg` adds a way to inject CSS/colors at runtime. Parsing a small SVG that's intended for icons seems like a fine tradeoff since parsing small SVGs should be on the scale of microseconds, and doesn't affect the general case where users aren't using this style.

I used a modified counter example to test this out with some inline Lucide icons:

```rs
use std::sync::LazyLock;

use iced::Center;
use iced::Length::Shrink;
use iced::widget::{Column, button, column, row, svg, text};

const PLUS_ICON: &str = r##"<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-plus-icon lucide-plus"><path d="M5 12h14"/><path d="M12 5v14"/></svg>"##;
const MINUS_ICON: &str = r##"<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-minus-icon lucide-minus"><path d="M5 12h14"/></svg>"##;

const PLUS: LazyLock<svg::Handle> =
    LazyLock::new(|| svg::Handle::from_memory(PLUS_ICON.as_bytes()));
const MINUS: LazyLock<svg::Handle> =
    LazyLock::new(|| svg::Handle::from_memory(MINUS_ICON.as_bytes()));

pub fn main() -> iced::Result {
    iced::run(Counter::update, Counter::view)
}

#[derive(Default)]
struct Counter {
    value: i64,
}

#[derive(Debug, Clone, Copy)]
enum Message {
    Increment,
    Decrement,
}

impl Counter {
    fn update(&mut self, message: Message) {
        match message {
            Message::Increment => self.value += 1,
            Message::Decrement => self.value -= 1,
        }
    }

    fn view(&self) -> Column<'_, Message> {
        column![
            button(
                row![
                    svg(PLUS.clone()).width(Shrink).style(svg::current_color),
                    text("Increment")
                ]
                .spacing(4)
            )
            .on_press(Message::Increment),
            text(self.value).size(50),
            button(row![svg(MINUS.clone()).width(Shrink), text("Decrement")].spacing(4))
                .on_press(Message::Decrement)
        ]
        .padding(20)
        .align_x(Center)
    }
}
```