### PR TITLE
Reduce Backtrace Frames

### DIFF
--- a/debug/src/lib.rs
+++ b/debug/src/lib.rs
@@ -114,6 +114,7 @@ pub fn commands() -> Subscription<Command> {
     internal::commands()
 }
 
+#[inline]
 pub fn hot<O>(f: impl FnOnce() -> O) -> O {
     hot::call(f)
 }
@@ -474,6 +475,7 @@ mod hot {
 mod hot {
     pub fn init() {}
 
+    #[inline]
     pub fn call<O>(f: impl FnOnce() -> O) -> O {
         f()
     }

--- a/devtools/src/lib.rs
+++ b/devtools/src/lib.rs
@@ -50,23 +50,27 @@ where
     P::Message: std::fmt::Debug + message::MaybeClone,
 {
     type State = DevTools<P>;
-    type Message = Event<P>;
+    type Message = Event<P::Message>;
     type Theme = P::Theme;
     type Renderer = P::Renderer;
     type Executor = P::Executor;
 
+    #[inline]
     fn name() -> &'static str {
         P::name()
     }
 
+    #[inline]
     fn settings(&self) -> Settings {
         self.program.settings()
     }
 
+    #[inline]
     fn window(&self) -> Option<window::Settings> {
         self.program.window()
     }
 
+    #[inline]
     fn boot(&self) -> (Self::State, Task<Self::Message>) {
         let (state, boot) = self.program.boot();
         let (devtools, task) = DevTools::new(state);
@@ -77,10 +81,12 @@ where
         )
     }
 
+    #[inline]
     fn update(&self, state: &mut Self::State, message: Self::Message) -> Task<Self::Message> {
         state.update(&self.program, message)
     }
 
+    #[inline]
     fn view<'a>(
         &self,
         state: &'a Self::State,
@@ -89,22 +95,27 @@ where
         state.view(&self.program, window)
     }
 
+    #[inline]
     fn title(&self, state: &Self::State, window: window::Id) -> String {
         state.title(&self.program, window)
     }
 
+    #[inline]
     fn subscription(&self, state: &Self::State) -> Subscription<Self::Message> {
         state.subscription(&self.program)
     }
 
+    #[inline]
     fn theme(&self, state: &Self::State, window: window::Id) -> Option<Self::Theme> {
         state.theme(&self.program, window)
     }
 
+    #[inline]
     fn style(&self, state: &Self::State, theme: &Self::Theme) -> theme::Style {
         state.style(&self.program, theme)
     }
 
+    #[inline]
     fn scale_factor(&self, state: &Self::State, window: window::Id) -> f32 {
         state.scale_factor(&self.program, window)
     }
@@ -171,7 +182,7 @@ where
         program.title(&self.state, window)
     }
 
-    pub fn update(&mut self, program: &P, event: Event<P>) -> Task<Event<P>> {
+    pub fn update(&mut self, program: &P, event: Event<P::Message>) -> Task<Event<P::Message>> {
         match event {
             Event::Message(message) => match message {
                 Message::HideNotification => {
@@ -297,7 +308,7 @@ where
         &self,
         program: &P,
         window: window::Id,
-    ) -> Element<'_, Event<P>, P::Theme, P::Renderer> {
+    ) -> Element<'_, Event<P::Message>, P::Theme, P::Renderer> {
         let state = self.state();
 
         let view = {
@@ -360,7 +371,7 @@ where
             .into()
     }
 
-    pub fn subscription(&self, program: &P) -> Subscription<Event<P>> {
+    pub fn subscription(&self, program: &P) -> Subscription<Event<P::Message>> {
         let subscription = program.subscription(&self.state).map(Event::Program);
         debug::subscriptions_tracked(subscription.units());
 
@@ -396,20 +407,16 @@ where
     }
 }
 
-pub enum Event<P>
-where
-    P: Program,
-{
+pub enum Event<T> {
     Message(Message),
-    Program(P::Message),
+    Program(T),
     Command(debug::Command),
     Discard,
 }
 
-impl<P> fmt::Debug for Event<P>
+impl<T> fmt::Debug for Event<T>
 where
-    P: Program,
-    P::Message: std::fmt::Debug,
+    T: std::fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -107,79 +107,6 @@ pub trait Program: Sized {
     }
 }
 
-/// Decorates a [`Program`] with the given title function.
-pub fn with_title<P: Program>(
-    program: P,
-    title: impl Fn(&P::State, window::Id) -> String,
-) -> impl Program<State = P::State, Message = P::Message, Theme = P::Theme> {
-    struct WithTitle<P, Title> {
-        program: P,
-        title: Title,
-    }
-
-    impl<P, Title> Program for WithTitle<P, Title>
-    where
-        P: Program,
-        Title: Fn(&P::State, window::Id) -> String,
-    {
-        type State = P::State;
-        type Message = P::Message;
-        type Theme = P::Theme;
-        type Renderer = P::Renderer;
-        type Executor = P::Executor;
-
-        fn title(&self, state: &Self::State, window: window::Id) -> String {
-            (self.title)(state, window)
-        }
-
-        fn name() -> &'static str {
-            P::name()
-        }
-
-        fn settings(&self) -> Settings {
-            self.program.settings()
-        }
-
-        fn window(&self) -> Option<window::Settings> {
-            self.program.window()
-        }
-
-        fn boot(&self) -> (Self::State, Task<Self::Message>) {
-            self.program.boot()
-        }
-
-        fn update(&self, state: &mut Self::State, message: Self::Message) -> Task<Self::Message> {
-            self.program.update(state, message)
-        }
-
-        fn view<'a>(
-            &self,
-            state: &'a Self::State,
-            window: window::Id,
-        ) -> Element<'a, Self::Message, Self::Theme, Self::Renderer> {
-            self.program.view(state, window)
-        }
-
-        fn theme(&self, state: &Self::State, window: window::Id) -> Option<Self::Theme> {
-            self.program.theme(state, window)
-        }
-
-        fn subscription(&self, state: &Self::State) -> Subscription<Self::Message> {
-            self.program.subscription(state)
-        }
-
-        fn style(&self, state: &Self::State, theme: &Self::Theme) -> theme::Style {
-            self.program.style(state, theme)
-        }
-
-        fn scale_factor(&self, state: &Self::State, window: window::Id) -> f32 {
-            self.program.scale_factor(state, window)
-        }
-    }
-
-    WithTitle { program, title }
-}
-
 /// Decorates a [`Program`] with the given subscription function.
 pub fn with_subscription<P: Program>(
     program: P,
@@ -200,30 +127,37 @@ pub fn with_subscription<P: Program>(
         type Renderer = P::Renderer;
         type Executor = P::Executor;
 
+        #[inline]
         fn subscription(&self, state: &Self::State) -> Subscription<Self::Message> {
             (self.subscription)(state)
         }
 
+        #[inline]
         fn name() -> &'static str {
             P::name()
         }
 
+        #[inline]
         fn settings(&self) -> Settings {
             self.program.settings()
         }
 
+        #[inline]
         fn window(&self) -> Option<window::Settings> {
             self.program.window()
         }
 
+        #[inline]
         fn boot(&self) -> (Self::State, Task<Self::Message>) {
             self.program.boot()
         }
 
+        #[inline]
         fn update(&self, state: &mut Self::State, message: Self::Message) -> Task<Self::Message> {
             self.program.update(state, message)
         }
 
+        #[inline]
         fn view<'a>(
             &self,
             state: &'a Self::State,
@@ -232,18 +166,22 @@ pub fn with_subscription<P: Program>(
             self.program.view(state, window)
         }
 
+        #[inline]
         fn title(&self, state: &Self::State, window: window::Id) -> String {
             self.program.title(state, window)
         }
 
+        #[inline]
         fn theme(&self, state: &Self::State, window: window::Id) -> Option<Self::Theme> {
             self.program.theme(state, window)
         }
 
+        #[inline]
         fn style(&self, state: &Self::State, theme: &Self::Theme) -> theme::Style {
             self.program.style(state, theme)
         }
 
+        #[inline]
         fn scale_factor(&self, state: &Self::State, window: window::Id) -> f32 {
             self.program.scale_factor(state, window)
         }
@@ -253,78 +191,6 @@ pub fn with_subscription<P: Program>(
         program,
         subscription: f,
     }
-}
-
-/// Decorates a [`Program`] with the given theme function.
-pub fn with_theme<P: Program>(
-    program: P,
-    f: impl Fn(&P::State, window::Id) -> Option<P::Theme>,
-) -> impl Program<State = P::State, Message = P::Message, Theme = P::Theme> {
-    struct WithTheme<P, F> {
-        program: P,
-        theme: F,
-    }
-
-    impl<P: Program, F> Program for WithTheme<P, F>
-    where
-        F: Fn(&P::State, window::Id) -> Option<P::Theme>,
-    {
-        type State = P::State;
-        type Message = P::Message;
-        type Theme = P::Theme;
-        type Renderer = P::Renderer;
-        type Executor = P::Executor;
-
-        fn theme(&self, state: &Self::State, window: window::Id) -> Option<Self::Theme> {
-            (self.theme)(state, window)
-        }
-
-        fn name() -> &'static str {
-            P::name()
-        }
-
-        fn settings(&self) -> Settings {
-            self.program.settings()
-        }
-
-        fn window(&self) -> Option<window::Settings> {
-            self.program.window()
-        }
-
-        fn boot(&self) -> (Self::State, Task<Self::Message>) {
-            self.program.boot()
-        }
-
-        fn title(&self, state: &Self::State, window: window::Id) -> String {
-            self.program.title(state, window)
-        }
-
-        fn update(&self, state: &mut Self::State, message: Self::Message) -> Task<Self::Message> {
-            self.program.update(state, message)
-        }
-
-        fn view<'a>(
-            &self,
-            state: &'a Self::State,
-            window: window::Id,
-        ) -> Element<'a, Self::Message, Self::Theme, Self::Renderer> {
-            self.program.view(state, window)
-        }
-
-        fn subscription(&self, state: &Self::State) -> Subscription<Self::Message> {
-            self.program.subscription(state)
-        }
-
-        fn style(&self, state: &Self::State, theme: &Self::Theme) -> theme::Style {
-            self.program.style(state, theme)
-        }
-
-        fn scale_factor(&self, state: &Self::State, window: window::Id) -> f32 {
-            self.program.scale_factor(state, window)
-        }
-    }
-
-    WithTheme { program, theme: f }
 }
 
 /// Decorates a [`Program`] with the given style function.
