### PR TITLE
Add `line_height` to `Settings`

### DIFF
--- a/core/src/renderer.rs
+++ b/core/src/renderer.rs
@@ -3,7 +3,7 @@
 mod null;
 
 use crate::image;
-use crate::text::LineHeight;
+use crate::text;
 use crate::{
     Background, Border, Color, Font, Pixels, Rectangle, Shadow, Size, Transformation, Vector,
 };
@@ -176,7 +176,7 @@ pub struct Settings {
     /// The default line height of text.
     ///
     /// By default, it will be set to `LineHeight::Relative(1.375)`.
-    pub line_height: LineHeight,
+    pub line_height: text::LineHeight,
 
     /// Whether the [`Renderer`] should perform metrics hinting.
     ///
@@ -189,7 +189,7 @@ impl Default for Settings {
         Self {
             font: Font::DEFAULT,
             text_size: Pixels(16.0),
-            line_height: LineHeight::default(),
+            line_height: text::LineHeight::default(),
             metrics_hinting: true,
         }
     }

--- a/core/src/renderer.rs
+++ b/core/src/renderer.rs
@@ -3,6 +3,7 @@
 mod null;
 
 use crate::image;
+use crate::text::LineHeight;
 use crate::{
     Background, Border, Color, Font, Pixels, Rectangle, Shadow, Size, Transformation, Vector,
 };
@@ -172,6 +173,11 @@ pub struct Settings {
     /// By default, it will be set to `16.0`.
     pub text_size: Pixels,
 
+    /// The default line height of text.
+    ///
+    /// By default, it will be set to `LineHeight::Relative(1.375)`.
+    pub line_height: LineHeight,
+
     /// Whether the [`Renderer`] should perform metrics hinting.
     ///
     /// By default, it is enabled.
@@ -183,6 +189,7 @@ impl Default for Settings {
         Self {
             font: Font::DEFAULT,
             text_size: Pixels(16.0),
+            line_height: LineHeight::default(),
             metrics_hinting: true,
         }
     }

--- a/core/src/settings.rs
+++ b/core/src/settings.rs
@@ -1,7 +1,7 @@
 //! Configure your application.
 use crate::backend;
 use crate::renderer;
-use crate::text::LineHeight;
+use crate::text;
 use crate::{Backend, Font, Pixels};
 
 use std::borrow::Cow;
@@ -31,7 +31,7 @@ pub struct Settings {
     /// The default line height of text.
     ///
     /// By default, it is `LineHeight::Relative(1.375)`.
-    pub line_height: LineHeight,
+    pub line_height: text::LineHeight,
 
     /// Whether certain widgets should be rendered using metrics hinting.
     ///

--- a/core/src/settings.rs
+++ b/core/src/settings.rs
@@ -1,6 +1,7 @@
 //! Configure your application.
 use crate::backend;
 use crate::renderer;
+use crate::text::LineHeight;
 use crate::{Backend, Font, Pixels};
 
 use std::borrow::Cow;
@@ -26,6 +27,11 @@ pub struct Settings {
     ///
     /// By default, it is `16.0`.
     pub text_size: Pixels,
+
+    /// The default line height of text.
+    ///
+    /// By default, it is `LineHeight::Relative(1.375)`.
+    pub line_height: LineHeight,
 
     /// Whether certain widgets should be rendered using metrics hinting.
     ///
@@ -71,6 +77,7 @@ impl Default for Settings {
             fonts: Vec::new(),
             font: renderer.font,
             text_size: renderer.text_size,
+            line_height: renderer.line_height,
             metrics_hinting: true,
             backend: Backend::default(),
             power_preference: backend::PowerPreference::None,
@@ -85,6 +92,7 @@ impl From<&Settings> for renderer::Settings {
         Self {
             font: settings.font,
             text_size: settings.text_size,
+            line_height: settings.line_height,
             metrics_hinting: settings.metrics_hinting,
         }
     }

--- a/core/src/text.rs
+++ b/core/src/text.rs
@@ -371,6 +371,11 @@ pub trait Renderer: crate::Renderer {
         self.settings().text_size
     }
 
+    /// Returns the default line height of [`Text`].
+    fn line_height(&self) -> LineHeight {
+        self.settings().line_height
+    }
+
     /// Draws the given [`Paragraph`] at the given position and with the given
     /// [`Color`].
     fn fill_paragraph(

--- a/core/src/text/input.rs
+++ b/core/src/text/input.rs
@@ -31,7 +31,7 @@ pub struct Layout<'a> {
     pub placeholder: &'a str,
     pub font: Option<Font>,
     pub size: Option<Pixels>,
-    pub line_height: LineHeight,
+    pub line_height: Option<LineHeight>,
     pub alignment: Alignment,
     pub multiline: Option<Wrapping>,
     pub is_secure: bool,
@@ -86,6 +86,7 @@ impl<R: text::Renderer> Input<R> {
 
         let font = layout.font.unwrap_or_else(|| renderer.font());
         let size = layout.size.unwrap_or_else(|| renderer.text_size());
+        let line_height = layout.line_height.unwrap_or_else(|| renderer.line_height());
         let hint_factor = renderer.hint_factor();
 
         if layout.is_secure {
@@ -105,7 +106,7 @@ impl<R: text::Renderer> Input<R> {
             limits.max(),
             font,
             size,
-            layout.line_height,
+            line_height,
             layout.multiline.unwrap_or(text::Wrapping::None),
             layout.alignment,
             hint_factor,
@@ -126,7 +127,7 @@ impl<R: text::Renderer> Input<R> {
         let _ = self.placeholder.update(Text {
             content: layout.placeholder,
             font,
-            line_height: layout.line_height,
+            line_height,
             bounds,
             size,
             align_x: layout.alignment,

--- a/core/src/widget/text.rs
+++ b/core/src/widget/text.rs
@@ -84,7 +84,7 @@ where
 
     /// Sets the [`LineHeight`] of the [`Text`].
     pub fn line_height(mut self, line_height: impl Into<LineHeight>) -> Self {
-        self.format.line_height = line_height.into();
+        self.format.line_height = Some(line_height.into());
         self
     }
 
@@ -266,7 +266,7 @@ pub struct Format {
     pub height: Length,
     pub size: Option<Pixels>,
     pub font: Option<Font>,
-    pub line_height: LineHeight,
+    pub line_height: Option<LineHeight>,
     pub align_x: text::Alignment,
     pub align_y: alignment::Vertical,
     pub shaping: Shaping,
@@ -278,7 +278,7 @@ impl Default for Format {
     fn default() -> Self {
         Self {
             size: None,
-            line_height: LineHeight::default(),
+            line_height: None,
             font: None,
             width: Length::Shrink,
             height: Length::Shrink,
@@ -307,12 +307,13 @@ where
 
         let size = format.size.unwrap_or_else(|| renderer.text_size());
         let font = format.font.unwrap_or_else(|| renderer.font());
+        let line_height = format.line_height.unwrap_or_else(|| renderer.line_height());
 
         let _ = paragraph.update(text::Text {
             content,
             bounds,
             size,
-            line_height: format.line_height,
+            line_height,
             font,
             align_x: format.align_x,
             align_y: format.align_y,

--- a/examples/checkbox/src/main.rs
+++ b/examples/checkbox/src/main.rs
@@ -64,7 +64,7 @@ impl Example {
                 font: ICON_FONT,
                 code_point: '\u{e901}',
                 size: None,
-                line_height: text::LineHeight::Relative(1.0),
+                line_height: Some(text::LineHeight::Relative(1.0)),
                 shaping: text::Shaping::Basic,
             });
 

--- a/src/application.rs
+++ b/src/application.rs
@@ -31,6 +31,7 @@
 //! }
 //! ```
 use crate::backend;
+use crate::core::text::LineHeight;
 use crate::message;
 use crate::program::{self, Program};
 use crate::shell;
@@ -232,6 +233,17 @@ impl<P: Program> Application<P> {
         Self {
             settings: Settings {
                 font: default_font,
+                ..self.settings
+            },
+            ..self
+        }
+    }
+
+    /// Sets the default [`LineHeight`] of the [`Application`].
+    pub fn line_height(self, default_line_height: LineHeight) -> Self {
+        Self {
+            settings: Settings {
+                line_height: default_line_height,
                 ..self.settings
             },
             ..self

--- a/src/application.rs
+++ b/src/application.rs
@@ -31,11 +31,11 @@
 //! }
 //! ```
 use crate::backend;
-use crate::core::text::LineHeight;
 use crate::message;
 use crate::program::{self, Program};
 use crate::shell;
 use crate::theme;
+use crate::widget::text;
 use crate::window;
 use crate::{
     Backend, Element, Executor, Font, Never, Preset, Result, Settings, Size, Subscription, Task,
@@ -229,21 +229,21 @@ impl<P: Program> Application<P> {
     }
 
     /// Sets the default [`Font`] of the [`Application`].
-    pub fn font(self, default_font: Font) -> Self {
+    pub fn font(self, font: Font) -> Self {
         Self {
             settings: Settings {
-                font: default_font,
+                font,
                 ..self.settings
             },
             ..self
         }
     }
 
-    /// Sets the default [`LineHeight`] of the [`Application`].
-    pub fn line_height(self, default_line_height: LineHeight) -> Self {
+    /// Sets the default [`text::LineHeight`] of the [`Application`].
+    pub fn line_height(self, line_height: text::LineHeight) -> Self {
         Self {
             settings: Settings {
-                line_height: default_line_height,
+                line_height,
                 ..self.settings
             },
             ..self

--- a/test/src/simulator.rs
+++ b/test/src/simulator.rs
@@ -69,6 +69,7 @@ where
                 core::renderer::Settings {
                     font: settings.font,
                     text_size: settings.text_size,
+                    line_height: settings.line_height,
                     metrics_hinting: settings.metrics_hinting,
                 },
                 backend.as_deref(),

--- a/widget/src/checkbox.rs
+++ b/widget/src/checkbox.rs
@@ -93,7 +93,7 @@ where
     size: f32,
     spacing: f32,
     text_size: Option<Pixels>,
-    line_height: text::LineHeight,
+    line_height: Option<text::LineHeight>,
     shaping: text::Shaping,
     wrapping: text::Wrapping,
     font: Option<Font>,
@@ -124,7 +124,7 @@ where
             size: Self::DEFAULT_SIZE,
             spacing: Self::DEFAULT_SIZE / 2.0,
             text_size: None,
-            line_height: text::LineHeight::default(),
+            line_height: None,
             shaping: text::Shaping::default(),
             wrapping: text::Wrapping::default(),
             font: None,
@@ -132,7 +132,7 @@ where
                 font: Renderer::ICON_FONT,
                 code_point: Renderer::CHECKMARK_ICON,
                 size: None,
-                line_height: text::LineHeight::default(),
+                line_height: None,
                 shaping: text::Shaping::Basic,
             },
             class: Theme::default(),
@@ -198,7 +198,7 @@ where
 
     /// Sets the text [`text::LineHeight`] of the [`Checkbox`].
     pub fn line_height(mut self, line_height: impl Into<text::LineHeight>) -> Self {
-        self.line_height = line_height.into();
+        self.line_height = Some(line_height.into());
         self
     }
 
@@ -415,6 +415,7 @@ where
                 shaping,
             } = &self.icon;
             let size = size.unwrap_or(Pixels(bounds.height * 0.7));
+            let line_height = line_height.unwrap_or_else(|| renderer.line_height());
 
             if self.is_checked {
                 renderer.fill_text(
@@ -422,7 +423,7 @@ where
                         content: code_point.to_string(),
                         font: *font,
                         size,
-                        line_height: *line_height,
+                        line_height,
                         bounds: bounds.size(),
                         align_x: text::Alignment::Center,
                         align_y: alignment::Vertical::Center,
@@ -496,7 +497,7 @@ pub struct Icon {
     /// Font size of the content.
     pub size: Option<Pixels>,
     /// The line height of the icon.
-    pub line_height: text::LineHeight,
+    pub line_height: Option<text::LineHeight>,
     /// The shaping strategy of the icon.
     pub shaping: text::Shaping,
 }

--- a/widget/src/combo_box.rs
+++ b/widget/src/combo_box.rs
@@ -435,7 +435,7 @@ where
                 placeholder: &self.placeholder,
                 font: self.font,
                 size: self.size,
-                line_height: self.line_height.unwrap_or_else(|| renderer.line_height()),
+                line_height: self.line_height,
                 alignment: text::Alignment::Default,
                 multiline: None,
                 is_secure: false,

--- a/widget/src/combo_box.rs
+++ b/widget/src/combo_box.rs
@@ -141,7 +141,7 @@ where
     placeholder: text::Fragment<'a>,
     selection: String,
     width: Length,
-    line_height: LineHeight,
+    line_height: Option<LineHeight>,
     font: Option<Font>,
     on_selected: Box<dyn Fn(T) -> Message + 'a>,
     on_option_hovered: Option<Box<dyn Fn(T) -> Message + 'a>>,
@@ -178,7 +178,7 @@ where
             placeholder: placeholder.into_fragment(),
             selection: selection.map(T::to_string).unwrap_or_default(),
             width: Length::Fill,
-            line_height: LineHeight::default(),
+            line_height: None,
             font: None,
             on_selected: Box::new(on_selected),
             on_option_hovered: None,
@@ -258,7 +258,7 @@ where
 
     /// Sets the [`LineHeight`] of the [`ComboBox`].
     pub fn line_height(mut self, line_height: impl Into<LineHeight>) -> Self {
-        self.line_height = line_height.into();
+        self.line_height = Some(line_height.into());
         self
     }
 
@@ -435,7 +435,7 @@ where
                 placeholder: &self.placeholder,
                 font: self.font,
                 size: self.size,
-                line_height: self.line_height,
+                line_height: self.line_height.unwrap_or_else(|| renderer.line_height()),
                 alignment: text::Alignment::Default,
                 multiline: None,
                 is_secure: false,

--- a/widget/src/overlay/menu.rs
+++ b/widget/src/overlay/menu.rs
@@ -31,7 +31,7 @@ where
     width: f32,
     padding: Padding,
     text_size: Option<Pixels>,
-    line_height: text::LineHeight,
+    line_height: Option<text::LineHeight>,
     shaping: text::Shaping,
     ellipsis: text::Ellipsis,
     font: Option<Font>,
@@ -66,7 +66,7 @@ where
             width: 0.0,
             padding: Padding::ZERO,
             text_size: None,
-            line_height: text::LineHeight::default(),
+            line_height: None,
             shaping: text::Shaping::default(),
             ellipsis: text::Ellipsis::default(),
             font: None,
@@ -94,7 +94,7 @@ where
 
     /// Sets the text [`text::LineHeight`] of the [`Menu`].
     pub fn line_height(mut self, line_height: impl Into<text::LineHeight>) -> Self {
-        self.line_height = line_height.into();
+        self.line_height = Some(line_height.into());
         self
     }
 
@@ -338,7 +338,7 @@ where
     on_option_hovered: Option<&'a dyn Fn(T) -> Message>,
     padding: Padding,
     text_size: Option<Pixels>,
-    line_height: text::LineHeight,
+    line_height: Option<text::LineHeight>,
     shaping: text::Shaping,
     ellipsis: text::Ellipsis,
     font: Option<Font>,
@@ -380,8 +380,9 @@ where
         use std::f32;
 
         let text_size = self.text_size.unwrap_or_else(|| renderer.text_size());
+        let line_height = self.line_height.unwrap_or_else(|| renderer.line_height());
 
-        let text_line_height = self.line_height.to_absolute(text_size);
+        let text_line_height = line_height.to_absolute(text_size);
 
         let size = {
             let intrinsic = Size::new(
@@ -422,9 +423,10 @@ where
             Event::Mouse(mouse::Event::CursorMoved { .. }) => {
                 if let Some(cursor_position) = cursor.position_in(layout.bounds()) {
                     let text_size = self.text_size.unwrap_or_else(|| renderer.text_size());
+                    let line_height = self.line_height.unwrap_or_else(|| renderer.line_height());
 
                     let option_height =
-                        f32::from(self.line_height.to_absolute(text_size)) + self.padding.y();
+                        f32::from(line_height.to_absolute(text_size)) + self.padding.y();
 
                     let new_hovered_option = (cursor_position.y / option_height) as usize;
 
@@ -444,9 +446,10 @@ where
             Event::Touch(touch::Event::FingerPressed { .. }) => {
                 if let Some(cursor_position) = cursor.position_in(layout.bounds()) {
                     let text_size = self.text_size.unwrap_or_else(|| renderer.text_size());
+                    let line_height = self.line_height.unwrap_or_else(|| renderer.line_height());
 
                     let option_height =
-                        f32::from(self.line_height.to_absolute(text_size)) + self.padding.y();
+                        f32::from(line_height.to_absolute(text_size)) + self.padding.y();
 
                     *self.hovered_option = Some((cursor_position.y / option_height) as usize);
 
@@ -504,7 +507,8 @@ where
         let bounds = layout.bounds();
 
         let text_size = self.text_size.unwrap_or_else(|| renderer.text_size());
-        let option_height = f32::from(self.line_height.to_absolute(text_size)) + self.padding.y();
+        let line_height = self.line_height.unwrap_or_else(|| renderer.line_height());
+        let option_height = f32::from(line_height.to_absolute(text_size)) + self.padding.y();
 
         let offset = viewport.y - bounds.y;
         let start = (offset / option_height) as usize;
@@ -546,7 +550,7 @@ where
                     content: (self.to_string)(option),
                     bounds: Size::new(bounds.width - self.padding.x(), bounds.height),
                     size: text_size,
-                    line_height: self.line_height,
+                    line_height,
                     font: self.font.unwrap_or_else(|| renderer.font()),
                     align_x: text::Alignment::Default,
                     align_y: alignment::Vertical::Center,

--- a/widget/src/pick_list.rs
+++ b/widget/src/pick_list.rs
@@ -161,7 +161,7 @@ where
     width: Length,
     padding: Padding,
     text_size: Option<Pixels>,
-    line_height: text::LineHeight,
+    line_height: Option<text::LineHeight>,
     shaping: text::Shaping,
     ellipsis: text::Ellipsis,
     font: Option<Font>,
@@ -194,7 +194,7 @@ where
             width: Length::Shrink,
             padding: crate::button::DEFAULT_PADDING,
             text_size: None,
-            line_height: text::LineHeight::default(),
+            line_height: None,
             shaping: text::Shaping::default(),
             ellipsis: text::Ellipsis::End,
             font: None,
@@ -238,7 +238,7 @@ where
 
     /// Sets the text [`text::LineHeight`] of the [`PickList`].
     pub fn line_height(mut self, line_height: impl Into<text::LineHeight>) -> Self {
-        self.line_height = line_height.into();
+        self.line_height = Some(line_height.into());
         self
     }
 
@@ -356,16 +356,17 @@ where
 
         let font = self.font.unwrap_or_else(|| renderer.font());
         let text_size = self.text_size.unwrap_or_else(|| renderer.text_size());
+        let line_height = self.line_height.unwrap_or_else(|| renderer.line_height());
         let options = self.options.borrow();
 
         let option_text = Text {
             content: "",
             bounds: Size::new(
                 limits.max().width,
-                self.line_height.to_absolute(text_size).into(),
+                line_height.to_absolute(text_size).into(),
             ),
             size: text_size,
-            line_height: self.line_height,
+            line_height,
             font,
             align_x: text::Alignment::Default,
             align_y: alignment::Vertical::Center,
@@ -412,7 +413,7 @@ where
         let size = {
             let intrinsic = Size::new(
                 max_width + text_size.0 + self.padding.left,
-                f32::from(self.line_height.to_absolute(text_size)),
+                f32::from(line_height.to_absolute(text_size)),
             );
 
             limits
@@ -601,7 +602,7 @@ where
                 Renderer::ICON_FONT,
                 Renderer::ARROW_DOWN_ICON,
                 *size,
-                text::LineHeight::default(),
+                None,
                 text::Shaping::Basic,
             )),
             Handle::Static(Icon {
@@ -635,6 +636,7 @@ where
 
         if let Some((font, code_point, size, line_height, shaping)) = handle {
             let size = size.unwrap_or_else(|| renderer.text_size());
+            let line_height = line_height.unwrap_or_else(|| renderer.line_height());
 
             renderer.fill_text(
                 Text {
@@ -663,16 +665,17 @@ where
 
         if let Some(label) = label.or_else(|| self.placeholder.clone()) {
             let text_size = self.text_size.unwrap_or_else(|| renderer.text_size());
+            let line_height = self.line_height.unwrap_or_else(|| renderer.line_height());
 
             renderer.fill_text(
                 Text {
                     content: label,
                     size: text_size,
-                    line_height: self.line_height,
+                    line_height,
                     font,
                     bounds: Size::new(
                         bounds.width - self.padding.x(),
-                        f32::from(self.line_height.to_absolute(text_size)),
+                        f32::from(line_height.to_absolute(text_size)),
                     ),
                     align_x: text::Alignment::Default,
                     align_y: alignment::Vertical::Center,
@@ -829,7 +832,7 @@ pub struct Icon {
     /// Font size of the content.
     pub size: Option<Pixels>,
     /// Line height of the content.
-    pub line_height: text::LineHeight,
+    pub line_height: Option<text::LineHeight>,
     /// The shaping strategy of the icon.
     pub shaping: text::Shaping,
 }

--- a/widget/src/radio.rs
+++ b/widget/src/radio.rs
@@ -140,7 +140,7 @@ where
     size: f32,
     spacing: f32,
     text_size: Option<Pixels>,
-    line_height: text::LineHeight,
+    line_height: Option<text::LineHeight>,
     shaping: text::Shaping,
     wrapping: text::Wrapping,
     font: Option<Font>,
@@ -180,7 +180,7 @@ where
             size: Self::DEFAULT_SIZE,
             spacing: Self::DEFAULT_SPACING,
             text_size: None,
-            line_height: text::LineHeight::default(),
+            line_height: None,
             shaping: text::Shaping::default(),
             wrapping: text::Wrapping::default(),
             font: None,
@@ -215,7 +215,7 @@ where
 
     /// Sets the text [`text::LineHeight`] of the [`Radio`] button.
     pub fn line_height(mut self, line_height: impl Into<text::LineHeight>) -> Self {
-        self.line_height = line_height.into();
+        self.line_height = Some(line_height.into());
         self
     }
 

--- a/widget/src/text/rich.rs
+++ b/widget/src/text/rich.rs
@@ -21,7 +21,7 @@ where
 {
     spans: Box<dyn AsRef<[Span<'a, Link>]> + 'a>,
     size: Option<Pixels>,
-    line_height: LineHeight,
+    line_height: Option<LineHeight>,
     width: Length,
     height: Length,
     font: Option<Font>,
@@ -44,7 +44,7 @@ where
         Self {
             spans: Box::new([]),
             size: None,
-            line_height: LineHeight::default(),
+            line_height: None,
             width: Length::Shrink,
             height: Length::Shrink,
             font: None,
@@ -74,7 +74,7 @@ where
 
     /// Sets the default [`LineHeight`] of the [`Rich`] text.
     pub fn line_height(mut self, line_height: impl Into<LineHeight>) -> Self {
-        self.line_height = line_height.into();
+        self.line_height = Some(line_height.into());
         self
     }
 
@@ -317,7 +317,8 @@ where
 
                     let line_height = span
                         .line_height
-                        .unwrap_or(self.line_height)
+                        .or(self.line_height)
+                        .unwrap_or_else(|| renderer.line_height())
                         .to_absolute(size);
 
                     let color = span.color.or(style.color).unwrap_or(defaults.text_color);
@@ -466,7 +467,7 @@ fn layout<Link, Renderer>(
     width: Length,
     height: Length,
     spans: &[Span<'_, Link>],
-    line_height: LineHeight,
+    line_height: Option<LineHeight>,
     size: Option<Pixels>,
     font: Option<Font>,
     align_x: Alignment,
@@ -483,6 +484,7 @@ where
 
         let size = size.unwrap_or_else(|| renderer.text_size());
         let font = font.unwrap_or_else(|| renderer.font());
+        let line_height = line_height.unwrap_or_else(|| renderer.line_height());
 
         let text_with_spans = || core::Text {
             content: spans,

--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -103,7 +103,7 @@ where
     placeholder: Option<text::Fragment<'a>>,
     font: Option<Font>,
     text_size: Option<Pixels>,
-    line_height: LineHeight,
+    line_height: Option<LineHeight>,
     width: Length,
     height: Length,
     padding: Padding,
@@ -129,7 +129,7 @@ where
             placeholder: None,
             font: None,
             text_size: None,
-            line_height: LineHeight::default(),
+            line_height: None,
             width: Length::Fill,
             height: Length::Fit,
             padding: Padding::new(5.0),
@@ -241,7 +241,7 @@ where
 
     /// Sets the [`text::LineHeight`] of the [`TextEditor`].
     pub fn line_height(mut self, line_height: impl Into<text::LineHeight>) -> Self {
-        self.line_height = line_height.into();
+        self.line_height = Some(line_height.into());
         self
     }
 
@@ -369,7 +369,7 @@ where
             limits.shrink(self.padding).max(),
             self.font.unwrap_or_else(|| renderer.font()),
             self.text_size.unwrap_or_else(|| renderer.text_size()),
-            self.line_height,
+            self.line_height.unwrap_or_else(|| renderer.line_height()),
             self.wrapping,
             text::Alignment::Default,
             renderer.hint_factor(),
@@ -556,7 +556,7 @@ where
                     content: placeholder.clone().into_owned(),
                     bounds: text_bounds.size(),
                     size: self.text_size.unwrap_or_else(|| renderer.text_size()),
-                    line_height: self.line_height,
+                    line_height: self.line_height.unwrap_or_else(|| renderer.line_height()),
                     font,
                     align_x: text::Alignment::Default,
                     align_y: alignment::Vertical::Top,

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -92,7 +92,7 @@ where
     height: Length,
     padding: Padding,
     size: Option<Pixels>,
-    line_height: text::LineHeight,
+    line_height: Option<text::LineHeight>,
     alignment: text::Alignment,
     multiline: Option<text::Wrapping>,
     on_input: Option<Box<dyn Fn(String) -> Message + 'a>>,
@@ -126,7 +126,7 @@ where
             height: Length::Fit,
             padding: DEFAULT_PADDING,
             size: None,
-            line_height: text::LineHeight::default(),
+            line_height: None,
             alignment: text::Alignment::Default,
             multiline: None,
             on_input: None,
@@ -223,7 +223,7 @@ where
 
     /// Sets the [`text::LineHeight`] of the [`TextInput`].
     pub fn line_height(mut self, line_height: impl Into<text::LineHeight>) -> Self {
-        self.line_height = line_height.into();
+        self.line_height = Some(line_height.into());
         self
     }
 
@@ -308,7 +308,7 @@ where
                 placeholder: self.placeholder.as_ref(),
                 font: self.font,
                 size: self.size,
-                line_height: self.line_height,
+                line_height: self.line_height.unwrap_or_else(|| renderer.line_height()),
                 alignment: self.alignment,
                 multiline: self.multiline,
                 is_secure: self.is_secure,

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -308,7 +308,7 @@ where
                 placeholder: self.placeholder.as_ref(),
                 font: self.font,
                 size: self.size,
-                line_height: self.line_height.unwrap_or_else(|| renderer.line_height()),
+                line_height: self.line_height,
                 alignment: self.alignment,
                 multiline: self.multiline,
                 is_secure: self.is_secure,

--- a/widget/src/toggler.rs
+++ b/widget/src/toggler.rs
@@ -87,7 +87,7 @@ where
     width: Length,
     size: f32,
     text_size: Option<Pixels>,
-    line_height: text::LineHeight,
+    line_height: Option<text::LineHeight>,
     alignment: text::Alignment,
     text_shaping: text::Shaping,
     wrapping: text::Wrapping,
@@ -120,7 +120,7 @@ where
             width: Length::Shrink,
             size: Self::DEFAULT_SIZE,
             text_size: None,
-            line_height: text::LineHeight::default(),
+            line_height: None,
             alignment: text::Alignment::Default,
             text_shaping: text::Shaping::default(),
             wrapping: text::Wrapping::default(),
@@ -175,7 +175,7 @@ where
 
     /// Sets the text [`text::LineHeight`] of the [`Toggler`].
     pub fn line_height(mut self, line_height: impl Into<text::LineHeight>) -> Self {
-        self.line_height = line_height.into();
+        self.line_height = Some(line_height.into());
         self
     }
 

--- a/winit/src/window.rs
+++ b/winit/src/window.rs
@@ -363,7 +363,7 @@ where
                 content: &spans,
                 bounds: Size::INFINITE,
                 size: preedit.text_size.unwrap_or_else(|| renderer.text_size()),
-                line_height: text::LineHeight::default(),
+                line_height: renderer.line_height(),
                 font: renderer.font(),
                 align_x: text::Alignment::Default,
                 align_y: alignment::Vertical::Top,


### PR DESCRIPTION
This PR introduces a `line_height` field to `Settings`, allowing users to configure the default line height of the application.
