### PR TITLE
Handle widget invalidation in `winit` shell

### DIFF
--- a/widget/src/component.rs
+++ b/widget/src/component.rs
@@ -288,10 +288,9 @@ where
         // 3. The overlay status of the component changes. The
         //    runtime will only call `overlay` again if the layout
         //    is invalidated.
-        if new_sizing != previous_sizing {
-            shell.invalidate_widgets();
-        } else if (new_sizing.width == Length::Shrink || new_sizing.height == Length::Shrink)
-            && previous_size != self.layout.size()
+        if new_sizing != previous_sizing
+            || ((new_sizing.width == Length::Shrink || new_sizing.height == Length::Shrink)
+                && previous_size != self.layout.size())
         {
             shell.invalidate_layout();
         } else {

--- a/widget/src/component.rs
+++ b/widget/src/component.rs
@@ -288,9 +288,10 @@ where
         // 3. The overlay status of the component changes. The
         //    runtime will only call `overlay` again if the layout
         //    is invalidated.
-        if new_sizing != previous_sizing
-            || ((new_sizing.width == Length::Shrink || new_sizing.height == Length::Shrink)
-                && previous_size != self.layout.size())
+        if new_sizing != previous_sizing {
+            shell.invalidate_widgets();
+        } else if (new_sizing.width == Length::Shrink || new_sizing.height == Length::Shrink)
+            && previous_size != self.layout.size()
         {
             shell.invalidate_layout();
         } else {

--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -817,7 +817,9 @@ async fn run_instance<P>(
 
                             redraw_count += 1;
 
-                            if !messages.is_empty() {
+                            if !messages.is_empty()
+                                || matches!(state, user_interface::State::Outdated)
+                            {
                                 let caches: FxHashMap<_, _> =
                                     ManuallyDrop::into_inner(user_interfaces)
                                         .into_iter()


### PR DESCRIPTION
Given this MCVE:
```rs
use iced::widget::{button, column, component, sensor, space, text, Renderer};

fn main() -> iced::Result {
    iced::application(|| false, update, view).run()
}

fn update(state: &mut bool, _: ()) {
    *state = true;
}

fn view(state: &bool) -> impl Into<iced::Element<'_, ()>> {
    column![
        button("show").on_press(()),
        state.then(|| component(Component))
    ]
}

struct Component;

impl<'a> component::Component<'a, ()> for Component {
    type State = bool;
    type Event = ();

    fn update(&mut self, state: &mut bool, _: (), _: &Renderer) -> Option<()> {
        *state = true;
        None
    }

    fn view(&self, state: &bool) -> iced::Element<'a, ()> {
        sensor(if *state {
            text("hi").height(20.8).into()
        } else {
            iced::Element::new(space())
        })
        .on_show(|_| ())
        .into()
    }
}
```
Clicking "show" wouldn't immediately show "hi", rather it would only show on an external event, such as the window resizing, happening. This PR fixes that.

I also just don't see any reason why this case should invalidate the entire widget tree, rather than just the layout.