### PR TITLE
enable image clipboard and image::allocate on image-without-codecs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,9 @@ wgpu-bare = ["iced_renderer/wgpu-bare", "iced_widget/wgpu"]
 # Enables the `tiny-skia` software renderer
 tiny-skia = ["iced_renderer/tiny-skia"]
 # Enables the `image` widget and image clipboard support
-image = ["image-without-codecs", "image/default", "iced_winit/image"]
+image = ["image-without-codecs", "image/default"]
 # Enables the `image` widget, without any built-in codecs of the `image` crate
-image-without-codecs = ["iced_widget/image", "dep:image"]
+image-without-codecs = ["iced_widget/image", "iced_winit/image", "dep:image"]
 # Enables the `svg` widget
 svg = ["iced_widget/svg"]
 # Enables the `canvas` widget

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -564,10 +564,10 @@ pub mod clipboard {
     pub use crate::core::clipboard::{Content, Error, Kind};
     pub use crate::runtime::clipboard::{read, read_files, read_html, read_text, write};
 
-    #[cfg(feature = "image")]
+    #[cfg(feature = "image-without-codecs")]
     pub use crate::core::clipboard::Image;
 
-    #[cfg(feature = "image")]
+    #[cfg(feature = "image-without-codecs")]
     pub use crate::runtime::clipboard::read_image;
 }
 


### PR DESCRIPTION
Allows you to use the image clipboard and `image::allocate` without needing the extra codecs that come with the image crate.