### PR TITLE
remove max bind groups limitation

### DIFF
--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -159,7 +159,6 @@ impl Compositor {
         ];
 
         let limits = limits.into_iter().map(|limits| wgpu::Limits {
-            max_bind_groups: 2,
             max_non_sampler_bindings: 2048,
             ..limits
         });


### PR DESCRIPTION
I've encountered a validation error in my custom shader that was caused by having more than 2 bind groups (mine has 3). This pr removes the hard-coded limit.

We could do the same thing to `max_non_sampler_bindings` but I'll leave it as is.