### PR TITLE
Add support for text decorations inside editor via highlighter

### DIFF
--- a/core/src/text/highlighter.rs
+++ b/core/src/text/highlighter.rs
@@ -76,6 +76,18 @@ pub struct Format<Font> {
     pub color: Option<Color>,
     /// The `Font` of the text.
     pub font: Option<Font>,
+    /// The underline decoration of the text.
+    pub underline: Option<Underline>,
+    /// The [`Color`] of the underline.
+    pub underline_color: Option<Color>,
+    /// Whether the text is strikethrough.
+    pub strikethrough: bool,
+    /// The [`Color`] of the strikethrough.
+    pub strikethrough_color: Option<Color>,
+    /// Whether the text is overlined.
+    pub overline: bool,
+    /// The [`Color`] of the overline.
+    pub overline_color: Option<Color>,
 }
 
 impl<Font> Default for Format<Font> {
@@ -83,6 +95,32 @@ impl<Font> Default for Format<Font> {
         Self {
             color: None,
             font: None,
+            underline: None,
+            underline_color: None,
+            strikethrough: false,
+            strikethrough_color: None,
+            overline: false,
+            overline_color: None,
         }
     }
+}
+
+impl<Font> Format<Font> {
+    /// Returns whether the [`Format`] needs to be processed.
+    pub fn needs_processing(&self) -> bool {
+        self.color.is_some()
+            || self.font.is_some()
+            || self.underline.is_some()
+            || self.strikethrough
+            || self.overline
+    }
+}
+
+/// The underline decoration of text.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Underline {
+    /// A single underline.
+    Single,
+    /// A double underline.
+    Double,
 }

--- a/examples/editor/Cargo.toml
+++ b/examples/editor/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 iced.workspace = true
-iced.features = ["highlighter", "tokio", "debug"]
+iced.features = ["highlighter", "tokio", "advanced","debug"]
 
 tokio.workspace = true
 tokio.features = ["fs"]