@@ -347,34 +213,42 @@ pub fn with_style<P: Program>(
         type Renderer = P::Renderer;
         type Executor = P::Executor;
 
+        #[inline]
         fn style(&self, state: &Self::State, theme: &Self::Theme) -> theme::Style {
             (self.style)(state, theme)
         }
 
+        #[inline]
         fn name() -> &'static str {
             P::name()
         }
 
+        #[inline]
         fn settings(&self) -> Settings {
             self.program.settings()
         }
 
+        #[inline]
         fn window(&self) -> Option<window::Settings> {
             self.program.window()
         }
 
+        #[inline]
         fn boot(&self) -> (Self::State, Task<Self::Message>) {
             self.program.boot()
         }
 
+        #[inline]
         fn title(&self, state: &Self::State, window: window::Id) -> String {
             self.program.title(state, window)
         }
 
+        #[inline]
         fn update(&self, state: &mut Self::State, message: Self::Message) -> Task<Self::Message> {
             self.program.update(state, message)
         }
 
+        #[inline]
         fn view<'a>(
             &self,
             state: &'a Self::State,
@@ -383,95 +257,23 @@ pub fn with_style<P: Program>(
             self.program.view(state, window)
         }
 
+        #[inline]
         fn subscription(&self, state: &Self::State) -> Subscription<Self::Message> {
             self.program.subscription(state)
         }
 
+        #[inline]
         fn theme(&self, state: &Self::State, window: window::Id) -> Option<Self::Theme> {
             self.program.theme(state, window)
         }
 
+        #[inline]
         fn scale_factor(&self, state: &Self::State, window: window::Id) -> f32 {
             self.program.scale_factor(state, window)
         }
     }
 
     WithStyle { program, style: f }
-}
-
-/// Decorates a [`Program`] with the given scale factor function.
-pub fn with_scale_factor<P: Program>(
-    program: P,
-    f: impl Fn(&P::State, window::Id) -> f32,
-) -> impl Program<State = P::State, Message = P::Message, Theme = P::Theme> {
-    struct WithScaleFactor<P, F> {
-        program: P,
-        scale_factor: F,
-    }
-
-    impl<P: Program, F> Program for WithScaleFactor<P, F>
-    where
-        F: Fn(&P::State, window::Id) -> f32,
-    {
-        type State = P::State;
-        type Message = P::Message;
-        type Theme = P::Theme;
-        type Renderer = P::Renderer;
-        type Executor = P::Executor;
-
-        fn title(&self, state: &Self::State, window: window::Id) -> String {
-            self.program.title(state, window)
-        }
-
-        fn name() -> &'static str {
-            P::name()
-        }
-
-        fn settings(&self) -> Settings {
-            self.program.settings()
-        }
-
-        fn window(&self) -> Option<window::Settings> {
-            self.program.window()
-        }
-
-        fn boot(&self) -> (Self::State, Task<Self::Message>) {
-            self.program.boot()
-        }
-
-        fn update(&self, state: &mut Self::State, message: Self::Message) -> Task<Self::Message> {
-            self.program.update(state, message)
-        }
-
-        fn view<'a>(
-            &self,
-            state: &'a Self::State,
-            window: window::Id,
-        ) -> Element<'a, Self::Message, Self::Theme, Self::Renderer> {
-            self.program.view(state, window)
-        }
-
-        fn subscription(&self, state: &Self::State) -> Subscription<Self::Message> {
-            self.program.subscription(state)
-        }
-
-        fn theme(&self, state: &Self::State, window: window::Id) -> Option<Self::Theme> {
-            self.program.theme(state, window)
-        }
-
-        fn style(&self, state: &Self::State, theme: &Self::Theme) -> theme::Style {
-            self.program.style(state, theme)
-        }
-
-        fn scale_factor(&self, state: &Self::State, window: window::Id) -> f32 {
-            (self.scale_factor)(state, window)
-        }
-    }
-
-    WithScaleFactor {
-        program,
-        scale_factor: f,
-    }
 }
 
 /// Decorates a [`Program`] with the given executor function.
@@ -495,30 +297,37 @@ pub fn with_executor<P: Program, E: Executor>(
         type Renderer = P::Renderer;
         type Executor = E;
 
+        #[inline]
         fn title(&self, state: &Self::State, window: window::Id) -> String {
             self.program.title(state, window)
         }
 
+        #[inline]
         fn name() -> &'static str {
             P::name()
         }
 
+        #[inline]
         fn settings(&self) -> Settings {
             self.program.settings()
         }
 
+        #[inline]
         fn window(&self) -> Option<window::Settings> {
             self.program.window()
         }
 
+        #[inline]
         fn boot(&self) -> (Self::State, Task<Self::Message>) {
             self.program.boot()
         }
 
+        #[inline]
         fn update(&self, state: &mut Self::State, message: Self::Message) -> Task<Self::Message> {
             self.program.update(state, message)
         }
 
