### PR TITLE
Snap bounds consistently in `iced_wgpu`

### DIFF
--- a/core/src/rectangle.rs
+++ b/core/src/rectangle.rs
@@ -19,7 +19,7 @@ pub struct Rectangle<T = f32> {
 
 impl<T> Rectangle<T>
 where
-    T: Default,
+    T: Default + Copy,
 {
     /// Creates a new [`Rectangle`] with its top-left corner at the origin
     /// and with the provided [`Size`].
@@ -30,6 +30,11 @@ where
             width: size.width,
             height: size.height,
         }
+    }
+
+    /// Returns the [`Size`] of the [`Rectangle`].
+    pub fn size(&self) -> Size<T> {
+        Size::new(self.width, self.height)
     }
 }
 
@@ -125,11 +130,6 @@ impl Rectangle<f32> {
     /// Returns the position of the top left corner of the [`Rectangle`].
     pub fn position(&self) -> Point {
         Point::new(self.x, self.y)
-    }
-
-    /// Returns the [`Size`] of the [`Rectangle`].
-    pub fn size(&self) -> Size {
-        Size::new(self.width, self.height)
     }
 
     /// Returns the area of the [`Rectangle`].

--- a/wgpu/src/image/mod.rs
+++ b/wgpu/src/image/mod.rs
@@ -13,6 +13,7 @@ use crate::Buffer;
 use crate::core::border;
 use crate::core::{Rectangle, Size, Transformation};
 use crate::graphics::Shell;
+use crate::nudge;
 
 use bytemuck::{Pod, Zeroable};
 
@@ -231,12 +232,12 @@ impl State {
                     bounds,
                     clip_bounds,
                 } => {
-                    let bounds = (*bounds * scale).round();
-                    let clip_bounds = (*clip_bounds * scale).round();
-
-                    if bounds.width < 1.0 || bounds.height < 1.0 {
+                    let Some(bounds) = nudge::snap(*bounds * scale) else {
                         continue;
-                    }
+                    };
+
+                    let clip_bounds = nudge::snap(*clip_bounds * scale)
+                        .map_or(Rectangle::with_size(Size::ZERO), Rectangle::from);
 
                     if let Some((atlas_entry, bind_group)) =
                         cache.upload_raster(device, encoder, belt, &image.handle)
@@ -280,12 +281,12 @@ impl State {
                     bounds,
                     clip_bounds,
                 } => {
-                    let bounds = (*bounds * scale).round();
-                    let clip_bounds = (*clip_bounds * scale).round();
-
-                    if bounds.width < 1.0 || bounds.height < 1.0 {
+                    let Some(bounds) = nudge::snap(*bounds * scale) else {
                         continue;
-                    }
+                    };
+
+                    let clip_bounds = nudge::snap(*clip_bounds * scale)
+                        .map_or(Rectangle::with_size(Size::ZERO), Rectangle::from);
 
                     if let Some((atlas_entry, bind_group)) = cache.upload_vector(
                         device,
@@ -293,7 +294,7 @@ impl State {
                         belt,
                         &svg.handle,
                         svg.color,
-                        Size::new(bounds.width as u32, bounds.height as u32),
+                        bounds.size(),
                     ) {
                         match atlas.as_mut() {
                             None => {
@@ -579,7 +580,7 @@ struct Uniforms {
 }
 
 fn add_instances(
-    bounds: Rectangle,
+    bounds: Rectangle<u32>,
     clip_bounds: Rectangle,
     border_radius: border::Radius,
     rotation: f32,
@@ -587,6 +588,8 @@ fn add_instances(
     entry: &atlas::Entry,
     instances: &mut Vec<Instance>,
 ) {
+    let bounds: Rectangle<f32> = bounds.into();
+
     let center = [
         bounds.x + bounds.width / 2.0,
         bounds.y + bounds.height / 2.0,

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -32,6 +32,7 @@ pub mod geometry;
 mod buffer;
 mod color;
 mod engine;
+mod nudge;
 mod quad;
 mod text;
 mod triangle;
@@ -291,11 +292,9 @@ impl Renderer {
         self.layers.merge();
 
         for layer in self.layers.iter() {
-            let clip_bounds = layer.bounds * scale_factor;
-
             if physical_bounds
-                .intersection(&clip_bounds)
-                .and_then(Rectangle::snap)
+                .intersection(&(layer.bounds * scale_factor))
+                .and_then(nudge::snap)
                 .is_none()
             {
                 continue;
@@ -453,7 +452,7 @@ impl Renderer {
                 continue;
             };
 
-            let Some(scissor_rect) = physical_bounds.snap() else {
+            let Some(scissor_rect) = nudge::snap(physical_bounds) else {
                 continue;
             };
 
@@ -521,7 +520,7 @@ impl Renderer {
 
                     if let Some(clip_bounds) = (instance.bounds * scale)
                         .intersection(&physical_bounds)
-                        .and_then(Rectangle::snap)
+                        .and_then(nudge::snap)
                     {
                         render_pass.set_viewport(
                             bounds.x,
@@ -633,7 +632,7 @@ impl Renderer {
                     !layer.is_empty()
                         && physical_bounds
                             .intersection(&(layer.bounds * scale_factor))
-                            .is_some_and(|viewport| viewport.snap().is_some())
+                            .is_some_and(|viewport| nudge::snap(viewport).is_some())
                 })
                 .count()
         });

--- a/wgpu/src/nudge.rs
+++ b/wgpu/src/nudge.rs
@@ -1,0 +1,60 @@
+//! Snapping coordinates to the physical pixel grid.
+//!
+//! # Why the nudge
+//!
+//! Snapping exists so that primitive edges land on the pixel grid and
+//! render as crisp, fully opaque pixels instead of anti-aliased seams (see
+//! [`CRISP`]). But `round`'s decision boundary — the half-pixel — is not
+//! stable under floating-point arithmetic: a coordinate meant to land
+//! exactly on a half-pixel (e.g. `5.25` logical pixels at 2× scale,
+//! `10.5` physical) can be computed a hair below it (e.g. `10.4998`),
+//! where plain `round` rounds down. The edge is then off the grid — the
+//! anti-aliased seam that snapping exists to remove — and one pixel away
+//! from its neighbours, which computed the same boundary cleanly.
+//!
+//! And half-pixels are common in UIs, not a corner case: centering and
+//! equal space distribution are constant in layouts, and `.25` logical
+//! pixels land exactly on physical half-pixels at 2× scale.
+//!
+//! Nudging each edge by [`NUDGE`] before rounding pulls the boundary down
+//! to `.499`: any coordinate within `0.001` below a half-pixel now rounds
+//! up onto the grid, so floating-point noise can no longer split a
+//! half-pixel edge off the grid. Coordinates further from the boundary are
+//! unaffected.
+//!
+//! # Consistency
+//!
+//! The same convention — nudging by [`NUDGE`] before rounding — is applied
+//! by the `quad` vertex shader (see `shader/quad/snap.wgsl`) and by every
+//! CPU-side snapping of these coordinates (the clip (scissor) bounds of the
+//! quad, triangle, image and text passes). The two must never diverge, or
+//! clip bounds may end up one pixel off from the snapped edges they clip.
+//!
+//! [`CRISP`]: crate::core::renderer::CRISP
+use crate::core::{Rectangle, Vector};
+
+/// The nudge applied when snapping a coordinate to the pixel grid.
+///
+/// Coordinates landing just below a half-pixel boundary round up because
+/// of it.
+///
+/// This must stay in sync with `nudge` in
+/// `shader/quad/snap.wgsl`.
+pub const NUDGE: f32 = 0.001;
+
+/// Snaps `bounds` to the physical pixel grid.
+///
+/// It uses the same rounding convention as the `quad` vertex shader
+/// (see `shader/quad/snap.wgsl`): each edge is nudged by [`NUDGE`] before
+/// being rounded, so that coordinates landing just below a half-pixel
+/// boundary round up.
+///
+/// This ensures that clip (scissor) bounds align exactly with the snapped
+/// edges of the [`Quad`] primitives drawn inside them.
+///
+/// Sub-pixel results are rejected, by [`Rectangle::snap`] itself.
+///
+/// [`Quad`]: crate::core::renderer::Quad
+pub fn snap(bounds: Rectangle) -> Option<Rectangle<u32>> {
+    (bounds + Vector::new(NUDGE, NUDGE)).snap()
+}

--- a/wgpu/src/quad/gradient.rs
+++ b/wgpu/src/quad/gradient.rs
@@ -81,6 +81,8 @@ impl Pipeline {
             let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
                 label: Some("iced_wgpu.quad.gradient.shader"),
                 source: wgpu::ShaderSource::Wgsl(std::borrow::Cow::Borrowed(concat!(
+                    include_str!("../shader/quad/snap.wgsl"),
+                    "\n",
                     include_str!("../shader/quad.wgsl"),
                     "\n",
                     include_str!("../shader/vertex.wgsl"),

--- a/wgpu/src/quad/solid.rs
+++ b/wgpu/src/quad/solid.rs
@@ -71,6 +71,8 @@ impl Pipeline {
         let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
             label: Some("iced_wgpu.quad.solid.shader"),
             source: wgpu::ShaderSource::Wgsl(std::borrow::Cow::Borrowed(concat!(
+                include_str!("../shader/quad/snap.wgsl"),
+                "\n",
                 include_str!("../shader/color.wgsl"),
                 "\n",
                 include_str!("../shader/quad.wgsl"),

--- a/wgpu/src/shader/quad/gradient.wgsl
+++ b/wgpu/src/shader/quad/gradient.wgsl
@@ -38,8 +38,8 @@ fn gradient_vs_main(input: GradientVertexInput) -> GradientVertexOutput {
     var scale_snap = vec2<f32>(0.0, 0.0);
 
     if bool(input.snap) {
-        pos_snap = round(pos + vec2(0.001, 0.001)) - pos;
-        scale_snap = round(pos + scale + vec2(0.001, 0.001)) - pos - pos_snap - scale;
+        pos_snap = round(pos + nudge) - pos;
+        scale_snap = round(pos + scale + nudge) - pos - pos_snap - scale;
     }
 
     var min_border_radius = min(input.position_and_scale.z, input.position_and_scale.w) * 0.5;

--- a/wgpu/src/shader/quad/snap.wgsl
+++ b/wgpu/src/shader/quad/snap.wgsl
@@ -1,0 +1,7 @@
+// The nudge applied when snapping coordinates to the pixel grid.
+//
+// The CPU applies the identical nudge (see `src/nudge.rs`) when
+// deriving clip (scissor) bounds, so that they align exactly with the
+// snapped edges of the quads drawn by the vertex shader. Keep the two in
+// sync!
+const nudge: vec2<f32> = vec2(0.001, 0.001);

--- a/wgpu/src/shader/quad/solid.wgsl
+++ b/wgpu/src/shader/quad/solid.wgsl
@@ -36,8 +36,8 @@ fn solid_vs_main(input: SolidVertexInput) -> SolidVertexOutput {
     var scale_snap = vec2<f32>(0.0, 0.0);
 
     if bool(input.snap) {
-        pos_snap = round(pos + vec2(0.001, 0.001)) - pos;
-        scale_snap = round(pos + scale + vec2(0.001, 0.001)) - pos - pos_snap - scale;
+        pos_snap = round(pos + nudge) - pos;
+        scale_snap = round(pos + scale + nudge) - pos - pos_snap - scale;
     }
 
     let border_radius = min(input.border_radius, vec4(min(input.scale.x, input.scale.y) / 2.0));

--- a/wgpu/src/text.rs
+++ b/wgpu/src/text.rs
@@ -5,6 +5,7 @@ use crate::graphics::cache;
 use crate::graphics::color;
 use crate::graphics::text::cache::{self as text_cache, Cache as BufferCache};
 use crate::graphics::text::{Editor, Paragraph, font_system, to_color};
+use crate::nudge;
 
 use rustc_hash::FxHashMap;
 use std::collections::hash_map;
@@ -599,7 +600,8 @@ fn prepare(
             };
 
             let clip_bounds = layer_bounds
-                .intersection(&(clip_bounds * transformation * layer_transformation))?;
+                .intersection(&(clip_bounds * transformation * layer_transformation))
+                .and_then(nudge::snap)?;
 
             let translation = Vector::new(-buffer.scroll().horizontal, 0.0);
 
@@ -629,10 +631,10 @@ fn prepare(
                 top: position.y,
                 scale,
                 bounds: cryoglyph::TextBounds {
-                    left: clip_bounds.x.round() as i32,
-                    top: clip_bounds.y.round() as i32,
-                    right: (clip_bounds.x + clip_bounds.width).round() as i32,
-                    bottom: (clip_bounds.y + clip_bounds.height).round() as i32,
+                    left: clip_bounds.x as i32,
+                    top: clip_bounds.y as i32,
+                    right: (clip_bounds.x + clip_bounds.width) as i32,
+                    bottom: (clip_bounds.y + clip_bounds.height) as i32,
                 },
                 default_color: to_color(color),
             })

--- a/wgpu/src/triangle.rs
+++ b/wgpu/src/triangle.rs
@@ -5,6 +5,7 @@ use crate::Buffer;
 use crate::core::{Point, Rectangle, Size, Transformation, Vector};
 use crate::graphics::Antialiasing;
 use crate::graphics::mesh::{self, Mesh};
+use crate::nudge;
 
 use rustc_hash::FxHashMap;
 use std::collections::hash_map;
@@ -395,8 +396,7 @@ impl Layer {
 
         for mesh in meshes {
             let clip_bounds = mesh.clip_bounds() * transformation;
-            let snap_distance = clip_bounds
-                .snap()
+            let snap_distance = nudge::snap(clip_bounds)
                 .map(|snapped_bounds| {
                     Point::new(snapped_bounds.x as f32, snapped_bounds.y as f32)
                         - clip_bounds.position()
@@ -467,7 +467,7 @@ impl Layer {
         for mesh in meshes {
             let Some(clip_bounds) = bounds
                 .intersection(&(mesh.clip_bounds() * transformation))
-                .and_then(Rectangle::snap)
+                .and_then(nudge::snap)
             else {
                 match mesh {
                     Mesh::Solid { buffers, .. } => {


### PR DESCRIPTION
This PR makes the nudging in the `quad` pipeline consistent over all the pipelines in `iced_wgpu`.

In practice, this should fix misalignment issues, specially when using `stack` and `scrollable`.