--- a/examples/editor/src/main.rs
+++ b/examples/editor/src/main.rs
@@ -1,3 +1,7 @@
+use iced::Color;
+use iced::advanced::text::Highlighter;
+use iced::advanced::text::highlighter::Format;
+use iced::advanced::text::highlighter::Underline;
 use iced::highlighter;
 use iced::keyboard;
 use iced::widget::{
@@ -7,8 +11,11 @@ use iced::widget::{
 use iced::window;
 use iced::{Center, Element, Fill, Font, Task, Theme, Window};
 
+use std::collections::HashMap;
 use std::ffi;
 use std::io;
+use std::ops::Deref;
+use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -20,6 +27,31 @@ pub fn main() -> iced::Result {
         .run()
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct ErrorMap(Arc<HashMap<usize, Vec<Range<usize>>>>);
+
+impl ErrorMap {
+    pub fn new(map: HashMap<usize, Vec<Range<usize>>>) -> Self {
+        Self(Arc::new(map))
+    }
+}
+
+impl PartialEq for ErrorMap {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+    }
+}
+
+impl Deref for ErrorMap {
+    type Target = HashMap<usize, Vec<Range<usize>>>;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 struct Editor {
     file: Option<PathBuf>,
     content: text_editor::Content,
@@ -27,6 +59,7 @@ struct Editor {
     word_wrap: bool,
     is_loading: bool,
     is_dirty: bool,
+    error_map: ErrorMap,
 }
 
 #[derive(Debug, Clone)]
@@ -51,6 +84,7 @@ impl Editor {
                 word_wrap: true,
                 is_loading: true,
                 is_dirty: false,
+                error_map: ErrorMap::new(HashMap::from([(0, vec![0..16; 1])])),
             },
             Task::batch([
                 Task::perform(
@@ -85,6 +119,7 @@ impl Editor {
                 if !self.is_loading {
                     self.file = None;
                     self.content = text_editor::Content::new();
+                    self.error_map = ErrorMap::default();
                 }
 
                 Task::none()
@@ -203,13 +238,21 @@ impl Editor {
                 } else {
                     text::Wrapping::None
                 })
-                .highlight(
-                    self.file
-                        .as_deref()
-                        .and_then(Path::extension)
-                        .and_then(ffi::OsStr::to_str)
-                        .unwrap_or("rs"),
-                    self.theme,
+                .highlight_with::<ConfigHighlighter>(
+                    Settings {
+                        highlighter: highlighter::Settings {
+                            theme: self.theme,
+                            token: self
+                                .file
+                                .as_deref()
+                                .and_then(Path::extension)
+                                .and_then(ffi::OsStr::to_str)
+                                .unwrap_or("rs")
+                                .to_owned(),
+                        },
+                        error_map: self.error_map.clone(),
+                    },
+                    token_format,
                 )
                 .key_binding(|key_press| {
                     match key_press.key.as_ref() {
@@ -232,6 +275,105 @@ impl Editor {
         } else {
             Theme::Light
         }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct Settings {
+    /// The settings for the syntax highlighter.
+    highlighter: highlighter::Settings,
+    /// Map of line to <start, end> of the error span.
+    error_map: ErrorMap,
+}
+
+enum Highlight {
+    Syntax(highlighter::Highlight),
+    Error(highlighter::Highlight),
+}
+
+fn token_format(highlight: &Highlight, _theme: &Theme) -> Format<Font> {
+    match highlight {
+        Highlight::Syntax(highlight) => highlight.to_format(),
+        Highlight::Error(syntax) => {
+            let mut format = syntax.to_format();
+            format.underline = Some(Underline::Single);
+            format.underline_color = Some(Color::from_rgb(1.0, 0.0, 0.0));
+            format.strikethrough = true;
+            format.strikethrough_color = Some(Color::from_rgb(0.0, 1.0, 0.0));
+            format.overline = true;
+            format.overline_color = Some(Color::from_rgb(0.0, 0.0, 1.0));
+            format
+        }
+    }
+}
+
+struct ConfigHighlighter {
+    inner: highlighter::Highlighter,
+    error_map: ErrorMap,
+}
+
+impl Highlighter for ConfigHighlighter {
+    type Settings = Settings;
+    type Highlight = Highlight;
+    type Iterator<'a> = Box<dyn Iterator<Item = (Range<usize>, Highlight)> + 'a>;
+
+    fn new(settings: &Self::Settings) -> Self {
+        Self {
+            inner: highlighter::Highlighter::new(&settings.highlighter),
+            error_map: settings.error_map.clone(),
+        }
+    }
+
+    fn update(&mut self, settings: &Self::Settings) {
+        self.inner.update(&settings.highlighter);
+        if self.error_map != settings.error_map {
+            self.error_map = settings.error_map.clone();
+        }
+    }
+
+    fn change_line(&mut self, line: usize) {
+        self.inner.change_line(line);
+    }
+
+    fn highlight_line(&mut self, line: &str) -> Self::Iterator<'_> {
+        let current_line = self.inner.current_line();
+        let highlighted_spans = self.inner.highlight_line(line);
+
+        let Some(errors) = self.error_map.get(&current_line) else {
+            return Box::new(
+                highlighted_spans.map(|(range, highlight)| (range, Highlight::Syntax(highlight))),
+            );
+        };
+
+        let mut result = Vec::new();
+        let mut err_idx = 0;
+
+        for (range, highlight) in highlighted_spans {
+            let mut cursor = range.start;
+
+            while cursor < range.end {
+                while err_idx < errors.len() && errors[err_idx].end <= cursor {
+                    err_idx += 1;
+                }
+
+                let (end, highlight) = match errors.get(err_idx) {
+                    Some(err) if err.start <= cursor => {
+                        (err.end.min(range.end), Highlight::Error(highlight))
+                    }
+                    Some(err) => (err.start.min(range.end), Highlight::Syntax(highlight)),
+                    None => (range.end, Highlight::Syntax(highlight)),
+                };
+
+                result.push((cursor..end, highlight));
+                cursor = end;
+            }
+        }
+
+        Box::new(result.into_iter())
+    }
+
+    fn current_line(&self) -> usize {
+        self.inner.current_line()
     }
 }
 

--- a/graphics/src/text/editor.rs
+++ b/graphics/src/text/editor.rs
@@ -853,11 +853,36 @@ impl editor::Editor for Editor {
             for (range, highlight) in highlighter.highlight_line(line.text()) {
                 let format = format_highlight(&highlight);
 
-                if format.color.is_some() || format.font.is_some() {
+                if format.needs_processing() {
                     list.add_span(
                         range,
                         &cosmic_text::Attrs {
                             color_opt: format.color.map(text::to_color),
+                            text_decoration: cosmic_text::TextDecoration {
+                                underline: match format.underline {
+                                    Some(highlighter::Underline::Single) => {
+                                        cosmic_text::UnderlineStyle::Single
+                                    }
+                                    Some(highlighter::Underline::Double) => {
+                                        cosmic_text::UnderlineStyle::Double
+                                    }
+                                    None => cosmic_text::UnderlineStyle::None,
+                                },
+                                underline_color_opt: format
+                                    .underline_color
+                                    .or(format.color)
+                                    .map(text::to_color),
+                                strikethrough: format.strikethrough,
+                                strikethrough_color_opt: format
+                                    .strikethrough_color
+                                    .or(format.color)
+                                    .map(text::to_color),
+                                overline: format.overline,
+                                overline_color_opt: format
+                                    .overline_color
+                                    .or(format.color)
+                                    .map(text::to_color),
+                            },
                             ..if let Some(font) = format.font {
                                 text::to_attributes(font)
                             } else {

--- a/highlighter/src/lib.rs
+++ b/highlighter/src/lib.rs
@@ -255,6 +255,12 @@ impl Highlight {
         Format {
             color: self.color(),
             font: self.font(),
+            underline: None,
+            underline_color: None,
+            strikethrough: false,
+            strikethrough_color: None,
+            overline: false,
+            overline_color: None,
         }
     }
 }

--- a/highlighter/src/lib.rs
+++ b/highlighter/src/lib.rs
@@ -204,7 +204,7 @@ pub struct Settings {
 }
 
 /// A highlight produced by a [`Highlighter`].
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct Highlight(highlighting::StyleModifier);
 
 impl Highlight {

--- a/tiny_skia/src/text.rs
+++ b/tiny_skia/src/text.rs
@@ -231,6 +231,117 @@ fn draw(
                 );
             }
         }
+
+        for span in run.decorations {
+            let glyphs = &run.glyphs[span.glyph_range.clone()];
+
+            if glyphs.is_empty() {
+                continue;
+            }
+
+            let deco = &span.data;
+            let td = &deco.text_decoration;
+            let font_size = span.font_size;
+
+            // Compute x extent as min/max over all glyphs, not first/last,
+            // because RTL paragraphs store glyphs in right-to-left order.
+            let mut x_min = f32::INFINITY;
+            let mut x_max = f32::NEG_INFINITY;
+            for g in glyphs {
+                x_min = x_min.min(g.x);
+                x_max = x_max.max(g.x + g.w);
+            }
+            let width = x_max - x_min;
+            if width <= 0.0 {
+                continue;
+            }
+
+            let scale = transformation.scale_factor();
+            let offset_x = position.x - scroll.horizontal;
+            let offset_y = position.y;
+
+            let draw_rect = |pixels: &mut tiny_skia::PixmapMut<'_>,
+                             x: f32,
+                             y: f32,
+                             w: f32,
+                             h: f32,
+                             c: Color| {
+                let x = (x + offset_x) * scale;
+                let y = (y + offset_y) * scale;
+                let w = w * scale;
+                let h = h * scale;
+
+                if let Some(rect) = tiny_skia::Rect::from_xywh(x, y, w, h) {
+                    let mut paint = tiny_skia::Paint::default();
+
+                    let [r, g, b, a] = c.into_rgba8();
+                    paint.set_color_rgba8(b, g, r, a); // Note: we use BGRA order
+
+                    pixels.fill_rect(rect, &paint, tiny_skia::Transform::identity(), clip_mask);
+                }
+            };
+
+            // Underline
+            match td.underline {
+                cosmic_text::UnderlineStyle::None => {}
+                cosmic_text::UnderlineStyle::Single => {
+                    let color = td
+                        .underline_color_opt
+                        .or(span.color_opt)
+                        .map(from_color)
+                        .unwrap_or(color);
+                    let thickness = (deco.underline_metrics.thickness * font_size)
+                        .max(1.0)
+                        .ceil();
+                    let y = run.line_y - deco.underline_metrics.offset * font_size;
+                    draw_rect(pixels, x_min, y, width, thickness, color);
+                }
+                cosmic_text::UnderlineStyle::Double => {
+                    let color = td
+                        .underline_color_opt
+                        .or(span.color_opt)
+                        .map(from_color)
+                        .unwrap_or(color);
+                    let thickness = (deco.underline_metrics.thickness * font_size)
+                        .max(1.0)
+                        .ceil();
+                    let gap = thickness;
+                    let y = run.line_y - deco.underline_metrics.offset * font_size;
+                    draw_rect(pixels, x_min, y, width, thickness, color);
+                    draw_rect(pixels, x_min, y + thickness + gap, width, thickness, color);
+                }
+            }
+
+            // Strikethrough
+            if td.strikethrough {
+                let color = td
+                    .strikethrough_color_opt
+                    .or(span.color_opt)
+                    .map(from_color)
+                    .unwrap_or(color);
+                let thickness = (deco.strikethrough_metrics.thickness * font_size)
+                    .max(1.0)
+                    .ceil();
+                let y = run.line_y - deco.strikethrough_metrics.offset * font_size;
+                draw_rect(pixels, x_min, y, width, thickness, color);
+            }
+
+            // Overline
+            if td.overline {
+                let color = td
+                    .overline_color_opt
+                    .or(span.color_opt)
+                    .map(from_color)
+                    .unwrap_or(color);
+                // Reuse underline thickness for overline
+                let thickness = (deco.underline_metrics.thickness * font_size)
+                    .max(1.0)
+                    .ceil();
+                // clamped so it doesn't go above the line top.
+                let y = (run.line_y - deco.ascent * font_size).max(run.line_top);
+                draw_rect(pixels, x_min, y, width, thickness, color);
+            }
+        }
     }
 }
 

--- a/wgpu/src/layer.rs
+++ b/wgpu/src/layer.rs
@@ -1,4 +1,8 @@
-use crate::core::{self, Background, Color, Point, Rectangle, Svg, Transformation, renderer};
+use cryoglyph::cosmic_text;
+
+use crate::core::{
+    self, Background, Color, Point, Rectangle, Size, Svg, Transformation, Vector, renderer,
+};
 use crate::graphics;
 use crate::graphics::Mesh;
 use crate::graphics::color;
@@ -14,6 +18,13 @@ use crate::triangle;
 pub type Stack = layer::Stack<Layer>;
 
 #[derive(Debug)]
+struct TextDecoration {
+    rect: Rectangle,
+    color: Color,
+    transformation: Transformation,
+}
+
+#[derive(Debug)]
 pub struct Layer {
     pub bounds: Rectangle,
     pub quads: quad::Batch,
@@ -23,6 +34,7 @@ pub struct Layer {
     pub text: text::Batch,
     pending_meshes: Vec<Mesh>,
     pending_text: Vec<Text>,
+    pending_decorations: Vec<TextDecoration>,
 }
 
 impl Layer {
@@ -34,6 +46,7 @@ impl Layer {
             && self.text.is_empty()
             && self.pending_meshes.is_empty()
             && self.pending_text.is_empty()
+            && self.pending_decorations.is_empty()
     }
 
     pub fn draw_quad(
@@ -86,6 +99,8 @@ impl Layer {
         clip_bounds: Rectangle,
         transformation: Transformation,
     ) {
+        self.draw_text_decorations(editor.buffer(), position, color, transformation);
+
         let editor = Text::Editor {
             editor: editor.downgrade(),
             position,
@@ -251,6 +266,109 @@ impl Layer {
             .push(primitive::Instance::new(bounds, primitive));
     }
 
+    fn draw_text_decorations(
+        &mut self,
+        buffer: &cosmic_text::Buffer,
+        position: Point,
+        default_color: Color,
+        transformation: Transformation,
+    ) {
+        for run in buffer.layout_runs() {
+            for span in run.decorations {
+                let glyphs = &run.glyphs[span.glyph_range.clone()];
+                if glyphs.is_empty() {
+                    continue;
+                }
+
+                let deco = &span.data;
+                let td = &deco.text_decoration;
+                let font_size = span.font_size;
+
+                // Compute x extent as min/max over all glyphs, not first/last,
+                // because RTL paragraphs store glyphs in right-to-left order.
+                let mut x_min = f32::INFINITY;
+                let mut x_max = f32::NEG_INFINITY;
+                for g in glyphs {
+                    x_min = x_min.min(g.x);
+                    x_max = x_max.max(g.x + g.w);
+                }
+                let width = x_max - x_min;
+                if width <= 0.0 {
+                    continue;
+                }
+
+                let mut record_quad = |x: f32, y: f32, w: f32, h: f32, color: Color| {
+                    self.pending_decorations.push(TextDecoration {
+                        rect: Rectangle::new(position + Vector::new(x, y), Size::new(w, h)),
+                        color,
+                        transformation,
+                    });
+                };
+
+                // Underline
+                match td.underline {
+                    cosmic_text::UnderlineStyle::None => {}
+                    cosmic_text::UnderlineStyle::Single => {
+                        let color = td
+                            .underline_color_opt
+                            .or(span.color_opt)
+                            .map(from_color)
+                            .unwrap_or(default_color);
+                        let thickness = (deco.underline_metrics.thickness * font_size)
+                            .max(1.0)
+                            .ceil();
+                        let y = run.line_y - deco.underline_metrics.offset * font_size;
+                        record_quad(x_min, y, width, thickness, color);
+                    }
+                    cosmic_text::UnderlineStyle::Double => {
+                        let color = td
+                            .underline_color_opt
+                            .or(span.color_opt)
+                            .map(from_color)
+                            .unwrap_or(default_color);
+                        let thickness = (deco.underline_metrics.thickness * font_size)
+                            .max(1.0)
+                            .ceil();
+                        let gap = thickness;
+                        let y = run.line_y - deco.underline_metrics.offset * font_size;
+                        record_quad(x_min, y, width, thickness, color);
+                        record_quad(x_min, y + thickness + gap, width, thickness, color);
+                    }
+                }
+
+                // Strikethrough
+                if td.strikethrough {
+                    let color = td
+                        .strikethrough_color_opt
+                        .or(span.color_opt)
+                        .map(from_color)
+                        .unwrap_or(default_color);
+                    let thickness = (deco.strikethrough_metrics.thickness * font_size)
+                        .max(1.0)
+                        .ceil();
+                    let y = run.line_y - deco.strikethrough_metrics.offset * font_size;
+                    record_quad(x_min, y, width, thickness, color);
+                }
+
+                // Overline
+                if td.overline {
+                    let color = td
+                        .overline_color_opt
+                        .or(span.color_opt)
+                        .map(from_color)
+                        .unwrap_or(default_color);
+                    // Reuse underline thickness for overline
+                    let thickness = (deco.underline_metrics.thickness * font_size)
+                        .max(1.0)
+                        .ceil();
+                    // clamped so it doesn't go above the line top.
+                    let y = (run.line_y - deco.ascent * font_size).max(run.line_top);
+                    record_quad(x_min, y, width, thickness, color);
+                }
+            }
+        }
+    }
+
     #[allow(clippy::drain_collect)] // We want to reuse `Layer` capacity
     fn flush_meshes(&mut self) {
         if !self.pending_meshes.is_empty() {
@@ -263,6 +381,17 @@ impl Layer {
 
     #[allow(clippy::drain_collect)] // We want to reuse `Layer` capacity
     fn flush_text(&mut self) {
+        for decoration in self.pending_decorations.drain(..).collect::<Vec<_>>() {
+            self.draw_quad(
+                renderer::Quad {
+                    bounds: decoration.rect,
+                    ..renderer::Quad::default()
+                },
+                Background::Color(decoration.color),
+                decoration.transformation,
+            );
+        }
+
         if !self.pending_text.is_empty() {
             self.text.push(text::Item::Group {
                 transformation: Transformation::IDENTITY,
@@ -270,6 +399,12 @@ impl Layer {
             });
         }
     }
+}
+
+fn from_color(color: cosmic_text::Color) -> Color {
+    let [r, g, b, a] = color.as_rgba();
+
+    Color::from_rgba8(r, g, b, a as f32 / 255.0)
 }
 
 impl graphics::Layer for Layer {
@@ -303,10 +438,11 @@ impl graphics::Layer for Layer {
         self.images.clear();
         self.pending_meshes.clear();
         self.pending_text.clear();
+        self.pending_decorations.clear();
     }
 
     fn start(&self) -> usize {
-        if !self.quads.is_empty() {
+        if !self.quads.is_empty() || !self.pending_decorations.is_empty() {
             return 1;
         }
 
@@ -346,7 +482,7 @@ impl graphics::Layer for Layer {
             return 2;
         }
 
-        if !self.quads.is_empty() {
+        if !self.quads.is_empty() || !self.pending_decorations.is_empty() {
             return 1;
         }
 
@@ -373,6 +509,7 @@ impl Default for Layer {
             images: image::Batch::default(),
             pending_meshes: Vec::new(),
             pending_text: Vec::new(),
+            pending_decorations: Vec::new(),
         }
     }
 }

--- a/wgpu/src/layer.rs
+++ b/wgpu/src/layer.rs
@@ -99,7 +99,13 @@ impl Layer {
         clip_bounds: Rectangle,
         transformation: Transformation,
     ) {
-        self.draw_text_decorations(editor.buffer(), position, color, transformation);
+        self.draw_text_decorations(
+            editor.buffer(),
+            position,
+            color,
+            clip_bounds,
+            transformation,
+        );
 
         let editor = Text::Editor {
             editor: editor.downgrade(),
@@ -271,6 +277,7 @@ impl Layer {
         buffer: &cosmic_text::Buffer,
         position: Point,
         default_color: Color,
+        clip_bounds: Rectangle,
         transformation: Transformation,
     ) {
         for run in buffer.layout_runs() {
@@ -298,11 +305,14 @@ impl Layer {
                 }
 
                 let mut record_quad = |x: f32, y: f32, w: f32, h: f32, color: Color| {
-                    self.pending_decorations.push(TextDecoration {
-                        rect: Rectangle::new(position + Vector::new(x, y), Size::new(w, h)),
-                        color,
-                        transformation,
-                    });
+                    let rect = Rectangle::new(position + Vector::new(x, y), Size::new(w, h));
+                    if let Some(clipped_bounds) = rect.intersection(&clip_bounds) {
+                        self.pending_decorations.push(TextDecoration {
+                            rect: clipped_bounds,
+                            color,
+                            transformation,
+                        });
+                    }
                 };
 
                 // Underline


### PR DESCRIPTION
The example update is crude but it shows how it could be used.

<img width="218" height="126" alt="image" src="https://github.com/user-attachments/assets/350cb381-6b1b-4d3f-8840-a4f73510625c" />

I tested both skia & wgpu backends, the code to draw the rects comes directly from [cosmic-text](https://github.com/pop-os/cosmic-text/blob/b0884c0/src/render.rs#L27)

This is an alternative to #3430 