+        #[inline]
         fn view<'a>(
             &self,
             state: &'a Self::State,
@@ -527,18 +336,22 @@ pub fn with_executor<P: Program, E: Executor>(
             self.program.view(state, window)
         }
 
+        #[inline]
         fn subscription(&self, state: &Self::State) -> Subscription<Self::Message> {
             self.program.subscription(state)
         }
 
+        #[inline]
         fn theme(&self, state: &Self::State, window: window::Id) -> Option<Self::Theme> {
             self.program.theme(state, window)
         }
 
+        #[inline]
         fn style(&self, state: &Self::State, theme: &Self::Theme) -> theme::Style {
             self.program.style(state, theme)
         }
 
+        #[inline]
         fn scale_factor(&self, state: &Self::State, window: window::Id) -> f32 {
             self.program.scale_factor(state, window)
         }
@@ -573,36 +386,43 @@ impl<P: Program> Instance<P> {
     }
 
     /// Returns the current title of the [`Instance`].
+    #[inline]
     pub fn title(&self, window: window::Id) -> String {
         self.program.title(&self.state, window)
     }
 
     /// Processes the given message and updates the [`Instance`].
+    #[inline]
     pub fn update(&mut self, message: P::Message) -> Task<P::Message> {
         self.program.update(&mut self.state, message)
     }
 
     /// Produces the current widget tree of the [`Instance`].
+    #[inline]
     pub fn view(&self, window: window::Id) -> Element<'_, P::Message, P::Theme, P::Renderer> {
         self.program.view(&self.state, window)
     }
 
     /// Returns the current [`Subscription`] of the [`Instance`].
+    #[inline]
     pub fn subscription(&self) -> Subscription<P::Message> {
         self.program.subscription(&self.state)
     }
 
     /// Returns the current theme of the [`Instance`].
+    #[inline]
     pub fn theme(&self, window: window::Id) -> Option<P::Theme> {
         self.program.theme(&self.state, window)
     }
 
     /// Returns the current [`theme::Style`] of the [`Instance`].
+    #[inline]
     pub fn style(&self, theme: &P::Theme) -> theme::Style {
         self.program.style(&self.state, theme)
     }
 
     /// Returns the current scale factor of the [`Instance`].
+    #[inline]
     pub fn scale_factor(&self, window: window::Id) -> f32 {
         self.program.scale_factor(&self.state, window)
     }

--- a/src/application.rs
+++ b/src/application.rs
@@ -41,6 +41,7 @@ use crate::{
     Theme,
 };
 
+#[cfg(feature = "hot")]
 use iced_debug as debug;
 
 use std::borrow::Cow;
