### PR TITLE
Add `blank` field to `window::Settings`

### DIFF
--- a/core/src/window/settings.rs
+++ b/core/src/window/settings.rs
@@ -98,6 +98,13 @@ pub struct Settings {
     ///
     /// By default this is enabled.
     pub exit_on_close_request: bool,
+
+    /// Whether this window should be blank, i.e. not show a user interface. If set, `view` will
+    /// never get called for this window. Window events will, however, still be emitted.
+    ///
+    /// This can be useful if you're embedding external content into this window and you don't want
+    /// `iced` to draw over it.
+    pub blank: bool,
 }
 
 impl Default for Settings {
@@ -120,6 +127,7 @@ impl Default for Settings {
             icon: None,
             exit_on_close_request: true,
             platform_specific: PlatformSpecific::default(),
+            blank: false,
         }
     }
 }

--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -304,8 +304,8 @@ where
                                 on_open,
                             } => {
                                 let exit_on_close_request = settings.exit_on_close_request;
-
                                 let visible = settings.visible;
+                                let blank = settings.blank;
 
                                 #[cfg(target_arch = "wasm32")]
                                 let target = settings.platform_specific.target.clone();
@@ -388,7 +388,8 @@ where
                                         id,
                                         window: Arc::new(window),
                                         exit_on_close_request,
-                                        make_visible: visible,
+                                        visible,
+                                        blank,
                                         on_open,
                                     },
                                 );
@@ -446,7 +447,8 @@ enum Event<Message: 'static> {
         id: window::Id,
         window: Arc<winit::window::Window>,
         exit_on_close_request: bool,
-        make_visible: bool,
+        visible: bool,
+        blank: bool,
         on_open: oneshot::Sender<window::Id>,
     },
     EventLoopAwakened(winit::event::Event<Message>),
