### PR TITLE
Remove `Font` Generics

### DIFF
--- a/core/src/renderer.rs
+++ b/core/src/renderer.rs
@@ -165,12 +165,12 @@ pub trait Headless {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Settings {
     /// The default [`Font`] to use.
-    pub default_font: Font,
+    pub font: Font,
 
     /// The default size of text.
     ///
     /// By default, it will be set to `16.0`.
-    pub default_text_size: Pixels,
+    pub text_size: Pixels,
 
     /// Whether the [`Renderer`] should perform metrics hinting.
     ///
@@ -181,8 +181,8 @@ pub struct Settings {
 impl Default for Settings {
     fn default() -> Self {
         Self {
-            default_font: Font::DEFAULT,
-            default_text_size: Pixels(16.0),
+            font: Font::DEFAULT,
+            text_size: Pixels(16.0),
             metrics_hinting: true,
         }
     }

--- a/core/src/renderer.rs
+++ b/core/src/renderer.rs
@@ -3,9 +3,7 @@
 mod null;
 
 use crate::image;
-use crate::{
-    Background, Border, Color, Font, Pixels, Rectangle, Shadow, Size, Transformation, Vector,
-};
+use crate::{Background, Border, Color, Pixels, Rectangle, Shadow, Size, Transformation, Vector};
 
 /// Whether anti-aliasing should be avoided by snapping primitive coordinates to the
 /// pixel grid.
@@ -13,6 +11,9 @@ pub const CRISP: bool = cfg!(feature = "crisp");
 
 /// A component that can be used by widgets to draw themselves on a screen.
 pub trait Renderer {
+    /// The font type used.
+    type Font: Copy + PartialEq;
+
     /// Starts recording a new layer.
     fn start_layer(&mut self, bounds: Rectangle);
 
@@ -87,7 +88,7 @@ pub trait Renderer {
     fn reset(&mut self, new_bounds: Rectangle);
 
     /// Returns the [`Settings`] of this [`Renderer`].
-    fn settings(&self) -> Settings;
+    fn settings(&self) -> Settings<Self::Font>;
 
     /// Polls any concurrent computations that may be pending in the [`Renderer`].
     ///
@@ -163,8 +164,8 @@ pub trait Headless {
 
 /// The settings of a [`Renderer`].
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Settings {
-    /// The default [`Font`] to use.
+pub struct Settings<Font = crate::Font> {
+    /// The default font to use.
     pub default_font: Font,
 
     /// The default size of text.
@@ -181,7 +182,7 @@ pub struct Settings {
 impl Default for Settings {
     fn default() -> Self {
         Self {
-            default_font: Font::DEFAULT,
+            default_font: crate::Font::DEFAULT,
             default_text_size: Pixels(16.0),
             metrics_hinting: true,
         }

--- a/core/src/renderer.rs
+++ b/core/src/renderer.rs
@@ -3,7 +3,9 @@
 mod null;
 
 use crate::image;
-use crate::{Background, Border, Color, Pixels, Rectangle, Shadow, Size, Transformation, Vector};
+use crate::{
+    Background, Border, Color, Font, Pixels, Rectangle, Shadow, Size, Transformation, Vector,
+};
 
 /// Whether anti-aliasing should be avoided by snapping primitive coordinates to the
 /// pixel grid.
@@ -11,9 +13,6 @@ pub const CRISP: bool = cfg!(feature = "crisp");
 
 /// A component that can be used by widgets to draw themselves on a screen.
 pub trait Renderer {
-    /// The font type used.
-    type Font: Copy + PartialEq;
-
     /// Starts recording a new layer.
     fn start_layer(&mut self, bounds: Rectangle);
 
@@ -88,7 +87,7 @@ pub trait Renderer {
     fn reset(&mut self, new_bounds: Rectangle);
 
     /// Returns the [`Settings`] of this [`Renderer`].
-    fn settings(&self) -> Settings<Self::Font>;
+    fn settings(&self) -> Settings;
 
     /// Polls any concurrent computations that may be pending in the [`Renderer`].
     ///
@@ -164,8 +163,8 @@ pub trait Headless {
 
 /// The settings of a [`Renderer`].
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Settings<Font = crate::Font> {
-    /// The default font to use.
+pub struct Settings {
+    /// The default [`Font`] to use.
     pub default_font: Font,
 
     /// The default size of text.
@@ -182,7 +181,7 @@ pub struct Settings<Font = crate::Font> {
 impl Default for Settings {
     fn default() -> Self {
         Self {
-            default_font: crate::Font::DEFAULT,
+            default_font: Font::DEFAULT,
             default_text_size: Pixels(16.0),
             metrics_hinting: true,
         }

--- a/core/src/renderer/null.rs
+++ b/core/src/renderer/null.rs
@@ -7,8 +7,6 @@ use crate::text::{self, Text};
 use crate::{Background, Color, Font, Pixels, Point, Rectangle, Size, Transformation};
 
 impl Renderer for () {
-    type Font = Font;
-
     fn start_layer(&mut self, _bounds: Rectangle) {}
 
     fn end_layer(&mut self) {}
@@ -83,11 +81,9 @@ impl text::Renderer for () {
 }
 
 impl text::Paragraph for () {
-    type Font = Font;
-
     fn with_text(_text: Text<&str>) -> Self {}
 
-    fn with_spans<Link>(_text: Text<&[text::Span<'_, Link, Self::Font>], Self::Font>) -> Self {}
+    fn with_spans<Link>(_text: Text<&[text::Span<'_, Link>]>) -> Self {}
 
     fn resize(&mut self, _new_bounds: Size) {}
 
@@ -153,8 +149,6 @@ impl text::Paragraph for () {
 }
 
 impl text::Editor for () {
-    type Font = Font;
-
     fn with_text(_text: &str) -> Self {}
 
     fn is_empty(&self) -> bool {
@@ -203,7 +197,7 @@ impl text::Editor for () {
     fn update(
         &mut self,
         _new_bounds: Size,
-        _new_font: Self::Font,
+        _new_font: Font,
         _new_size: Pixels,
         _new_line_height: text::LineHeight,
         _new_wrapping: text::Wrapping,
@@ -217,7 +211,7 @@ impl text::Editor for () {
 
     fn highlight<P: text::Parser>(
         &mut self,
-        _font: Self::Font,
+        _font: Font,
         _parser: &mut P,
         _highlighter: impl Fn(P::Output) -> highlighter::Style,
     ) {
@@ -231,8 +225,8 @@ impl text::Editor for () {
         text::LineHeight::default()
     }
 
-    fn font(&self) -> Self::Font {
-        Self::Font::default()
+    fn font(&self) -> Font {
+        Font::default()
     }
 }
 

--- a/core/src/renderer/null.rs
+++ b/core/src/renderer/null.rs
@@ -7,6 +7,8 @@ use crate::text::{self, Text};
 use crate::{Background, Color, Font, Pixels, Point, Rectangle, Size, Transformation};
 
 impl Renderer for () {
+    type Font = Font;
+
     fn start_layer(&mut self, _bounds: Rectangle) {}
 
     fn end_layer(&mut self) {}
@@ -40,7 +42,6 @@ impl Renderer for () {
 }
 
 impl text::Renderer for () {
-    type Font = Font;
     type Paragraph = ();
     type Editor = ();
 
@@ -52,14 +53,6 @@ impl text::Renderer for () {
     const SCROLL_LEFT_ICON: char = '0';
     const SCROLL_RIGHT_ICON: char = '0';
     const ICED_LOGO: char = '0';
-
-    fn default_font(&self) -> Self::Font {
-        Font::default()
-    }
-
-    fn default_size(&self) -> Pixels {
-        Pixels(16.0)
-    }
 
     fn fill_paragraph(
         &mut self,

--- a/core/src/settings.rs
+++ b/core/src/settings.rs
@@ -20,12 +20,12 @@ pub struct Settings {
     /// The default [`Font`] to be used.
     ///
     /// By default, it uses [`Family::SansSerif`](crate::font::Family::SansSerif).
-    pub default_font: Font,
+    pub font: Font,
 
     /// The text size that will be used by default.
     ///
     /// By default, it is `16.0`.
-    pub default_text_size: Pixels,
+    pub text_size: Pixels,
 
     /// Whether certain widgets should be rendered using metrics hinting.
     ///
@@ -69,8 +69,8 @@ impl Default for Settings {
         Self {
             id: None,
             fonts: Vec::new(),
-            default_font: renderer.default_font,
-            default_text_size: renderer.default_text_size,
+            font: renderer.font,
+            text_size: renderer.text_size,
             metrics_hinting: true,
             backend: Backend::default(),
             power_preference: backend::PowerPreference::None,
@@ -83,8 +83,8 @@ impl Default for Settings {
 impl From<&Settings> for renderer::Settings {
     fn from(settings: &Settings) -> Self {
         Self {
-            default_font: settings.default_font,
-            default_text_size: settings.default_text_size,
+            font: settings.font,
+            text_size: settings.text_size,
             metrics_hinting: settings.metrics_hinting,
         }
     }

--- a/core/src/text.rs
+++ b/core/src/text.rs
@@ -13,14 +13,14 @@ pub use paragraph::Paragraph;
 pub use parser::Parser;
 
 use crate::alignment;
-use crate::{Background, Border, Color, Padding, Pixels, Point, Rectangle, Size};
+use crate::{Background, Border, Color, Font, Padding, Pixels, Point, Rectangle, Size};
 
 use std::borrow::Cow;
 use std::hash::{Hash, Hasher};
 
 /// A paragraph.
 #[derive(Debug, Clone, Copy)]
-pub struct Text<Content = String, Font = crate::Font> {
+pub struct Text<Content = String> {
     /// The content of the paragraph.
     pub content: Content,
 
@@ -33,7 +33,7 @@ pub struct Text<Content = String, Font = crate::Font> {
     /// The line height of the [`Text`].
     pub line_height: LineHeight,
 
-    /// The font of the [`Text`].
+    /// The [`Font`] of the [`Text`].
     pub font: Font,
 
     /// The horizontal alignment of the [`Text`].
@@ -62,13 +62,10 @@ pub struct Text<Content = String, Font = crate::Font> {
     pub hint_factor: Option<f32>,
 }
 
-impl<Content, Font> Text<Content, Font>
-where
-    Font: Copy,
-{
+impl<Content> Text<Content> {
     /// Returns a new [`Text`] replacing only the content with the
     /// given value.
-    pub fn with_content<T>(&self, content: T) -> Text<T, Font> {
+    pub fn with_content<T>(&self, content: T) -> Text<T> {
         Text {
             content,
             bounds: self.bounds,
@@ -85,13 +82,9 @@ where
     }
 }
 
-impl<Content, Font> Text<Content, Font>
-where
-    Content: AsRef<str>,
-    Font: Copy,
-{
+impl<Content: AsRef<str>> Text<Content> {
     /// Returns a borrowed version of [`Text`].
-    pub fn as_ref(&self) -> Text<&str, Font> {
+    pub fn as_ref(&self) -> Text<&str> {
         self.with_content(self.content.as_ref())
     }
 }
@@ -325,13 +318,13 @@ pub enum Difference {
 /// A renderer capable of measuring and drawing [`Text`].
 pub trait Renderer: crate::Renderer {
     /// The [`Paragraph`] of this [`Renderer`].
-    type Paragraph: Paragraph<Font = Self::Font> + 'static;
+    type Paragraph: Paragraph + 'static;
 
     /// The [`Editor`] of this [`Renderer`].
-    type Editor: Editor<Font = Self::Font> + 'static;
+    type Editor: Editor + 'static;
 
     /// The icon font of the backend.
-    const ICON_FONT: Self::Font;
+    const ICON_FONT: Font;
 
     /// The `char` representing a ✔ icon in the [`ICON_FONT`].
     ///
@@ -392,7 +385,7 @@ pub trait Renderer: crate::Renderer {
     /// [`Color`].
     fn fill_text(
         &mut self,
-        text: Text<String, Self::Font>,
+        text: Text<String>,
         position: Point,
         color: Color,
         clip_bounds: Rectangle,
@@ -401,14 +394,14 @@ pub trait Renderer: crate::Renderer {
 
 /// A span of text.
 #[derive(Debug, Clone)]
-pub struct Span<'a, Link = (), Font = crate::Font> {
+pub struct Span<'a, Link = ()> {
     /// The [`Fragment`] of text.
     pub text: Fragment<'a>,
     /// The size of the [`Span`] in [`Pixels`].
     pub size: Option<Pixels>,
     /// The [`LineHeight`] of the [`Span`].
     pub line_height: Option<LineHeight>,
-    /// The font of the [`Span`].
+    /// The [`Font`] of the [`Span`].
     pub font: Option<Font>,
     /// The [`Color`] of the [`Span`].
     pub color: Option<Color>,
@@ -435,7 +428,7 @@ pub struct Highlight {
     pub border: Border,
 }
 
-impl<'a, Link, Font> Span<'a, Link, Font> {
+impl<'a, Link> Span<'a, Link> {
     /// Creates a new [`Span`] of text with the given text fragment.
     pub fn new(fragment: impl IntoFragment<'a>) -> Self {
         Self {
@@ -569,7 +562,7 @@ impl<'a, Link, Font> Span<'a, Link, Font> {
     }
 
     /// Turns the [`Span`] into a static one.
-    pub fn to_static(self) -> Span<'static, Link, Font> {
+    pub fn to_static(self) -> Span<'static, Link> {
         Span {
             text: Cow::Owned(self.text.into_owned()),
             size: self.size,
@@ -585,7 +578,7 @@ impl<'a, Link, Font> Span<'a, Link, Font> {
     }
 }
 
-impl<Link, Font> Default for Span<'_, Link, Font> {
+impl<Link> Default for Span<'_, Link> {
     fn default() -> Self {
         Self {
             text: Cow::default(),
@@ -602,13 +595,13 @@ impl<Link, Font> Default for Span<'_, Link, Font> {
     }
 }
 
-impl<'a, Link, Font> From<&'a str> for Span<'a, Link, Font> {
+impl<'a, Link> From<&'a str> for Span<'a, Link> {
     fn from(value: &'a str) -> Self {
         Span::new(value)
     }
 }
 
-impl<Link, Font: PartialEq> PartialEq for Span<'_, Link, Font> {
+impl<Link> PartialEq for Span<'_, Link> {
     fn eq(&self, other: &Self) -> bool {
         self.text == other.text
             && self.size == other.size

--- a/core/src/text.rs
+++ b/core/src/text.rs
@@ -361,6 +361,16 @@ pub trait Renderer: crate::Renderer {
     /// ['ICON_FONT']: Self::ICON_FONT
     const ICED_LOGO: char;
 
+    /// Returns the default [`Font`].
+    fn font(&self) -> Font {
+        self.settings().font
+    }
+
+    /// Returns the default size of [`Text`].
+    fn text_size(&self) -> Pixels {
+        self.settings().text_size
+    }
+
     /// Draws the given [`Paragraph`] at the given position and with the given
     /// [`Color`].
     fn fill_paragraph(

--- a/core/src/text.rs
+++ b/core/src/text.rs
@@ -324,9 +324,6 @@ pub enum Difference {
 
 /// A renderer capable of measuring and drawing [`Text`].
 pub trait Renderer: crate::Renderer {
-    /// The font type used.
-    type Font: Copy + PartialEq;
-
     /// The [`Paragraph`] of this [`Renderer`].
     type Paragraph: Paragraph<Font = Self::Font> + 'static;
 
@@ -370,12 +367,6 @@ pub trait Renderer: crate::Renderer {
     ///
     /// ['ICON_FONT']: Self::ICON_FONT
     const ICED_LOGO: char;
-
-    /// Returns the default [`Self::Font`].
-    fn default_font(&self) -> Self::Font;
-
-    /// Returns the default size of [`Text`].
-    fn default_size(&self) -> Pixels;
 
     /// Draws the given [`Paragraph`] at the given position and with the given
     /// [`Color`].

--- a/core/src/text/editor.rs
+++ b/core/src/text/editor.rs
@@ -10,16 +10,15 @@ use crate::text::{self, Alignment, LineHeight, Position, Wrapping};
 use crate::time::{Duration, Instant};
 use crate::widget::operation::{Focusable, TextInput};
 use crate::window;
-use crate::{Color, Event, InputMethod, Padding, Pixels, Point, Rectangle, Size, SmolStr, Vector};
+use crate::{
+    Color, Event, Font, InputMethod, Padding, Pixels, Point, Rectangle, Size, SmolStr, Vector,
+};
 
 use std::borrow::Cow;
 use std::sync::Arc;
 
 /// A component that can be used by widgets to edit multi-line text.
 pub trait Editor: Sized + Default {
-    /// The font of the [`Editor`].
-    type Font: Copy + PartialEq + Default;
-
     /// Creates a new [`Editor`] laid out with the given text.
     fn with_text(text: &str) -> Self;
 
@@ -61,7 +60,7 @@ pub trait Editor: Sized + Default {
     fn update(
         &mut self,
         new_bounds: Size,
-        new_font: Self::Font,
+        new_font: Font,
         new_size: Pixels,
         new_line_height: LineHeight,
         new_wrapping: Wrapping,
@@ -76,7 +75,7 @@ pub trait Editor: Sized + Default {
     /// Runs a [`text::Highlighter`] in the [`Editor`].
     fn highlight<P: text::Parser>(
         &mut self,
-        font: Self::Font,
+        font: Font,
         parser: &mut P,
         highlight: impl Fn(P::Output) -> highlighter::Style,
     );
@@ -109,8 +108,8 @@ pub trait Editor: Sized + Default {
         contents
     }
 
-    /// Returns the current [`Font`](Self::Font) of the [`Editor`].
-    fn font(&self) -> Self::Font;
+    /// Returns the current [`Font`] of the [`Editor`].
+    fn font(&self) -> Font;
 
     /// Returns the current text size of the [`Editor`].
     fn text_size(&self) -> Pixels;

--- a/core/src/text/input.rs
+++ b/core/src/text/input.rs
@@ -84,12 +84,8 @@ impl<R: text::Renderer> Input<R> {
             .height(layout.height)
             .shrink(layout.padding);
 
-        let font = layout
-            .font
-            .unwrap_or_else(|| renderer.settings().font);
-        let size = layout
-            .size
-            .unwrap_or_else(|| renderer.settings().text_size);
+        let font = layout.font.unwrap_or_else(|| renderer.font());
+        let size = layout.size.unwrap_or_else(|| renderer.text_size());
         let hint_factor = renderer.hint_factor();
 
         if layout.is_secure {

--- a/core/src/text/input.rs
+++ b/core/src/text/input.rs
@@ -84,8 +84,12 @@ impl<R: text::Renderer> Input<R> {
             .height(layout.height)
             .shrink(layout.padding);
 
-        let font = layout.font.unwrap_or_else(|| renderer.default_font());
-        let size = layout.size.unwrap_or_else(|| renderer.default_size());
+        let font = layout
+            .font
+            .unwrap_or_else(|| renderer.settings().default_font);
+        let size = layout
+            .size
+            .unwrap_or_else(|| renderer.settings().default_text_size);
         let hint_factor = renderer.hint_factor();
 
         if layout.is_secure {

--- a/core/src/text/input.rs
+++ b/core/src/text/input.rs
@@ -86,10 +86,10 @@ impl<R: text::Renderer> Input<R> {
 
         let font = layout
             .font
-            .unwrap_or_else(|| renderer.settings().default_font);
+            .unwrap_or_else(|| renderer.settings().font);
         let size = layout
             .size
-            .unwrap_or_else(|| renderer.settings().default_text_size);
+            .unwrap_or_else(|| renderer.settings().text_size);
         let hint_factor = renderer.hint_factor();
 
         if layout.is_secure {

--- a/core/src/text/input.rs
+++ b/core/src/text/input.rs
@@ -7,7 +7,7 @@ use crate::text::editor;
 use crate::text::paragraph;
 use crate::text::{self, Alignment, Editor, LineHeight, Position, Text, Wrapping};
 use crate::widget::operation::{Focusable, TextInput};
-use crate::{Color, Event, InputMethod, Length, Padding, Pixels, Point, Rectangle, Shell};
+use crate::{Color, Event, Font, InputMethod, Length, Padding, Pixels, Point, Rectangle, Shell};
 
 use unicode_segmentation::UnicodeSegmentation;
 
@@ -24,7 +24,7 @@ pub struct Input<R: text::Renderer> {
     multiline: Option<Wrapping>,
 }
 
-pub struct Layout<'a, Font> {
+pub struct Layout<'a> {
     pub width: Length,
     pub height: Length,
     pub padding: Padding,
@@ -74,7 +74,7 @@ impl<R: text::Renderer> Input<R> {
         &mut self,
         renderer: &R,
         limits: &layout::Limits,
-        layout: Layout<'_, R::Font>,
+        layout: Layout<'_>,
     ) -> layout::Node {
         self.padding = layout.padding;
         self.multiline = layout.multiline;

--- a/core/src/text/paragraph.rs
+++ b/core/src/text/paragraph.rs
@@ -3,25 +3,22 @@ use crate::alignment;
 use crate::text::{
     Alignment, Difference, Ellipsis, Hit, LineHeight, Shaping, Span, Text, Wrapping,
 };
-use crate::{Pixels, Point, Rectangle, Size};
+use crate::{Font, Pixels, Point, Rectangle, Size};
 
 /// A text paragraph.
 pub trait Paragraph: Sized + Default {
-    /// The font of this [`Paragraph`].
-    type Font: Copy + PartialEq;
+    /// Creates a new [`Paragraph`] laid out with the given [`Text`].
+    fn with_text(text: Text<&str>) -> Self;
 
     /// Creates a new [`Paragraph`] laid out with the given [`Text`].
-    fn with_text(text: Text<&str, Self::Font>) -> Self;
-
-    /// Creates a new [`Paragraph`] laid out with the given [`Text`].
-    fn with_spans<Link>(text: Text<&[Span<'_, Link, Self::Font>], Self::Font>) -> Self;
+    fn with_spans<Link>(text: Text<&[Span<'_, Link>]>) -> Self;
 
     /// Lays out the [`Paragraph`] with some new boundaries.
     fn resize(&mut self, new_bounds: Size);
 
     /// Compares the [`Paragraph`] with some desired [`Text`] and returns the
     /// [`Difference`].
-    fn compare(&self, text: Text<(), Self::Font>) -> Difference;
+    fn compare(&self, text: Text<()>) -> Difference;
 
     /// Returns the text size of the [`Paragraph`] in [`Pixels`].
     fn size(&self) -> Pixels;
@@ -29,8 +26,8 @@ pub trait Paragraph: Sized + Default {
     /// Returns the hint factor of the [`Paragraph`].
     fn hint_factor(&self) -> Option<f32>;
 
-    /// Returns the font of the [`Paragraph`].
-    fn font(&self) -> Self::Font;
+    /// Returns the [`Font`] of the [`Paragraph`].
+    fn font(&self) -> Font;
 
     /// Returns the [`LineHeight`] of the [`Paragraph`].
     fn line_height(&self) -> LineHeight;
@@ -90,7 +87,7 @@ pub struct Plain<P: Paragraph> {
 
 impl<P: Paragraph> Plain<P> {
     /// Creates a new [`Plain`] paragraph.
-    pub fn new(text: Text<String, P::Font>) -> Self {
+    pub fn new(text: Text<String>) -> Self {
         Self {
             raw: P::with_text(text.as_ref()),
             content: text.content,
@@ -100,7 +97,7 @@ impl<P: Paragraph> Plain<P> {
     /// Updates the plain [`Paragraph`] to match the given [`Text`], if needed.
     ///
     /// Returns true if the [`Paragraph`] changed.
-    pub fn update(&mut self, text: Text<&str, P::Font>) -> bool {
+    pub fn update(&mut self, text: Text<&str>) -> bool {
         if self.content != text.content {
             text.content.clone_into(&mut self.content);
             self.raw = P::with_text(text);
@@ -159,7 +156,7 @@ impl<P: Paragraph> Plain<P> {
     }
 
     /// Returns the [`Paragraph`] as a [`Text`] definition.
-    pub fn as_text(&self) -> Text<&str, P::Font> {
+    pub fn as_text(&self) -> Text<&str> {
         Text {
             content: &self.content,
             bounds: self.raw.bounds(),

--- a/core/src/widget/text.rs
+++ b/core/src/widget/text.rs
@@ -307,10 +307,10 @@ where
 
         let size = format
             .size
-            .unwrap_or_else(|| renderer.settings().default_text_size);
+            .unwrap_or_else(|| renderer.settings().text_size);
         let font = format
             .font
-            .unwrap_or_else(|| renderer.settings().default_font);
+            .unwrap_or_else(|| renderer.settings().font);
 
         let _ = paragraph.update(text::Text {
             content,

--- a/core/src/widget/text.rs
+++ b/core/src/widget/text.rs
@@ -92,7 +92,7 @@ where
 
     /// Sets the [`Font`] of the [`Text`].
     ///
-    /// [`Font`]: crate::text::Renderer::Font
+    /// [`Font`]: crate::Renderer::Font
     pub fn font(mut self, font: impl Into<Renderer::Font>) -> Self {
         self.format.font = Some(font.into());
         self
@@ -100,7 +100,7 @@ where
 
     /// Sets the [`Font`] of the [`Text`], if `Some`.
     ///
-    /// [`Font`]: crate::text::Renderer::Font
+    /// [`Font`]: crate::Renderer::Font
     pub fn font_maybe(mut self, font: Option<impl Into<Renderer::Font>>) -> Self {
         self.format.font = font.map(Into::into);
         self
@@ -311,8 +311,12 @@ where
     layout::sized(limits, format.width, format.height, |limits| {
         let bounds = limits.max();
 
-        let size = format.size.unwrap_or_else(|| renderer.default_size());
-        let font = format.font.unwrap_or_else(|| renderer.default_font());
+        let size = format
+            .size
+            .unwrap_or_else(|| renderer.settings().default_text_size);
+        let font = format
+            .font
+            .unwrap_or_else(|| renderer.settings().default_font);
 
         let _ = paragraph.update(text::Text {
             content,

--- a/core/src/widget/text.rs
+++ b/core/src/widget/text.rs
@@ -2,7 +2,7 @@
 //!
 //! # Example
 //! ```no_run
-//! # mod iced { pub mod widget { pub fn text<T>(t: T) -> iced_core::widget::Text<'static, iced_core::Theme, ()> { unimplemented!() } }
+//! # mod iced { pub mod widget { pub fn text<T>(t: T) -> iced_core::widget::Text<'static, iced_core::Theme> { unimplemented!() } }
 //! #            pub use iced_core::color; }
 //! # pub type State = ();
 //! # pub type Element<'a, Message> = iced_core::Element<'a, Message, iced_core::Theme, ()>;
@@ -27,7 +27,7 @@ use crate::renderer;
 use crate::text;
 use crate::text::paragraph::{self, Paragraph};
 use crate::widget::tree::{self, Tree};
-use crate::{Color, Element, Layout, Length, Pixels, Rectangle, Size, Theme, Widget};
+use crate::{Color, Element, Font, Layout, Length, Pixels, Rectangle, Size, Theme, Widget};
 
 pub use text::{Alignment, Ellipsis, LineHeight, Position, Shaping, Wrapping};
 
@@ -35,7 +35,7 @@ pub use text::{Alignment, Ellipsis, LineHeight, Position, Shaping, Wrapping};
 ///
 /// # Example
 /// ```no_run
-/// # mod iced { pub mod widget { pub fn text<T>(t: T) -> iced_core::widget::Text<'static, iced_core::Theme, ()> { unimplemented!() } }
+/// # mod iced { pub mod widget { pub fn text<T>(t: T) -> iced_core::widget::Text<'static, iced_core::Theme> { unimplemented!() } }
 /// #            pub use iced_core::color; }
 /// # pub type State = ();
 /// # pub type Element<'a, Message> = iced_core::Element<'a, Message, iced_core::Theme, ()>;
@@ -54,20 +54,18 @@ pub use text::{Alignment, Ellipsis, LineHeight, Position, Shaping, Wrapping};
 /// }
 /// ```
 #[must_use]
-pub struct Text<'a, Theme, Renderer>
+pub struct Text<'a, Theme>
 where
     Theme: Catalog,
-    Renderer: text::Renderer,
 {
     fragment: text::Fragment<'a>,
-    format: Format<Renderer::Font>,
+    format: Format,
     class: Theme::Class<'a>,
 }
 
-impl<'a, Theme, Renderer> Text<'a, Theme, Renderer>
+impl<'a, Theme> Text<'a, Theme>
 where
     Theme: Catalog,
-    Renderer: text::Renderer,
 {
     /// Create a new fragment of [`Text`] with the given contents.
     pub fn new(fragment: impl text::IntoFragment<'a>) -> Self {
@@ -91,17 +89,13 @@ where
     }
 
     /// Sets the [`Font`] of the [`Text`].
-    ///
-    /// [`Font`]: crate::Renderer::Font
-    pub fn font(mut self, font: impl Into<Renderer::Font>) -> Self {
+    pub fn font(mut self, font: impl Into<Font>) -> Self {
         self.format.font = Some(font.into());
         self
     }
 
     /// Sets the [`Font`] of the [`Text`], if `Some`.
-    ///
-    /// [`Font`]: crate::Renderer::Font
-    pub fn font_maybe(mut self, font: Option<impl Into<Renderer::Font>>) -> Self {
+    pub fn font_maybe(mut self, font: Option<impl Into<Font>>) -> Self {
         self.format.font = font.map(Into::into);
         self
     }
@@ -192,7 +186,7 @@ where
 /// The internal state of a [`Text`] widget.
 pub type State<P> = paragraph::Plain<P>;
 
-impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer> for Text<'_, Theme, Renderer>
+impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer> for Text<'_, Theme>
 where
     Theme: Catalog,
     Renderer: text::Renderer,
@@ -267,7 +261,7 @@ where
 /// to learn more about each field.
 #[derive(Debug, Clone, Copy)]
 #[allow(missing_docs)]
-pub struct Format<Font> {
+pub struct Format {
     pub width: Length,
     pub height: Length,
     pub size: Option<Pixels>,
@@ -280,7 +274,7 @@ pub struct Format<Font> {
     pub ellipsis: Ellipsis,
 }
 
-impl<Font> Default for Format<Font> {
+impl Default for Format {
     fn default() -> Self {
         Self {
             size: None,
@@ -303,7 +297,7 @@ pub fn layout<Renderer>(
     renderer: &Renderer,
     limits: &layout::Limits,
     content: &str,
-    format: Format<Renderer::Font>,
+    format: Format,
 ) -> layout::Node
 where
     Renderer: text::Renderer,
@@ -361,21 +355,19 @@ pub fn draw<Renderer>(
     );
 }
 
-impl<'a, Message, Theme, Renderer> From<Text<'a, Theme, Renderer>>
-    for Element<'a, Message, Theme, Renderer>
+impl<'a, Message, Theme, Renderer> From<Text<'a, Theme>> for Element<'a, Message, Theme, Renderer>
 where
     Theme: Catalog + 'a,
     Renderer: text::Renderer + 'a,
 {
-    fn from(text: Text<'a, Theme, Renderer>) -> Element<'a, Message, Theme, Renderer> {
+    fn from(text: Text<'a, Theme>) -> Element<'a, Message, Theme, Renderer> {
         Element::new(text)
     }
 }
 
-impl<'a, Theme, Renderer> From<&'a str> for Text<'a, Theme, Renderer>
+impl<'a, Theme> From<&'a str> for Text<'a, Theme>
 where
     Theme: Catalog + 'a,
-    Renderer: text::Renderer,
 {
     fn from(content: &'a str) -> Self {
         Self::new(content)

--- a/core/src/widget/text.rs
+++ b/core/src/widget/text.rs
@@ -305,12 +305,8 @@ where
     layout::sized(limits, format.width, format.height, |limits| {
         let bounds = limits.max();
 
-        let size = format
-            .size
-            .unwrap_or_else(|| renderer.settings().text_size);
-        let font = format
-            .font
-            .unwrap_or_else(|| renderer.settings().font);
+        let size = format.size.unwrap_or_else(|| renderer.text_size());
+        let font = format.font.unwrap_or_else(|| renderer.font());
 
         let _ = paragraph.update(text::Text {
             content,

--- a/examples/checkbox/src/main.rs
+++ b/examples/checkbox/src/main.rs
@@ -5,7 +5,7 @@ const ICON_FONT: Font = Font::new("icons");
 
 pub fn main() -> iced::Result {
     iced::application(Example::default, Example::update, Example::view)
-        .font(include_bytes!("../fonts/icons.ttf").as_slice())
+        .fonts([include_bytes!("../fonts/icons.ttf").as_slice()])
         .run()
 }
 

--- a/examples/color_palette/src/main.rs
+++ b/examples/color_palette/src/main.rs
@@ -16,7 +16,7 @@ pub fn main() -> iced::Result {
         ColorPalette::view,
     )
     .theme(ColorPalette::theme)
-    .default_font(Font::MONOSPACE)
+    .font(Font::MONOSPACE)
     .run()
 }
 

--- a/examples/editor/src/main.rs
+++ b/examples/editor/src/main.rs
@@ -14,8 +14,8 @@ use std::sync::Arc;
 pub fn main() -> iced::Result {
     iced::application(Editor::new, Editor::update, Editor::view)
         .theme(Editor::theme)
-        .font(include_bytes!("../fonts/icons.ttf").as_slice())
-        .default_font(Font::MONOSPACE)
+        .fonts([include_bytes!("../fonts/icons.ttf").as_slice()])
+        .font(Font::MONOSPACE)
         .run()
 }
 

--- a/examples/markdown/src/main.rs
+++ b/examples/markdown/src/main.rs
@@ -22,7 +22,7 @@ pub fn main() -> iced::Result {
         Markdown::subscription,
         Markdown::view,
     )
-    .font(icon::FONT)
+    .fonts([icon::FONT])
     .theme(Markdown::theme)
     .run()
 }

--- a/examples/todos/src/main.rs
+++ b/examples/todos/src/main.rs
@@ -23,7 +23,7 @@ fn application() -> Application<impl Program<Message = Message, Theme = Theme>> 
     iced::application(Todos::new, Todos::update, Todos::view)
         .subscription(Todos::subscription)
         .title(Todos::title)
-        .font(Todos::ICON_FONT)
+        .fonts([Todos::ICON_FONT])
         .window_size((500.0, 800.0))
         .presets(presets())
 }

--- a/graphics/src/text/editor.rs
+++ b/graphics/src/text/editor.rs
@@ -82,8 +82,6 @@ impl Editor {
 }
 
 impl editor::Editor for Editor {
-    type Font = Font;
-
     fn with_text(text: &str) -> Self {
         let mut buffer = cosmic_text::Buffer::new_empty(cosmic_text::Metrics {
             font_size: 1.0,
@@ -799,7 +797,7 @@ impl editor::Editor for Editor {
 
     fn highlight<P: Parser>(
         &mut self,
-        font: Self::Font,
+        font: Font,
         parser: &mut P,
         highlight: impl Fn(P::Output) -> highlighter::Style,
     ) {
@@ -893,7 +891,7 @@ impl editor::Editor for Editor {
         ))
     }
 
-    fn font(&self) -> Self::Font {
+    fn font(&self) -> Font {
         self.internal().font
     }
 }

--- a/graphics/src/text/paragraph.rs
+++ b/graphics/src/text/paragraph.rs
@@ -61,8 +61,6 @@ impl Paragraph {
 }
 
 impl core::text::Paragraph for Paragraph {
-    type Font = Font;
-
     fn with_text(text: Text<&str>) -> Self {
         log::trace!("Allocating plain paragraph: {}", text.content);
 

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -14,7 +14,7 @@ use crate::core::renderer;
 use crate::core::text;
 use crate::core::theme;
 use crate::core::window;
-use crate::core::{Element, Font, Settings};
+use crate::core::{Element, Settings};
 use crate::futures::{Executor, Subscription};
 use crate::graphics::compositor;
 use crate::runtime::Task;
@@ -551,18 +551,9 @@ pub fn with_executor<P: Program, E: Executor>(
 }
 
 /// The renderer of some [`Program`].
-pub trait Renderer:
-    text::Renderer + crate::core::Renderer<Font = Font> + compositor::Default + renderer::Headless
-{
-}
+pub trait Renderer: text::Renderer + compositor::Default + renderer::Headless {}
 
-impl<T> Renderer for T where
-    T: text::Renderer
-        + crate::core::Renderer<Font = Font>
-        + compositor::Default
-        + renderer::Headless
-{
-}
+impl<T> Renderer for T where T: text::Renderer + compositor::Default + renderer::Headless {}
 
 /// A particular instance of a running [`Program`].
 pub struct Instance<P: Program> {

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -551,10 +551,16 @@ pub fn with_executor<P: Program, E: Executor>(
 }
 
 /// The renderer of some [`Program`].
-pub trait Renderer: text::Renderer<Font = Font> + compositor::Default + renderer::Headless {}
+pub trait Renderer:
+    text::Renderer + crate::core::Renderer<Font = Font> + compositor::Default + renderer::Headless
+{
+}
 
 impl<T> Renderer for T where
-    T: text::Renderer<Font = Font> + compositor::Default + renderer::Headless
+    T: text::Renderer
+        + crate::core::Renderer<Font = Font>
+        + compositor::Default
+        + renderer::Headless
 {
 }
 

--- a/renderer/src/fallback.rs
+++ b/renderer/src/fallback.rs
@@ -36,10 +36,8 @@ macro_rules! delegate {
 impl<A, B> core::Renderer for Renderer<A, B>
 where
     A: core::Renderer,
-    B: core::Renderer<Font = A::Font>,
+    B: core::Renderer,
 {
-    type Font = A::Font;
-
     fn fill_quad(&mut self, quad: renderer::Quad, background: impl Into<Background>) {
         delegate!(self, renderer, renderer.fill_quad(quad, background.into()));
     }
@@ -88,7 +86,7 @@ where
         delegate!(self, renderer, renderer.reset(new_bounds));
     }
 
-    fn settings(&self) -> renderer::Settings<Self::Font> {
+    fn settings(&self) -> renderer::Settings {
         delegate!(self, renderer, renderer.settings())
     }
 }
@@ -96,13 +94,12 @@ where
 impl<A, B> core::text::Renderer for Renderer<A, B>
 where
     A: core::text::Renderer,
-    B: core::text::Renderer<Paragraph = A::Paragraph, Editor = A::Editor>
-        + core::Renderer<Font = A::Font>,
+    B: core::text::Renderer<Paragraph = A::Paragraph, Editor = A::Editor>,
 {
     type Paragraph = A::Paragraph;
     type Editor = A::Editor;
 
-    const ICON_FONT: Self::Font = A::ICON_FONT;
+    const ICON_FONT: core::Font = A::ICON_FONT;
     const CHECKMARK_ICON: char = A::CHECKMARK_ICON;
     const ARROW_DOWN_ICON: char = A::ARROW_DOWN_ICON;
     const SCROLL_UP_ICON: char = A::SCROLL_UP_ICON;
@@ -141,7 +138,7 @@ where
 
     fn fill_text(
         &mut self,
-        text: core::Text<String, Self::Font>,
+        text: core::Text<String>,
         position: Point,
         color: Color,
         clip_bounds: Rectangle,
@@ -167,7 +164,7 @@ where
 impl<A, B> image::Renderer for Renderer<A, B>
 where
     A: image::Renderer,
-    B: image::Renderer<Handle = A::Handle> + core::Renderer<Font = A::Font>,
+    B: image::Renderer<Handle = A::Handle>,
 {
     type Handle = A::Handle;
 
@@ -191,7 +188,7 @@ where
 impl<A, B> svg::Renderer for Renderer<A, B>
 where
     A: svg::Renderer,
-    B: svg::Renderer + core::Renderer<Font = A::Font>,
+    B: svg::Renderer,
 {
     fn measure_svg(&self, handle: &svg::Handle) -> Size<u32> {
         delegate!(self, renderer, renderer.measure_svg(handle))
@@ -393,7 +390,7 @@ where
 impl<A, B> iced_wgpu::primitive::Renderer for Renderer<A, B>
 where
     A: iced_wgpu::primitive::Renderer,
-    B: core::Renderer<Font = A::Font>,
+    B: core::Renderer,
 {
     fn draw_primitive(&mut self, bounds: Rectangle, primitive: impl iced_wgpu::Primitive) {
         match self {
@@ -417,7 +414,7 @@ mod geometry {
     impl<A, B> geometry::Renderer for Renderer<A, B>
     where
         A: geometry::Renderer,
-        B: geometry::Renderer + crate::core::Renderer<Font = A::Font>,
+        B: geometry::Renderer,
     {
         type Geometry = Geometry<A::Geometry, B::Geometry>;
         type Frame = Frame<A::Frame, B::Frame>;

--- a/renderer/src/fallback.rs
+++ b/renderer/src/fallback.rs
@@ -36,8 +36,10 @@ macro_rules! delegate {
 impl<A, B> core::Renderer for Renderer<A, B>
 where
     A: core::Renderer,
-    B: core::Renderer,
+    B: core::Renderer<Font = A::Font>,
 {
+    type Font = A::Font;
+
     fn fill_quad(&mut self, quad: renderer::Quad, background: impl Into<Background>) {
         delegate!(self, renderer, renderer.fill_quad(quad, background.into()));
     }
@@ -86,7 +88,7 @@ where
         delegate!(self, renderer, renderer.reset(new_bounds));
     }
 
-    fn settings(&self) -> renderer::Settings {
+    fn settings(&self) -> renderer::Settings<Self::Font> {
         delegate!(self, renderer, renderer.settings())
     }
 }
@@ -94,9 +96,9 @@ where
 impl<A, B> core::text::Renderer for Renderer<A, B>
 where
     A: core::text::Renderer,
-    B: core::text::Renderer<Font = A::Font, Paragraph = A::Paragraph, Editor = A::Editor>,
+    B: core::text::Renderer<Paragraph = A::Paragraph, Editor = A::Editor>
+        + core::Renderer<Font = A::Font>,
 {
-    type Font = A::Font;
     type Paragraph = A::Paragraph;
     type Editor = A::Editor;
 
@@ -108,14 +110,6 @@ where
     const SCROLL_LEFT_ICON: char = A::SCROLL_LEFT_ICON;
     const SCROLL_RIGHT_ICON: char = A::SCROLL_RIGHT_ICON;
     const ICED_LOGO: char = A::ICED_LOGO;
-
-    fn default_font(&self) -> Self::Font {
-        delegate!(self, renderer, renderer.default_font())
-    }
-
-    fn default_size(&self) -> core::Pixels {
-        delegate!(self, renderer, renderer.default_size())
-    }
 
     fn fill_paragraph(
         &mut self,
@@ -173,7 +167,7 @@ where
 impl<A, B> image::Renderer for Renderer<A, B>
 where
     A: image::Renderer,
-    B: image::Renderer<Handle = A::Handle>,
+    B: image::Renderer<Handle = A::Handle> + core::Renderer<Font = A::Font>,
 {
     type Handle = A::Handle;
 
@@ -197,7 +191,7 @@ where
 impl<A, B> svg::Renderer for Renderer<A, B>
 where
     A: svg::Renderer,
-    B: svg::Renderer,
+    B: svg::Renderer + core::Renderer<Font = A::Font>,
 {
     fn measure_svg(&self, handle: &svg::Handle) -> Size<u32> {
         delegate!(self, renderer, renderer.measure_svg(handle))
@@ -399,7 +393,7 @@ where
 impl<A, B> iced_wgpu::primitive::Renderer for Renderer<A, B>
 where
     A: iced_wgpu::primitive::Renderer,
-    B: core::Renderer,
+    B: core::Renderer<Font = A::Font>,
 {
     fn draw_primitive(&mut self, bounds: Rectangle, primitive: impl iced_wgpu::Primitive) {
         match self {
@@ -423,7 +417,7 @@ mod geometry {
     impl<A, B> geometry::Renderer for Renderer<A, B>
     where
         A: geometry::Renderer,
-        B: geometry::Renderer,
+        B: geometry::Renderer + crate::core::Renderer<Font = A::Font>,
     {
         type Geometry = Geometry<A::Geometry, B::Geometry>;
         type Frame = Frame<A::Frame, B::Frame>;

--- a/src/application.rs
+++ b/src/application.rs
@@ -228,19 +228,22 @@ impl<P: Program> Application<P> {
     }
 
     /// Sets the default [`Font`] of the [`Application`].
-    pub fn default_font(self, default_font: Font) -> Self {
+    pub fn font(self, default_font: Font) -> Self {
         Self {
             settings: Settings {
-                default_font,
+                font: default_font,
                 ..self.settings
             },
             ..self
         }
     }
 
-    /// Adds a font to the list of fonts that will be loaded at the start of the [`Application`].
-    pub fn font(mut self, font: impl Into<Cow<'static, [u8]>>) -> Self {
-        self.settings.fonts.push(font.into());
+    /// Adds a set of fonts to the list of fonts that will be loaded at the start of the [`Application`].
+    pub fn fonts(mut self, fonts: impl IntoIterator<Item = impl Into<Cow<'static, [u8]>>>) -> Self {
+        self.settings
+            .fonts
+            .extend(fonts.into_iter().map(Into::into));
+
         self
     }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -166,7 +166,7 @@ impl<P: Program> Daemon<P> {
     pub fn default_font(self, default_font: Font) -> Self {
         Self {
             settings: Settings {
-                default_font,
+                font: default_font,
                 ..self.settings
             },
             ..self

--- a/test/src/simulator.rs
+++ b/test/src/simulator.rs
@@ -67,8 +67,8 @@ where
 
             crate::futures::futures::executor::block_on(Renderer::new(
                 core::renderer::Settings {
-                    default_font: settings.default_font,
-                    default_text_size: settings.default_text_size,
+                    font: settings.font,
+                    text_size: settings.text_size,
                     metrics_hinting: settings.metrics_hinting,
                 },
                 backend.as_deref(),

--- a/tester/src/icon.rs
+++ b/tester/src/icon.rs
@@ -1,118 +1,103 @@
 #![allow(unused)]
 use crate::core::Font;
-use crate::program;
 use crate::widget::{Text, text};
 
 pub const FONT: &[u8] = include_bytes!("../fonts/iced_tester-icons.ttf");
 
-pub fn cancel<'a, Theme, Renderer>() -> Text<'a, Theme, Renderer>
+pub fn cancel<'a, Theme>() -> Text<'a, Theme>
 where
     Theme: text::Catalog + 'a,
-    Renderer: program::Renderer,
 {
     icon("\u{2715}")
 }
 
-pub fn check<'a, Theme, Renderer>() -> Text<'a, Theme, Renderer>
+pub fn check<'a, Theme>() -> Text<'a, Theme>
 where
     Theme: text::Catalog + 'a,
-    Renderer: program::Renderer,
 {
     icon("\u{2713}")
 }
 
-pub fn floppy<'a, Theme, Renderer>() -> Text<'a, Theme, Renderer>
+pub fn floppy<'a, Theme>() -> Text<'a, Theme>
 where
     Theme: text::Catalog + 'a,
-    Renderer: program::Renderer,
 {
     icon("\u{1F4BE}")
 }
 
-pub fn folder<'a, Theme, Renderer>() -> Text<'a, Theme, Renderer>
+pub fn folder<'a, Theme>() -> Text<'a, Theme>
 where
     Theme: text::Catalog + 'a,
-    Renderer: program::Renderer,
 {
     icon("\u{1F4C1}")
 }
 
-pub fn keyboard<'a, Theme, Renderer>() -> Text<'a, Theme, Renderer>
+pub fn keyboard<'a, Theme>() -> Text<'a, Theme>
 where
     Theme: text::Catalog + 'a,
-    Renderer: program::Renderer,
 {
     icon("\u{2328}")
 }
 
-pub fn lightbulb<'a, Theme, Renderer>() -> Text<'a, Theme, Renderer>
+pub fn lightbulb<'a, Theme>() -> Text<'a, Theme>
 where
     Theme: text::Catalog + 'a,
-    Renderer: program::Renderer,
 {
     icon("\u{F0EB}")
 }
 
-pub fn mouse_pointer<'a, Theme, Renderer>() -> Text<'a, Theme, Renderer>
+pub fn mouse_pointer<'a, Theme>() -> Text<'a, Theme>
 where
     Theme: text::Catalog + 'a,
-    Renderer: program::Renderer,
 {
     icon("\u{F245}")
 }
 
-pub fn pause<'a, Theme, Renderer>() -> Text<'a, Theme, Renderer>
+pub fn pause<'a, Theme>() -> Text<'a, Theme>
 where
     Theme: text::Catalog + 'a,
-    Renderer: program::Renderer,
 {
     icon("\u{2389}")
 }
 
-pub fn pencil<'a, Theme, Renderer>() -> Text<'a, Theme, Renderer>
+pub fn pencil<'a, Theme>() -> Text<'a, Theme>
 where
     Theme: text::Catalog + 'a,
-    Renderer: program::Renderer,
 {
     icon("\u{270E}")
 }
 
-pub fn play<'a, Theme, Renderer>() -> Text<'a, Theme, Renderer>
+pub fn play<'a, Theme>() -> Text<'a, Theme>
 where
     Theme: text::Catalog + 'a,
-    Renderer: program::Renderer,
 {
     icon("\u{25B6}")
 }
 
-pub fn record<'a, Theme, Renderer>() -> Text<'a, Theme, Renderer>
+pub fn record<'a, Theme>() -> Text<'a, Theme>
 where
     Theme: text::Catalog + 'a,
-    Renderer: program::Renderer,
 {
     icon("\u{26AB}")
 }
 
-pub fn stop<'a, Theme, Renderer>() -> Text<'a, Theme, Renderer>
+pub fn stop<'a, Theme>() -> Text<'a, Theme>
 where
     Theme: text::Catalog + 'a,
-    Renderer: program::Renderer,
 {
     icon("\u{25A0}")
 }
 
-pub fn tape<'a, Theme, Renderer>() -> Text<'a, Theme, Renderer>
+pub fn tape<'a, Theme>() -> Text<'a, Theme>
 where
     Theme: text::Catalog + 'a,
-    Renderer: program::Renderer,
 {
     icon("\u{2707}")
 }
 
-fn icon<'a, Theme, Renderer>(codepoint: &'a str) -> Text<'a, Theme, Renderer>
+fn icon<'a, Theme>(codepoint: &'a str) -> Text<'a, Theme>
 where
     Theme: text::Catalog + 'a,
-    Renderer: program::Renderer,
 {
     text(codepoint).font("iced_devtools-icons")
 }

--- a/tester/src/lib.rs
+++ b/tester/src/lib.rs
@@ -729,7 +729,7 @@ impl<P: Program + 'static> Tester<P> {
                 .into()
             };
 
-            let control = |icon: text::Text<'static, _, _>| {
+            let control = |icon: text::Text<'static, _>| {
                 button(icon.size(14).width(Fill).height(Fill).center())
             };
 

--- a/tiny_skia/src/lib.rs
+++ b/tiny_skia/src/lib.rs
@@ -187,8 +187,6 @@ impl Renderer {
 }
 
 impl core::Renderer for Renderer {
-    type Font = Font;
-
     fn start_layer(&mut self, bounds: Rectangle) {
         self.layers.push_clip(bounds);
     }

--- a/tiny_skia/src/lib.rs
+++ b/tiny_skia/src/lib.rs
@@ -27,7 +27,7 @@ pub use primitive::Primitive;
 pub use geometry::Geometry;
 
 use crate::core::renderer;
-use crate::core::{Background, Color, Font, Pixels, Point, Rectangle, Size, Transformation};
+use crate::core::{Background, Color, Font, Point, Rectangle, Size, Transformation};
 use crate::engine::Engine;
 use crate::graphics::Viewport;
 use crate::graphics::compositor;
@@ -187,6 +187,8 @@ impl Renderer {
 }
 
 impl core::Renderer for Renderer {
+    type Font = Font;
+
     fn start_layer(&mut self, bounds: Rectangle) {
         self.layers.push_clip(bounds);
     }
@@ -241,7 +243,6 @@ impl core::Renderer for Renderer {
 }
 
 impl core::text::Renderer for Renderer {
-    type Font = Font;
     type Paragraph = Paragraph;
     type Editor = Editor;
 
@@ -253,14 +254,6 @@ impl core::text::Renderer for Renderer {
     const SCROLL_DOWN_ICON: char = '\u{e803}';
     const SCROLL_LEFT_ICON: char = '\u{e804}';
     const SCROLL_RIGHT_ICON: char = '\u{e805}';
-
-    fn default_font(&self) -> Self::Font {
-        self.settings.default_font
-    }
-
-    fn default_size(&self) -> Pixels {
-        self.settings.default_text_size
-    }
 
     fn fill_paragraph(
         &mut self,

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -663,8 +663,6 @@ impl Renderer {
 }
 
 impl core::Renderer for Renderer {
-    type Font = Font;
-
     fn start_layer(&mut self, bounds: Rectangle) {
         self.layers.push_clip(bounds);
     }

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -60,7 +60,7 @@ pub use primitive::Primitive;
 pub use geometry::Geometry;
 
 use crate::core::renderer;
-use crate::core::{Background, Color, Font, Pixels, Point, Rectangle, Size, Transformation};
+use crate::core::{Background, Color, Font, Point, Rectangle, Size, Transformation};
 use crate::graphics::mesh;
 use crate::graphics::text::{Editor, Paragraph};
 use crate::graphics::{Shell, Viewport};
@@ -663,6 +663,8 @@ impl Renderer {
 }
 
 impl core::Renderer for Renderer {
+    type Font = Font;
+
     fn start_layer(&mut self, bounds: Rectangle) {
         self.layers.push_clip(bounds);
     }
@@ -723,7 +725,6 @@ impl core::Renderer for Renderer {
 }
 
 impl core::text::Renderer for Renderer {
-    type Font = Font;
     type Paragraph = Paragraph;
     type Editor = Editor;
 
@@ -735,14 +736,6 @@ impl core::text::Renderer for Renderer {
     const SCROLL_DOWN_ICON: char = '\u{e803}';
     const SCROLL_LEFT_ICON: char = '\u{e804}';
     const SCROLL_RIGHT_ICON: char = '\u{e805}';
-
-    fn default_font(&self) -> Self::Font {
-        self.settings.default_font
-    }
-
-    fn default_size(&self) -> Pixels {
-        self.settings.default_text_size
-    }
 
     fn fill_paragraph(
         &mut self,

--- a/widget/src/checkbox.rs
+++ b/widget/src/checkbox.rs
@@ -31,6 +31,8 @@
 //! }
 //! ```
 //! ![Checkbox drawn by `iced_wgpu`](https://github.com/iced-rs/iced/blob/7760618fb112074bc40b148944521f312152012a/docs/images/checkbox.png?raw=true)
+use std::marker::PhantomData;
+
 use crate::core::alignment;
 use crate::core::layout;
 use crate::core::mouse;
@@ -42,8 +44,8 @@ use crate::core::widget;
 use crate::core::widget::tree::{self, Tree};
 use crate::core::window;
 use crate::core::{
-    Background, Border, Color, Element, Event, Layout, Length, Pixels, Rectangle, Shell, Size,
-    Theme, Widget,
+    Background, Border, Color, Element, Event, Font, Layout, Length, Pixels, Rectangle, Shell,
+    Size, Theme, Widget,
 };
 
 /// A box that can be checked.
@@ -81,8 +83,8 @@ use crate::core::{
 /// ![Checkbox drawn by `iced_wgpu`](https://github.com/iced-rs/iced/blob/7760618fb112074bc40b148944521f312152012a/docs/images/checkbox.png?raw=true)
 pub struct Checkbox<'a, Message, Theme = crate::Theme, Renderer = crate::Renderer>
 where
-    Renderer: text::Renderer,
     Theme: Catalog,
+    Renderer: text::Renderer,
 {
     is_checked: bool,
     on_toggle: Option<Box<dyn Fn(bool) -> Message + 'a>>,
@@ -94,10 +96,11 @@ where
     line_height: text::LineHeight,
     shaping: text::Shaping,
     wrapping: text::Wrapping,
-    font: Option<Renderer::Font>,
-    icon: Icon<Renderer::Font>,
+    font: Option<Font>,
+    icon: Icon,
     class: Theme::Class<'a>,
     last_status: Option<Status>,
+    renderer_: PhantomData<Renderer>,
 }
 
 impl<'a, Message, Theme, Renderer> Checkbox<'a, Message, Theme, Renderer>
@@ -134,6 +137,7 @@ where
             },
             class: Theme::default(),
             last_status: None,
+            renderer_: PhantomData,
         }
     }
 
@@ -210,16 +214,16 @@ where
         self
     }
 
-    /// Sets the [`Renderer::Font`] of the text of the [`Checkbox`].
+    /// Sets the [`Font`] of the text of the [`Checkbox`].
     ///
-    /// [`Renderer::Font`]: crate::core::text::Renderer
-    pub fn font(mut self, font: impl Into<Renderer::Font>) -> Self {
+    /// [`Font`]: crate::core::Font
+    pub fn font(mut self, font: impl Into<Font>) -> Self {
         self.font = Some(font.into());
         self
     }
 
     /// Sets the [`Icon`] of the [`Checkbox`].
-    pub fn icon(mut self, icon: Icon<Renderer::Font>) -> Self {
+    pub fn icon(mut self, icon: Icon) -> Self {
         self.icon = icon;
         self
     }
@@ -484,7 +488,7 @@ where
 
 /// The icon in a [`Checkbox`].
 #[derive(Debug, Clone, PartialEq)]
-pub struct Icon<Font> {
+pub struct Icon {
     /// Font that will be used to display the `code_point`,
     pub font: Font,
     /// The unicode code point that will be used as the icon.

--- a/widget/src/combo_box.rs
+++ b/widget/src/combo_box.rs
@@ -66,7 +66,9 @@ use crate::core::text::input;
 use crate::core::widget::operation::Focusable as _;
 use crate::core::widget::{self, Widget};
 use crate::core::window;
-use crate::core::{Element, Event, Length, Padding, Pixels, Rectangle, Shell, Size, Theme, Vector};
+use crate::core::{
+    Element, Event, Font, Length, Padding, Pixels, Rectangle, Shell, Size, Theme, Vector,
+};
 use crate::overlay::menu;
 use crate::text::LineHeight;
 use crate::text_input;
@@ -130,10 +132,9 @@ use std::sync::atomic::{self, AtomicU64};
 ///     }
 /// }
 /// ```
-pub struct ComboBox<'a, T, Message, Theme = crate::Theme, Renderer = crate::Renderer>
+pub struct ComboBox<'a, T, Message, Theme = crate::Theme>
 where
     Theme: Catalog,
-    Renderer: text::Renderer,
 {
     state: &'a State<T>,
     id: Option<widget::Id>,
@@ -141,7 +142,7 @@ where
     selection: String,
     width: Length,
     line_height: LineHeight,
-    font: Option<Renderer::Font>,
+    font: Option<Font>,
     on_selected: Box<dyn Fn(T) -> Message + 'a>,
     on_option_hovered: Option<Box<dyn Fn(T) -> Message + 'a>>,
     on_open: Option<Message>,
@@ -157,11 +158,10 @@ where
     last_status: Option<text_input::Status>,
 }
 
-impl<'a, T, Message, Theme, Renderer> ComboBox<'a, T, Message, Theme, Renderer>
+impl<'a, T, Message, Theme> ComboBox<'a, T, Message, Theme>
 where
     T: std::fmt::Display + Clone,
     Theme: Catalog,
-    Renderer: text::Renderer,
 {
     /// Creates a new [`ComboBox`] with the given list of options, a placeholder,
     /// the current selected value, and the message to produce when an option is
@@ -236,10 +236,10 @@ where
         self
     }
 
-    /// Sets the [`Renderer::Font`] of the [`ComboBox`].
+    /// Sets the [`Font`] of the [`ComboBox`].
     ///
-    /// [`Renderer::Font`]: text::Renderer
-    pub fn font(mut self, font: Renderer::Font) -> Self {
+    /// [`Font`]: crate::core::Font
+    pub fn font(mut self, font: Font) -> Self {
         self.font = Some(font);
         self
     }
@@ -403,7 +403,7 @@ struct Editor<R: text::Renderer> {
 }
 
 impl<T, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
-    for ComboBox<'_, T, Message, Theme, Renderer>
+    for ComboBox<'_, T, Message, Theme>
 where
     T: Display + Clone + 'static,
     Message: Clone,
@@ -769,7 +769,7 @@ where
     }
 }
 
-impl<'a, T, Message, Theme, Renderer> From<ComboBox<'a, T, Message, Theme, Renderer>>
+impl<'a, T, Message, Theme, Renderer> From<ComboBox<'a, T, Message, Theme>>
     for Element<'a, Message, Theme, Renderer>
 where
     T: Display + Clone + 'static,
@@ -777,7 +777,7 @@ where
     Theme: Catalog + 'a,
     Renderer: text::Renderer + 'static,
 {
-    fn from(combo_box: ComboBox<'a, T, Message, Theme, Renderer>) -> Self {
+    fn from(combo_box: ComboBox<'a, T, Message, Theme>) -> Self {
         Self::new(combo_box)
     }
 }

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -1804,7 +1804,7 @@ pub fn iced<'a, Message, Theme, Renderer>(
 ) -> Element<'a, Message, Theme, Renderer>
 where
     Message: 'a,
-    Renderer: core::Renderer + core::text::Renderer<Font = core::Font> + 'a,
+    Renderer: core::Renderer<Font = core::Font> + core::text::Renderer + 'a,
     Theme: text::Catalog + container::Catalog + 'a,
     <Theme as container::Catalog>::Class<'a>: From<container::StyleFn<'a, Theme>>,
     <Theme as text::Catalog>::Class<'a>: From<text::StyleFn<'a, Theme>>,

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -1100,19 +1100,17 @@ where
 ///         .into()
 /// }
 /// ```
-pub fn text<'a, Theme, Renderer>(text: impl text::IntoFragment<'a>) -> Text<'a, Theme, Renderer>
+pub fn text<'a, Theme>(text: impl text::IntoFragment<'a>) -> Text<'a, Theme>
 where
     Theme: text::Catalog + 'a,
-    Renderer: core::text::Renderer,
 {
     Text::new(text)
 }
 
 /// Creates a new [`Text`] widget that displays the provided value.
-pub fn value<'a, Theme, Renderer>(value: impl ToString) -> Text<'a, Theme, Renderer>
+pub fn value<'a, Theme>(value: impl ToString) -> Text<'a, Theme>
 where
     Theme: text::Catalog + 'a,
-    Renderer: core::text::Renderer,
 {
     Text::new(value.to_string())
 }
@@ -1147,14 +1145,12 @@ where
 ///     .into()
 /// }
 /// ```
-pub fn rich_text<'a, Link, Message, Theme, Renderer>(
-    spans: impl AsRef<[text::Span<'a, Link, Renderer::Font>]> + 'a,
-) -> text::Rich<'a, Link, Message, Theme, Renderer>
+pub fn rich_text<'a, Link, Message, Theme>(
+    spans: impl AsRef<[text::Span<'a, Link>]> + 'a,
+) -> text::Rich<'a, Link, Message, Theme>
 where
     Link: Clone + 'static,
     Theme: text::Catalog + 'a,
-    Renderer: core::text::Renderer,
-    Renderer::Font: 'a,
 {
     text::Rich::with_spans(spans)
 }
@@ -1191,7 +1187,7 @@ where
 ///     .into()
 /// }
 /// ```
-pub fn span<'a, Link, Font>(text: impl text::IntoFragment<'a>) -> text::Span<'a, Link, Font> {
+pub fn span<'a, Link>(text: impl text::IntoFragment<'a>) -> text::Span<'a, Link> {
     text::Span::new(text)
 }
 
@@ -1302,16 +1298,15 @@ where
 ///     column![a, b, c, all].into()
 /// }
 /// ```
-pub fn radio<'a, Message, Theme, Renderer, V>(
+pub fn radio<'a, Message, Theme, V>(
     label: impl Into<String>,
     value: V,
     selected: Option<V>,
     on_click: impl FnOnce(V) -> Message,
-) -> Radio<'a, Message, Theme, Renderer>
+) -> Radio<'a, Message, Theme>
 where
     Message: Clone,
     Theme: radio::Catalog + 'a,
-    Renderer: core::text::Renderer,
     V: Copy + Eq,
 {
     Radio::new(label, value, selected, on_click)
@@ -1351,12 +1346,9 @@ where
 ///     }
 /// }
 /// ```
-pub fn toggler<'a, Message, Theme, Renderer>(
-    is_checked: bool,
-) -> Toggler<'a, Message, Theme, Renderer>
+pub fn toggler<'a, Message, Theme>(is_checked: bool) -> Toggler<'a, Message, Theme>
 where
     Theme: toggler::Catalog + 'a,
-    Renderer: core::text::Renderer,
 {
     Toggler::new(is_checked)
 }
@@ -1395,14 +1387,13 @@ where
 ///     }
 /// }
 /// ```
-pub fn text_input<'a, Message, Theme, Renderer>(
+pub fn text_input<'a, Message, Theme>(
     placeholder: impl text::IntoFragment<'a>,
     value: impl text::IntoFragment<'a>,
-) -> TextInput<'a, Message, Theme, Renderer>
+) -> TextInput<'a, Message, Theme>
 where
     Message: Clone,
     Theme: text_input::Catalog + 'a,
-    Renderer: core::text::Renderer,
 {
     TextInput::new(placeholder, value)
 }
@@ -1608,18 +1599,17 @@ where
 ///     }
 /// }
 /// ```
-pub fn pick_list<'a, T, L, V, Message, Theme, Renderer>(
+pub fn pick_list<'a, T, L, V, Message, Theme>(
     selected: Option<V>,
     options: L,
     to_string: impl Fn(&T) -> String + 'a,
-) -> PickList<'a, T, L, V, Message, Theme, Renderer>
+) -> PickList<'a, T, L, V, Message, Theme>
 where
     T: PartialEq + Clone + 'a,
     L: Borrow<[T]> + 'a,
     V: Borrow<T> + 'a,
     Message: Clone,
     Theme: pick_list::Catalog + overlay::menu::Catalog,
-    Renderer: core::text::Renderer,
 {
     PickList::new(selected, options, to_string)
 }
@@ -1682,16 +1672,15 @@ where
 ///     }
 /// }
 /// ```
-pub fn combo_box<'a, T, Message, Theme, Renderer>(
+pub fn combo_box<'a, T, Message, Theme>(
     state: &'a combo_box::State<T>,
     placeholder: impl text::IntoFragment<'a>,
     selection: Option<&T>,
     on_selected: impl Fn(T) -> Message + 'a,
-) -> ComboBox<'a, T, Message, Theme, Renderer>
+) -> ComboBox<'a, T, Message, Theme>
 where
     T: std::fmt::Display + Clone,
     Theme: combo_box::Catalog + 'a,
-    Renderer: core::text::Renderer,
 {
     ComboBox::new(state, placeholder, selection, on_selected)
 }
@@ -1804,7 +1793,7 @@ pub fn iced<'a, Message, Theme, Renderer>(
 ) -> Element<'a, Message, Theme, Renderer>
 where
     Message: 'a,
-    Renderer: core::Renderer<Font = core::Font> + core::text::Renderer + 'a,
+    Renderer: core::text::Renderer + 'a,
     Theme: text::Catalog + container::Catalog + 'a,
     <Theme as container::Catalog>::Class<'a>: From<container::StyleFn<'a, Theme>>,
     <Theme as text::Catalog>::Class<'a>: From<text::StyleFn<'a, Theme>>,

--- a/widget/src/markdown.rs
+++ b/widget/src/markdown.rs
@@ -1161,7 +1161,7 @@ pub fn view<'a, Theme, Renderer>(
 ) -> Element<'a, Uri, Theme, Renderer>
 where
     Theme: Catalog + 'a,
-    Renderer: core::text::Renderer<Font = Font> + 'a,
+    Renderer: core::text::Renderer + core::Renderer<Font = Font> + 'a,
 {
     view_with(
         items,
@@ -1186,7 +1186,7 @@ pub fn view_with<'a, Message, Theme, Renderer>(
 where
     Message: 'a,
     Theme: Catalog + 'a,
-    Renderer: core::text::Renderer<Font = Font> + 'a,
+    Renderer: core::text::Renderer + core::Renderer<Font = Font> + 'a,
 {
     self::items(viewer, settings.into(), items)
 }
@@ -1200,7 +1200,7 @@ pub fn item<'a, Message, Theme, Renderer>(
 where
     Message: 'a,
     Theme: Catalog + 'a,
-    Renderer: core::text::Renderer<Font = Font> + 'a,
+    Renderer: core::text::Renderer + core::Renderer<Font = Font> + 'a,
 {
     match item {
         Item::Image { url, title, alt } => viewer.image(settings, url, title, alt),
@@ -1236,7 +1236,7 @@ pub fn heading<'a, Message, Theme, Renderer>(
 where
     Message: 'a,
     Theme: Catalog + 'a,
-    Renderer: core::text::Renderer<Font = Font> + 'a,
+    Renderer: core::text::Renderer + core::Renderer<Font = Font> + 'a,
 {
     let Settings {
         h1_size,
@@ -1284,7 +1284,7 @@ pub fn paragraph<'a, Message, Theme, Renderer>(
 where
     Message: 'a,
     Theme: Catalog + 'a,
-    Renderer: core::text::Renderer<Font = Font> + 'a,
+    Renderer: core::text::Renderer + core::Renderer<Font = Font> + 'a,
 {
     rich_text(text.spans(settings, viewer.theme(), viewer.highlighter()))
         .size(settings.text_size)
@@ -1303,7 +1303,7 @@ pub fn unordered_list<'a, Message, Theme, Renderer>(
 where
     Message: 'a,
     Theme: Catalog + 'a,
-    Renderer: core::text::Renderer<Font = Font> + 'a,
+    Renderer: core::text::Renderer + core::Renderer<Font = Font> + 'a,
 {
     column(bullets.iter().map(|bullet| {
         row![
@@ -1346,7 +1346,7 @@ pub fn ordered_list<'a, Message, Theme, Renderer>(
 where
     Message: 'a,
     Theme: Catalog + 'a,
-    Renderer: core::text::Renderer<Font = Font> + 'a,
+    Renderer: core::text::Renderer + core::Renderer<Font = Font> + 'a,
 {
     let digits = (start + bullets.len() as u64).max(1).ilog10() + 1;
 
@@ -1382,7 +1382,7 @@ pub fn code_block<'a, Message, Theme, Renderer>(
 where
     Message: 'a,
     Theme: Catalog + 'a,
-    Renderer: core::text::Renderer<Font = Font> + 'a,
+    Renderer: core::text::Renderer + core::Renderer<Font = Font> + 'a,
 {
     container(
         scrollable(column(lines.iter().map(|line| {
@@ -1415,7 +1415,7 @@ pub fn quote<'a, Message, Theme, Renderer>(
 where
     Message: 'a,
     Theme: Catalog + 'a,
-    Renderer: core::text::Renderer<Font = Font> + 'a,
+    Renderer: core::text::Renderer + core::Renderer<Font = Font> + 'a,
 {
     container(
         column(
@@ -1436,7 +1436,7 @@ pub fn rule<'a, Message, Theme, Renderer>() -> Element<'a, Message, Theme, Rende
 where
     Message: 'a,
     Theme: Catalog + 'a,
-    Renderer: core::text::Renderer<Font = Font> + 'a,
+    Renderer: core::text::Renderer + core::Renderer<Font = Font> + 'a,
 {
     rule::horizontal(2).into()
 }
@@ -1451,7 +1451,7 @@ pub fn table<'a, Message, Theme, Renderer>(
 where
     Message: 'a,
     Theme: Catalog + 'a,
-    Renderer: core::text::Renderer<Font = Font> + 'a,
+    Renderer: core::text::Renderer + core::Renderer<Font = Font> + 'a,
 {
     use crate::table;
 
@@ -1495,7 +1495,7 @@ pub fn items<'a, Message, Theme, Renderer>(
 where
     Message: 'a,
     Theme: Catalog + 'a,
-    Renderer: core::text::Renderer<Font = Font> + 'a,
+    Renderer: core::text::Renderer + core::Renderer<Font = Font> + 'a,
 {
     column(sections(items).map(|(heading, contents)| {
         let contents = column(
@@ -1527,7 +1527,7 @@ where
     Self: Sized + 'a,
     Message: 'a,
     Theme: Catalog + 'a,
-    Renderer: core::text::Renderer<Font = Font> + 'a,
+    Renderer: core::text::Renderer + core::Renderer<Font = Font> + 'a,
 {
     /// The [`Theme`] used for styling the Markdown elements.
     fn theme(&self) -> &Theme;
@@ -1674,7 +1674,7 @@ impl<'a, Theme> DefaultViewer<'a, Theme> {
 impl<'a, Theme, Renderer> Viewer<'a, Uri, Theme, Renderer> for DefaultViewer<'a, Theme>
 where
     Theme: Catalog + 'a,
-    Renderer: core::text::Renderer<Font = Font> + 'a,
+    Renderer: core::text::Renderer + core::Renderer<Font = Font> + 'a,
 {
     fn theme(&self) -> &Theme {
         &self.theme

--- a/widget/src/markdown.rs
+++ b/widget/src/markdown.rs
@@ -1161,7 +1161,7 @@ pub fn view<'a, Theme, Renderer>(
 ) -> Element<'a, Uri, Theme, Renderer>
 where
     Theme: Catalog + 'a,
-    Renderer: core::text::Renderer + core::Renderer<Font = Font> + 'a,
+    Renderer: core::text::Renderer + 'a,
 {
     view_with(
         items,
@@ -1186,7 +1186,7 @@ pub fn view_with<'a, Message, Theme, Renderer>(
 where
     Message: 'a,
     Theme: Catalog + 'a,
-    Renderer: core::text::Renderer + core::Renderer<Font = Font> + 'a,
+    Renderer: core::text::Renderer + 'a,
 {
     self::items(viewer, settings.into(), items)
 }
@@ -1200,7 +1200,7 @@ pub fn item<'a, Message, Theme, Renderer>(
 where
     Message: 'a,
     Theme: Catalog + 'a,
-    Renderer: core::text::Renderer + core::Renderer<Font = Font> + 'a,
+    Renderer: core::text::Renderer + 'a,
 {
     match item {
         Item::Image { url, title, alt } => viewer.image(settings, url, title, alt),
@@ -1236,7 +1236,7 @@ pub fn heading<'a, Message, Theme, Renderer>(
 where
     Message: 'a,
     Theme: Catalog + 'a,
-    Renderer: core::text::Renderer + core::Renderer<Font = Font> + 'a,
+    Renderer: core::text::Renderer + 'a,
 {
     let Settings {
         h1_size,
@@ -1284,7 +1284,7 @@ pub fn paragraph<'a, Message, Theme, Renderer>(
 where
     Message: 'a,
     Theme: Catalog + 'a,
-    Renderer: core::text::Renderer + core::Renderer<Font = Font> + 'a,
+    Renderer: core::text::Renderer + 'a,
 {
     rich_text(text.spans(settings, viewer.theme(), viewer.highlighter()))
         .size(settings.text_size)
@@ -1303,7 +1303,7 @@ pub fn unordered_list<'a, Message, Theme, Renderer>(
 where
     Message: 'a,
     Theme: Catalog + 'a,
-    Renderer: core::text::Renderer + core::Renderer<Font = Font> + 'a,
+    Renderer: core::text::Renderer + 'a,
 {
     column(bullets.iter().map(|bullet| {
         row![
@@ -1346,7 +1346,7 @@ pub fn ordered_list<'a, Message, Theme, Renderer>(
 where
     Message: 'a,
     Theme: Catalog + 'a,
-    Renderer: core::text::Renderer + core::Renderer<Font = Font> + 'a,
+    Renderer: core::text::Renderer + 'a,
 {
     let digits = (start + bullets.len() as u64).max(1).ilog10() + 1;
 
@@ -1382,7 +1382,7 @@ pub fn code_block<'a, Message, Theme, Renderer>(
 where
     Message: 'a,
     Theme: Catalog + 'a,
-    Renderer: core::text::Renderer + core::Renderer<Font = Font> + 'a,
+    Renderer: core::text::Renderer + 'a,
 {
     container(
         scrollable(column(lines.iter().map(|line| {
@@ -1415,7 +1415,7 @@ pub fn quote<'a, Message, Theme, Renderer>(
 where
     Message: 'a,
     Theme: Catalog + 'a,
-    Renderer: core::text::Renderer + core::Renderer<Font = Font> + 'a,
+    Renderer: core::text::Renderer + 'a,
 {
     container(
         column(
@@ -1436,7 +1436,7 @@ pub fn rule<'a, Message, Theme, Renderer>() -> Element<'a, Message, Theme, Rende
 where
     Message: 'a,
     Theme: Catalog + 'a,
-    Renderer: core::text::Renderer + core::Renderer<Font = Font> + 'a,
+    Renderer: core::text::Renderer + 'a,
 {
     rule::horizontal(2).into()
 }
@@ -1451,7 +1451,7 @@ pub fn table<'a, Message, Theme, Renderer>(
 where
     Message: 'a,
     Theme: Catalog + 'a,
-    Renderer: core::text::Renderer + core::Renderer<Font = Font> + 'a,
+    Renderer: core::text::Renderer + 'a,
 {
     use crate::table;
 
@@ -1495,7 +1495,7 @@ pub fn items<'a, Message, Theme, Renderer>(
 where
     Message: 'a,
     Theme: Catalog + 'a,
-    Renderer: core::text::Renderer + core::Renderer<Font = Font> + 'a,
+    Renderer: core::text::Renderer + 'a,
 {
     column(sections(items).map(|(heading, contents)| {
         let contents = column(
@@ -1527,7 +1527,7 @@ where
     Self: Sized + 'a,
     Message: 'a,
     Theme: Catalog + 'a,
-    Renderer: core::text::Renderer + core::Renderer<Font = Font> + 'a,
+    Renderer: core::text::Renderer + 'a,
 {
     /// The [`Theme`] used for styling the Markdown elements.
     fn theme(&self) -> &Theme;
@@ -1674,7 +1674,7 @@ impl<'a, Theme> DefaultViewer<'a, Theme> {
 impl<'a, Theme, Renderer> Viewer<'a, Uri, Theme, Renderer> for DefaultViewer<'a, Theme>
 where
     Theme: Catalog + 'a,
-    Renderer: core::text::Renderer + core::Renderer<Font = Font> + 'a,
+    Renderer: core::text::Renderer + 'a,
 {
     fn theme(&self) -> &Theme {
         &self.theme

--- a/widget/src/overlay/menu.rs
+++ b/widget/src/overlay/menu.rs
@@ -378,7 +378,9 @@ where
     ) -> layout::Node {
         use std::f32;
 
-        let text_size = self.text_size.unwrap_or_else(|| renderer.default_size());
+        let text_size = self
+            .text_size
+            .unwrap_or_else(|| renderer.settings().default_text_size);
 
         let text_line_height = self.line_height.to_absolute(text_size);
 
@@ -420,7 +422,9 @@ where
             }
             Event::Mouse(mouse::Event::CursorMoved { .. }) => {
                 if let Some(cursor_position) = cursor.position_in(layout.bounds()) {
-                    let text_size = self.text_size.unwrap_or_else(|| renderer.default_size());
+                    let text_size = self
+                        .text_size
+                        .unwrap_or_else(|| renderer.settings().default_text_size);
 
                     let option_height =
                         f32::from(self.line_height.to_absolute(text_size)) + self.padding.y();
@@ -442,7 +446,9 @@ where
             }
             Event::Touch(touch::Event::FingerPressed { .. }) => {
                 if let Some(cursor_position) = cursor.position_in(layout.bounds()) {
-                    let text_size = self.text_size.unwrap_or_else(|| renderer.default_size());
+                    let text_size = self
+                        .text_size
+                        .unwrap_or_else(|| renderer.settings().default_text_size);
 
                     let option_height =
                         f32::from(self.line_height.to_absolute(text_size)) + self.padding.y();
@@ -502,7 +508,9 @@ where
         let style = Catalog::style(theme, self.class);
         let bounds = layout.bounds();
 
-        let text_size = self.text_size.unwrap_or_else(|| renderer.default_size());
+        let text_size = self
+            .text_size
+            .unwrap_or_else(|| renderer.settings().default_text_size);
         let option_height = f32::from(self.line_height.to_absolute(text_size)) + self.padding.y();
 
         let offset = viewport.y - bounds.y;
@@ -546,7 +554,9 @@ where
                     bounds: Size::new(bounds.width - self.padding.x(), bounds.height),
                     size: text_size,
                     line_height: self.line_height,
-                    font: self.font.unwrap_or_else(|| renderer.default_font()),
+                    font: self
+                        .font
+                        .unwrap_or_else(|| renderer.settings().default_font),
                     align_x: text::Alignment::Default,
                     align_y: alignment::Vertical::Center,
                     shaping: self.shaping,

--- a/widget/src/overlay/menu.rs
+++ b/widget/src/overlay/menu.rs
@@ -379,9 +379,7 @@ where
     ) -> layout::Node {
         use std::f32;
 
-        let text_size = self
-            .text_size
-            .unwrap_or_else(|| renderer.settings().text_size);
+        let text_size = self.text_size.unwrap_or_else(|| renderer.text_size());
 
         let text_line_height = self.line_height.to_absolute(text_size);
 
@@ -423,9 +421,7 @@ where
             }
             Event::Mouse(mouse::Event::CursorMoved { .. }) => {
                 if let Some(cursor_position) = cursor.position_in(layout.bounds()) {
-                    let text_size = self
-                        .text_size
-                        .unwrap_or_else(|| renderer.settings().text_size);
+                    let text_size = self.text_size.unwrap_or_else(|| renderer.text_size());
 
                     let option_height =
                         f32::from(self.line_height.to_absolute(text_size)) + self.padding.y();
@@ -447,9 +443,7 @@ where
             }
             Event::Touch(touch::Event::FingerPressed { .. }) => {
                 if let Some(cursor_position) = cursor.position_in(layout.bounds()) {
-                    let text_size = self
-                        .text_size
-                        .unwrap_or_else(|| renderer.settings().text_size);
+                    let text_size = self.text_size.unwrap_or_else(|| renderer.text_size());
 
                     let option_height =
                         f32::from(self.line_height.to_absolute(text_size)) + self.padding.y();
@@ -509,9 +503,7 @@ where
         let style = Catalog::style(theme, self.class);
         let bounds = layout.bounds();
 
-        let text_size = self
-            .text_size
-            .unwrap_or_else(|| renderer.settings().text_size);
+        let text_size = self.text_size.unwrap_or_else(|| renderer.text_size());
         let option_height = f32::from(self.line_height.to_absolute(text_size)) + self.padding.y();
 
         let offset = viewport.y - bounds.y;
@@ -555,9 +547,7 @@ where
                     bounds: Size::new(bounds.width - self.padding.x(), bounds.height),
                     size: text_size,
                     line_height: self.line_height,
-                    font: self
-                        .font
-                        .unwrap_or_else(|| renderer.settings().font),
+                    font: self.font.unwrap_or_else(|| renderer.font()),
                     align_x: text::Alignment::Default,
                     align_y: alignment::Vertical::Center,
                     shaping: self.shaping,

--- a/widget/src/overlay/menu.rs
+++ b/widget/src/overlay/menu.rs
@@ -10,17 +10,16 @@ use crate::core::touch;
 use crate::core::widget::tree::{self, Tree};
 use crate::core::window;
 use crate::core::{
-    Background, Color, Event, Length, Padding, Pixels, Point, Rectangle, Shadow, Size, Theme,
+    Background, Color, Event, Font, Length, Padding, Pixels, Point, Rectangle, Shadow, Size, Theme,
     Vector,
 };
 use crate::core::{Element, Shell, Widget};
 use crate::scrollable::{self, Scrollable};
 
 /// A list of selectable options.
-pub struct Menu<'a, 'b, T, Message, Theme = crate::Theme, Renderer = crate::Renderer>
+pub struct Menu<'a, 'b, T, Message, Theme = crate::Theme>
 where
     Theme: Catalog,
-    Renderer: text::Renderer,
     'b: 'a,
 {
     state: &'a mut State,
@@ -35,16 +34,15 @@ where
     line_height: text::LineHeight,
     shaping: text::Shaping,
     ellipsis: text::Ellipsis,
-    font: Option<Renderer::Font>,
+    font: Option<Font>,
     class: &'a <Theme as Catalog>::Class<'b>,
 }
 
-impl<'a, 'b, T, Message, Theme, Renderer> Menu<'a, 'b, T, Message, Theme, Renderer>
+impl<'a, 'b, T, Message, Theme> Menu<'a, 'b, T, Message, Theme>
 where
     T: Clone,
     Message: 'a,
     Theme: Catalog + 'a,
-    Renderer: text::Renderer + 'a,
     'b: 'a,
 {
     /// Creates a new [`Menu`] with the given [`State`], a list of options,
@@ -113,7 +111,7 @@ where
     }
 
     /// Sets the font of the [`Menu`].
-    pub fn font(mut self, font: impl Into<Renderer::Font>) -> Self {
+    pub fn font(mut self, font: impl Into<Font>) -> Self {
         self.font = Some(font.into());
         self
     }
@@ -124,13 +122,16 @@ where
     /// The `target_height` will be used to display the menu either on top
     /// of the target or under it, depending on the screen position and the
     /// dimensions of the [`Menu`].
-    pub fn overlay(
+    pub fn overlay<Renderer>(
         self,
         position: Point,
         viewport: Rectangle,
         target_height: f32,
         menu_height: Length,
-    ) -> overlay::Element<'a, Message, Theme, Renderer> {
+    ) -> overlay::Element<'a, Message, Theme, Renderer>
+    where
+        Renderer: text::Renderer + 'a,
+    {
         overlay::Element::new(Box::new(Overlay::new(
             position,
             viewport,
@@ -186,7 +187,7 @@ where
     pub fn new<T>(
         position: Point,
         viewport: Rectangle,
-        menu: Menu<'a, 'b, T, Message, Theme, Renderer>,
+        menu: Menu<'a, 'b, T, Message, Theme>,
         target_height: f32,
         menu_height: Length,
     ) -> Self
@@ -208,6 +209,7 @@ where
             shaping,
             ellipsis,
             class,
+            ..
         } = menu;
 
         let mut list = Scrollable::new(List {
@@ -325,10 +327,9 @@ where
     }
 }
 
-struct List<'a, 'b, T, Message, Theme, Renderer>
+struct List<'a, 'b, T, Message, Theme>
 where
     Theme: Catalog,
-    Renderer: text::Renderer,
 {
     options: &'a [T],
     hovered_option: &'a mut Option<usize>,
@@ -340,7 +341,7 @@ where
     line_height: text::LineHeight,
     shaping: text::Shaping,
     ellipsis: text::Ellipsis,
-    font: Option<Renderer::Font>,
+    font: Option<Font>,
     class: &'a <Theme as Catalog>::Class<'b>,
 }
 
@@ -349,7 +350,7 @@ struct ListState {
 }
 
 impl<T, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
-    for List<'_, '_, T, Message, Theme, Renderer>
+    for List<'_, '_, T, Message, Theme>
 where
     T: Clone,
     Theme: Catalog,
@@ -576,7 +577,7 @@ where
     }
 }
 
-impl<'a, 'b, T, Message, Theme, Renderer> From<List<'a, 'b, T, Message, Theme, Renderer>>
+impl<'a, 'b, T, Message, Theme, Renderer> From<List<'a, 'b, T, Message, Theme>>
     for Element<'a, Message, Theme, Renderer>
 where
     T: Clone,
@@ -585,7 +586,7 @@ where
     Renderer: 'a + text::Renderer,
     'b: 'a,
 {
-    fn from(list: List<'a, 'b, T, Message, Theme, Renderer>) -> Self {
+    fn from(list: List<'a, 'b, T, Message, Theme>) -> Self {
         Element::new(list)
     }
 }

--- a/widget/src/overlay/menu.rs
+++ b/widget/src/overlay/menu.rs
@@ -381,7 +381,7 @@ where
 
         let text_size = self
             .text_size
-            .unwrap_or_else(|| renderer.settings().default_text_size);
+            .unwrap_or_else(|| renderer.settings().text_size);
 
         let text_line_height = self.line_height.to_absolute(text_size);
 
@@ -425,7 +425,7 @@ where
                 if let Some(cursor_position) = cursor.position_in(layout.bounds()) {
                     let text_size = self
                         .text_size
-                        .unwrap_or_else(|| renderer.settings().default_text_size);
+                        .unwrap_or_else(|| renderer.settings().text_size);
 
                     let option_height =
                         f32::from(self.line_height.to_absolute(text_size)) + self.padding.y();
@@ -449,7 +449,7 @@ where
                 if let Some(cursor_position) = cursor.position_in(layout.bounds()) {
                     let text_size = self
                         .text_size
-                        .unwrap_or_else(|| renderer.settings().default_text_size);
+                        .unwrap_or_else(|| renderer.settings().text_size);
 
                     let option_height =
                         f32::from(self.line_height.to_absolute(text_size)) + self.padding.y();
@@ -511,7 +511,7 @@ where
 
         let text_size = self
             .text_size
-            .unwrap_or_else(|| renderer.settings().default_text_size);
+            .unwrap_or_else(|| renderer.settings().text_size);
         let option_height = f32::from(self.line_height.to_absolute(text_size)) + self.padding.y();
 
         let offset = viewport.y - bounds.y;
@@ -557,7 +557,7 @@ where
                     line_height: self.line_height,
                     font: self
                         .font
-                        .unwrap_or_else(|| renderer.settings().default_font),
+                        .unwrap_or_else(|| renderer.settings().font),
                     align_x: text::Alignment::Default,
                     align_y: alignment::Vertical::Center,
                     shaping: self.shaping,

--- a/widget/src/pick_list.rs
+++ b/widget/src/pick_list.rs
@@ -73,8 +73,8 @@ use crate::core::touch;
 use crate::core::widget::tree::{self, Tree};
 use crate::core::window;
 use crate::core::{
-    Background, Border, Color, Element, Event, Layout, Length, Padding, Pixels, Point, Rectangle,
-    Shell, Size, Theme, Vector, Widget,
+    Background, Border, Color, Element, Event, Font, Layout, Length, Padding, Pixels, Point,
+    Rectangle, Shell, Size, Theme, Vector, Widget,
 };
 use crate::overlay::menu::{self, Menu};
 
@@ -144,13 +144,12 @@ use std::f32;
 ///     }
 /// }
 /// ```
-pub struct PickList<'a, T, L, V, Message, Theme = crate::Theme, Renderer = crate::Renderer>
+pub struct PickList<'a, T, L, V, Message, Theme = crate::Theme>
 where
     T: PartialEq + Clone,
     L: Borrow<[T]> + 'a,
     V: Borrow<T> + 'a,
     Theme: Catalog,
-    Renderer: text::Renderer,
 {
     options: L,
     to_string: Box<dyn Fn(&T) -> String + 'a>,
@@ -165,22 +164,21 @@ where
     line_height: text::LineHeight,
     shaping: text::Shaping,
     ellipsis: text::Ellipsis,
-    font: Option<Renderer::Font>,
-    handle: Handle<Renderer::Font>,
+    font: Option<Font>,
+    handle: Handle,
     class: <Theme as Catalog>::Class<'a>,
     menu_class: <Theme as menu::Catalog>::Class<'a>,
     last_status: Option<Status>,
     menu_height: Length,
 }
 
-impl<'a, T, L, V, Message, Theme, Renderer> PickList<'a, T, L, V, Message, Theme, Renderer>
+impl<'a, T, L, V, Message, Theme> PickList<'a, T, L, V, Message, Theme>
 where
     T: PartialEq + Clone,
     L: Borrow<[T]> + 'a,
     V: Borrow<T> + 'a,
     Message: Clone,
     Theme: Catalog,
-    Renderer: text::Renderer,
 {
     /// Creates a new [`PickList`] with the given list of options, the current
     /// selected value, and the message to produce when an option is selected.
@@ -257,13 +255,13 @@ where
     }
 
     /// Sets the font of the [`PickList`].
-    pub fn font(mut self, font: impl Into<Renderer::Font>) -> Self {
+    pub fn font(mut self, font: impl Into<Font>) -> Self {
         self.font = Some(font.into());
         self
     }
 
     /// Sets the [`Handle`] of the [`PickList`].
-    pub fn handle(mut self, handle: Handle<Renderer::Font>) -> Self {
+    pub fn handle(mut self, handle: Handle) -> Self {
         self.handle = handle;
         self
     }
@@ -324,7 +322,7 @@ where
 }
 
 impl<'a, T, L, V, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
-    for PickList<'a, T, L, V, Message, Theme, Renderer>
+    for PickList<'a, T, L, V, Message, Theme>
 where
     T: Clone + PartialEq + 'a,
     L: Borrow<[T]>,
@@ -757,7 +755,7 @@ where
     }
 }
 
-impl<'a, T, L, V, Message, Theme, Renderer> From<PickList<'a, T, L, V, Message, Theme, Renderer>>
+impl<'a, T, L, V, Message, Theme, Renderer> From<PickList<'a, T, L, V, Message, Theme>>
     for Element<'a, Message, Theme, Renderer>
 where
     T: Clone + PartialEq + 'a,
@@ -767,7 +765,7 @@ where
     Theme: Catalog + 'a,
     Renderer: text::Renderer + 'a,
 {
-    fn from(pick_list: PickList<'a, T, L, V, Message, Theme, Renderer>) -> Self {
+    fn from(pick_list: PickList<'a, T, L, V, Message, Theme>) -> Self {
         Self::new(pick_list)
     }
 }
@@ -804,7 +802,7 @@ impl<P: text::Paragraph> Default for State<P> {
 
 /// The handle to the right side of the [`PickList`].
 #[derive(Debug, Clone, PartialEq)]
-pub enum Handle<Font> {
+pub enum Handle {
     /// Displays an arrow icon (▼).
     ///
     /// This is the default.
@@ -813,19 +811,19 @@ pub enum Handle<Font> {
         size: Option<Pixels>,
     },
     /// A custom static handle.
-    Static(Icon<Font>),
+    Static(Icon),
     /// A custom dynamic handle.
     Dynamic {
         /// The [`Icon`] used when [`PickList`] is closed.
-        closed: Icon<Font>,
+        closed: Icon,
         /// The [`Icon`] used when [`PickList`] is open.
-        open: Icon<Font>,
+        open: Icon,
     },
     /// No handle will be shown.
     None,
 }
 
-impl<Font> Default for Handle<Font> {
+impl Default for Handle {
     fn default() -> Self {
         Self::Arrow { size: None }
     }
@@ -833,7 +831,7 @@ impl<Font> Default for Handle<Font> {
 
 /// The icon of a [`Handle`].
 #[derive(Debug, Clone, PartialEq)]
-pub struct Icon<Font> {
+pub struct Icon {
     /// Font that will be used to display the `code_point`,
     pub font: Font,
     /// The unicode code point that will be used as the icon.

--- a/widget/src/pick_list.rs
+++ b/widget/src/pick_list.rs
@@ -354,10 +354,8 @@ where
     ) -> layout::Node {
         let state = tree.state.downcast_mut::<State<Renderer::Paragraph>>();
 
-        let font = self.font.unwrap_or_else(|| renderer.settings().font);
-        let text_size = self
-            .text_size
-            .unwrap_or_else(|| renderer.settings().text_size);
+        let font = self.font.unwrap_or_else(|| renderer.font());
+        let text_size = self.text_size.unwrap_or_else(|| renderer.text_size());
         let options = self.options.borrow();
 
         let option_text = Text {
@@ -577,7 +575,7 @@ where
         _cursor: mouse::Cursor,
         viewport: &Rectangle,
     ) {
-        let font = self.font.unwrap_or_else(|| renderer.settings().font);
+        let font = self.font.unwrap_or_else(|| renderer.font());
         let selected = self.selected.as_ref().map(Borrow::borrow);
         let state = tree.state.downcast_ref::<State<Renderer::Paragraph>>();
 
@@ -636,7 +634,7 @@ where
         };
 
         if let Some((font, code_point, size, line_height, shaping)) = handle {
-            let size = size.unwrap_or_else(|| renderer.settings().text_size);
+            let size = size.unwrap_or_else(|| renderer.text_size());
 
             renderer.fill_text(
                 Text {
@@ -664,9 +662,7 @@ where
         let label = selected.map(&self.to_string);
 
         if let Some(label) = label.or_else(|| self.placeholder.clone()) {
-            let text_size = self
-                .text_size
-                .unwrap_or_else(|| renderer.settings().text_size);
+            let text_size = self.text_size.unwrap_or_else(|| renderer.text_size());
 
             renderer.fill_text(
                 Text {
@@ -709,7 +705,7 @@ where
         };
 
         let state = tree.state.downcast_mut::<State<Renderer::Paragraph>>();
-        let font = self.font.unwrap_or_else(|| renderer.settings().font);
+        let font = self.font.unwrap_or_else(|| renderer.font());
 
         if state.is_open {
             let bounds = layout.bounds();

--- a/widget/src/pick_list.rs
+++ b/widget/src/pick_list.rs
@@ -354,12 +354,10 @@ where
     ) -> layout::Node {
         let state = tree.state.downcast_mut::<State<Renderer::Paragraph>>();
 
-        let font = self
-            .font
-            .unwrap_or_else(|| renderer.settings().default_font);
+        let font = self.font.unwrap_or_else(|| renderer.settings().font);
         let text_size = self
             .text_size
-            .unwrap_or_else(|| renderer.settings().default_text_size);
+            .unwrap_or_else(|| renderer.settings().text_size);
         let options = self.options.borrow();
 
         let option_text = Text {
@@ -579,9 +577,7 @@ where
         _cursor: mouse::Cursor,
         viewport: &Rectangle,
     ) {
-        let font = self
-            .font
-            .unwrap_or_else(|| renderer.settings().default_font);
+        let font = self.font.unwrap_or_else(|| renderer.settings().font);
         let selected = self.selected.as_ref().map(Borrow::borrow);
         let state = tree.state.downcast_ref::<State<Renderer::Paragraph>>();
 
@@ -640,7 +636,7 @@ where
         };
 
         if let Some((font, code_point, size, line_height, shaping)) = handle {
-            let size = size.unwrap_or_else(|| renderer.settings().default_text_size);
+            let size = size.unwrap_or_else(|| renderer.settings().text_size);
 
             renderer.fill_text(
                 Text {
@@ -670,7 +666,7 @@ where
         if let Some(label) = label.or_else(|| self.placeholder.clone()) {
             let text_size = self
                 .text_size
-                .unwrap_or_else(|| renderer.settings().default_text_size);
+                .unwrap_or_else(|| renderer.settings().text_size);
 
             renderer.fill_text(
                 Text {
@@ -713,9 +709,7 @@ where
         };
 
         let state = tree.state.downcast_mut::<State<Renderer::Paragraph>>();
-        let font = self
-            .font
-            .unwrap_or_else(|| renderer.settings().default_font);
+        let font = self.font.unwrap_or_else(|| renderer.settings().font);
 
         if state.is_open {
             let bounds = layout.bounds();

--- a/widget/src/pick_list.rs
+++ b/widget/src/pick_list.rs
@@ -356,8 +356,12 @@ where
     ) -> layout::Node {
         let state = tree.state.downcast_mut::<State<Renderer::Paragraph>>();
 
-        let font = self.font.unwrap_or_else(|| renderer.default_font());
-        let text_size = self.text_size.unwrap_or_else(|| renderer.default_size());
+        let font = self
+            .font
+            .unwrap_or_else(|| renderer.settings().default_font);
+        let text_size = self
+            .text_size
+            .unwrap_or_else(|| renderer.settings().default_text_size);
         let options = self.options.borrow();
 
         let option_text = Text {
@@ -577,7 +581,9 @@ where
         _cursor: mouse::Cursor,
         viewport: &Rectangle,
     ) {
-        let font = self.font.unwrap_or_else(|| renderer.default_font());
+        let font = self
+            .font
+            .unwrap_or_else(|| renderer.settings().default_font);
         let selected = self.selected.as_ref().map(Borrow::borrow);
         let state = tree.state.downcast_ref::<State<Renderer::Paragraph>>();
 
@@ -636,7 +642,7 @@ where
         };
 
         if let Some((font, code_point, size, line_height, shaping)) = handle {
-            let size = size.unwrap_or_else(|| renderer.default_size());
+            let size = size.unwrap_or_else(|| renderer.settings().default_text_size);
 
             renderer.fill_text(
                 Text {
@@ -664,7 +670,9 @@ where
         let label = selected.map(&self.to_string);
 
         if let Some(label) = label.or_else(|| self.placeholder.clone()) {
-            let text_size = self.text_size.unwrap_or_else(|| renderer.default_size());
+            let text_size = self
+                .text_size
+                .unwrap_or_else(|| renderer.settings().default_text_size);
 
             renderer.fill_text(
                 Text {
@@ -707,7 +715,9 @@ where
         };
 
         let state = tree.state.downcast_mut::<State<Renderer::Paragraph>>();
-        let font = self.font.unwrap_or_else(|| renderer.default_font());
+        let font = self
+            .font
+            .unwrap_or_else(|| renderer.settings().default_font);
 
         if state.is_open {
             let bounds = layout.bounds();

--- a/widget/src/radio.rs
+++ b/widget/src/radio.rs
@@ -67,7 +67,7 @@ use crate::core::widget;
 use crate::core::widget::tree::{self, Tree};
 use crate::core::window;
 use crate::core::{
-    Background, Color, Element, Event, Layout, Length, Pixels, Rectangle, Shell, Size, Theme,
+    Background, Color, Element, Event, Font, Layout, Length, Pixels, Rectangle, Shell, Size, Theme,
     Widget,
 };
 
@@ -129,10 +129,9 @@ use crate::core::{
 ///     column![a, b, c, all].into()
 /// }
 /// ```
-pub struct Radio<'a, Message, Theme = crate::Theme, Renderer = crate::Renderer>
+pub struct Radio<'a, Message, Theme = crate::Theme>
 where
     Theme: Catalog,
-    Renderer: text::Renderer,
 {
     is_selected: bool,
     on_click: Message,
@@ -144,16 +143,15 @@ where
     line_height: text::LineHeight,
     shaping: text::Shaping,
     wrapping: text::Wrapping,
-    font: Option<Renderer::Font>,
+    font: Option<Font>,
     class: Theme::Class<'a>,
     last_status: Option<Status>,
 }
 
-impl<'a, Message, Theme, Renderer> Radio<'a, Message, Theme, Renderer>
+impl<'a, Message, Theme> Radio<'a, Message, Theme>
 where
     Message: Clone,
     Theme: Catalog,
-    Renderer: text::Renderer,
 {
     /// The default size of a [`Radio`] button.
     pub const DEFAULT_SIZE: f32 = 16.0;
@@ -234,7 +232,7 @@ where
     }
 
     /// Sets the text font of the [`Radio`] button.
-    pub fn font(mut self, font: impl Into<Renderer::Font>) -> Self {
+    pub fn font(mut self, font: impl Into<Font>) -> Self {
         self.font = Some(font.into());
         self
     }
@@ -258,8 +256,7 @@ where
     }
 }
 
-impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer>
-    for Radio<'_, Message, Theme, Renderer>
+impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer> for Radio<'_, Message, Theme>
 where
     Message: Clone,
     Theme: Catalog,
@@ -448,14 +445,14 @@ where
     }
 }
 
-impl<'a, Message, Theme, Renderer> From<Radio<'a, Message, Theme, Renderer>>
+impl<'a, Message, Theme, Renderer> From<Radio<'a, Message, Theme>>
     for Element<'a, Message, Theme, Renderer>
 where
     Message: 'a + Clone,
     Theme: 'a + Catalog,
     Renderer: 'a + text::Renderer,
 {
-    fn from(radio: Radio<'a, Message, Theme, Renderer>) -> Element<'a, Message, Theme, Renderer> {
+    fn from(radio: Radio<'a, Message, Theme>) -> Element<'a, Message, Theme, Renderer> {
         Element::new(radio)
     }
 }

--- a/widget/src/text.rs
+++ b/widget/src/text.rs
@@ -27,5 +27,4 @@ pub use rich::Rich;
 ///         .into()
 /// }
 /// ```
-pub type Text<'a, Theme = crate::Theme, Renderer = crate::Renderer> =
-    crate::core::widget::Text<'a, Theme, Renderer>;
+pub type Text<'a, Theme = crate::Theme> = crate::core::widget::Text<'a, Theme>;

--- a/widget/src/text/rich.rs
+++ b/widget/src/text/rich.rs
@@ -318,7 +318,10 @@ where
                 }
 
                 if span.underline || span.strikethrough || is_hovered_link {
-                    let size = span.size.or(self.size).unwrap_or(renderer.default_size());
+                    let size = span
+                        .size
+                        .or(self.size)
+                        .unwrap_or(renderer.settings().default_text_size);
 
                     let line_height = span
                         .line_height
@@ -486,8 +489,8 @@ where
     layout::sized(limits, width, height, |limits| {
         let bounds = limits.max();
 
-        let size = size.unwrap_or_else(|| renderer.default_size());
-        let font = font.unwrap_or_else(|| renderer.default_font());
+        let size = size.unwrap_or_else(|| renderer.settings().default_text_size);
+        let font = font.unwrap_or_else(|| renderer.settings().default_font);
 
         let text_with_spans = || core::Text {
             content: spans,

--- a/widget/src/text/rich.rs
+++ b/widget/src/text/rich.rs
@@ -316,7 +316,7 @@ where
                     let size = span
                         .size
                         .or(self.size)
-                        .unwrap_or(renderer.settings().default_text_size);
+                        .unwrap_or(renderer.settings().text_size);
 
                     let line_height = span
                         .line_height
@@ -484,8 +484,8 @@ where
     layout::sized(limits, width, height, |limits| {
         let bounds = limits.max();
 
-        let size = size.unwrap_or_else(|| renderer.settings().default_text_size);
-        let font = font.unwrap_or_else(|| renderer.settings().default_font);
+        let size = size.unwrap_or_else(|| renderer.settings().text_size);
+        let font = font.unwrap_or_else(|| renderer.settings().font);
 
         let text_with_spans = || core::Text {
             content: spans,

--- a/widget/src/text/rich.rs
+++ b/widget/src/text/rich.rs
@@ -9,23 +9,22 @@ use crate::core::widget::text::{
 };
 use crate::core::widget::tree::{self, Tree};
 use crate::core::{
-    self, Border, Color, Element, Event, Layout, Length, Pixels, Point, Rectangle, Shell, Size,
-    Vector, Widget,
+    self, Border, Color, Element, Event, Font, Layout, Length, Pixels, Point, Rectangle, Shell,
+    Size, Vector, Widget,
 };
 
 /// A bunch of [`Rich`] text.
-pub struct Rich<'a, Link, Message, Theme = crate::Theme, Renderer = crate::Renderer>
+pub struct Rich<'a, Link, Message, Theme = crate::Theme>
 where
     Link: Clone + 'static,
     Theme: Catalog,
-    Renderer: core::text::Renderer,
 {
-    spans: Box<dyn AsRef<[Span<'a, Link, Renderer::Font>]> + 'a>,
+    spans: Box<dyn AsRef<[Span<'a, Link>]> + 'a>,
     size: Option<Pixels>,
     line_height: LineHeight,
     width: Length,
     height: Length,
-    font: Option<Renderer::Font>,
+    font: Option<Font>,
     align_x: Alignment,
     align_y: alignment::Vertical,
     wrapping: Wrapping,
@@ -35,12 +34,10 @@ where
     on_link_click: Option<Box<dyn Fn(Link) -> Message + 'a>>,
 }
 
-impl<'a, Link, Message, Theme, Renderer> Rich<'a, Link, Message, Theme, Renderer>
+impl<'a, Link, Message, Theme> Rich<'a, Link, Message, Theme>
 where
     Link: Clone + 'static,
     Theme: Catalog,
-    Renderer: core::text::Renderer,
-    Renderer::Font: 'a,
 {
     /// Creates a new empty [`Rich`] text.
     pub fn new() -> Self {
@@ -62,7 +59,7 @@ where
     }
 
     /// Creates a new [`Rich`] text with the given text spans.
-    pub fn with_spans(spans: impl AsRef<[Span<'a, Link, Renderer::Font>]> + 'a) -> Self {
+    pub fn with_spans(spans: impl AsRef<[Span<'a, Link>]> + 'a) -> Self {
         Self {
             spans: Box::new(spans),
             ..Self::new()
@@ -82,7 +79,7 @@ where
     }
 
     /// Sets the default font of the [`Rich`] text.
-    pub fn font(mut self, font: impl Into<Renderer::Font>) -> Self {
+    pub fn font(mut self, font: impl Into<Font>) -> Self {
         self.font = Some(font.into());
         self
     }
@@ -177,12 +174,10 @@ where
     }
 }
 
-impl<'a, Link, Message, Theme, Renderer> Default for Rich<'a, Link, Message, Theme, Renderer>
+impl<'a, Link, Message, Theme> Default for Rich<'a, Link, Message, Theme>
 where
     Link: Clone + 'a,
     Theme: Catalog,
-    Renderer: core::text::Renderer,
-    Renderer::Font: 'a,
 {
     fn default() -> Self {
         Self::new()
@@ -190,13 +185,13 @@ where
 }
 
 struct State<Link, P: Paragraph> {
-    spans: Vec<Span<'static, Link, P::Font>>,
+    spans: Vec<Span<'static, Link>>,
     span_pressed: Option<usize>,
     paragraph: P,
 }
 
 impl<Link, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
-    for Rich<'_, Link, Message, Theme, Renderer>
+    for Rich<'_, Link, Message, Theme>
 where
     Link: Clone + 'static,
     Theme: Catalog,
@@ -473,10 +468,10 @@ fn layout<Link, Renderer>(
     limits: &layout::Limits,
     width: Length,
     height: Length,
-    spans: &[Span<'_, Link, Renderer::Font>],
+    spans: &[Span<'_, Link>],
     line_height: LineHeight,
     size: Option<Pixels>,
-    font: Option<Renderer::Font>,
+    font: Option<Font>,
     align_x: Alignment,
     align_y: alignment::Vertical,
     wrapping: Wrapping,
@@ -537,20 +532,17 @@ where
     })
 }
 
-impl<'a, Link, Message, Theme, Renderer> FromIterator<Span<'a, Link, Renderer::Font>>
-    for Rich<'a, Link, Message, Theme, Renderer>
+impl<'a, Link, Message, Theme> FromIterator<Span<'a, Link>> for Rich<'a, Link, Message, Theme>
 where
     Link: Clone + 'a,
     Theme: Catalog,
-    Renderer: core::text::Renderer,
-    Renderer::Font: 'a,
 {
-    fn from_iter<T: IntoIterator<Item = Span<'a, Link, Renderer::Font>>>(spans: T) -> Self {
+    fn from_iter<T: IntoIterator<Item = Span<'a, Link>>>(spans: T) -> Self {
         Self::with_spans(spans.into_iter().collect::<Vec<_>>())
     }
 }
 
-impl<'a, Link, Message, Theme, Renderer> From<Rich<'a, Link, Message, Theme, Renderer>>
+impl<'a, Link, Message, Theme, Renderer> From<Rich<'a, Link, Message, Theme>>
     for Element<'a, Message, Theme, Renderer>
 where
     Message: 'a,
@@ -558,9 +550,7 @@ where
     Theme: Catalog + 'a,
     Renderer: core::text::Renderer + 'a,
 {
-    fn from(
-        text: Rich<'a, Link, Message, Theme, Renderer>,
-    ) -> Element<'a, Message, Theme, Renderer> {
+    fn from(text: Rich<'a, Link, Message, Theme>) -> Element<'a, Message, Theme, Renderer> {
         Element::new(text)
     }
 }

--- a/widget/src/text/rich.rs
+++ b/widget/src/text/rich.rs
@@ -313,10 +313,7 @@ where
                 }
 
                 if span.underline || span.strikethrough || is_hovered_link {
-                    let size = span
-                        .size
-                        .or(self.size)
-                        .unwrap_or(renderer.settings().text_size);
+                    let size = span.size.or(self.size).unwrap_or(renderer.text_size());
 
                     let line_height = span
                         .line_height
@@ -484,8 +481,8 @@ where
     layout::sized(limits, width, height, |limits| {
         let bounds = limits.max();
 
-        let size = size.unwrap_or_else(|| renderer.settings().text_size);
-        let font = font.unwrap_or_else(|| renderer.settings().font);
+        let size = size.unwrap_or_else(|| renderer.text_size());
+        let font = font.unwrap_or_else(|| renderer.font());
 
         let text_with_spans = || core::Text {
             content: spans,

--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -45,8 +45,8 @@ use crate::core::theme;
 use crate::core::widget::{self, Widget};
 use crate::core::window;
 use crate::core::{
-    Background, Border, Color, Element, Event, Length, Padding, Pixels, Rectangle, Shell, Size,
-    Theme,
+    Background, Border, Color, Element, Event, Font, Length, Padding, Pixels, Rectangle, Shell,
+    Size, Theme,
 };
 
 use std::borrow::Cow;
@@ -101,7 +101,7 @@ where
     id: Option<widget::Id>,
     content: &'a Content<Renderer>,
     placeholder: Option<text::Fragment<'a>>,
-    font: Option<Renderer::Font>,
+    font: Option<Font>,
     text_size: Option<Pixels>,
     line_height: LineHeight,
     width: Length,
@@ -175,7 +175,7 @@ where
         syntax: &str,
     ) -> TextEditor<'a, iced_highlighter::Parser, Message, crate::Theme, Renderer>
     where
-        Renderer: text::Renderer + crate::core::Renderer<Font = crate::core::Font>,
+        Renderer: text::Renderer,
     {
         self.highlight_with(
             iced_highlighter::Settings {
@@ -227,8 +227,8 @@ where
 
     /// Sets the [`Font`] of the [`TextEditor`].
     ///
-    /// [`Font`]: crate::core::Renderer::Font
-    pub fn font(mut self, font: impl Into<Renderer::Font>) -> Self {
+    /// [`Font`]: crate::core::Font
+    pub fn font(mut self, font: impl Into<Font>) -> Self {
         self.font = Some(font.into());
         self
     }

--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -367,9 +367,8 @@ where
 
         internal.editor.update(
             limits.shrink(self.padding).max(),
-            self.font.unwrap_or_else(|| renderer.settings().font),
-            self.text_size
-                .unwrap_or_else(|| renderer.settings().text_size),
+            self.font.unwrap_or_else(|| renderer.font()),
+            self.text_size.unwrap_or_else(|| renderer.text_size()),
             self.line_height,
             self.wrapping,
             text::Alignment::Default,
@@ -512,7 +511,7 @@ where
         let mut internal = self.content.0.borrow_mut();
         let state = tree.state.downcast_ref::<State<Parser>>();
 
-        let font = self.font.unwrap_or_else(|| renderer.settings().font);
+        let font = self.font.unwrap_or_else(|| renderer.font());
 
         let theme_name = theme.name();
 
@@ -556,9 +555,7 @@ where
                 Text {
                     content: placeholder.clone().into_owned(),
                     bounds: text_bounds.size(),
-                    size: self
-                        .text_size
-                        .unwrap_or_else(|| renderer.settings().text_size),
+                    size: self.text_size.unwrap_or_else(|| renderer.text_size()),
                     line_height: self.line_height,
                     font,
                     align_x: text::Alignment::Default,

--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -367,10 +367,9 @@ where
 
         internal.editor.update(
             limits.shrink(self.padding).max(),
-            self.font
-                .unwrap_or_else(|| renderer.settings().default_font),
+            self.font.unwrap_or_else(|| renderer.settings().font),
             self.text_size
-                .unwrap_or_else(|| renderer.settings().default_text_size),
+                .unwrap_or_else(|| renderer.settings().text_size),
             self.line_height,
             self.wrapping,
             text::Alignment::Default,
@@ -513,9 +512,7 @@ where
         let mut internal = self.content.0.borrow_mut();
         let state = tree.state.downcast_ref::<State<Parser>>();
 
-        let font = self
-            .font
-            .unwrap_or_else(|| renderer.settings().default_font);
+        let font = self.font.unwrap_or_else(|| renderer.settings().font);
 
         let theme_name = theme.name();
 
@@ -561,7 +558,7 @@ where
                     bounds: text_bounds.size(),
                     size: self
                         .text_size
-                        .unwrap_or_else(|| renderer.settings().default_text_size),
+                        .unwrap_or_else(|| renderer.settings().text_size),
                     line_height: self.line_height,
                     font,
                     align_x: text::Alignment::Default,

--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -175,7 +175,7 @@ where
         syntax: &str,
     ) -> TextEditor<'a, iced_highlighter::Parser, Message, crate::Theme, Renderer>
     where
-        Renderer: text::Renderer<Font = crate::core::Font>,
+        Renderer: text::Renderer + crate::core::Renderer<Font = crate::core::Font>,
     {
         self.highlight_with(
             iced_highlighter::Settings {
@@ -227,7 +227,7 @@ where
 
     /// Sets the [`Font`] of the [`TextEditor`].
     ///
-    /// [`Font`]: text::Renderer::Font
+    /// [`Font`]: crate::core::Renderer::Font
     pub fn font(mut self, font: impl Into<Renderer::Font>) -> Self {
         self.font = Some(font.into());
         self
@@ -367,8 +367,10 @@ where
 
         internal.editor.update(
             limits.shrink(self.padding).max(),
-            self.font.unwrap_or_else(|| renderer.default_font()),
-            self.text_size.unwrap_or_else(|| renderer.default_size()),
+            self.font
+                .unwrap_or_else(|| renderer.settings().default_font),
+            self.text_size
+                .unwrap_or_else(|| renderer.settings().default_text_size),
             self.line_height,
             self.wrapping,
             text::Alignment::Default,
@@ -511,7 +513,9 @@ where
         let mut internal = self.content.0.borrow_mut();
         let state = tree.state.downcast_ref::<State<Parser>>();
 
-        let font = self.font.unwrap_or_else(|| renderer.default_font());
+        let font = self
+            .font
+            .unwrap_or_else(|| renderer.settings().default_font);
 
         let theme_name = theme.name();
 
@@ -555,7 +559,9 @@ where
                 Text {
                     content: placeholder.clone().into_owned(),
                     bounds: text_bounds.size(),
-                    size: self.text_size.unwrap_or_else(|| renderer.default_size()),
+                    size: self
+                        .text_size
+                        .unwrap_or_else(|| renderer.settings().default_text_size),
                     line_height: self.line_height,
                     font,
                     align_x: text::Alignment::Default,

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -199,7 +199,7 @@ where
 
     /// Sets the [`Font`] of the [`TextInput`].
     ///
-    /// [`Font`]: text::Renderer::Font
+    /// [`Font`]: crate::core::Renderer::Font
     pub fn font(mut self, font: Renderer::Font) -> Self {
         self.font = Some(font);
         self

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -43,8 +43,8 @@ use crate::core::widget::operation::{self, Focusable, Operation};
 use crate::core::widget::tree::{self, Tree};
 use crate::core::window;
 use crate::core::{
-    Background, Border, Color, Element, Event, Layout, Length, Padding, Pixels, Rectangle, Shell,
-    Size, Theme, Widget,
+    Background, Border, Color, Element, Event, Font, Layout, Length, Padding, Pixels, Rectangle,
+    Shell, Size, Theme, Widget,
 };
 
 /// A field that can be filled with text.
@@ -79,16 +79,15 @@ use crate::core::{
 ///     }
 /// }
 /// ```
-pub struct TextInput<'a, Message, Theme = crate::Theme, Renderer = crate::Renderer>
+pub struct TextInput<'a, Message, Theme = crate::Theme>
 where
     Theme: Catalog,
-    Renderer: text::Renderer,
 {
     id: Option<widget::Id>,
     placeholder: text::Fragment<'a>,
     value: text::Fragment<'a>,
     is_secure: bool,
-    font: Option<Renderer::Font>,
+    font: Option<Font>,
     width: Length,
     height: Length,
     padding: Padding,
@@ -106,11 +105,10 @@ where
 /// The default [`Padding`] of a [`TextInput`].
 pub const DEFAULT_PADDING: Padding = Padding::new(5.0);
 
-impl<'a, Message, Theme, Renderer> TextInput<'a, Message, Theme, Renderer>
+impl<'a, Message, Theme> TextInput<'a, Message, Theme>
 where
     Message: Clone,
     Theme: Catalog,
-    Renderer: text::Renderer,
 {
     /// Creates a new [`TextInput`] with the given placeholder and
     /// its current value.
@@ -199,8 +197,8 @@ where
 
     /// Sets the [`Font`] of the [`TextInput`].
     ///
-    /// [`Font`]: crate::core::Renderer::Font
-    pub fn font(mut self, font: Renderer::Font) -> Self {
+    /// [`Font`]: crate::core::Font
+    pub fn font(mut self, font: Font) -> Self {
         self.font = Some(font);
         self
     }
@@ -261,8 +259,7 @@ where
     }
 }
 
-impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer>
-    for TextInput<'_, Message, Theme, Renderer>
+impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer> for TextInput<'_, Message, Theme>
 where
     Message: Clone,
     Theme: Catalog,
@@ -457,16 +454,14 @@ where
     }
 }
 
-impl<'a, Message, Theme, Renderer> From<TextInput<'a, Message, Theme, Renderer>>
+impl<'a, Message, Theme, Renderer> From<TextInput<'a, Message, Theme>>
     for Element<'a, Message, Theme, Renderer>
 where
     Message: Clone + 'a,
     Theme: Catalog + 'a,
     Renderer: text::Renderer + 'static,
 {
-    fn from(
-        text_input: TextInput<'a, Message, Theme, Renderer>,
-    ) -> Element<'a, Message, Theme, Renderer> {
+    fn from(text_input: TextInput<'a, Message, Theme>) -> Element<'a, Message, Theme, Renderer> {
         Element::new(text_input)
     }
 }

--- a/widget/src/toggler.rs
+++ b/widget/src/toggler.rs
@@ -41,8 +41,8 @@ use crate::core::widget;
 use crate::core::widget::tree::{self, Tree};
 use crate::core::window;
 use crate::core::{
-    Background, Border, Color, Element, Event, Layout, Length, Pixels, Rectangle, Shell, Size,
-    Theme, Widget,
+    Background, Border, Color, Element, Event, Font, Layout, Length, Pixels, Rectangle, Shell,
+    Size, Theme, Widget,
 };
 
 /// A toggler widget.
@@ -77,10 +77,9 @@ use crate::core::{
 ///     }
 /// }
 /// ```
-pub struct Toggler<'a, Message, Theme = crate::Theme, Renderer = crate::Renderer>
+pub struct Toggler<'a, Message, Theme = crate::Theme>
 where
     Theme: Catalog,
-    Renderer: text::Renderer,
 {
     is_toggled: bool,
     on_toggle: Option<Box<dyn Fn(bool) -> Message + 'a>>,
@@ -93,15 +92,14 @@ where
     text_shaping: text::Shaping,
     wrapping: text::Wrapping,
     spacing: f32,
-    font: Option<Renderer::Font>,
+    font: Option<Font>,
     class: Theme::Class<'a>,
     last_status: Option<Status>,
 }
 
-impl<'a, Message, Theme, Renderer> Toggler<'a, Message, Theme, Renderer>
+impl<'a, Message, Theme> Toggler<'a, Message, Theme>
 where
     Theme: Catalog,
-    Renderer: text::Renderer,
 {
     /// The default size of a [`Toggler`].
     pub const DEFAULT_SIZE: f32 = 16.0;
@@ -205,10 +203,10 @@ where
         self
     }
 
-    /// Sets the [`Renderer::Font`] of the text of the [`Toggler`]
+    /// Sets the [`Font`] of the text of the [`Toggler`]
     ///
-    /// [`Renderer::Font`]: crate::core::text::Renderer
-    pub fn font(mut self, font: impl Into<Renderer::Font>) -> Self {
+    /// [`Font`]: crate::core::Font
+    pub fn font(mut self, font: impl Into<Font>) -> Self {
         self.font = Some(font.into());
         self
     }
@@ -232,8 +230,7 @@ where
     }
 }
 
-impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer>
-    for Toggler<'_, Message, Theme, Renderer>
+impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer> for Toggler<'_, Message, Theme>
 where
     Theme: Catalog,
     Renderer: text::Renderer,
@@ -474,16 +471,14 @@ where
     }
 }
 
-impl<'a, Message, Theme, Renderer> From<Toggler<'a, Message, Theme, Renderer>>
+impl<'a, Message, Theme, Renderer> From<Toggler<'a, Message, Theme>>
     for Element<'a, Message, Theme, Renderer>
 where
     Message: 'a,
     Theme: Catalog + 'a,
     Renderer: text::Renderer + 'a,
 {
-    fn from(
-        toggler: Toggler<'a, Message, Theme, Renderer>,
-    ) -> Element<'a, Message, Theme, Renderer> {
+    fn from(toggler: Toggler<'a, Message, Theme>) -> Element<'a, Message, Theme, Renderer> {
         Element::new(toggler)
     }
 }

--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -1669,8 +1669,8 @@ fn run_action<'a, P, C>(
                 }
             }
             font::Action::SetDefaults { font, text_size } => {
-                renderer_settings.default_font = font;
-                renderer_settings.default_text_size = text_size;
+                renderer_settings.font = font;
+                renderer_settings.text_size = text_size;
 
                 let Some(compositor) = compositor else {
                     return;

--- a/winit/src/window.rs
+++ b/winit/src/window.rs
@@ -311,7 +311,7 @@ where
 {
     position: Point,
     content: Renderer::Paragraph,
-    spans: Vec<text::Span<'static, (), Renderer::Font>>,
+    spans: Vec<text::Span<'static, ()>>,
 }
 
 impl<Renderer> Preedit<Renderer>

--- a/winit/src/window.rs
+++ b/winit/src/window.rs
@@ -362,9 +362,11 @@ where
             self.content = Renderer::Paragraph::with_spans(Text {
                 content: &spans,
                 bounds: Size::INFINITE,
-                size: preedit.text_size.unwrap_or_else(|| renderer.default_size()),
+                size: preedit
+                    .text_size
+                    .unwrap_or_else(|| renderer.settings().default_text_size),
                 line_height: text::LineHeight::default(),
-                font: renderer.default_font(),
+                font: renderer.settings().default_font,
                 align_x: text::Alignment::Default,
                 align_y: alignment::Vertical::Top,
                 shaping: text::Shaping::Advanced,

--- a/winit/src/window.rs
+++ b/winit/src/window.rs
@@ -364,9 +364,9 @@ where
                 bounds: Size::INFINITE,
                 size: preedit
                     .text_size
-                    .unwrap_or_else(|| renderer.settings().default_text_size),
+                    .unwrap_or_else(|| renderer.settings().text_size),
                 line_height: text::LineHeight::default(),
-                font: renderer.settings().default_font,
+                font: renderer.settings().font,
                 align_x: text::Alignment::Default,
                 align_y: alignment::Vertical::Top,
                 shaping: text::Shaping::Advanced,

--- a/winit/src/window.rs
+++ b/winit/src/window.rs
@@ -362,11 +362,9 @@ where
             self.content = Renderer::Paragraph::with_spans(Text {
                 content: &spans,
                 bounds: Size::INFINITE,
-                size: preedit
-                    .text_size
-                    .unwrap_or_else(|| renderer.settings().text_size),
+                size: preedit.text_size.unwrap_or_else(|| renderer.text_size()),
                 line_height: text::LineHeight::default(),
-                font: renderer.settings().font,
+                font: renderer.font(),
                 align_x: text::Alignment::Default,
                 align_y: alignment::Vertical::Top,
                 shaping: text::Shaping::Advanced,


### PR DESCRIPTION
This PR removes the `Font` generic type all over our codebase.

It's a bit of legacy from early days when `iced` was meant to be really renderer-agnostic and work with different kinds of game engines.

The reality is that this is barely used by downstream users and, even when it is, it should be possible to map back and forth between types easily (like we do ourselves with `cosmic-text`).