### PR TITLE
Fix: restore emulator cache after taking screenshot

### DIFF
--- a/test/src/emulator.rs
+++ b/test/src/emulator.rs
@@ -501,6 +501,8 @@ impl<P: Program + 'static> Emulator<P> {
             mouse::Cursor::Unavailable,
         );
 
+        self.cache = Some(user_interface.into_cache());
+
         let physical_size = Size::new(
             (self.size.width * scale_factor).round() as u32,
             (self.size.height * scale_factor).round() as u32,


### PR DESCRIPTION
## Summary

Restore the emulator UI cache after taking a screenshot.

`Emulator::screenshot` currently removes the cache with `self.cache.take()` to build the user interface but does not put the resulting cache back. Consequently, attempting to execute another instruction or take another screenshot with the same emulator panics when the missing cache is unwrapped.

## Changes

* Restore the updated UI cache after drawing the screenshot.

## Validation

Verified by:

1. Executing a sequence of emulator instructions.
2. Taking a screenshot after an intermediate instruction.
3. Continuing with further instructions.
4. Taking another screenshot from the same emulator.

Without this change, the next emulator operation after the first screenshot panics because the cache is `None`.