@@ -551,7 +553,8 @@ async fn run_instance<P>(
                 id,
                 window,
                 exit_on_close_request,
-                make_visible,
+                visible,
+                blank,
                 on_open,
             } => {
                 if compositor.is_none() {
@@ -637,6 +640,7 @@ async fn run_instance<P>(
                     proxy.clone(),
                     renderer_settings,
                     exit_on_close_request,
+                    blank,
                     system_theme,
                 );
 
@@ -654,21 +658,23 @@ async fn run_instance<P>(
 
                 let logical_size = window.state.logical_size();
 
-                window.renderer.hint(window.state.scale());
+                if let Some(interface) = &mut window.interface {
+                    interface.renderer.hint(window.state.scale());
 
-                let _ = user_interfaces.insert(
-                    id,
-                    build_user_interface(
-                        &program,
-                        user_interface::Cache::default(),
-                        &mut window.renderer,
-                        logical_size,
+                    let _ = user_interfaces.insert(
                         id,
-                    ),
-                );
-                let _ = ui_caches.insert(id, user_interface::Cache::default());
+                        build_user_interface(
+                            &program,
+                            user_interface::Cache::default(),
+                            &mut interface.renderer,
+                            logical_size,
+                            id,
+                        ),
+                    );
+                    let _ = ui_caches.insert(id, user_interface::Cache::default());
+                }
 
-                if make_visible {
+                if visible {
                     window.raw.set_visible(true);
                 }
 
@@ -695,11 +701,12 @@ async fn run_instance<P>(
                         let now = Instant::now();
 
                         for (_id, window) in window_manager.iter_mut() {
-                            if let Some(redraw_at) = window.redraw_at
+                            if let Some(interface) = &mut window.interface
+                                && let Some(redraw_at) = interface.redraw_at
                                 && redraw_at <= now
                             {
                                 window.raw.request_redraw();
-                                window.redraw_at = None;
+                                interface.redraw_at = None;
                             }
                         }
 
@@ -753,6 +760,10 @@ async fn run_instance<P>(
                             continue;
                         };
 
+                        let Some(mut interface_) = window.interface.as_mut() else {
+                            continue;
+                        };
+
                         let physical_size = window.state.physical_size();
                         let mut logical_size = window.state.logical_size();
 
@@ -761,23 +772,23 @@ async fn run_instance<P>(
                         }
 
                         // Window was resized between redraws
-                        if window.surface_version != window.state.surface_version() {
-                            window.renderer.hint(window.state.scale());
+                        if interface_.surface_version != window.state.surface_version() {
+                            interface_.renderer.hint(window.state.scale());
 
                             let ui = user_interfaces.remove(&id).expect("Remove user interface");
 
                             let layout_span = debug::layout(id);
                             let _ = user_interfaces
-                                .insert(id, ui.relayout(logical_size, &mut window.renderer));
+                                .insert(id, ui.relayout(logical_size, &mut interface_.renderer));
                             layout_span.finish();
 
                             current_compositor.configure_surface(
-                                &mut window.surface,
+                                &mut interface_.surface,
                                 physical_size.width,
                                 physical_size.height,
                             );
 
-                            window.surface_version = window.state.surface_version();
+                            interface_.surface_version = window.state.surface_version();
                         }
 
                         let redraw_event =
@@ -795,10 +806,10 @@ async fn run_instance<P>(
                             let message_count = messages.len();
                             let (state, _) = interface.update(
                                 &window.raw,
-                                &window.waker,
+                                &interface_.waker,
                                 slice::from_ref(&redraw_event),
                                 cursor,
-                                &mut window.renderer,
+                                &mut interface_.renderer,
                                 &mut messages,
                             );
 
@@ -875,6 +886,7 @@ async fn run_instance<P>(
 
                                 current_compositor = next_compositor;
                                 window = window_manager.get_mut(id).unwrap();
+                                interface_ = window.interface.as_mut().unwrap();
 
                                 // Window scale factor changed during a redraw request
                                 if logical_size != window.state.logical_size() {
@@ -890,7 +902,7 @@ async fn run_instance<P>(
                                     let layout_span = debug::layout(id);
                                     let _ = user_interfaces.insert(
                                         id,
-                                        ui.relayout(logical_size, &mut window.renderer),
+                                        ui.relayout(logical_size, &mut interface_.renderer),
                                     );
                                     layout_span.finish();
                                 }
@@ -902,7 +914,7 @@ async fn run_instance<P>(
 
                         let draw_span = debug::draw(id);
                         interface.draw(
-                            &mut window.renderer,
+                            &mut interface_.renderer,
                             window.state.theme(),
                             &renderer::Style {
                                 text_color: window.state.text_color(),
@@ -919,9 +931,13 @@ async fn run_instance<P>(
                             ..
                         } = state
                         {
-                            window.request_redraw(redraw_request);
-                            window.request_input_method(input_method);
-                            window.update_mouse(mouse_interaction);
+                            interface_.request_redraw(redraw_request, &window.raw);
+                            interface_.request_input_method(
+                                input_method,
+                                &window.raw,
+                                &window.state,
+                            );
+                            interface_.update_mouse(mouse_interaction, &window.raw);
 
                             run_clipboard(&mut proxy, &mut clipboard, clipboard_requests, id);
                         }
@@ -932,12 +948,12 @@ async fn run_instance<P>(
                             status: core::event::Status::Ignored,
                         });
 
-                        window.draw_preedit();
+                        interface_.draw_preedit(&window.state);
 
                         let present_span = debug::present(id);
                         match current_compositor.present(
-                            &mut window.renderer,
-                            &mut window.surface,
+                            &mut interface_.renderer,
+                            &mut interface_.surface,
                             window.state.viewport(),
                             window.state.background_color(),
                             || window.raw.pre_present_notify(),
@@ -958,14 +974,14 @@ async fn run_instance<P>(
                                     let physical_size = window.state.physical_size();
 
                                     if error == compositor::SurfaceError::Lost {
-                                        window.surface = current_compositor.create_surface(
+                                        interface_.surface = current_compositor.create_surface(
                                             window.raw.clone(),
                                             physical_size.width,
                                             physical_size.height,
                                         );
                                     } else {
                                         current_compositor.configure_surface(
-                                            &mut window.surface,
+                                            &mut interface_.surface,
                                             physical_size.width,
                                             physical_size.height,
                                         );
@@ -1090,20 +1106,35 @@ async fn run_instance<P>(
                                 continue;
                             }
 
+                            let Some(interface) = &mut window.interface else {
+                                for event in window_events {
+                                    runtime.broadcast(subscription::Event::Interaction {
+                                        window: id,
+                                        event,
+                                        status: core::event::Status::Ignored,
+                                    });
+                                }
+
+                                continue;
+                            };
+
                             let (ui_state, statuses) = user_interfaces
                                 .get_mut(&id)
                                 .expect("Get user interface")
                                 .update(
                                     &window.raw,
-                                    &window.waker,
+                                    &interface.waker,
                                     &window_events,
                                     window.state.cursor(),
-                                    &mut window.renderer,
+                                    &mut interface.renderer,
                                     &mut messages,
                                 );
 
                             #[cfg(feature = "unconditional-rendering")]
-                            window.request_redraw(window::RedrawRequest::NextFrame);
+                            interface.request_redraw(
+                                core::window::RedrawRequest::NextFrame,
+                                &window.raw,
+                            );
 
                             match ui_state {
                                 user_interface::State::Updated {
@@ -1112,10 +1143,10 @@ async fn run_instance<P>(
                                     clipboard: clipboard_requests,
                                     ..
                                 } => {
-                                    window.update_mouse(mouse_interaction);
+                                    interface.update_mouse(mouse_interaction, &window.raw);
 
                                     #[cfg(not(feature = "unconditional-rendering"))]
-                                    window.request_redraw(_redraw_request);
+                                    interface.request_redraw(_redraw_request, &window.raw);
 
                                     run_clipboard(
                                         &mut proxy,
@@ -1556,9 +1587,10 @@ fn run_action<'a, P, C>(
             window::Action::Screenshot(id, channel) => {
                 if let Some(window) = window_manager.get_mut(id)
                     && let Some(compositor) = compositor
+                    && let Some(interface) = &mut window.interface
                 {
                     let bytes = compositor.screenshot(
-                        &mut window.renderer,
+                        &mut interface.renderer,
                         window.state.viewport(),
                         window.state.background_color(),
                     );
@@ -1607,7 +1639,10 @@ fn run_action<'a, P, C>(
                     if let Some(ui) = interfaces.remove(&id) {
                         let _ = interfaces.insert(
                             id,
-                            ui.relayout(window.state.logical_size(), &mut window.renderer),
+                            ui.relayout(
+                                window.state.logical_size(),
+                                &mut window.interface.as_mut().unwrap().renderer,
+                            ),
                         );
                     }
 
@@ -1676,14 +1711,16 @@ fn run_action<'a, P, C>(
 
                 // Recreate renderers and relayout all windows
                 for (id, window) in window_manager.iter_mut() {
-                    window.renderer = compositor.create_renderer(*renderer_settings);
-
                     let Some(ui) = interfaces.remove(&id) else {
                         continue;
                     };
 
+                    let interface = window.interface.as_mut().unwrap();
+
+                    interface.renderer = compositor.create_renderer(*renderer_settings);
+
                     let size = window.state.logical_size();
-                    let ui = ui.relayout(size, &mut window.renderer);
+                    let ui = ui.relayout(size, &mut interface.renderer);
                     let _ = interfaces.insert(id, ui);
 
                     window.raw.request_redraw();
@@ -1696,7 +1733,10 @@ fn run_action<'a, P, C>(
             while let Some(mut operation) = current_operation.take() {
                 for (id, ui) in interfaces.iter_mut() {
                     if let Some(window) = window_manager.get_mut(*id) {
-                        ui.operate(&window.renderer, operation.as_mut());
+                        ui.operate(
+                            &window.interface.as_ref().unwrap().renderer,
+                            operation.as_mut(),
+                        );
                     }
                 }
 
@@ -1717,10 +1757,14 @@ fn run_action<'a, P, C>(
         Action::Image(action) => match action {
             image::Action::Allocate(handle, sender) => {
                 // TODO: Shared image cache in compositor
-                if let Some((_id, window)) = window_manager.iter_mut().next() {
-                    window.renderer.allocate_image(&handle, move |allocation| {
-                        let _ = sender.send(allocation);
-                    });
+                if let Some((_id, window)) = window_manager.iter_mut().next()
+                    && let Some(interface) = &mut window.interface
+                {
+                    interface
+                        .renderer
+                        .allocate_image(&handle, move |allocation| {
+                            let _ = sender.send(allocation);
+                        });
                 }
             }
         },
@@ -1749,14 +1793,20 @@ fn run_action<'a, P, C>(
                 graphics::cache::invalidate_all();
 
                 window_manager.replace_with(|mut window| {
+                    let Some(mut interface) = window.interface.take() else {
+                        return window;
+                    };
+
                     let size = window.state.physical_size();
 
-                    drop(window.renderer);
-                    drop(window.surface);
+                    drop(interface.renderer);
+                    drop(interface.surface);
 
-                    window.renderer = new_compositor.create_renderer(*renderer_settings);
-                    window.surface =
+                    interface.renderer = new_compositor.create_renderer(*renderer_settings);
+                    interface.surface =
                         new_compositor.create_surface(window.raw.clone(), size.width, size.height);
+
+                    window.interface = Some(interface);
 
                     window
                 });
@@ -1773,7 +1823,9 @@ fn run_action<'a, P, C>(
         }
         Action::Tick => {
             for (_id, window) in window_manager.iter_mut() {
-                window.renderer.tick();
+                if let Some(interface) = &mut window.interface {
+                    interface.renderer.tick();
+                }
             }
         }
         Action::Reload => {
@@ -1787,7 +1839,13 @@ fn run_action<'a, P, C>(
 
                 let _ = interfaces.insert(
                     id,
-                    build_user_interface(program, cache, &mut window.renderer, size, id),
+                    build_user_interface(
+                        program,
+                        cache,
+                        &mut window.interface.as_mut().unwrap().renderer,
+                        size,
+                        id,
+                    ),
                 );
 
                 window.raw.request_redraw();
@@ -1826,7 +1884,9 @@ where
             });
         }
 
-        window.renderer.hint(window.state.scale());
+        if let Some(interface) = &mut window.interface {
+            interface.renderer.hint(window.state.scale());
+        }
     }
 
     debug::theme_changed(|| {
@@ -1845,7 +1905,7 @@ where
                 build_user_interface(
                     program,
                     cache,
-                    &mut window.renderer,
+                    &mut window.interface.as_mut().unwrap().renderer,
                     window.state.logical_size(),
                     id,
                 ),

--- a/winit/src/window.rs
+++ b/winit/src/window.rs
@@ -1,25 +1,22 @@
+mod interface;
 mod state;
 
+use interface::Interface;
 use state::State;
 
-pub use crate::core::window::{Event, Id, RedrawRequest, Settings};
+pub use crate::core::window::{Event, Id, Settings};
 
 use crate::Proxy;
-use crate::conversion;
-use crate::core;
 use crate::core::alignment;
 use crate::core::input_method;
-use crate::core::mouse;
 use crate::core::renderer;
-use crate::core::shell;
 use crate::core::text;
 use crate::core::theme;
 use crate::core::time::Instant;
-use crate::core::{Color, InputMethod, Padding, Point, Rectangle, Size, Text, Vector};
+use crate::core::{Color, Padding, Point, Rectangle, Size, Text, Vector};
 use crate::graphics::Compositor;
 use crate::program::{self, Program};
 
-use winit::dpi::{LogicalPosition, LogicalSize};
 use winit::monitor::MonitorHandle;
 
 use std::collections::BTreeMap;
@@ -57,20 +54,20 @@ where
         proxy: Proxy<P::Message>,
         renderer_settings: renderer::Settings,
         exit_on_close_request: bool,
+        blank: bool,
         system_theme: theme::Mode,
     ) -> &mut Window<P, C> {
         let state = State::new(program, id, &window, system_theme);
-        let surface_size = state.physical_size();
-        let surface_version = state.surface_version();
-        let surface =
-            compositor.create_surface(window.clone(), surface_size.width, surface_size.height);
-        let renderer = compositor.create_renderer(renderer_settings);
 
-        let waker = shell::Waker::new(move || {
-            proxy.send_action(iced_runtime::Action::Event {
-                window: id,
-                event: core::Event::Waken,
-            });
+        let interface = (!blank).then(|| {
+            Interface::new(
+                id,
+                window.clone(),
+                compositor,
+                proxy,
+                renderer_settings,
+                &state,
+            )
         });
 
         let _ = self.aliases.insert(window.id(), id);
@@ -79,16 +76,9 @@ where
             id,
             Window {
                 raw: window,
-                waker,
                 state,
                 exit_on_close_request,
-                surface,
-                surface_version,
-                renderer,
-                mouse_interaction: mouse::Interaction::None,
-                redraw_at: None,
-                preedit: None,
-                ime_state: None,
+                interface,
             },
         );
 
@@ -102,15 +92,18 @@ where
     }
 
     pub fn is_idle(&self) -> bool {
-        self.entries
-            .values()
-            .all(|window| window.redraw_at.is_none())
+        self.entries.values().all(|window| {
+            window
+                .interface
+                .as_ref()
+                .is_none_or(|interface| interface.redraw_at.is_none())
+        })
     }
 
     pub fn redraw_at(&self) -> Option<Instant> {
         self.entries
             .values()
-            .filter_map(|window| window.redraw_at)
+            .filter_map(|window| window.interface.as_ref()?.redraw_at)
             .min()
     }
 
@@ -176,16 +169,9 @@ where
     P::Theme: theme::Base,
 {
     pub raw: Arc<winit::window::Window>,
-    pub waker: shell::Waker,
     pub state: State<P>,
+    pub interface: Option<Interface<P, C>>,
     pub exit_on_close_request: bool,
-    pub mouse_interaction: mouse::Interaction,
-    pub surface: C::Surface,
-    pub surface_version: u64,
-    pub renderer: P::Renderer,
-    pub redraw_at: Option<Instant>,
-    preedit: Option<Preedit<P::Renderer>>,
-    ime_state: Option<(Rectangle, input_method::Purpose)>,
 }
 
 impl<P, C> Window<P, C>
@@ -203,105 +189,6 @@ where
                 x: position.x,
                 y: position.y,
             })
-    }
-
-    pub fn request_redraw(&mut self, redraw_request: RedrawRequest) {
-        match redraw_request {
-            RedrawRequest::NextFrame => {
-                self.raw.request_redraw();
-                self.redraw_at = None;
-            }
-            RedrawRequest::At(at) => {
-                self.redraw_at = Some(at);
-            }
-            RedrawRequest::Wait => {}
-        }
-    }
-
-    pub fn request_input_method(&mut self, input_method: InputMethod) {
-        match input_method {
-            InputMethod::Disabled => {
-                self.disable_ime();
-            }
-            InputMethod::Enabled {
-                cursor,
-                purpose,
-                preedit,
-            } => {
-                self.enable_ime(cursor, purpose);
-
-                if let Some(preedit) = preedit {
-                    if preedit.content.is_empty() {
-                        self.preedit = None;
-                    } else {
-                        let mut overlay = self.preedit.take().unwrap_or_else(Preedit::new);
-
-                        overlay.update(
-                            cursor,
-                            &preedit,
-                            self.state.background_color(),
-                            &self.renderer,
-                        );
-
-                        self.preedit = Some(overlay);
-                    }
-                } else {
-                    self.preedit = None;
-                }
-            }
-        }
-    }
-
-    pub fn update_mouse(&mut self, interaction: mouse::Interaction) {
-        if interaction != self.mouse_interaction {
-            if let Some(icon) = conversion::mouse_interaction(interaction) {
-                self.raw.set_cursor(icon);
-
-                if self.mouse_interaction == mouse::Interaction::Hidden {
-                    self.raw.set_cursor_visible(true);
-                }
-            } else {
-                self.raw.set_cursor_visible(false);
-            }
-
-            self.mouse_interaction = interaction;
-        }
-    }
-
-    pub fn draw_preedit(&mut self) {
-        if let Some(preedit) = &self.preedit {
-            preedit.draw(
-                &mut self.renderer,
-                self.state.text_color(),
-                self.state.background_color(),
-                &Rectangle::new(Point::ORIGIN, self.state.viewport().logical_size()),
-            );
-        }
-    }
-
-    fn enable_ime(&mut self, cursor: Rectangle, purpose: input_method::Purpose) {
-        if self.ime_state.is_none() {
-            self.raw.set_ime_allowed(true);
-        }
-
-        if self.ime_state != Some((cursor, purpose)) {
-            self.raw.set_ime_cursor_area(
-                LogicalPosition::new(cursor.x, cursor.y),
-                LogicalSize::new(cursor.width, cursor.height),
-            );
-            self.raw.set_ime_purpose(conversion::ime_purpose(purpose));
-
-            self.ime_state = Some((cursor, purpose));
-        }
-    }
-
-    fn disable_ime(&mut self) {
-        if self.ime_state.is_some() {
-            self.raw.set_ime_allowed(false);
-            self.ime_state = None;
-        }
-
-        self.preedit = None;
     }
 }
 

--- a/winit/src/window/interface.rs
+++ b/winit/src/window/interface.rs
@@ -1,0 +1,186 @@
+use std::sync::Arc;
+
+use winit::dpi::LogicalPosition;
+use winit::dpi::LogicalSize;
+
+use crate::Proxy;
+use crate::conversion;
+use crate::core;
+use crate::core::InputMethod;
+use crate::core::Point;
+use crate::core::Rectangle;
+use crate::core::input_method;
+use crate::core::mouse;
+use crate::core::renderer;
+use crate::core::shell;
+use crate::core::time::Instant;
+use crate::core::window::Id;
+use crate::core::window::RedrawRequest;
+use crate::graphics::Compositor;
+use crate::program::Program;
+use crate::window::Preedit;
+use crate::window::state::State;
+
+pub struct Interface<P, C>
+where
+    P: Program,
+    C: Compositor<Renderer = P::Renderer>,
+{
+    pub waker: shell::Waker,
+    pub mouse_interaction: mouse::Interaction,
+    pub surface: C::Surface,
+    pub surface_version: u64,
+    pub renderer: P::Renderer,
+    pub redraw_at: Option<Instant>,
+    preedit: Option<Preedit<P::Renderer>>,
+    ime_state: Option<(Rectangle, input_method::Purpose)>,
+}
+
+impl<P, C> Interface<P, C>
+where
+    P: Program,
+    C: Compositor<Renderer = P::Renderer>,
+{
+    pub fn new(
+        id: Id,
+        window: Arc<winit::window::Window>,
+        compositor: &mut C,
+        proxy: Proxy<P::Message>,
+        renderer_settings: renderer::Settings,
+        state: &State<P>,
+    ) -> Self {
+        let surface_size = state.physical_size();
+        let surface_version = state.surface_version();
+        let surface =
+            compositor.create_surface(window.clone(), surface_size.width, surface_size.height);
+        let renderer = compositor.create_renderer(renderer_settings);
+
+        let waker = shell::Waker::new(move || {
+            proxy.send_action(iced_runtime::Action::Event {
+                window: id,
+                event: core::Event::Waken,
+            });
+        });
+
+        Interface {
+            waker,
+            mouse_interaction: mouse::Interaction::None,
+            surface,
+            surface_version,
+            renderer,
+            redraw_at: None,
+            preedit: None,
+            ime_state: None,
+        }
+    }
+}
+
+impl<P, C> Interface<P, C>
+where
+    P: Program,
+    C: Compositor<Renderer = P::Renderer>,
+{
+    pub fn request_redraw(&mut self, redraw_request: RedrawRequest, raw: &winit::window::Window) {
+        match redraw_request {
+            RedrawRequest::NextFrame => {
+                raw.request_redraw();
+                self.redraw_at = None;
+            }
+            RedrawRequest::At(at) => {
+                self.redraw_at = Some(at);
+            }
+            RedrawRequest::Wait => {}
+        }
+    }
+
+    pub fn request_input_method(
+        &mut self,
+        input_method: InputMethod,
+        raw: &winit::window::Window,
+        state: &State<P>,
+    ) {
+        match input_method {
+            InputMethod::Disabled => {
+                self.disable_ime(raw);
+            }
+            InputMethod::Enabled {
+                cursor,
+                purpose,
+                preedit,
+            } => {
+                self.enable_ime(cursor, purpose, raw);
+
+                if let Some(preedit) = preedit {
+                    if preedit.content.is_empty() {
+                        self.preedit = None;
+                    } else {
+                        let mut overlay = self.preedit.take().unwrap_or_else(Preedit::new);
+
+                        overlay.update(cursor, &preedit, state.background_color(), &self.renderer);
+
+                        self.preedit = Some(overlay);
+                    }
+                } else {
+                    self.preedit = None;
+                }
+            }
+        }
+    }
+
+    pub fn update_mouse(&mut self, interaction: mouse::Interaction, raw: &winit::window::Window) {
+        if interaction != self.mouse_interaction {
+            if let Some(icon) = conversion::mouse_interaction(interaction) {
+                raw.set_cursor(icon);
+
+                if self.mouse_interaction == mouse::Interaction::Hidden {
+                    raw.set_cursor_visible(true);
+                }
+            } else {
+                raw.set_cursor_visible(false);
+            }
+
+            self.mouse_interaction = interaction;
+        }
+    }
+
+    pub fn draw_preedit(&mut self, state: &State<P>) {
+        if let Some(preedit) = &self.preedit {
+            preedit.draw(
+                &mut self.renderer,
+                state.text_color(),
+                state.background_color(),
+                &Rectangle::new(Point::ORIGIN, state.viewport().logical_size()),
+            );
+        }
+    }
+
+    fn enable_ime(
+        &mut self,
+        cursor: Rectangle,
+        purpose: input_method::Purpose,
+        raw: &winit::window::Window,
+    ) {
+        if self.ime_state.is_none() {
+            raw.set_ime_allowed(true);
+        }
+
+        if self.ime_state != Some((cursor, purpose)) {
+            raw.set_ime_cursor_area(
+                LogicalPosition::new(cursor.x, cursor.y),
+                LogicalSize::new(cursor.width, cursor.height),
+            );
+            raw.set_ime_purpose(conversion::ime_purpose(purpose));
+
+            self.ime_state = Some((cursor, purpose));
+        }
+    }
+
+    fn disable_ime(&mut self, raw: &winit::window::Window) {
+        if self.ime_state.is_some() {
+            raw.set_ime_allowed(false);
+            self.ime_state = None;
+        }
+
+        self.preedit = None;
+    }
+}


### PR DESCRIPTION
This PR makes it possible to fix https://github.com/generic-daw/generic-daw/issues/13.

When embedding external content into an `iced` window, the render order seems to differ between platforms. Sometimes the embedded content renders on top of `iced`, sometimes `iced` renders on top of the embedded content. In principle, this could be worked around by simply making the background color of the window that the content is embedded in transparent (**not** setting the `transparent` field in `window::Settings`), so `iced` just draws nothing, however this *somehow* makes some embedded content translucent. I'm not sure why. Simply skipping `present` for that window doesn't fix this happening, the surface for that window must never be created to fix this.

Changes:
- Moves UI-related fields and methods of `Window` to a new `window::Interface` struct
- Makes that struct optional in `Window` via a `blank` field in `window::Settings`