@@ -367,7 +368,7 @@ impl<P: Program> Application<P> {
         title: impl TitleFn<P::State>,
     ) -> Application<impl Program<State = P::State, Message = P::Message, Theme = P::Theme>> {
         Application {
-            raw: program::with_title(self.raw, move |state, _window| title.title(state)),
+            raw: with_title(self.raw, title),
             settings: self.settings,
             window: self.window,
             presets: self.presets,
@@ -393,7 +394,7 @@ impl<P: Program> Application<P> {
         f: impl ThemeFn<P::State, P::Theme>,
     ) -> Application<impl Program<State = P::State, Message = P::Message, Theme = P::Theme>> {
         Application {
-            raw: program::with_theme(self.raw, move |state, _window| f.theme(state)),
+            raw: with_theme(self.raw, f),
             settings: self.settings,
             window: self.window,
             presets: self.presets,
@@ -419,7 +420,7 @@ impl<P: Program> Application<P> {
         f: impl Fn(&P::State) -> f32,
     ) -> Application<impl Program<State = P::State, Message = P::Message, Theme = P::Theme>> {
         Application {
-            raw: program::with_scale_factor(self.raw, move |state, _window| f(state)),
+            raw: with_scale_factor(self.raw, f),
             settings: self.settings,
             window: self.window,
             presets: self.presets,
@@ -473,40 +474,97 @@ impl<P: Program> Program for Application<P> {
         Some(self.window.clone())
     }
 
+    #[inline]
     fn boot(&self) -> (Self::State, Task<Self::Message>) {
         self.raw.boot()
     }
 
+    #[inline]
     fn update(&self, state: &mut Self::State, message: Self::Message) -> Task<Self::Message> {
-        debug::hot(|| self.raw.update(state, message))
+        #[cfg(feature = "hot")]
+        {
+            debug::hot(|| self.raw.update(state, message))
+        }
+        #[cfg(not(feature = "hot"))]
+        {
+            self.raw.update(state, message)
+        }
     }
 
+    #[inline]
     fn view<'a>(
         &self,
         state: &'a Self::State,
         window: window::Id,
     ) -> Element<'a, Self::Message, Self::Theme, Self::Renderer> {
-        debug::hot(|| self.raw.view(state, window))
+        #[cfg(feature = "hot")]
+        {
+            debug::hot(|| self.raw.view(state, window))
+        }
+        #[cfg(not(feature = "hot"))]
+        {
+            self.raw.view(state, window)
+        }
     }
 
+    #[inline]
     fn title(&self, state: &Self::State, window: window::Id) -> String {
-        debug::hot(|| self.raw.title(state, window))
+        #[cfg(feature = "hot")]
+        {
+            debug::hot(|| self.raw.title(state, window))
+        }
+        #[cfg(not(feature = "hot"))]
+        {
+            self.raw.title(state, window)
+        }
     }
 
+    #[inline]
     fn subscription(&self, state: &Self::State) -> Subscription<Self::Message> {
-        debug::hot(|| self.raw.subscription(state))
+        #[cfg(feature = "hot")]
+        {
+            debug::hot(|| self.raw.subscription(state))
+        }
+        #[cfg(not(feature = "hot"))]
+        {
+            self.raw.subscription(state)
+        }
     }
 
+    #[inline]
     fn theme(&self, state: &Self::State, window: iced_core::window::Id) -> Option<Self::Theme> {
-        debug::hot(|| self.raw.theme(state, window))
+        #[cfg(feature = "hot")]
+        {
+            debug::hot(|| self.raw.theme(state, window))
+        }
+        #[cfg(not(feature = "hot"))]
+        {
+            self.raw.theme(state, window)
+        }
     }
 
+    #[inline]
     fn style(&self, state: &Self::State, theme: &Self::Theme) -> theme::Style {
-        debug::hot(|| self.raw.style(state, theme))
+        #[cfg(feature = "hot")]
+        {
+            debug::hot(|| self.raw.style(state, theme))
+        }
+        #[cfg(not(feature = "hot"))]
+        {
+            self.raw.style(state, theme)
+        }
     }
 
+    #[inline]
     fn scale_factor(&self, state: &Self::State, window: window::Id) -> f32 {
-        debug::hot(|| self.raw.scale_factor(state, window))
+        #[cfg(feature = "hot")]
+        {
+            debug::hot(|| self.raw.scale_factor(state, window))
+        }
+        #[cfg(not(feature = "hot"))]
+        {
+            self.raw.scale_factor(state, window)
+        }
     }
 
     fn presets(&self) -> &[Preset<Self::State, Self::Message>] {
@@ -557,16 +615,17 @@ impl<State, Message> IntoBoot<State, Message> for (State, Task<Message>) {
 
 /// The title logic of some [`Application`].
 ///
-/// This trait is implemented both for `&static str` and
+/// This trait is implemented both for `&'static str` and
 /// any closure `Fn(&State) -> String`.
 ///
-/// This trait allows the [`application`] builder to take any of them.
+/// This trait allows the [`Application::title`] builder to take any of them.
 pub trait TitleFn<State> {
     /// Produces the title of the [`Application`].
     fn title(&self, state: &State) -> String;
 }
 
 impl<State> TitleFn<State> for &'static str {
+    #[inline]
     fn title(&self, _state: &State) -> String {
         self.to_string()
     }
@@ -576,8 +635,47 @@ impl<T, State> TitleFn<State> for T
 where
     T: Fn(&State) -> String,
 {
+    #[inline]
     fn title(&self, state: &State) -> String {
-        self(state)
+        (self)(state)
+    }
+}
+
+/// The theme logic of some [`Application`].
+///
+/// Any implementors of this trait can be provided as an argument to
+/// [`Application::theme`].
+///
+/// `iced` provides two implementors:
+/// - the built-in [`Theme`] itself
+/// - and any `Fn(&State) -> impl Into<Option<Theme>>`.
+pub trait ThemeFn<State, Theme>
+where
+    Theme: theme::Base,
+{
+    /// Returns the theme of the [`Application`] for the current state.
+    ///
+    /// If `None` is returned, `iced` will try to use a theme that
+    /// matches the system color scheme.
+    fn theme(&self, state: &State) -> Option<Theme>;
+}
+
+impl<State> ThemeFn<State, Theme> for Theme {
+    #[inline]
+    fn theme(&self, _state: &State) -> Option<Theme> {
+        Some(self.clone())
+    }
+}
+
+impl<F, T, State, Theme> ThemeFn<State, Theme> for F
+where
+    F: Fn(&State) -> T,
+    T: Into<Option<Theme>>,
+    Theme: theme::Base,
+{
+    #[inline]
+    fn theme(&self, state: &State) -> Option<Theme> {
+        (self)(state).into()
     }
 }
 
@@ -622,39 +720,262 @@ where
     State: 'static,
     Widget: Into<Element<'a, Message, Theme, Renderer>>,
 {
+    #[inline]
     fn view(&self, state: &'a State) -> Element<'a, Message, Theme, Renderer> {
         self(state).into()
     }
 }
 
-/// The theme logic of some [`Application`].
-///
-/// Any implementors of this trait can be provided as an argument to
-/// [`Application::theme`].
-///
-/// `iced` provides two implementors:
-/// - the built-in [`Theme`] itself
-/// - and any `Fn(&State) -> impl Into<Option<Theme>>`.
-pub trait ThemeFn<State, Theme> {
-    /// Returns the theme of the [`Application`] for the current state.
-    ///
-    /// If `None` is returned, `iced` will try to use a theme that
-    /// matches the system color scheme.
-    fn theme(&self, state: &State) -> Option<Theme>;
-}
-
-impl<State> ThemeFn<State, Theme> for Theme {
-    fn theme(&self, _state: &State) -> Option<Theme> {
-        Some(self.clone())
+/// Decorates a [`Program`] with the given title function.
+fn with_title<P: Program>(
+    program: P,
+    title: impl TitleFn<P::State>,
+) -> impl Program<State = P::State, Message = P::Message, Theme = P::Theme> {
+    struct WithTitle<P, Title> {
+        program: P,
+        title: Title,
     }
+
+    impl<P, Title> Program for WithTitle<P, Title>
+    where
+        P: Program,
+        Title: TitleFn<P::State>,
+    {
+        type State = P::State;
+        type Message = P::Message;
+        type Theme = P::Theme;
+        type Renderer = P::Renderer;
+        type Executor = P::Executor;
+
+        #[inline]
+        fn title(&self, state: &Self::State, _window: window::Id) -> String {
+            self.title.title(state)
+        }
+
+        #[inline]
+        fn name() -> &'static str {
+            P::name()
+        }
+
+        #[inline]
+        fn settings(&self) -> Settings {
+            self.program.settings()
+        }
+
+        #[inline]
+        fn window(&self) -> Option<window::Settings> {
+            self.program.window()
+        }
+
+        #[inline]
+        fn boot(&self) -> (Self::State, Task<Self::Message>) {
+            self.program.boot()
+        }
+
+        #[inline]
+        fn update(&self, state: &mut Self::State, message: Self::Message) -> Task<Self::Message> {
+            self.program.update(state, message)
+        }
+
+        #[inline]
+        fn view<'a>(
+            &self,
+            state: &'a Self::State,
+            window: window::Id,
+        ) -> Element<'a, Self::Message, Self::Theme, Self::Renderer> {
+            self.program.view(state, window)
+        }
+
+        #[inline]
+        fn theme(&self, state: &Self::State, window: window::Id) -> Option<Self::Theme> {
+            self.program.theme(state, window)
+        }
+
+        #[inline]
+        fn subscription(&self, state: &Self::State) -> Subscription<Self::Message> {
+            self.program.subscription(state)
+        }
+
+        #[inline]
+        fn style(&self, state: &Self::State, theme: &Self::Theme) -> theme::Style {
+            self.program.style(state, theme)
+        }
+
+        #[inline]
+        fn scale_factor(&self, state: &Self::State, window: window::Id) -> f32 {
+            self.program.scale_factor(state, window)
+        }
+    }
+
+    WithTitle { program, title }
 }
 
-impl<F, T, State, Theme> ThemeFn<State, Theme> for F
-where
-    F: Fn(&State) -> T,
-    T: Into<Option<Theme>>,
-{
-    fn theme(&self, state: &State) -> Option<Theme> {
-        (self)(state).into()
+/// Decorates a [`Program`] with the given theme function.
+fn with_theme<P: Program>(
+    program: P,
+    f: impl ThemeFn<P::State, P::Theme>,
+) -> impl Program<State = P::State, Message = P::Message, Theme = P::Theme> {
+    struct WithTheme<P, F> {
+        program: P,
+        theme: F,
+    }
+
+    impl<P: Program, F> Program for WithTheme<P, F>
+    where
+        F: ThemeFn<P::State, P::Theme>,
+    {
+        type State = P::State;
+        type Message = P::Message;
+        type Theme = P::Theme;
+        type Renderer = P::Renderer;
+        type Executor = P::Executor;
+
+        #[inline]
+        fn theme(&self, state: &Self::State, _window: window::Id) -> Option<Self::Theme> {
+            self.theme.theme(state)
+        }
+
+        #[inline]
+        fn name() -> &'static str {
+            P::name()
+        }
+
+        #[inline]
+        fn settings(&self) -> Settings {
+            self.program.settings()
+        }
+
+        #[inline]
+        fn window(&self) -> Option<window::Settings> {
+            self.program.window()
+        }
+
+        #[inline]
+        fn boot(&self) -> (Self::State, Task<Self::Message>) {
+            self.program.boot()
+        }
+
+        #[inline]
+        fn title(&self, state: &Self::State, window: window::Id) -> String {
+            self.program.title(state, window)
+        }
+
+        #[inline]
+        fn update(&self, state: &mut Self::State, message: Self::Message) -> Task<Self::Message> {
+            self.program.update(state, message)
+        }
+
+        #[inline]
+        fn view<'a>(
+            &self,
+            state: &'a Self::State,
+            window: window::Id,
+        ) -> Element<'a, Self::Message, Self::Theme, Self::Renderer> {
+            self.program.view(state, window)
+        }
+
+        #[inline]
+        fn subscription(&self, state: &Self::State) -> Subscription<Self::Message> {
+            self.program.subscription(state)
+        }
+
+        #[inline]
+        fn style(&self, state: &Self::State, theme: &Self::Theme) -> theme::Style {
+            self.program.style(state, theme)
+        }
+
+        #[inline]
+        fn scale_factor(&self, state: &Self::State, window: window::Id) -> f32 {
+            self.program.scale_factor(state, window)
+        }
+    }
+
+    WithTheme { program, theme: f }
+}
+
+/// Decorates a [`Program`] with the given scale factor function.
+fn with_scale_factor<P: Program>(
+    program: P,
+    f: impl Fn(&P::State) -> f32,
+) -> impl Program<State = P::State, Message = P::Message, Theme = P::Theme> {
+    struct WithScaleFactor<P, F> {
+        program: P,
+        scale_factor: F,
+    }
+
+    impl<P, F> Program for WithScaleFactor<P, F>
+    where
+        P: Program,
+        F: Fn(&P::State) -> f32,
+    {
+        type State = P::State;
+        type Message = P::Message;
+        type Theme = P::Theme;
+        type Renderer = P::Renderer;
+        type Executor = P::Executor;
+
+        #[inline]
+        fn title(&self, state: &Self::State, window: window::Id) -> String {
+            self.program.title(state, window)
+        }
+
+        #[inline]
+        fn name() -> &'static str {
+            P::name()
+        }
+
+        #[inline]
+        fn settings(&self) -> Settings {
+            self.program.settings()
+        }
+
+        #[inline]
+        fn window(&self) -> Option<window::Settings> {
+            self.program.window()
+        }
+
+        #[inline]
+        fn boot(&self) -> (Self::State, Task<Self::Message>) {
+            self.program.boot()
+        }
+
+        #[inline]
+        fn update(&self, state: &mut Self::State, message: Self::Message) -> Task<Self::Message> {
+            self.program.update(state, message)
+        }
+
+        #[inline]
+        fn view<'a>(
+            &self,
+            state: &'a Self::State,
+            window: window::Id,
+        ) -> Element<'a, Self::Message, Self::Theme, Self::Renderer> {
+            self.program.view(state, window)
+        }
+
+        #[inline]
+        fn subscription(&self, state: &Self::State) -> Subscription<Self::Message> {
+            self.program.subscription(state)
+        }
+
+        #[inline]
+        fn theme(&self, state: &Self::State, window: window::Id) -> Option<Self::Theme> {
+            self.program.theme(state, window)
+        }
+
+        #[inline]
+        fn style(&self, state: &Self::State, theme: &Self::Theme) -> theme::Style {
+            self.program.style(state, theme)
+        }
+
+        #[inline]
+        fn scale_factor(&self, state: &Self::State, _window: window::Id) -> f32 {
+            (self.scale_factor)(state)
+        }
+    }
+
+    WithScaleFactor {
+        program,
+        scale_factor: f,
     }
 }

--- a/src/application.rs
+++ b/src/application.rs
@@ -42,7 +42,7 @@ use crate::{
 };
 
 #[cfg(feature = "hot")]
-use iced_debug as debug;
+use crate::hot::Hot;
 
 use std::borrow::Cow;
 
@@ -208,6 +208,9 @@ impl<P: Program> Application<P> {
             all(feature = "debug", not(target_arch = "wasm32"))
         )))]
         let program = self;
