### PR TITLE
Fix dropped events when an overlay disappears during update

### DIFF
--- a/runtime/src/user_interface.rs
+++ b/runtime/src/user_interface.rs
@@ -263,6 +263,7 @@ where
                         .map(overlay::Nested::new);
 
                     if maybe_overlay.is_none() {
+                        event_statuses.resize(events.len(), event::Status::Ignored);
                         break;
                     }
 
@@ -300,13 +301,15 @@ where
                 (cursor, mouse::Interaction::None)
             };
 
-            self.overlay = Some(Overlay {
+            self.overlay = maybe_overlay.as_ref().map(|_| Overlay {
                 layout,
                 interaction,
             });
 
             (base_cursor, event_statuses, interaction)
         } else {
+            self.overlay = None;
+
             (
                 cursor,
                 vec![event::Status::Ignored; events.len()],
@@ -657,5 +660,153 @@ impl State {
                 has_layout_changed, ..
             } => *has_layout_changed,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Cache, UserInterface};
+
+    use crate::core;
+    use crate::core::layout;
+    use crate::core::overlay;
+    use crate::core::renderer;
+    use crate::core::shell;
+    use crate::core::widget;
+    use crate::core::window;
+    use crate::core::{Element, Event, Length, Rectangle, Shell, Size};
+
+    type Renderer = ();
+
+    struct Root {
+        overlay_visible: bool,
+    }
+
+    impl widget::Widget<(), core::Theme, Renderer> for Root {
+        fn size(&self) -> Size<Length> {
+            Size::new(Length::Shrink, Length::Shrink)
+        }
+
+        fn layout(
+            &mut self,
+            _tree: &mut widget::Tree,
+            _renderer: &Renderer,
+            _limits: &layout::Limits,
+        ) -> layout::Node {
+            layout::Node::new(Size::ZERO)
+        }
+
+        fn draw(
+            &self,
+            _tree: &widget::Tree,
+            _renderer: &mut Renderer,
+            _theme: &core::Theme,
+            _style: &renderer::Style,
+            _layout: layout::Layout<'_>,
+            _cursor: core::mouse::Cursor,
+            _viewport: &Rectangle,
+        ) {
+        }
+
+        fn update(
+            &mut self,
+            _tree: &mut widget::Tree,
+            event: &Event,
+            _layout: layout::Layout<'_>,
+            _cursor: core::mouse::Cursor,
+            _renderer: &Renderer,
+            shell: &mut Shell<'_, ()>,
+            _viewport: &Rectangle,
+        ) {
+            if matches!(event, Event::Mouse(core::mouse::Event::ButtonReleased(_))) {
+                shell.publish(());
+            }
+        }
+
+        fn overlay<'a>(
+            &'a mut self,
+            _tree: &'a mut widget::Tree,
+            _layout: layout::Layout<'a>,
+            _renderer: &Renderer,
+            _viewport: &Rectangle,
+            _translation: core::Vector,
+        ) -> Option<overlay::Element<'a, (), core::Theme, Renderer>> {
+            if self.overlay_visible {
+                Some(overlay::Element::new(Box::new(HidingOverlay {
+                    overlay_visible: &mut self.overlay_visible,
+                })))
+            } else {
+                None
+            }
+        }
+    }
+
+    struct HidingOverlay<'a> {
+        overlay_visible: &'a mut bool,
+    }
+
+    impl<'a> overlay::Overlay<(), core::Theme, Renderer> for HidingOverlay<'a> {
+        fn layout(&mut self, _renderer: &Renderer, _bounds: Size) -> layout::Node {
+            layout::Node::new(Size::new(1.0, 1.0))
+        }
+
+        fn draw(
+            &self,
+            _renderer: &mut Renderer,
+            _theme: &core::Theme,
+            _style: &renderer::Style,
+            _layout: layout::Layout<'_>,
+            _cursor: core::mouse::Cursor,
+        ) {
+        }
+
+        fn update(
+            &mut self,
+            event: &Event,
+            _layout: layout::Layout<'_>,
+            _cursor: core::mouse::Cursor,
+            _renderer: &Renderer,
+            shell: &mut Shell<'_, ()>,
+        ) {
+            if matches!(event, Event::Mouse(core::mouse::Event::ButtonPressed(_))) {
+                *self.overlay_visible = false;
+                shell.invalidate_layout();
+            }
+        }
+    }
+
+    #[test]
+    fn events_after_an_overlay_disappears_reach_the_base_widget() {
+        let mut renderer = ();
+
+        let mut user_interface = UserInterface::build(
+            Element::new(Root {
+                overlay_visible: true,
+            }),
+            window::Settings::default().size,
+            Cache::default(),
+            &mut renderer,
+        );
+
+        let mut messages = shell::Bus::new();
+
+        let events = [
+            Event::Mouse(core::mouse::Event::ButtonPressed(core::mouse::Button::Left)),
+            Event::Mouse(core::mouse::Event::ButtonReleased(
+                core::mouse::Button::Left,
+            )),
+        ];
+
+        let (_state, statuses) = user_interface.update(
+            &window::Headless,
+            &shell::Waker::noop(),
+            &events,
+            core::mouse::Cursor::Unavailable,
+            &mut renderer,
+            &mut messages,
+        );
+
+        assert_eq!(statuses.len(), 2);
+        assert_eq!(messages.len(), 1);
     }
 }


### PR DESCRIPTION
## Summary

Fixes an event loss bug in `UserInterface::update` when an overlay disappears
after invalidating the layout during event processing.

## Problem

When an overlay invalidates the layout and the rebuilt overlay is `None`, `UserInterface::update` breaks out of the overlay event loop.

This leaves `overlay_statuses` shorter than the original event batch. The later `events.iter().zip(overlay_statuses)` then stops at the shorter iterator, so events after the event that closed the overlay are never dispatched to the base widget.

This can happen when multiple events are passed to `UserInterface::update`, including the event sequences generated by `iced_test::Simulator`.

The cached `self.overlay` could also remain populated after the actual overlay had disappeared.

