### PR TITLE
Horizontal `Span` Padding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -996,8 +996,7 @@ dependencies = [
 [[package]]
 name = "cosmic-text"
 version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be17b688510d934ce13f48a2beba700e11583e281e0fda99c22bb256a14eda73"
+source = "git+https://github.com/hecrj/cosmic-text.git?rev=bff7050390dcb9bde57b9f38eb042fdfc223b8a7#bff7050390dcb9bde57b9f38eb042fdfc223b8a7"
 dependencies = [
  "bitflags 2.13.1",
  "fontdb",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1121,7 +1121,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "cryoglyph"
 version = "0.1.0"
-source = "git+https://github.com/iced-rs/cryoglyph.git?rev=f4e7e4eb84dc1d2f335a98c67d8694640d53a433#f4e7e4eb84dc1d2f335a98c67d8694640d53a433"
+source = "git+https://github.com/iced-rs/cryoglyph.git?rev=e6aec585e0db7cc0281c37b4e66ee91d732adb92#e6aec585e0db7cc0281c37b4e66ee91d732adb92"
 dependencies = [
  "cosmic-text",
  "etagere",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -996,7 +996,7 @@ dependencies = [
 [[package]]
 name = "cosmic-text"
 version = "0.19.0"
-source = "git+https://github.com/hecrj/cosmic-text.git?rev=bff7050390dcb9bde57b9f38eb042fdfc223b8a7#bff7050390dcb9bde57b9f38eb042fdfc223b8a7"
+source = "git+https://github.com/hecrj/cosmic-text.git?rev=6e10ac2ce889f48c9eeb1f19c1340a37d6afae31#6e10ac2ce889f48c9eeb1f19c1340a37d6afae31"
 dependencies = [
  "bitflags 2.13.1",
  "fontdb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -270,3 +270,7 @@ useless_conversion = "deny"
 
 [workspace.lints.rustdoc]
 broken_intra_doc_links = "forbid"
+
+[patch.crates-io]
+cosmic-text.git = "https://github.com/hecrj/cosmic-text.git"
+cosmic-text.rev = "bff7050390dcb9bde57b9f38eb042fdfc223b8a7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -273,4 +273,4 @@ broken_intra_doc_links = "forbid"
 
 [patch.crates-io]
 cosmic-text.git = "https://github.com/hecrj/cosmic-text.git"
-cosmic-text.rev = "bff7050390dcb9bde57b9f38eb042fdfc223b8a7"
+cosmic-text.rev = "6e10ac2ce889f48c9eeb1f19c1340a37d6afae31"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,8 +198,8 @@ bitflags = "2.0"
 bytemuck = { version = "1.0", features = ["derive"] }
 bytes = "1.6"
 cargo-hot = { version = "0.1", package = "cargo-hot-protocol" }
-cosmic-text = "0.19"
-cryoglyph = { git = "https://github.com/iced-rs/cryoglyph.git", rev = "f4e7e4eb84dc1d2f335a98c67d8694640d53a433" }
+cosmic-text = { git = "https://github.com/hecrj/cosmic-text.git", rev = "6e10ac2ce889f48c9eeb1f19c1340a37d6afae31" }
+cryoglyph = { git = "https://github.com/iced-rs/cryoglyph.git", rev = "e6aec585e0db7cc0281c37b4e66ee91d732adb92" }
 futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
 glam = "0.33.2"
 guillotiere = "0.6"
@@ -270,7 +270,3 @@ useless_conversion = "deny"
 
 [workspace.lints.rustdoc]
 broken_intra_doc_links = "forbid"
-
-[patch.crates-io]
-cosmic-text.git = "https://github.com/hecrj/cosmic-text.git"
-cosmic-text.rev = "6e10ac2ce889f48c9eeb1f19c1340a37d6afae31"

--- a/graphics/src/text/paragraph.rs
+++ b/graphics/src/text/paragraph.rs
@@ -347,8 +347,11 @@ impl core::text::Paragraph for Paragraph {
     fn span_bounds(&self, index: usize) -> Vec<Rectangle> {
         let internal = self.internal();
 
+        let scale = 1.0 / internal.hint_factor;
+
         let mut bounds = Vec::new();
-        let mut current_bounds = None;
+        let mut current = None;
+        let mut current_baseline = 0.0;
 
         let mut y = 0.0;
         let buffer_height = internal.buffer.metrics().line_height;
@@ -356,65 +359,67 @@ impl core::text::Paragraph for Paragraph {
             .buffer
             .lines
             .iter()
-            .flat_map(|paragraph| {
-                paragraph
-                    .layout_opt()
-                    .map(Vec::as_slice)
-                    .unwrap_or_default()
-                    .iter()
-                    .flat_map(move |line| {
-                        let line_height = line.line_height(buffer_height);
-                        let ink_height = line.max_ascent + line.max_descent;
+            .filter_map(|paragraph| paragraph.layout_opt().map(Vec::as_slice))
+            .flat_map(|lines| lines.iter())
+            .flat_map(move |line| {
+                let line_height = line.line_height(buffer_height);
+                let ink_height = line.max_ascent + line.max_descent;
 
-                        let glyphs = line.glyphs.iter().map(move |glyph| {
-                            let span_height = glyph.line_height_opt.unwrap_or(buffer_height);
+                // The renderer centers the line's ink within the line
+                // height and places the baseline `max_ascent` below the
+                // top of the ink:
+                let baseline = y + (line_height - ink_height) / 2.0 + line.max_ascent;
 
-                            // TODO:
-                            let top_pad = 0.0;
-                            let bottom_pad = 0.0;
+                let glyphs = line.glyphs.iter().map(move |glyph| (baseline, glyph));
 
-                            let centering_offset =
-                                (line_height - top_pad - bottom_pad - span_height) / 2.0
-                                    + (span_height - ink_height).abs() / 2.0;
+                y += line_height;
 
-                            let top = y + top_pad + centering_offset;
-
-                            (top, top + span_height, glyph)
-                        });
-
-                        y += line_height;
-
-                        glyphs
-                    })
+                glyphs
             })
-            .skip_while(|(_, _, glyph)| glyph.metadata != index)
-            .take_while(|(_, _, glyph)| glyph.metadata == index);
+            .skip_while(|(_, glyph)| glyph.metadata != index)
+            .take_while(|(_, glyph)| glyph.metadata == index);
 
-        for (line_top, line_bottom, glyph) in glyphs {
-            let y = line_top;
+        for (baseline, glyph) in glyphs {
+            // Glyphs can be offset from the line's baseline (e.g. by complex
+            // scripts); mirror the anchor used in `LayoutGlyph::physical`:
+            let anchor = baseline + glyph.y - glyph.font_size * glyph.y_offset;
+            let ink_top = anchor - glyph.ascender;
+            let ink_bottom = anchor + glyph.descender;
 
-            let new_bounds = || {
-                Rectangle::new(
-                    Point::new(glyph.x, line_top),
-                    Size::new(glyph.w, line_bottom - line_top),
-                ) * (1.0 / self.0.hint_factor)
-            };
-
-            match current_bounds.as_mut() {
+            match current.as_mut() {
                 None => {
-                    current_bounds = Some(new_bounds());
+                    current_baseline = baseline;
+                    current = Some(
+                        Rectangle::new(
+                            Point::new(glyph.x, ink_top),
+                            Size::new(glyph.w, ink_bottom - ink_top),
+                        ) * scale,
+                    );
                 }
-                Some(current_bounds) if y != current_bounds.y => {
-                    bounds.push(*current_bounds);
-                    *current_bounds = new_bounds();
+                Some(current) if baseline != current_baseline => {
+                    bounds.push(*current);
+                    current_baseline = baseline;
+                    *current = Rectangle::new(
+                        Point::new(glyph.x, ink_top),
+                        Size::new(glyph.w, ink_bottom - ink_top),
+                    ) * scale;
                 }
-                Some(current_bounds) => {
-                    current_bounds.width += glyph.w / self.0.hint_factor;
+                Some(current) => {
+                    // Union the glyph's ink with the span's bounds on this
+                    // line:
+                    let left = current.x.min(glyph.x * scale);
+                    let top = current.y.min(ink_top * scale);
+                    let right = (current.x + current.width).max((glyph.x + glyph.w) * scale);
+                    let bottom = (current.y + current.height).max(ink_bottom * scale);
+                    *current = Rectangle::new(
+                        Point::new(left, top),
+                        Size::new(right - left, bottom - top),
+                    );
                 }
             }
         }
 
-        bounds.extend(current_bounds);
+        bounds.extend(current);
         bounds
     }
 }
@@ -499,5 +504,117 @@ impl PartialEq for Weak {
             (Some(p1), Some(p2)) => p1 == p2,
             _ => false,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::text::Paragraph as _;
+
+    fn rich_paragraph(content: &[Span<'_, ()>]) -> Paragraph {
+        let text = Text {
+            content,
+            bounds: Size::new(1000.0, f32::INFINITY),
+            size: Pixels(20.0),
+            line_height: LineHeight::Relative(1.5),
+            font: Font::default(),
+            align_x: Alignment::Default,
+            align_y: alignment::Vertical::Top,
+            shaping: Shaping::default(),
+            wrapping: Wrapping::default(),
+            ellipsis: Ellipsis::default(),
+            hint_factor: None,
+        };
+
+        Paragraph::with_spans(text)
+    }
+
+    /// Bounds should cover the ink of the span, without stretching to the
+    /// line height.
+    #[test]
+    fn span_bounds_cover_ink() {
+        let paragraph = rich_paragraph(&[Span::new("a"), Span::new("a").size(40.0)]);
+
+        let small = paragraph.span_bounds(0);
+        let big = paragraph.span_bounds(1);
+
+        assert_eq!(small.len(), 1);
+        assert_eq!(big.len(), 1);
+
+        let buffer = paragraph.buffer();
+        let line = &buffer.lines[0].layout_opt().unwrap()[0];
+        let line_height = line.line_height(buffer.metrics().line_height);
+        let ink_height = line.max_ascent + line.max_descent;
+        let centering = (line_height - ink_height) / 2.0;
+
+        // The larger span determines the line's ink:
+        assert!((big[0].y - centering).abs() < 1e-2);
+        assert!((big[0].height - ink_height).abs() < 1e-2);
+
+        // Both spans share the line's baseline:
+        let baseline = centering + line.max_ascent;
+        assert!((small[0].y + line.max_ascent / 2.0 - baseline).abs() < 1e-2);
+        assert!((big[0].y + line.max_ascent - baseline).abs() < 1e-2);
+
+        // The smaller span is strictly inside the line's ink box...
+        assert!(small[0].y > centering);
+        assert!(small[0].y + small[0].height < centering + ink_height);
+        assert!((small[0].height - ink_height / 2.0).abs() < 1e-2);
+
+        // ...and the ink stays inside the line box:
+        if ink_height < line_height {
+            assert!(big[0].height < line_height);
+        }
+    }
+
+    /// Bounds should cover the horizontal extent of the span's glyphs.
+    #[test]
+    fn span_bounds_cover_width() {
+        let paragraph = rich_paragraph(&[Span::new("Hello"), Span::new(", world!")]);
+
+        let first = paragraph.span_bounds(0);
+        let second = paragraph.span_bounds(1);
+
+        assert_eq!(first.len(), 1);
+        assert_eq!(second.len(), 1);
+
+        let buffer = paragraph.buffer();
+        let line = &buffer.lines[0].layout_opt().unwrap()[0];
+
+        // The first span starts at the beginning of the line and is a
+        // proper prefix of it:
+        assert!((first[0].x - 0.0).abs() < 1e-2);
+        assert!(first[0].width > 0.0);
+        assert!(first[0].width < line.w);
+
+        // The second span starts where the first span ends, and ends at
+        // the end of the line:
+        assert!((second[0].x - (first[0].x + first[0].width)).abs() < 1e-2);
+        assert!((second[0].x + second[0].width - line.w).abs() < 1e-2);
+    }
+
+    /// A span on multiple lines produces one bounds per line.
+    #[test]
+    fn span_bounds_cover_each_line() {
+        let paragraph = rich_paragraph(&[Span::new("ab\ncd")]);
+
+        let bounds = paragraph.span_bounds(0);
+
+        assert_eq!(bounds.len(), 2);
+
+        let buffer = paragraph.buffer();
+        let line_height = buffer.metrics().line_height;
+
+        for bounds in &bounds {
+            assert!((bounds.x - 0.0).abs() < 1e-2);
+            assert!(bounds.height > 0.0);
+            assert!(bounds.height < line_height);
+        }
+
+        // The lines are stacked without overlap, and both lines have the
+        // same ink height:
+        assert!(bounds[0].y + bounds[0].height <= bounds[1].y + 1e-2);
+        assert!((bounds[0].height - bounds[1].height).abs() < 1e-2);
     }
 }

--- a/graphics/src/text/paragraph.rs
+++ b/graphics/src/text/paragraph.rs
@@ -176,8 +176,6 @@ impl core::text::Paragraph for Paragraph {
                 };
 
                 let attrs = attrs.padding(cosmic_text::SpanPadding {
-                    // top: span.padding.top,
-                    // bottom: span.padding.bottom,
                     start: span.padding.left,
                     end: span.padding.right,
                 });

--- a/graphics/src/text/paragraph.rs
+++ b/graphics/src/text/paragraph.rs
@@ -175,6 +175,13 @@ impl core::text::Paragraph for Paragraph {
                     attrs
                 };
 
+                let attrs = attrs.padding(cosmic_text::SpanPadding {
+                    // top: span.padding.top,
+                    // bottom: span.padding.bottom,
+                    start: span.padding.left,
+                    end: span.padding.right,
+                });
+
                 (span.text.as_ref(), attrs.metadata(i))
             }),
             &text::to_attributes(text.font),
@@ -344,7 +351,7 @@ impl core::text::Paragraph for Paragraph {
         let mut current_bounds = None;
 
         let mut y = 0.0;
-        let line_height = internal.buffer.metrics().line_height;
+        let buffer_height = internal.buffer.metrics().line_height;
         let glyphs = internal
             .buffer
             .lines
@@ -356,17 +363,25 @@ impl core::text::Paragraph for Paragraph {
                     .unwrap_or_default()
                     .iter()
                     .flat_map(move |line| {
-                        let glyph_height = line.max_ascent + line.max_descent;
+                        let line_height = line.line_height(buffer_height);
+                        let ink_height = line.max_ascent + line.max_descent;
 
                         let glyphs = line.glyphs.iter().map(move |glyph| {
-                            (
-                                y + (line_height - glyph_height) / 2.0,
-                                y + glyph_height,
-                                glyph,
-                            )
+                            let span_height = glyph.line_height_opt.unwrap_or(buffer_height);
+
+                            // TODO:
+                            let top_pad = 0.0;
+                            let bottom_pad = 0.0;
+
+                            let centering_offset =
+                                (line_height - top_pad - bottom_pad - span_height) / 2.0
+                                    + (span_height - ink_height).abs() / 2.0;
+
+                            let top = y + top_pad + centering_offset;
+
+                            (top, top + span_height, glyph)
                         });
 
-                        let line_height = line.line_height_opt.unwrap_or(line_height);
                         y += line_height;
 
                         glyphs

--- a/widget/src/markdown.rs
+++ b/widget/src/markdown.rs
@@ -1252,6 +1252,15 @@ where
         ..
     } = settings;
 
+    let size = match level {
+        pulldown_cmark::HeadingLevel::H1 => h1_size,
+        pulldown_cmark::HeadingLevel::H2 => h2_size,
+        pulldown_cmark::HeadingLevel::H3 => h3_size,
+        pulldown_cmark::HeadingLevel::H4 => h4_size,
+        pulldown_cmark::HeadingLevel::H5 => h5_size,
+        pulldown_cmark::HeadingLevel::H6 => h6_size,
+    };
+
     container(
         rich_text(text.spans(
             Settings {
@@ -1259,20 +1268,18 @@ where
                     weight: font::Weight::Bold,
                     ..settings.font
                 },
+                inline_code_font: Font {
+                    weight: font::Weight::Bold,
+                    ..settings.inline_code_font
+                },
+                inline_code_size: size * (settings.inline_code_size / settings.text_size),
                 ..settings
             },
             viewer.theme(),
             viewer.highlighter(),
         ))
         .on_link_click(on_link_click)
-        .size(match level {
-            pulldown_cmark::HeadingLevel::H1 => h1_size,
-            pulldown_cmark::HeadingLevel::H2 => h2_size,
-            pulldown_cmark::HeadingLevel::H3 => h3_size,
-            pulldown_cmark::HeadingLevel::H4 => h4_size,
-            pulldown_cmark::HeadingLevel::H5 => h5_size,
-            pulldown_cmark::HeadingLevel::H6 => h6_size,
-        })
+        .size(size)
         .line_height(settings.line_height),
     )
     .into()

--- a/widget/src/markdown.rs
+++ b/widget/src/markdown.rs
@@ -1751,7 +1751,7 @@ impl Catalog for Theme {
         let palette = self.palette();
 
         InlineCode {
-            padding: padding::horizontal(4),
+            padding: padding::horizontal(4).vertical(1),
             highlight: Highlight {
                 background: palette.background.weaker.color.into(),
                 border: border::rounded(4),

--- a/widget/src/markdown.rs
+++ b/widget/src/markdown.rs
@@ -420,31 +420,37 @@ impl Span {
             } => {
                 let span = span(text.clone()).strikethrough(*strikethrough);
 
+                let weight = if *strong {
+                    font::Weight::Bold
+                } else {
+                    font::Weight::Normal
+                };
+
+                let style = if *emphasis {
+                    font::Style::Italic
+                } else {
+                    font::Style::Normal
+                };
+
                 let span = if *inline_code {
                     let code = theme.code();
 
-                    span.font(settings.inline_code_font)
-                        .size(settings.inline_code_size)
-                        .color(code.color)
-                        .background(code.highlight.background)
-                        .border(code.highlight.border)
-                        .padding(code.padding)
-                } else if *strong || *emphasis {
                     span.font(Font {
-                        weight: if *strong {
-                            font::Weight::Bold
-                        } else {
-                            font::Weight::Normal
-                        },
-                        style: if *emphasis {
-                            font::Style::Italic
-                        } else {
-                            font::Style::Normal
-                        },
+                        weight,
+                        style,
+                        ..settings.inline_code_font
+                    })
+                    .size(settings.inline_code_size)
+                    .color(code.color)
+                    .background(code.highlight.background)
+                    .border(code.highlight.border)
+                    .padding(code.padding)
+                } else {
+                    span.font(Font {
+                        weight,
+                        style,
                         ..settings.font
                     })
-                } else {
-                    span.font(settings.font)
                 };
 
                 if let Some(link) = link.as_ref() {

--- a/widget/src/markdown.rs
+++ b/widget/src/markdown.rs
@@ -1401,6 +1401,8 @@ where
     Theme: Catalog + 'a,
     Renderer: core::text::Renderer + 'a,
 {
+    let padding = settings.code_block_size / 0.85 * 0.75;
+
     container(
         scrollable(column(lines.iter().map(|line| {
             rich_text(line.spans(settings, viewer.theme(), viewer.highlighter()))
@@ -1412,13 +1414,13 @@ where
         })))
         .direction(scrollable::Direction::Horizontal(
             scrollable::Scrollbar::default()
-                .width(settings.code_block_size / 2)
-                .scroller_width(settings.code_block_size / 2),
+                .width(padding / 2.0)
+                .scroller_width(padding / 2.0),
         ))
-        .spacing(settings.spacing * 0.75),
+        .spacing(padding),
     )
     .width(Length::Fill)
-    .padding(settings.spacing * 0.75)
+    .padding(padding)
     .class(Theme::code_block())
     .into()
 }

--- a/widget/src/markdown.rs
+++ b/widget/src/markdown.rs
@@ -423,13 +423,13 @@ impl Span {
                 let weight = if *strong {
                     font::Weight::Bold
                 } else {
-                    font::Weight::Normal
+                    settings.font.weight
                 };
 
                 let style = if *emphasis {
                     font::Style::Italic
                 } else {
-                    font::Style::Normal
+                    settings.font.style
                 };
 
                 let span = if *inline_code {

--- a/widget/src/markdown.rs
+++ b/widget/src/markdown.rs
@@ -424,6 +424,7 @@ impl Span {
                     let code = theme.code();
 
                     span.font(settings.inline_code_font)
+                        .size(settings.inline_code_size)
                         .color(code.color)
                         .background(code.highlight.background)
                         .border(code.highlight.border)
@@ -1040,10 +1041,14 @@ pub struct Settings {
     pub inline_code_font: Font,
     /// The [`Font`] to be applied to code blocks.
     pub code_block_font: Font,
-    /// The base text size.
-    pub text_size: Pixels,
     /// The base line height.
     pub line_height: LineHeight,
+    /// The base text size.
+    pub text_size: Pixels,
+    /// The text size used in code blocks.
+    pub code_block_size: Pixels,
+    /// The text size used in inline code.
+    pub inline_code_size: Pixels,
     /// The text size of level 1 heading.
     pub h1_size: Pixels,
     /// The text size of level 2 heading.
@@ -1056,8 +1061,6 @@ pub struct Settings {
     pub h5_size: Pixels,
     /// The text size of level 6 heading.
     pub h6_size: Pixels,
-    /// The text size used in code blocks.
-    pub code_size: Pixels,
     /// The spacing to be used between elements.
     pub spacing: Pixels,
 }
@@ -1077,15 +1080,16 @@ impl Settings {
             font: Font::DEFAULT,
             inline_code_font: Font::MONOSPACE,
             code_block_font: Font::MONOSPACE,
-            text_size,
             line_height,
+            text_size,
+            inline_code_size: text_size * 0.85,
+            code_block_size: text_size * 0.85,
             h1_size: text_size * 1.5,
             h2_size: text_size * 1.25,
             h3_size: text_size * 1.125,
             h4_size: text_size,
             h5_size: text_size,
             h6_size: text_size,
-            code_size: text_size * 0.85,
             spacing: line_height.to_absolute(text_size) / 1.5,
         }
     }
@@ -1389,14 +1393,14 @@ where
             rich_text(line.spans(settings, viewer.theme(), viewer.highlighter()))
                 .on_link_click(on_link_click.clone())
                 .font(settings.code_block_font)
-                .size(settings.code_size)
+                .size(settings.code_block_size)
                 .line_height(settings.line_height)
                 .into()
         })))
         .direction(scrollable::Direction::Horizontal(
             scrollable::Scrollbar::default()
-                .width(settings.code_size / 2)
-                .scroller_width(settings.code_size / 2),
+                .width(settings.code_block_size / 2)
+                .scroller_width(settings.code_block_size / 2),
         ))
         .spacing(settings.spacing * 0.75),
     )
@@ -1747,7 +1751,7 @@ impl Catalog for Theme {
         let palette = self.palette();
 
         InlineCode {
-            padding: padding::horizontal(1),
+            padding: padding::horizontal(4),
             highlight: Highlight {
                 background: palette.background.weaker.color.into(),
                 border: border::rounded(4),

--- a/widget/src/text/rich.rs
+++ b/widget/src/text/rich.rs
@@ -269,40 +269,31 @@ where
 
                 if let Some(highlight) = span.highlight {
                     for (i, bounds) in regions.iter().enumerate() {
-                        let bounds = Rectangle::new(
-                            bounds.position() - Vector::new(span.padding.left, span.padding.top),
-                            bounds.size() + Size::new(span.padding.x(), span.padding.y()),
-                        );
-
                         let starts = i == 0;
                         let ends = i + 1 == regions.len();
+
+                        // The horizontal padding belongs to the start and end
+                        // of the span, not to each of its lines
+                        let left = if starts { span.padding.left } else { 0.0 };
+                        let right = if ends { span.padding.right } else { 0.0 };
+
+                        let bounds = Rectangle::new(
+                            bounds.position() - Vector::new(left, span.padding.top),
+                            bounds.size() + Size::new(left + right, span.padding.y()),
+                        );
+
+                        let radius = border::Radius {
+                            top_left: highlight.border.radius.top_left * f32::from(starts),
+                            bottom_left: highlight.border.radius.bottom_left * f32::from(starts),
+                            top_right: highlight.border.radius.top_right * f32::from(ends),
+                            bottom_right: highlight.border.radius.bottom_right * f32::from(ends),
+                        };
 
                         renderer.fill_quad(
                             renderer::Quad {
                                 bounds: bounds + translation,
                                 border: Border {
-                                    radius: border::Radius {
-                                        top_left: if starts {
-                                            highlight.border.radius.top_left
-                                        } else {
-                                            0.0
-                                        },
-                                        bottom_left: if starts {
-                                            highlight.border.radius.bottom_left
-                                        } else {
-                                            0.0
-                                        },
-                                        top_right: if ends {
-                                            highlight.border.radius.top_right
-                                        } else {
-                                            0.0
-                                        },
-                                        bottom_right: if ends {
-                                            highlight.border.radius.bottom_right
-                                        } else {
-                                            0.0
-                                        },
-                                    },
+                                    radius,
                                     ..highlight.border
                                 },
                                 ..Default::default()
@@ -331,8 +322,7 @@ where
                             renderer.fill_quad(
                                 renderer::Quad {
                                     bounds: Rectangle::new(
-                                        bounds.position() + baseline
-                                            - Vector::new(0.0, size.0 * 0.08),
+                                        bounds.position() + baseline,
                                         Size::new(bounds.width, 1.0),
                                     ),
                                     ..Default::default()


### PR DESCRIPTION
This PR switches `cosmic-text` to my own experimental fork with certain improvements:

- [Check only overlapping attr spans when shaping a word](https://github.com/hecrj/cosmic-text/compare/main...hecrj:cosmic-text:perf/word-attr-span-check)
- [Skip unicode-script scan for pure ASCII shaping runs](https://github.com/hecrj/cosmic-text/compare/main...hecrj:cosmic-text:perf/skip-ascii-script-scan)
- [Fast-path BidiInfo for pure ASCII lines](https://github.com/hecrj/cosmic-text/compare/main...hecrj:cosmic-text:perf/bidi-ascii-fast-path)
- [Cache monospace fallback candidates to speed up Monospace shaping](https://github.com/hecrj/cosmic-text/compare/main...hecrj:cosmic-text:perf/monospace-fallback-cache)
- [Add SpanPadding type and Attrs builder](https://github.com/hecrj/cosmic-text/compare/main...hecrj:cosmic-text:horizontal-span-padding)
- [Fix bigger line height wins over smaller span line heights](https://github.com/hecrj/cosmic-text/compare/main...hecrj:cosmic-text:fix/smaller-span-line-height)
- [Expose ascender and descender on LayoutGlyph](https://github.com/hecrj/cosmic-text/compare/main...hecrj:cosmic-text:glyph-ascender-descender)

I implemented most of these with Qwen 3.8 and, while I review all the code it generates, I would be lying to you if I said I _fully_ understand all the changes. Therefore, I won't be opening PRs to `cosmic-text` until I test the changes properly and grasp them well.

From what I tested and measured so far, these changes make shaping consistently faster in the general case (~10-20%) and much, much faster for monospace fonts (almost a 3x).

Furthermore, the improvements add horizontal padding support for `Attrs` as well as they expose the ink bounds at the glyph level.

In practice, this allows us to have properly spaced highlights in `rich_text`:

<img width="1026" height="1122" alt="image" src="https://github.com/user-attachments/assets/e8c9748b-d6ea-4d0f-9519-b99c1bf6c699" />

You can compare it with `master`, which simply rendered the background of highlights without text layout being affected whatsoever:

<img width="1022" height="1122" alt="image" src="https://github.com/user-attachments/assets/0badb1df-7ea0-48f1-a1f2-27961e7c1081" />