+
+        #[cfg(feature = "hot")]
+        let program = Hot::new(program);
 
         Ok(shell::run(program)?)
     }
@@ -481,14 +484,7 @@ impl<P: Program> Program for Application<P> {
 
     #[inline]
     fn update(&self, state: &mut Self::State, message: Self::Message) -> Task<Self::Message> {
-        #[cfg(feature = "hot")]
-        {
-            debug::hot(|| self.raw.update(state, message))
-        }
-        #[cfg(not(feature = "hot"))]
-        {
-            self.raw.update(state, message)
-        }
+        self.raw.update(state, message)
     }
 
     #[inline]
@@ -497,74 +493,32 @@ impl<P: Program> Program for Application<P> {
         state: &'a Self::State,
         window: window::Id,
     ) -> Element<'a, Self::Message, Self::Theme, Self::Renderer> {
-        #[cfg(feature = "hot")]
-        {
-            debug::hot(|| self.raw.view(state, window))
-        }
-        #[cfg(not(feature = "hot"))]
-        {
-            self.raw.view(state, window)
-        }
+        self.raw.view(state, window)
     }
 
     #[inline]
     fn title(&self, state: &Self::State, window: window::Id) -> String {
-        #[cfg(feature = "hot")]
-        {
-            debug::hot(|| self.raw.title(state, window))
-        }
-        #[cfg(not(feature = "hot"))]
-        {
-            self.raw.title(state, window)
-        }
+        self.raw.title(state, window)
     }
 
     #[inline]
     fn subscription(&self, state: &Self::State) -> Subscription<Self::Message> {
-        #[cfg(feature = "hot")]
-        {
-            debug::hot(|| self.raw.subscription(state))
-        }
-        #[cfg(not(feature = "hot"))]
-        {
-            self.raw.subscription(state)
-        }
+        self.raw.subscription(state)
     }
 
     #[inline]
     fn theme(&self, state: &Self::State, window: iced_core::window::Id) -> Option<Self::Theme> {
-        #[cfg(feature = "hot")]
-        {
-            debug::hot(|| self.raw.theme(state, window))
-        }
-        #[cfg(not(feature = "hot"))]
-        {
-            self.raw.theme(state, window)
-        }
+        self.raw.theme(state, window)
     }
 
     #[inline]
     fn style(&self, state: &Self::State, theme: &Self::Theme) -> theme::Style {
-        #[cfg(feature = "hot")]
-        {
-            debug::hot(|| self.raw.style(state, theme))
-        }
-        #[cfg(not(feature = "hot"))]
-        {
-            self.raw.style(state, theme)
-        }
+        self.raw.style(state, theme)
     }
 
     #[inline]
     fn scale_factor(&self, state: &Self::State, window: window::Id) -> f32 {
-        #[cfg(feature = "hot")]
-        {
-            debug::hot(|| self.raw.scale_factor(state, window))
-        }
-        #[cfg(not(feature = "hot"))]
-        {
-            self.raw.scale_factor(state, window)
-        }
+        self.raw.scale_factor(state, window)
     }
 
     fn presets(&self) -> &[Preset<Self::State, Self::Message>] {

--- a/src/application/timed.rs
+++ b/src/application/timed.rs
@@ -6,9 +6,6 @@ use crate::time::Instant;
 use crate::window;
 use crate::{Element, Program, Settings, Subscription, Task};
 
-#[cfg(feature = "hot")]
-use iced_debug as debug;
-
 /// Creates an [`Application`] with an `update` function that also
 /// takes the [`Instant`] of each `Message`.
 ///
@@ -88,21 +85,10 @@ where
             state: &mut Self::State,
             (message, now): Self::Message,
         ) -> Task<Self::Message> {
-            #[cfg(feature = "hot")]
-            let task = debug::hot(move || {
-                self.update
-                    .update(state, message, now)
-                    .into()
-                    .map(|message| (message, Instant::now()))
-            });
-            #[cfg(not(feature = "hot"))]
-            let task = self
-                .update
+            self.update
                 .update(state, message, now)
                 .into()
-                .map(|message| (message, Instant::now()));
-
-            task
+                .map(|message| (message, Instant::now()))
         }
 
         #[inline]
@@ -111,30 +97,14 @@ where
             state: &'a Self::State,
             _window: window::Id,
         ) -> Element<'a, Self::Message, Self::Theme, Self::Renderer> {
-            #[cfg(feature = "hot")]
-            let widget = debug::hot(|| {
-                self.view
-                    .view(state)
-                    .map(|message| (message, Instant::now()))
-            });
-            #[cfg(not(feature = "hot"))]
-            let widget = self
-                .view
+            self.view
                 .view(state)
