### PR TITLE
Handle screenshot buffer mapping failures

### DIFF
--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -262,12 +262,30 @@ impl Renderer {
         self.staging_belt.recall();
 
         let slice = output_buffer.slice(..);
-        slice.map_async(wgpu::MapMode::Read, |_| {});
+        let (sender, receiver) = std::sync::mpsc::sync_channel(1);
+        slice.map_async(wgpu::MapMode::Read, move |result| {
+            let _ = sender.send(result);
+        });
 
-        let _ = self.engine.device.poll(wgpu::PollType::Wait {
+        if let Err(error) = self.engine.device.poll(wgpu::PollType::Wait {
             submission_index: Some(index),
             timeout: None,
-        });
+        }) {
+            log::error!("Failed to wait for screenshot readback: {error}");
+            return Vec::new();
+        }
+
+        match receiver.try_recv() {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => {
+                log::error!("Failed to map screenshot buffer: {error}");
+                return Vec::new();
+            }
+            Err(error) => {
+                log::error!("Screenshot buffer mapping did not complete: {error}");
+                return Vec::new();
+            }
+        }
 
         let mapped_buffer = slice.get_mapped_range();
 


### PR DESCRIPTION
The wgpu screenshot path ignored both the buffer mapping callback result and the device poll result before calling `get_mapped_range`. If mapping fails, the unconditional read panics with `Buffer is not mapped`.

Check both results and return an empty capture after logging the original error. The current screenshot API has no error variant, and empty bytes let callers treat the capture as unavailable without crashing.

Checked with `cargo check -p iced_wgpu`.