### PR TITLE
Keep extending selection when dragging outside text_editor bounds

### DIFF
--- a/core/src/text/editor.rs
+++ b/core/src/text/editor.rs
@@ -417,8 +417,8 @@ impl State {
                     Some(Update::Release)
                 }
                 mouse::Event::CursorMoved { .. } if self.is_dragging => {
-                    let position =
-                        cursor.position_in(bounds)? - Vector::new(padding.left, padding.top);
+                    let position = cursor.position_from(bounds.position())?
+                        - Vector::new(padding.left, padding.top);
 
                     Some(Update::Action(Action::Drag(position)))
                 }


### PR DESCRIPTION
`position_in` returns `None` once the cursor leaves the widget bounds, so the `?` short-circuits the `CursorMoved` arm and no `Action::Drag` is produced. Selection therefore stops growing the moment the pointer crosses the edge, even though the left button is still held.

`position_from` keeps reporting a position relative to the same origin regardless of whether the cursor is inside the bounds, so the drag keeps extending the selection, matching the behavior of other text editors.