-                .map(|message| (message, Instant::now()));
-
-            widget
+                .map(|message| (message, Instant::now()))
         }
 
         #[inline]
         fn subscription(&self, state: &Self::State) -> self::Subscription<Self::Message> {
-            #[cfg(feature = "hot")]
-            let subscription =
-                debug::hot(|| (self.subscription)(state).map(|message| (message, Instant::now())));
-            #[cfg(not(feature = "hot"))]
-            let subscription = (self.subscription)(state).map(|message| (message, Instant::now()));
-
-            subscription
+            (self.subscription)(state).map(|message| (message, Instant::now()))
         }
     }
 

--- a/src/application/timed.rs
+++ b/src/application/timed.rs
@@ -6,6 +6,7 @@ use crate::time::Instant;
 use crate::window;
 use crate::{Element, Program, Settings, Subscription, Task};
 
+#[cfg(feature = "hot")]
 use iced_debug as debug;
 
 /// Creates an [`Application`] with an `update` function that also
@@ -81,33 +82,59 @@ where
             (state, task.map(|message| (message, Instant::now())))
         }
 
+        #[inline]
         fn update(
             &self,
             state: &mut Self::State,
             (message, now): Self::Message,
         ) -> Task<Self::Message> {
-            debug::hot(move || {
+            #[cfg(feature = "hot")]
+            let task = debug::hot(move || {
                 self.update
                     .update(state, message, now)
                     .into()
                     .map(|message| (message, Instant::now()))
-            })
+            });
+            #[cfg(not(feature = "hot"))]
+            let task = self
+                .update
+                .update(state, message, now)
+                .into()
+                .map(|message| (message, Instant::now()));
+
+            task
         }
 
+        #[inline]
         fn view<'a>(
             &self,
             state: &'a Self::State,
             _window: window::Id,
         ) -> Element<'a, Self::Message, Self::Theme, Self::Renderer> {
-            debug::hot(|| {
+            #[cfg(feature = "hot")]
+            let widget = debug::hot(|| {
                 self.view
                     .view(state)
                     .map(|message| (message, Instant::now()))
-            })
+            });
+            #[cfg(not(feature = "hot"))]
+            let widget = self
+                .view
+                .view(state)
+                .map(|message| (message, Instant::now()));
+
+            widget
         }
 
+        #[inline]
         fn subscription(&self, state: &Self::State) -> self::Subscription<Self::Message> {
-            debug::hot(|| (self.subscription)(state).map(|message| (message, Instant::now())))
+            #[cfg(feature = "hot")]
+            let subscription =
+                debug::hot(|| (self.subscription)(state).map(|message| (message, Instant::now())));
+            #[cfg(not(feature = "hot"))]
+            let subscription = (self.subscription)(state).map(|message| (message, Instant::now()));
+
+            subscription
         }
     }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -7,6 +7,7 @@ use crate::theme;
 use crate::window;
 use crate::{Element, Executor, Font, Preset, Result, Settings, Subscription, Task, Theme};
 
+#[cfg(feature = "hot")]
 use iced_debug as debug;
 
 use std::borrow::Cow;
@@ -185,7 +186,10 @@ impl<P: Program> Daemon<P> {
         title: impl TitleFn<P::State>,
     ) -> Daemon<impl Program<State = P::State, Message = P::Message, Theme = P::Theme>> {
         Daemon {
-            raw: program::with_title(self.raw, move |state, window| title.title(state, window)),
+            raw: WithTitle {
+                program: self.raw,
+                title,
+            },
             settings: self.settings,
             presets: self.presets,
         }
@@ -209,7 +213,10 @@ impl<P: Program> Daemon<P> {
         f: impl ThemeFn<P::State, P::Theme>,
     ) -> Daemon<impl Program<State = P::State, Message = P::Message, Theme = P::Theme>> {
         Daemon {
-            raw: program::with_theme(self.raw, move |state, window| f.theme(state, window)),
+            raw: WithTheme {
+                program: self.raw,
+                theme: f,
+            },
             settings: self.settings,
             presets: self.presets,
         }
@@ -233,7 +240,10 @@ impl<P: Program> Daemon<P> {
         f: impl Fn(&P::State, window::Id) -> f32,
     ) -> Daemon<impl Program<State = P::State, Message = P::Message, Theme = P::Theme>> {
         Daemon {
-            raw: program::with_scale_factor(self.raw, f),
+            raw: WithScaleFactor {
+                program: self.raw,
+                scale_factor: f,
+            },
             settings: self.settings,
             presets: self.presets,
         }
@@ -289,36 +299,92 @@ impl<P: Program> Program for Daemon<P> {
         self.raw.boot()
     }
 
+    #[inline]
     fn update(&self, state: &mut Self::State, message: Self::Message) -> Task<Self::Message> {
-        debug::hot(|| self.raw.update(state, message))
+        #[cfg(feature = "hot")]
+        {
+            debug::hot(|| self.raw.update(state, message))
+        }
+        #[cfg(not(feature = "hot"))]
+        {
+            self.raw.update(state, message)
+        }
     }
 
+    #[inline]
     fn view<'a>(
         &self,
         state: &'a Self::State,
         window: window::Id,
     ) -> Element<'a, Self::Message, Self::Theme, Self::Renderer> {
-        debug::hot(|| self.raw.view(state, window))
+        #[cfg(feature = "hot")]
+        {
+            debug::hot(|| self.raw.view(state, window))
+        }
+        #[cfg(not(feature = "hot"))]
+        {
+            self.raw.view(state, window)
+        }
     }
 
+    #[inline]
     fn title(&self, state: &Self::State, window: window::Id) -> String {
-        debug::hot(|| self.raw.title(state, window))
+        #[cfg(feature = "hot")]
+        {
+            debug::hot(|| self.raw.title(state, window))
+        }
+        #[cfg(not(feature = "hot"))]
+        {
+            self.raw.title(state, window)
+        }
     }
 
+    #[inline]
     fn subscription(&self, state: &Self::State) -> Subscription<Self::Message> {
-        debug::hot(|| self.raw.subscription(state))
+        #[cfg(feature = "hot")]
+        {
+            debug::hot(|| self.raw.subscription(state))
+        }
+        #[cfg(not(feature = "hot"))]
+        {
+            self.raw.subscription(state)
+        }
     }
 
+    #[inline]
     fn theme(&self, state: &Self::State, window: iced_core::window::Id) -> Option<Self::Theme> {
-        debug::hot(|| self.raw.theme(state, window))
+        #[cfg(feature = "hot")]
+        {
+            debug::hot(|| self.raw.theme(state, window))
+        }
+        #[cfg(not(feature = "hot"))]
+        {
+            self.raw.theme(state, window)
+        }
     }
 
+    #[inline]
     fn style(&self, state: &Self::State, theme: &Self::Theme) -> theme::Style {
-        debug::hot(|| self.raw.style(state, theme))
+        #[cfg(feature = "hot")]
+        {
+            debug::hot(|| self.raw.style(state, theme))
+        }
+        #[cfg(not(feature = "hot"))]
+        {
+            self.raw.style(state, theme)
+        }
     }
 
+    #[inline]
     fn scale_factor(&self, state: &Self::State, window: window::Id) -> f32 {
-        debug::hot(|| self.raw.scale_factor(state, window))
+        #[cfg(feature = "hot")]
+        {
+            debug::hot(|| self.raw.scale_factor(state, window))
+        }
+        #[cfg(not(feature = "hot"))]
+        {
+            self.raw.scale_factor(state, window)
+        }
     }
 
     fn presets(&self) -> &[Preset<Self::State, Self::Message>] {
@@ -368,6 +434,7 @@ where
     State: 'static,
     Widget: Into<Element<'a, Message, Theme, Renderer>>,
 {
+    #[inline]
     fn view(&self, state: &'a State, window: window::Id) -> Element<'a, Message, Theme, Renderer> {
         self(state, window).into()
     }
@@ -402,5 +469,233 @@ where
 {
     fn theme(&self, state: &State, window: window::Id) -> Option<Theme> {
         (self)(state, window).into()
+    }
+}
+
+/// Decorates a [`Program`] with a window-aware [`TitleFn`].
+struct WithTitle<P, Title> {
+    program: P,
+    title: Title,
+}
+
+impl<P, Title> Program for WithTitle<P, Title>
+where
+    P: Program,
+    Title: TitleFn<P::State>,
+{
+    type State = P::State;
+    type Message = P::Message;
+    type Theme = P::Theme;
+    type Renderer = P::Renderer;
+    type Executor = P::Executor;
+
+    fn name() -> &'static str {
+        P::name()
+    }
+
+    #[inline]
+    fn settings(&self) -> Settings {
+        self.program.settings()
+    }
+
+    #[inline]
+    fn window(&self) -> Option<window::Settings> {
+        self.program.window()
+    }
+
+    #[inline]
+    fn boot(&self) -> (Self::State, Task<Self::Message>) {
+        self.program.boot()
+    }
+
+    #[inline]
+    fn update(&self, state: &mut Self::State, message: Self::Message) -> Task<Self::Message> {
+        self.program.update(state, message)
+    }
+
+    #[inline]
+    fn view<'a>(
+        &self,
+        state: &'a Self::State,
+        window: window::Id,
+    ) -> Element<'a, Self::Message, Self::Theme, Self::Renderer> {
+        self.program.view(state, window)
+    }
+
+    #[inline]
+    fn title(&self, state: &Self::State, window: window::Id) -> String {
+        self.title.title(state, window)
+    }
+
+    #[inline]
+    fn subscription(&self, state: &Self::State) -> Subscription<Self::Message> {
+        self.program.subscription(state)
+    }
+
+    #[inline]
+    fn theme(&self, state: &Self::State, window: window::Id) -> Option<Self::Theme> {
+        self.program.theme(state, window)
+    }
+
+    #[inline]
+    fn style(&self, state: &Self::State, theme: &Self::Theme) -> theme::Style {
+        self.program.style(state, theme)
+    }
+
+    #[inline]
+    fn scale_factor(&self, state: &Self::State, window: window::Id) -> f32 {
+        self.program.scale_factor(state, window)
+    }
+}
+
+/// Decorates a [`Program`] with a window-aware [`ThemeFn`].
+struct WithTheme<P, Theme> {
+    program: P,
+    theme: Theme,
+}
+
+impl<P, Theme> Program for WithTheme<P, Theme>
+where
+    P: Program,
+    Theme: ThemeFn<P::State, P::Theme>,
+{
+    type State = P::State;
+    type Message = P::Message;
+    type Theme = P::Theme;
+    type Renderer = P::Renderer;
+    type Executor = P::Executor;
+
+    fn name() -> &'static str {
+        P::name()
+    }
+
+    #[inline]
+    fn settings(&self) -> Settings {
+        self.program.settings()
+    }
+
+    #[inline]
+    fn window(&self) -> Option<window::Settings> {
+        self.program.window()
+    }
+
+    #[inline]
+    fn boot(&self) -> (Self::State, Task<Self::Message>) {
+        self.program.boot()
+    }
+
+    #[inline]
+    fn update(&self, state: &mut Self::State, message: Self::Message) -> Task<Self::Message> {
+        self.program.update(state, message)
+    }
+
+    #[inline]
+    fn view<'a>(
+        &self,
+        state: &'a Self::State,
+        window: window::Id,
+    ) -> Element<'a, Self::Message, Self::Theme, Self::Renderer> {
+        self.program.view(state, window)
+    }
+
+    #[inline]
+    fn title(&self, state: &Self::State, window: window::Id) -> String {
+        self.program.title(state, window)
+    }
+
+    #[inline]
+    fn subscription(&self, state: &Self::State) -> Subscription<Self::Message> {
+        self.program.subscription(state)
+    }
+
+    #[inline]
+    fn theme(&self, state: &Self::State, window: window::Id) -> Option<Self::Theme> {
+        self.theme.theme(state, window)
+    }
+
+    #[inline]
+    fn style(&self, state: &Self::State, theme: &Self::Theme) -> theme::Style {
+        self.program.style(state, theme)
+    }
+
+    #[inline]
+    fn scale_factor(&self, state: &Self::State, window: window::Id) -> f32 {
+        self.program.scale_factor(state, window)
+    }
+}
+
+/// Decorates a [`Program`] with a window-aware scale factor function.
+struct WithScaleFactor<P, F> {
+    program: P,
+    scale_factor: F,
+}
+
+impl<P, F> Program for WithScaleFactor<P, F>
+where
+    P: Program,
+    F: Fn(&P::State, window::Id) -> f32,
+{
+    type State = P::State;
+    type Message = P::Message;
+    type Theme = P::Theme;
+    type Renderer = P::Renderer;
+    type Executor = P::Executor;
+
+    fn name() -> &'static str {
+        P::name()
+    }
+
+    #[inline]
+    fn settings(&self) -> Settings {
+        self.program.settings()
+    }
+
+    #[inline]
+    fn window(&self) -> Option<window::Settings> {
+        self.program.window()
+    }
+
+    #[inline]
+    fn boot(&self) -> (Self::State, Task<Self::Message>) {
+        self.program.boot()
+    }
+
+    #[inline]
+    fn update(&self, state: &mut Self::State, message: Self::Message) -> Task<Self::Message> {
+        self.program.update(state, message)
+    }
+
+    #[inline]
+    fn view<'a>(
+        &self,
+        state: &'a Self::State,
+        window: window::Id,
+    ) -> Element<'a, Self::Message, Self::Theme, Self::Renderer> {
+        self.program.view(state, window)
+    }
+
+    #[inline]
+    fn title(&self, state: &Self::State, window: window::Id) -> String {
+        self.program.title(state, window)
+    }
+
+    #[inline]
+    fn subscription(&self, state: &Self::State) -> Subscription<Self::Message> {
+        self.program.subscription(state)
+    }
+
+    #[inline]
+    fn theme(&self, state: &Self::State, window: window::Id) -> Option<Self::Theme> {
+        self.program.theme(state, window)
+    }
+
+    #[inline]
+    fn style(&self, state: &Self::State, theme: &Self::Theme) -> theme::Style {
+        self.program.style(state, theme)
+    }
+
+    #[inline]
+    fn scale_factor(&self, state: &Self::State, window: window::Id) -> f32 {
+        (self.scale_factor)(state, window)
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -8,7 +8,7 @@ use crate::window;
 use crate::{Element, Executor, Font, Preset, Result, Settings, Subscription, Task, Theme};
 
 #[cfg(feature = "hot")]
-use iced_debug as debug;
+use crate::hot::Hot;
 
 use std::borrow::Cow;
 
@@ -143,6 +143,9 @@ impl<P: Program> Daemon<P> {
 
         #[cfg(not(any(feature = "tester", feature = "debug")))]
         let program = self;
+
+        #[cfg(feature = "hot")]
+        let program = Hot::new(program);
 
         Ok(shell::run(program)?)
     }
@@ -301,14 +304,7 @@ impl<P: Program> Program for Daemon<P> {
 
     #[inline]
     fn update(&self, state: &mut Self::State, message: Self::Message) -> Task<Self::Message> {
-        #[cfg(feature = "hot")]
-        {
-            debug::hot(|| self.raw.update(state, message))
-        }
-        #[cfg(not(feature = "hot"))]
-        {
-            self.raw.update(state, message)
-        }
+        self.raw.update(state, message)
     }
 
     #[inline]
@@ -317,74 +313,32 @@ impl<P: Program> Program for Daemon<P> {
         state: &'a Self::State,
         window: window::Id,
     ) -> Element<'a, Self::Message, Self::Theme, Self::Renderer> {
-        #[cfg(feature = "hot")]
-        {
-            debug::hot(|| self.raw.view(state, window))
-        }
-        #[cfg(not(feature = "hot"))]
-        {
-            self.raw.view(state, window)
-        }
+        self.raw.view(state, window)
     }
 
     #[inline]
     fn title(&self, state: &Self::State, window: window::Id) -> String {
-        #[cfg(feature = "hot")]
-        {
-            debug::hot(|| self.raw.title(state, window))
-        }
-        #[cfg(not(feature = "hot"))]
-        {
-            self.raw.title(state, window)
-        }
+        self.raw.title(state, window)
     }
 
     #[inline]
     fn subscription(&self, state: &Self::State) -> Subscription<Self::Message> {
-        #[cfg(feature = "hot")]
-        {
-            debug::hot(|| self.raw.subscription(state))
-        }
-        #[cfg(not(feature = "hot"))]
-        {
-            self.raw.subscription(state)
-        }
+        self.raw.subscription(state)
     }
 
     #[inline]
     fn theme(&self, state: &Self::State, window: iced_core::window::Id) -> Option<Self::Theme> {
-        #[cfg(feature = "hot")]
-        {
-            debug::hot(|| self.raw.theme(state, window))
-        }
-        #[cfg(not(feature = "hot"))]
-        {
-            self.raw.theme(state, window)
-        }
+        self.raw.theme(state, window)
     }
 
     #[inline]
     fn style(&self, state: &Self::State, theme: &Self::Theme) -> theme::Style {
-        #[cfg(feature = "hot")]
-        {
-            debug::hot(|| self.raw.style(state, theme))
-        }
-        #[cfg(not(feature = "hot"))]
-        {
-            self.raw.style(state, theme)
-        }
+        self.raw.style(state, theme)
     }
 
     #[inline]
     fn scale_factor(&self, state: &Self::State, window: window::Id) -> f32 {
-        #[cfg(feature = "hot")]
-        {
-            debug::hot(|| self.raw.scale_factor(state, window))
-        }
-        #[cfg(not(feature = "hot"))]
-        {
-            self.raw.scale_factor(state, window)
-        }
+        self.raw.scale_factor(state, window)
     }
 
     fn presets(&self) -> &[Preset<Self::State, Self::Message>] {

--- a/src/hot.rs
+++ b/src/hot.rs
@@ -1,0 +1,96 @@
+//! Decorates a [`Program`] with hot reloading support.
+//!
+//! This module is only available when the `hot` feature is enabled.
+use crate::program::Program;
+use crate::theme;
+use crate::window;
+use crate::{Element, Preset, Settings, Subscription, Task};
+
+use iced_debug as debug;
+
+/// A [`Program`] decorator that makes the inner program hot-reloadable.
+///
+/// All the logic of the program is wrapped in [`iced_debug::hot`],
+/// so that it can be hot-patched while the program is running.
+pub struct Hot<P: Program> {
+    program: P,
+}
+
+impl<P: Program> Hot<P> {
+    /// Wraps the given [`Program`] with hot reloading support.
+    pub fn new(program: P) -> Self {
+        Self { program }
+    }
+}
+
+impl<P: Program> Program for Hot<P> {
+    type State = P::State;
+    type Message = P::Message;
+    type Theme = P::Theme;
+    type Renderer = P::Renderer;
+    type Executor = P::Executor;
+
+    #[inline]
+    fn name() -> &'static str {
+        P::name()
+    }
+
+    #[inline]
+    fn settings(&self) -> Settings {
+        self.program.settings()
+    }
+
+    #[inline]
+    fn window(&self) -> Option<window::Settings> {
+        self.program.window()
+    }
+
+    #[inline]
+    fn boot(&self) -> (Self::State, Task<Self::Message>) {
+        self.program.boot()
+    }
+
+    #[inline]
+    fn update(&self, state: &mut Self::State, message: Self::Message) -> Task<Self::Message> {
+        debug::hot(|| self.program.update(state, message))
+    }
+
+    #[inline]
+    fn view<'a>(
+        &self,
+        state: &'a Self::State,
+        window: window::Id,
+    ) -> Element<'a, Self::Message, Self::Theme, Self::Renderer> {
+        debug::hot(|| self.program.view(state, window))
+    }
+
+    #[inline]
+    fn title(&self, state: &Self::State, window: window::Id) -> String {
+        debug::hot(|| self.program.title(state, window))
+    }
+
+    #[inline]
+    fn subscription(&self, state: &Self::State) -> Subscription<Self::Message> {
+        debug::hot(|| self.program.subscription(state))
+    }
+
+    #[inline]
+    fn theme(&self, state: &Self::State, window: window::Id) -> Option<Self::Theme> {
+        debug::hot(|| self.program.theme(state, window))
+    }
+
+    #[inline]
+    fn style(&self, state: &Self::State, theme: &Self::Theme) -> theme::Style {
+        debug::hot(|| self.program.style(state, theme))
+    }
+
+    #[inline]
+    fn scale_factor(&self, state: &Self::State, window: window::Id) -> f32 {
+        debug::hot(|| self.program.scale_factor(state, window))
+    }
+
+    #[inline]
+    fn presets(&self) -> &[Preset<Self::State, Self::Message>] {
+        self.program.presets()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -513,6 +513,9 @@ pub use iced_renderer::wgpu::wgpu;
 
 mod error;
 
+#[cfg(feature = "hot")]
+mod hot;
+
 pub mod application;
 pub mod daemon;
 pub mod time;

--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -129,7 +129,7 @@ where
     let (control_sender, control_receiver) = mpsc::unbounded();
     let (system_theme_sender, system_theme_receiver) = oneshot::channel();
 
-    let instance = Box::pin(run_instance::<P>(
+    let instance: std::pin::Pin<Box<dyn Future<Output = ()>>> = Box::pin(run_instance::<P>(
         program,
         runtime,
         proxy.clone(),
@@ -145,8 +145,8 @@ where
 
     let context = task::Context::from_waker(task::noop_waker_ref());
 
-    struct Runner<Message: 'static, F> {
-        instance: std::pin::Pin<Box<F>>,
+    struct Runner<Message: 'static> {
+        instance: std::pin::Pin<Box<dyn Future<Output = ()>>>,
         context: task::Context<'static>,
         id: Option<String>,
         sender: mpsc::UnboundedSender<Event<Action<Message>>>,
@@ -173,10 +173,7 @@ where
 
     boot_span.finish();
 
-    impl<Message, F> winit::application::ApplicationHandler<Action<Message>> for Runner<Message, F>
-    where
-        F: Future<Output = ()>,
-    {
+    impl<Message> winit::application::ApplicationHandler<Action<Message>> for Runner<Message> {
         fn resumed(&mut self, event_loop: &winit::event_loop::ActiveEventLoop) {
             if let Some(sender) = self.system_theme.take() {
                 let _ = sender.send(
@@ -259,10 +256,7 @@ where
         }
     }
 
-    impl<Message, F> Runner<Message, F>
-    where
-        F: Future<Output = ()>,
-    {
+    impl<Message> Runner<Message> {
         fn process_event(
             &mut self,
             event_loop: &winit::event_loop::ActiveEventLoop,


### PR DESCRIPTION
This PR removes generics that captured the `Program` type from a bunch of places to reduce the overall size of debug symbols.

Effectively, this makes stack and profiler traces more readable; and may also reduce binary size as well.